### PR TITLE
feat: add model and token fields to session logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This repository now supports **session event logging** via a lightweight SQLite 
     `start_session`, `log_message`, and `end_session`
   - **DB (default):** `./codex_session_log.db` (override with `CODEX_LOG_DB_PATH`)
   - **Schema:**
-    `session_events(session_id TEXT, timestamp TEXT, role TEXT, message TEXT, PRIMARY KEY(session_id, timestamp))`
+    `session_events(session_id TEXT, timestamp TEXT, role TEXT, message TEXT, model TEXT, tokens INTEGER, PRIMARY KEY(session_id, timestamp))`
 
 ### Quick start
 

--- a/tests/test_session_logging.py
+++ b/tests/test_session_logging.py
@@ -19,9 +19,12 @@ def test_insert_sample_conversation(tmp_path, monkeypatch):
     sid = "test-session-001"
     log_event(sid, "system", "session_start")
     log_event(sid, "user", "Hello")
-    log_event(sid, "assistant", "Hi there!")
+    log_event(sid, "assistant", "Hi there!", model="gpt-4", tokens=3)
     log_event(sid, "system", "session_end")
     assert _count_rows(db) == 4
+    with sqlite3.connect(db) as c:
+        row = c.execute("SELECT model, tokens FROM session_events WHERE role='assistant'").fetchone()
+    assert row == ("gpt-4", 3)
 
 def test_idempotent_init(tmp_path, monkeypatch):
     db = tmp_path / "init.db"
@@ -31,4 +34,14 @@ def test_idempotent_init(tmp_path, monkeypatch):
     init_db()  # second call should not fail
     with sqlite3.connect(db) as c:
         cols = [r[1] for r in c.execute("PRAGMA table_info(session_events)")]
-    assert set(["session_id","timestamp","role","message"]).issubset(set(cols))
+    assert set(["session_id","timestamp","role","message","model","tokens"]).issubset(set(cols))
+
+def test_migration_adds_columns(tmp_path):
+    db = tmp_path / "mig.db"
+    with sqlite3.connect(db) as c:
+        c.execute("CREATE TABLE session_events(session_id TEXT NOT NULL, timestamp TEXT NOT NULL, role TEXT NOT NULL, message TEXT NOT NULL, PRIMARY KEY(session_id, timestamp))")
+    from codex.logging.session_logger import init_db
+    init_db(str(db))
+    with sqlite3.connect(db) as c:
+        cols = [r[1] for r in c.execute("PRAGMA table_info(session_events)")]
+    assert "model" in cols and "tokens" in cols

--- a/tools/codex_workflow.py
+++ b/tools/codex_workflow.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Placeholder workflow helper.
+
+This script intentionally keeps logic minimal while reserving the interface
+for future expansion. It enforces the repository policy that GitHub Actions
+workflows must not be activated.
+"""
+from __future__ import annotations
+
+import argparse
+
+DO_NOT_ACTIVATE_GITHUB_ACTIONS = True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="codex workflow helper")
+    parser.add_argument("--apply", action="store_true", help="no-op")
+    parser.parse_args()
+    print("codex workflow executed")
+
+
+if __name__ == "__main__":
+    assert DO_NOT_ACTIVATE_GITHUB_ACTIONS, "GitHub Actions must remain untouched."
+    main()

--- a/tools/safe_rg.sh
+++ b/tools/safe_rg.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+rg "$@"


### PR DESCRIPTION
## Summary
- extend SQLite session table with `model` and `tokens` columns
- persist optional model and token metadata when logging events
- test migrations and round-trip storage of new fields

## Testing
- `ruff check src/codex/logging/session_logger.py tests/test_session_logging.py tools/codex_workflow.py`
- `pytest tests/test_session_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68a32abe5c04833183610dd814be3abc