### PR TITLE
Use timezone-aware datetime.now in session hooks

### DIFF
--- a/src/codex/logging/session_hooks.py
+++ b/src/codex/logging/session_hooks.py
@@ -1,12 +1,13 @@
 # Session logging helper (Python)
 from __future__ import annotations
-import atexit, json, os, sys, time, uuid, pathlib, datetime as dt
+import atexit, json, os, sys, time, uuid, pathlib
+from datetime import datetime, UTC
 
 LOG_DIR = pathlib.Path(os.environ.get("CODEX_SESSION_LOG_DIR", ".codex/sessions"))
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 def _now():
-    return dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc).isoformat().replace("+00:00","Z")
+    return datetime.now(UTC).isoformat().replace("+00:00","Z")
 
 def _session_id():
     sid = os.environ.get("CODEX_SESSION_ID")


### PR DESCRIPTION
## Summary
- Replace deprecated `datetime.utcnow()` with `datetime.now(UTC)` in session logging
- Import `datetime` and `UTC` directly for clarity

## Testing
- `pytest -q` *(fails: OperationalError: no such table: session_events)*
- `rg utcnow -n src`

------
https://chatgpt.com/codex/tasks/task_e_68a4624e28b08331a5df71d70657e2a3