### PR TITLE
refactor(tools): log hook errors in session logging workflow

### DIFF
--- a/tools/codex_session_logging_workflow.py
+++ b/tools/codex_session_logging_workflow.py
@@ -110,8 +110,10 @@ def phase1_prep():
 
 TEST_FILE = TESTS_DIR / "test_session_logging.py"
 TEST_BODY = r'''
-import os, json, sqlite3, uuid, subprocess, sys, importlib, pathlib, time
+import os, json, sqlite3, uuid, subprocess, sys, importlib, pathlib, time, logging
 import pytest
+
+logger = logging.getLogger(__name__)
 
 def _import_any(paths):
     for p in paths:
@@ -176,8 +178,9 @@ def test_context_manager_emits_start_end(tmp_path, monkeypatch):
                 with cm:
                     time.sleep(0.01)
                 used = "python_cm"
-    except Exception:
-        pass
+    except Exception as exc:
+        hook_name = locals().get("name", "unknown")
+        logger.warning("Failed to execute session hook '%s': %s", hook_name, exc)
 
     if used is None:
         # Fallback to shell helpers via source


### PR DESCRIPTION
## Summary
- log hook exceptions with hook name for session logging workflow test
- include logger setup in generated test body for debugging

## Testing
- `python -m py_compile tools/codex_session_logging_workflow.py`
- `pytest -q` *(fails: tests/test_session_logging.py::test_log_conversation_helper)*

------
https://chatgpt.com/codex/tasks/task_e_68a384c907b88331a31d21d03aca3de9