### PR TITLE
feat: add chat session helper with logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This repository now supports **session event logging** via a lightweight SQLite 
   - `src/codex/logging/session_logger.py` – low-level logger
   - `src/codex/logging/conversation_logger.py` – convenience wrapper with
     `start_session`, `log_message`, and `end_session`
+  - `src/codex/chat.py` – context manager that propagates `CODEX_SESSION_ID`
   - **DB (default):** `./codex_session_log.db` (override with `CODEX_LOG_DB_PATH`)
   - **Schema:**
     `session_events(session_id TEXT, timestamp TEXT, role TEXT, message TEXT, model TEXT, tokens INTEGER, PRIMARY KEY(session_id, timestamp))`
@@ -85,6 +86,13 @@ sid = "demo-session"
 cl.start_session(sid)
 cl.log_message(sid, "user", "Hello")
 cl.end_session(sid)
+```
+```python
+from codex.chat import ChatSession
+
+with ChatSession() as chat:
+    chat.log_user("Hello")
+    chat.log_assistant("Hi there!")
 ```
 ```
 

--- a/src/codex/chat.py
+++ b/src/codex/chat.py
@@ -1,0 +1,56 @@
+"""Simple chat session helper that logs messages via SessionLogger.
+
+This module provides a ``ChatSession`` context manager that initializes
+``SessionLogger`` on entry, captures user and assistant messages, and ensures
+the session is closed on exit. The current session ID is propagated via the
+``CODEX_SESSION_ID`` environment variable so that other components can access it
+consistently.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Optional
+
+from .logging import conversation_logger as _cl
+
+
+class ChatSession:
+    """Context manager for logging a chat conversation.
+
+    Parameters
+    ----------
+    session_id:
+        Optional explicit session identifier. If omitted, uses the existing
+        ``CODEX_SESSION_ID`` environment variable or generates one from the
+        current timestamp.
+    db_path:
+        Optional path to the SQLite database.
+    """
+
+    def __init__(self, session_id: Optional[str] = None, db_path: Optional[str] = None) -> None:
+        sid = session_id or os.getenv("CODEX_SESSION_ID") or str(int(time.time()))
+        self.session_id = sid
+        self.db_path = db_path
+        self._prev_sid = None
+
+    def __enter__(self) -> ChatSession:
+        self._prev_sid = os.getenv("CODEX_SESSION_ID")
+        os.environ["CODEX_SESSION_ID"] = self.session_id
+        _cl.start_session(self.session_id, db_path=self.db_path)
+        return self
+
+    def log_user(self, message: str) -> None:
+        """Record an inbound user message."""
+        _cl.log_message(self.session_id, "user", message, db_path=self.db_path)
+
+    def log_assistant(self, message: str) -> None:
+        """Record an outbound assistant message."""
+        _cl.log_message(self.session_id, "assistant", message, db_path=self.db_path)
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        _cl.end_session(self.session_id, db_path=self.db_path)
+        if self._prev_sid is None:
+            os.environ.pop("CODEX_SESSION_ID", None)
+        else:
+            os.environ["CODEX_SESSION_ID"] = self._prev_sid

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -1,0 +1,25 @@
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+# ensure src is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from codex.chat import ChatSession
+
+
+def _count(db):
+    with sqlite3.connect(db) as c:
+        return c.execute("SELECT COUNT(*) FROM session_events").fetchone()[0]
+
+
+def test_chat_session_logs_and_env(tmp_path, monkeypatch):
+    db = tmp_path / "chat.db"
+    monkeypatch.delenv("CODEX_SESSION_ID", raising=False)
+    with ChatSession(session_id="env-session", db_path=str(db)) as chat:
+        assert os.getenv("CODEX_SESSION_ID") == "env-session"
+        chat.log_user("hi")
+        chat.log_assistant("yo")
+    assert _count(db) == 4
+    assert os.getenv("CODEX_SESSION_ID") is None


### PR DESCRIPTION
## Summary
- add `ChatSession` context manager to log user and assistant messages
- propagate `CODEX_SESSION_ID` and automatically start/end sessions
- document chat session helper and add tests

## Testing
- `ruff check src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a32f0bbe0c8331bb099746ffc0c030