### PR TITLE
docs: document pre-commit setup

### DIFF
--- a/.github/workflows/build-image.yml.disabled
+++ b/.github/workflows/build-image.yml.disabled
@@ -17,7 +17,20 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install pre-commit
+        run: pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+
   build-and-push:
+    needs: pre-commit
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,7 +49,7 @@ jobs:
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    
+
     - name: Build and push
       id: docker_build
       uses: docker/build-push-action@v6
@@ -46,7 +59,7 @@ jobs:
         tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
-    
+
     - name: Generate artifact attestation
       uses: actions/attest-build-provenance@v2
       if: ${{ github.event_name == 'push' }}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ In addition to the packages specified in the table above, the following packages
 
 See [Dockerfile](Dockerfile) for the full details of installed packages.
 
+## Development
+
+Set up the git hooks before committing:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Pull requests are validated with `pre-commit run --all-files`; submissions failing these
+hooks will be rejected.
+
 ## Session Logging (SQLite)
 
 This repository provides a CLI viewer for session-scoped logs stored in SQLite.
@@ -282,4 +294,3 @@ No code changes are required beyond importing `sqlite3` normally.
 
 - Disable: `CODEX_SQLITE_POOL=0` (default)
 - DB path for adapters: `CODEX_SQLITE_DB` (defaults to `codex_data.sqlite3`)
-

--- a/README_UPDATED.md
+++ b/README_UPDATED.md
@@ -54,6 +54,18 @@ In addition to the packages specified in the table above, the following packages
 
 See [Dockerfile](Dockerfile) for the full details of installed packages.
 
+## Development
+
+Set up the git hooks before committing:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Pull requests are validated with `pre-commit run --all-files`; submissions failing these
+hooks will be rejected.
+
 ## Session Logging (SQLite)
 
 This repository now supports **session event logging** via a lightweight SQLite module:


### PR DESCRIPTION
## Summary
- document installing and enabling pre-commit hooks
- warn that PRs failing hooks will be rejected
- run pre-commit in CI before building

## Testing
- `pre-commit run --files README.md README_UPDATED.md .github/workflows/build-image.yml.disabled`
- `pytest` *(fails: invalid role 'INFO'; expected one of {'user', 'tool', 'system', 'assistant'})*

------
https://chatgpt.com/codex/tasks/task_e_68a462505aec833194247d497ec816b1