### PR TITLE
Use UUID-based chat session IDs

### DIFF
--- a/src/codex/chat.py
+++ b/src/codex/chat.py
@@ -9,7 +9,7 @@ consistently.
 from __future__ import annotations
 
 import os
-import time
+import uuid
 from typing import Optional
 
 from .logging import conversation_logger as _cl
@@ -22,14 +22,13 @@ class ChatSession:
     ----------
     session_id:
         Optional explicit session identifier. If omitted, uses the existing
-        ``CODEX_SESSION_ID`` environment variable or generates one from the
-        current timestamp.
+        ``CODEX_SESSION_ID`` environment variable or generates a new UUID4.
     db_path:
         Optional path to the SQLite database.
     """
 
     def __init__(self, session_id: Optional[str] = None, db_path: Optional[str] = None) -> None:
-        sid = session_id or os.getenv("CODEX_SESSION_ID") or str(int(time.time()))
+        sid = session_id or os.getenv("CODEX_SESSION_ID") or uuid.uuid4().hex
         self.session_id = sid
         self.db_path = db_path
         self._prev_sid = None

--- a/src/codex/logging/session_hooks.py
+++ b/src/codex/logging/session_hooks.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 import atexit, json, os, sys, time, uuid, pathlib
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
 LOG_DIR = pathlib.Path(os.environ.get("CODEX_SESSION_LOG_DIR", ".codex/sessions"))
 LOG_DIR.mkdir(parents=True, exist_ok=True)
@@ -10,12 +10,7 @@ LOG_DIR.mkdir(parents=True, exist_ok=True)
 def _now():
     """Return current UTC time in ISO-8601 Zulu format."""
 
-    return (
-        dt.datetime.utcnow()
-        .replace(tzinfo=dt.timezone.utc)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 def _session_id():
     """Fetch or create a session identifier and cache it in the environment."""

--- a/src/codex/monkeypatch/log_adapters.py
+++ b/src/codex/monkeypatch/log_adapters.py
@@ -43,14 +43,8 @@ def log_event(level: str, message: str, meta: str | None = None, db_path: Path |
     conn = sqlite3.connect(str(db))
     cur = conn.cursor()
     cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS session_events(
-            ts REAL NOT NULL,
-            session_id TEXT NOT NULL,
-            role TEXT NOT NULL,
-            message TEXT NOT NULL
-        )
-        """
+        "INSERT INTO app_log(ts, level, message, meta) VALUES(?,?,?,?)",
+        (time.time(), level, message, meta),
     )
     conn.commit()
     cur.close()

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+import uuid
 
 from src.codex.chat import ChatSession
 
@@ -17,4 +18,14 @@ def test_chat_session_logs_and_env(tmp_path, monkeypatch):
         chat.log_user("hi")
         chat.log_assistant("yo")
     assert _count(db) == 4
+    assert os.getenv("CODEX_SESSION_ID") is None
+
+
+def test_chat_session_generates_uuid(tmp_path, monkeypatch):
+    db = tmp_path / "chat.db"
+    monkeypatch.delenv("CODEX_SESSION_ID", raising=False)
+    with ChatSession(db_path=str(db)) as chat:
+        sid = chat.session_id
+        assert os.getenv("CODEX_SESSION_ID") == sid
+        uuid.UUID(sid)
     assert os.getenv("CODEX_SESSION_ID") is None


### PR DESCRIPTION
## Summary
- generate default chat session IDs with `uuid.uuid4().hex`
- test ChatSession's default ID is a UUID
- fix session logging utilities to insert log records and use `datetime.now(UTC)`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4647aaa408331a04e6a8f050a01e7