### PR TITLE
Support INFO and WARN roles in session logging

### DIFF
--- a/README_UPDATED.md
+++ b/README_UPDATED.md
@@ -77,6 +77,7 @@ This repository now supports **session event logging** via a lightweight SQLite 
   - **DB (default):** `src.codex.logging.config.DEFAULT_LOG_DB` (override with `CODEX_LOG_DB_PATH`)
   - **Schema:**
     `session_events(session_id TEXT, timestamp TEXT, role TEXT, message TEXT, PRIMARY KEY(session_id, timestamp))`
+  - **Accepted roles:** `system`, `user`, `assistant`, `tool`, `INFO`, `WARN`
 
 ### Quick start
 

--- a/scripts/apply_session_logging_workflow.py
+++ b/scripts/apply_session_logging_workflow.py
@@ -154,7 +154,7 @@ If the repo already defines `log_event`, `init_db`, and `_DB_LOCK` under `codex.
 we import and use them. Otherwise we fall back to local, minimal implementations
 (scoped in this file) to preserve end-to-end behavior without polluting global API.
 
-Roles allowed: system|user|assistant|tool.
+Roles allowed: system|user|assistant|tool|INFO|WARN.
 
 This module is intentionally small and self-contained; it does NOT activate any
 GitHub Actions or external services.
@@ -221,14 +221,14 @@ def log_event(session_id: str, role: str, message: str, db_path: Optional[Path] 
         return _shared_log_event(session_id, role, message, db_path=db_path)
     return _fallback_log_event(session_id, role, message, db_path=db_path)
 
-_ALLOWED_ROLES = {"system","user","assistant","tool"}
+_ALLOWED_ROLES = {"system","user","assistant","tool","INFO","WARN"}
 
 def log_message(session_id: str, role: str, message, db_path: Optional[Path] = None):
     """Validate role, normalize message to string, ensure DB init, and write.
 
     Args:
         session_id: Correlates related events.
-        role: One of {system,user,assistant,tool}.
+        role: One of {system,user,assistant,tool,INFO,WARN}.
         message: Any object; will be coerced to str().
         db_path: Optional path (Path/str). If None, uses CODEX_LOG_DB_PATH or .codex/session_logs.db.
 

--- a/src/codex/chat.py
+++ b/src/codex/chat.py
@@ -31,7 +31,7 @@ class ChatSession:
     def __init__(
         self, session_id: Optional[str] = None, db_path: Optional[str] = None
     ) -> None:
-        sid = session_id or os.getenv("CODEX_SESSION_ID") or str(int(time.time()))
+        sid = session_id or os.getenv("CODEX_SESSION_ID") or str(uuid.uuid4())
         self.session_id = sid
         self.db_path = db_path
         self._prev_sid: Optional[str] = None

--- a/src/codex/logging/session_logger.py
+++ b/src/codex/logging/session_logger.py
@@ -11,7 +11,7 @@ If the repo already defines `log_event`, `init_db`, and `_DB_LOCK` under
 minimal implementations (scoped in this file) to preserve end-to-end behavior
 without polluting global API.
 
-Roles allowed: system|user|assistant|tool.
+Roles allowed: system|user|assistant|tool|INFO|WARN.
 
 This module is intentionally small and self-contained; it does NOT activate any
 GitHub Actions or external services.
@@ -108,7 +108,7 @@ def log_event(session_id: str, role: str, message: str, db_path: Optional[Path] 
     return _fallback_log_event(session_id, role, message, db_path=db_path)
 
 
-_ALLOWED_ROLES = {"system", "user", "assistant", "tool"}
+_ALLOWED_ROLES = {"system", "user", "assistant", "tool", "INFO", "WARN"}
 
 
 def get_session_id() -> str:
@@ -125,7 +125,7 @@ def log_message(session_id: str, role: str, message, db_path: Optional[Path] = N
 
     Args:
         session_id: Correlates related events.
-        role: One of {system,user,assistant,tool}.
+        role: One of {system,user,assistant,tool,INFO,WARN}.
         message: Any object; will be coerced to str().
         db_path: Optional path (Path/str). If None, uses CODEX_LOG_DB_PATH or
             DEFAULT_LOG_DB.


### PR DESCRIPTION
## Summary
- allow `INFO` and `WARN` roles to be logged
- adjust fetch message tests and docs for expanded role set
- ensure `ChatSession` generates a UUID when none is provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a467c218708331a8774e5f236d4501