### PR TITLE
docs: document end-to-end logging workflow

### DIFF
--- a/.codex/change_log.md
+++ b/.codex/change_log.md
@@ -1198,3 +1198,9 @@ Rationale: Provide executable workflow for generating viewer, tests, docs.
 ```diff
 ```
 
+
+## 2025-08-18T16:53:56Z
+- **File:** README.md — add End-to-End Logging section
+- **File:** documentation/end_to_end_logging.md — create logging guide
+- **File:** tools/codex_log_viewer.py — create log viewer CLI
+- **File:** .codex/results.md — append inventory and summary

--- a/.codex/errors.ndjson
+++ b/.codex/errors.ndjson
@@ -2,3 +2,5 @@
 {"ts": "2025-08-18T16:21:09.076578+00:00", "step": "1.1 Verify clean working state", "error": "Working tree not clean", "context": "?? tools/codex_logging_workflow.py"}
 {"ts":"2025-08-18T16:32:50Z","step":"tests","msg":"ImportError: fetch_messages not found","context":"pytest tests/test_session_logging_mirror.py"}
 {"time": "2025-08-18T16:45:00+00:00", "step": "Tests", "error": "ImportError: cannot import name 'fetch_messages'", "context": "pytest -q"}
+{"question_for":"ChatGPT-5","step":"tests: pytest","error":"ImportError: cannot import name 'fetch_messages'","context":"pytest -q","ts":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
+{"question_for":"ChatGPT-5","step":"tests: pytest","error":"ImportError: cannot import name 'fetch_messages'","context":"pytest -q","ts":"2025-08-18T16:54:11Z"}

--- a/.codex/results.md
+++ b/.codex/results.md
@@ -33,3 +33,25 @@
 - Run `scripts/codex_end_to_end.py --repo . --yes` to regenerate assets if needed.
 
 **DO NOT ACTIVATE ANY GitHub Actions files.**
+
+## Inventory @ 2025-08-18T16:52:56Z
+- README.md
+- Dockerfile
+- setup.sh
+- setup_universal.sh
+- entrypoint.sh
+- documentation/
+
+## Mapping
+- T1 → README.md + documentation/end_to_end_logging.md
+- T2 → README.md environment section
+- T3 → README quick-start snippet
+- T4 → tools/codex_log_viewer.py (new CLI)
+
+## Results Summary
+- Implemented End-to-End Logging docs and examples
+- Created log viewer CLI
+- No pruning performed
+- Next steps: integrate logging into repo tools if needed
+
+**DO NOT ACTIVATE ANY GitHub Actions files.**

--- a/documentation/end_to_end_logging.md
+++ b/documentation/end_to_end_logging.md
@@ -1,0 +1,63 @@
+# End-to-End Logging
+
+This guide describes the environment variables and the start→message→end logging pattern.
+
+## 1) Environment
+
+* **CODEX_SESSION_ID**: A UUID tying multiple invocations together.
+* **CODEX_LOG_DB_PATH**: Path to a SQLite DB (or NDJSON) where events are stored.
+
+### Shell Setup
+
+**Bash/Zsh**
+
+```bash
+export CODEX_SESSION_ID="$(uuidgen || python -c 'import uuid;print(uuid.uuid4())')"
+export CODEX_LOG_DB_PATH="${PWD}/.codex/codex_logs.sqlite"
+```
+
+**PowerShell**
+
+```powershell
+$env:CODEX_SESSION_ID = [guid]::NewGuid().ToString()
+$env:CODEX_LOG_DB_PATH = (Join-Path (Get-Location) ".codex/codex_logs.sqlite")
+```
+
+## 2) Quick Start
+
+```python
+import os, sqlite3, time, pathlib
+
+sid = os.getenv("CODEX_SESSION_ID", "dev-session")
+db = pathlib.Path(os.getenv("CODEX_LOG_DB_PATH", ".codex/codex_logs.sqlite"))
+db.parent.mkdir(parents=True, exist_ok=True)
+
+con = sqlite3.connect(db)
+cur = con.cursor()
+cur.execute("CREATE TABLE IF NOT EXISTS logs(ts REAL, session TEXT, kind TEXT, message TEXT)")
+
+def log(kind, msg):
+    cur.execute("INSERT INTO logs(ts, session, kind, message) VALUES(strftime('%s','now'), ?, ?, ?)", (sid, kind, msg))
+
+log("start", "session begin")
+log("message", "processing step A")
+log("message", "processing step B")
+log("end", "session end")
+con.commit(); con.close()
+```
+
+## 3) Viewing Logs
+
+If you have `tools/codex_log_viewer.py`:
+
+```bash
+python tools/codex_log_viewer.py --db "$CODEX_LOG_DB_PATH" --session "$CODEX_SESSION_ID"
+```
+
+Options:
+
+* `--db` (default: `./.codex/codex_logs.sqlite`)
+* `--session` (optional filter)
+* `--tail` (show latest N rows)
+
+> **Compliance:** DO NOT ACTIVATE ANY GitHub Actions files.

--- a/tools/codex_log_viewer.py
+++ b/tools/codex_log_viewer.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Minimal SQLite/NDJSON log viewer for codex."""
+
+import argparse, os, sys, json, sqlite3, pathlib, time
+
+
+def print_rows(rows):
+    if not rows:
+        print("(no rows)")
+        return
+    for ts, session, kind, message in rows:
+        stamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(ts))
+        print(f"{stamp} [{session}] {kind}: {message}")
+
+
+def view_sqlite(db_path, session=None, tail=None):
+    con = sqlite3.connect(db_path)
+    cur = con.cursor()
+    base = "SELECT ts, session, kind, message FROM logs"
+    where = []
+    args = []
+    if session:
+        where.append("session = ?")
+        args.append(session)
+    sql = base + (" WHERE " + " AND ".join(where) if where else "") + " ORDER BY ts DESC"
+    if tail:
+        sql += f" LIMIT {int(tail)}"
+    rows = list(cur.execute(sql, args))
+    print_rows(reversed(rows))
+    con.close()
+
+
+def view_ndjson(file_path, session=None, tail=None):
+    rows = []
+    with open(file_path, "r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                obj = json.loads(line)
+            except Exception:
+                continue
+            ts = float(obj.get("ts") or obj.get("time") or 0)
+            rows.append((ts, obj.get("session", ""), obj.get("kind", ""), obj.get("message", "")))
+    if session:
+        rows = [r for r in rows if r[1] == session]
+    rows.sort(key=lambda r: r[0])
+    if tail:
+        rows = rows[-int(tail):]
+    print_rows(rows)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", default=os.getenv("CODEX_LOG_DB_PATH", ".codex/codex_logs.sqlite"))
+    ap.add_argument("--session", default=os.getenv("CODEX_SESSION_ID"))
+    ap.add_argument("--tail", type=int)
+    args = ap.parse_args()
+
+    p = pathlib.Path(args.db)
+    if p.suffix.lower() == ".sqlite":
+        if not p.exists():
+            print(f"SQLite DB not found at {p}", file=sys.stderr)
+            return 1
+        view_sqlite(str(p), session=args.session, tail=args.tail)
+    else:
+        if not p.exists():
+            print(f"NDJSON file not found at {p}", file=sys.stderr)
+            return 1
+        view_ndjson(str(p), session=args.session, tail=args.tail)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document CODEX_SESSION_ID and CODEX_LOG_DB_PATH usage
- add end-to-end logging guide and sample viewer CLI

## Testing
- `python -m py_compile tools/codex_log_viewer.py`
- `pytest -q` *(fails: ImportError: cannot import name 'fetch_messages')*


------
https://chatgpt.com/codex/tasks/task_e_68a359e7d5848331af484505772f36ef