### PR TITLE
Resolve session log paths and add cwd regression tests

### DIFF
--- a/scripts/session_logging.sh
+++ b/scripts/session_logging.sh
@@ -3,6 +3,11 @@
 set -euo pipefail
 
 : "${CODEX_SESSION_LOG_DIR:=.codex/sessions}"
+CODEX_SESSION_LOG_DIR="$(python - <<'PY'
+import os, pathlib
+print(pathlib.Path(os.environ['CODEX_SESSION_LOG_DIR']).expanduser().resolve())
+PY
+)"
 mkdir -p "$CODEX_SESSION_LOG_DIR"
 
 codex__timestamp() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }

--- a/src/codex/logging/session_hooks.py
+++ b/src/codex/logging/session_hooks.py
@@ -12,6 +12,7 @@ import uuid
 from datetime import UTC, datetime
 
 LOG_DIR = pathlib.Path(os.environ.get("CODEX_SESSION_LOG_DIR", ".codex/sessions"))
+LOG_DIR = LOG_DIR.expanduser().resolve()
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
 
@@ -35,7 +36,7 @@ def _log(obj: dict):
     """Append a JSON object as a single line to the session log file."""
 
     sid = _session_id()
-    path = LOG_DIR / f"{sid}.ndjson"
+    path = (LOG_DIR / f"{sid}.ndjson").resolve()
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(obj, separators=(",", ":")) + "\n")
@@ -51,9 +52,8 @@ class session:
 
     def __enter__(self):
         # Write quick meta file and record start event
-        (LOG_DIR / f"{self.sid}.meta").write_text(
-            f"{_now()} session_start {self.sid}\n"
-        )
+        meta_path = (LOG_DIR / f"{self.sid}.meta").resolve()
+        meta_path.write_text(f"{_now()} session_start {self.sid}\n")
         _log(
             {
                 "ts": _now(),

--- a/tests/test_session_hooks.py
+++ b/tests/test_session_hooks.py
@@ -1,7 +1,14 @@
-import os, subprocess, tempfile, pathlib, json, unittest
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SHELL_HELPER = ROOT / "scripts" / "session_logging.sh"
+
 
 @unittest.skipUnless(SHELL_HELPER.exists(), "shell helper missing")
 class TestSessionHooks(unittest.TestCase):
@@ -23,11 +30,68 @@ true
             subprocess.run([runner.as_posix()], check=True)
             ndjson = logdir / f"{sid}.ndjson"
             self.assertTrue(ndjson.exists(), "ndjson log not found")
-            lines = [json.loads(l) for l in ndjson.read_text().strip().splitlines()]
-            types = [l.get("type") for l in lines]
+            lines = [
+                json.loads(line) for line in ndjson.read_text().strip().splitlines()
+            ]
+            types = [line.get("type") for line in lines]
             self.assertIn("session_start", types)
             self.assertIn("session_end", types)
-            self.assertEqual(len([t for t in types if t in ("session_start","session_end")]), 2)
+            self.assertEqual(
+                len([t for t in types if t in ("session_start", "session_end")]), 2
+            )
+
+    def test_shell_helper_handles_cwd_change(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            sid = "test-chdir-1234"
+            runner = root / "runner.sh"
+            runner.write_text(
+                f"""#!/usr/bin/env bash
+set -euo pipefail
+export CODEX_SESSION_LOG_DIR=logs
+export CODEX_SESSION_ID=\"{sid}\"
+. \"{SHELL_HELPER.as_posix()}\"
+codex_session_start
+trap 'codex_session_end $?' EXIT
+mkdir sub && cd sub
+true
+"""
+            )
+            runner.chmod(0o755)
+            subprocess.run([runner.as_posix()], cwd=root, check=True)
+            ndjson = root / "logs" / f"{sid}.ndjson"
+            self.assertTrue(ndjson.exists(), "ndjson log not found in resolved logdir")
+            self.assertFalse(
+                (root / "sub" / "logs").exists(), "logdir should not depend on cwd"
+            )
+
+
+class TestPythonSessionHooks(unittest.TestCase):
+    def test_session_logs_after_cwd_change(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = pathlib.Path(td)
+            env = os.environ.copy()
+            env.pop("CODEX_SESSION_ID", None)
+            env["CODEX_SESSION_LOG_DIR"] = "logs"
+            env["PYTHONPATH"] = str(ROOT)
+            script = root / "runner.py"
+            script.write_text(
+                "import os, pathlib\n"
+                "from codex.logging.session_hooks import session\n"
+                "pathlib.Path('sub').mkdir()\n"
+                "os.chdir('sub')\n"
+                "with session():\n"
+                "    pass\n"
+            )
+            subprocess.run([sys.executable, script.name], cwd=root, check=True, env=env)
+            logdir = root / "logs"
+            self.assertTrue(
+                any(logdir.glob("*.ndjson")), "log not created in resolved dir"
+            )
+            self.assertFalse(
+                (root / "sub" / "logs").exists(), "logdir should not depend on cwd"
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure session hooks resolve log directory and files to absolute paths
- update shell helper to resolve CODEX_SESSION_LOG_DIR before use
- add regression tests covering cwd changes for both shell and Python helpers

## Testing
- `pre-commit run --files src/codex/logging/session_hooks.py scripts/session_logging.sh tools/codex_workflow.sh tests/test_session_hooks.py`
- `pytest tests/test_session_hooks.py`


------
https://chatgpt.com/codex/tasks/task_e_68a467d2ac348331b647ec1ceebc0f50