### PR TITLE
feat: add conversation logging wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,13 @@ See [Dockerfile](Dockerfile) for the full details of installed packages.
 
 This repository now supports **session event logging** via a lightweight SQLite module:
 
-- **Module:** `src/codex/logging/session_logger.py`
-- **DB (default):** `./codex_session_log.db` (override with `CODEX_LOG_DB_PATH`)
-- **Schema:**  
-  `session_events(session_id TEXT, timestamp TEXT, role TEXT, message TEXT, PRIMARY KEY(session_id, timestamp))`
+- **Modules:**
+  - `src/codex/logging/session_logger.py` – low-level logger
+  - `src/codex/logging/conversation_logger.py` – convenience wrapper with
+    `start_session`, `log_message`, and `end_session`
+  - **DB (default):** `./codex_session_log.db` (override with `CODEX_LOG_DB_PATH`)
+  - **Schema:**
+    `session_events(session_id TEXT, timestamp TEXT, role TEXT, message TEXT, PRIMARY KEY(session_id, timestamp))`
 
 ### Quick start
 
@@ -73,6 +76,16 @@ python -m codex.logging.session_logger --event end   --session-id "$CODEX_SESSIO
 # Log messages
 python -m codex.logging.session_logger --event message \
   --session-id "$CODEX_SESSION_ID" --role user --message "Hello"
+
+# Programmatic usage
+```python
+from codex.logging import conversation_logger as cl
+
+sid = "demo-session"
+cl.start_session(sid)
+cl.log_message(sid, "user", "Hello")
+cl.end_session(sid)
+```
 ```
 
 ### Querying

--- a/README_UPDATED.md
+++ b/README_UPDATED.md
@@ -58,10 +58,13 @@ See [Dockerfile](Dockerfile) for the full details of installed packages.
 
 This repository now supports **session event logging** via a lightweight SQLite module:
 
-- **Module:** `src/codex/logging/session_logger.py`
-- **DB (default):** `./codex_session_log.db` (override with `CODEX_LOG_DB_PATH`)
-- **Schema:**  
-  `session_events(session_id TEXT, timestamp TEXT, role TEXT, message TEXT, PRIMARY KEY(session_id, timestamp))`
+- **Modules:**
+  - `src/codex/logging/session_logger.py` – low-level logger
+  - `src/codex/logging/conversation_logger.py` – convenience wrapper with
+    `start_session`, `log_message`, and `end_session`
+  - **DB (default):** `./codex_session_log.db` (override with `CODEX_LOG_DB_PATH`)
+  - **Schema:**
+    `session_events(session_id TEXT, timestamp TEXT, role TEXT, message TEXT, PRIMARY KEY(session_id, timestamp))`
 
 ### Quick start
 
@@ -73,6 +76,16 @@ python -m codex.logging.session_logger --event end   --session-id "$CODEX_SESSIO
 # Log messages
 python -m codex.logging.session_logger --event message \
   --session-id "$CODEX_SESSION_ID" --role user --message "Hello"
+
+# Programmatic usage
+```python
+from codex.logging import conversation_logger as cl
+
+sid = "demo-session"
+cl.start_session(sid)
+cl.log_message(sid, "user", "Hello")
+cl.end_session(sid)
+```
 ```
 
 ### Querying

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,12 +6,13 @@
 # Requires Python available in PATH.
 
 if command -v python3 >/dev/null 2>&1; then PYTHON=python3; else PYTHON=python; fi
+export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$(pwd)/src"
 : "${CODEX_SESSION_ID:=$(date +%s)}"
-($PYTHON -m codex.logging.session_logger --event start --session-id "$CODEX_SESSION_ID") >/dev/null 2>&1 || true
+($PYTHON -m codex.logging.conversation_logger --event start --session-id "$CODEX_SESSION_ID") >/dev/null 2>&1 || true
 
 # On exit, log end once.
 
-trap '($PYTHON -m codex.logging.session_logger --event end --session-id "$CODEX_SESSION_ID") >/dev/null 2>&1 || true' EXIT
+trap '($PYTHON -m codex.logging.conversation_logger --event end --session-id "$CODEX_SESSION_ID") >/dev/null 2>&1 || true' EXIT
 
 # === END_CODEX_SESSION_LOGGING ===
 

--- a/src/codex/logging/conversation_logger.py
+++ b/src/codex/logging/conversation_logger.py
@@ -1,0 +1,55 @@
+"""High-level conversation logging wrapper.
+
+Provides start_session, log_message, and end_session helpers that forward to
+``codex.logging.session_logger.log_event``. All helpers accept an optional
+``db_path`` to override the default SQLite database location.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Optional
+
+from . import session_logger
+
+
+def start_session(session_id: str, db_path: Optional[str] = None) -> None:
+    """Record the start of a session."""
+    session_logger.log_event(session_id, "system", "session_start", db_path)
+
+
+def log_message(
+    session_id: str,
+    role: str,
+    text: str,
+    db_path: Optional[str] = None,
+) -> None:
+    """Log a user/assistant/system message."""
+    session_logger.log_event(session_id, role, text, db_path)
+
+
+def end_session(session_id: str, db_path: Optional[str] = None) -> None:
+    """Record the end of a session."""
+    session_logger.log_event(session_id, "system", "session_end", db_path)
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", choices=["start", "message", "end"], required=True)
+    parser.add_argument("--session-id", dest="sid", default=os.getenv("CODEX_SESSION_ID", ""))
+    parser.add_argument("--role", default="system")
+    parser.add_argument("--message", default="")
+    parser.add_argument("--db-path", dest="db_path", default=None)
+    args = parser.parse_args()
+
+    sid = args.sid or os.getenv("CODEX_SESSION_ID") or ""
+    if args.event == "start":
+        start_session(sid, db_path=args.db_path)
+    elif args.event == "end":
+        end_session(sid, db_path=args.db_path)
+    else:
+        log_message(sid, args.role, args.message, db_path=args.db_path)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/tests/test_conversation_logger.py
+++ b/tests/test_conversation_logger.py
@@ -1,0 +1,27 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+# ensure src is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from codex.logging.conversation_logger import (
+    end_session,
+    log_message,
+    start_session,
+)
+
+
+def _count(db):
+    with sqlite3.connect(db) as c:
+        return c.execute("SELECT COUNT(*) FROM session_events").fetchone()[0]
+
+
+def test_wrapper_logs_messages(tmp_path):
+    db = tmp_path / "conv.db"
+    sid = "wrapper-session"
+    start_session(sid, db_path=str(db))
+    log_message(sid, "user", "hi", db_path=str(db))
+    log_message(sid, "assistant", "yo", db_path=str(db))
+    end_session(sid, db_path=str(db))
+    assert _count(db) == 4


### PR DESCRIPTION
## Summary
- add `conversation_logger` wrapper around session logging
- route start/end events through the wrapper in `entrypoint.sh`
- document and test conversation logging utilities

## Testing
- `ruff check src tests`
- `pytest`
- `git lfs status`
- `python scripts/wlc_session_manager.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3216da9088331a72ac3a02db3c49d