### PR TITLE
Add concurrent sqlite pool test and document limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,3 +294,10 @@ No code changes are required beyond importing `sqlite3` normally.
 
 - Disable: `CODEX_SQLITE_POOL=0` (default)
 - DB path for adapters: `CODEX_SQLITE_DB` (defaults to `codex_data.sqlite3`)
+- Connections are cached **per thread** and are not safe to share between
+  threads or processes. Each thread gets its own connection, and highly
+  concurrent or long-running applications should consider a more robust
+  database.
+- Calling `close()` on a pooled connection leaves it in a closed state within
+  the pool. Avoid context managers like `with sqlite3.connect(...)` when pooling
+  is enabled.

--- a/src/codex/db/sqlite_patch.py
+++ b/src/codex/db/sqlite_patch.py
@@ -4,7 +4,17 @@ This module monkey-patches :func:`sqlite3.connect` to reuse connections based on
 database path, process, thread, and optional ``CODEX_SESSION_ID``. Pooling is
 enabled via the ``CODEX_SQLITE_POOL`` environment variable and applies several
 pragmas aimed at improving concurrent write performance. All pooled connections
-are closed automatically on interpreter exit.
+remain open for the duration of the interpreter and are closed automatically on
+interpreter exit.
+
+Limitations:
+
+* Connections are cached **per thread**; they are not shared between threads
+  or processes. Sharing a connection across threads is not supported by the
+  underlying :mod:`sqlite3` driver and may result in race conditions.
+* Calling :meth:`sqlite3.Connection.close` on a pooled connection leaves a
+  closed instance in the pool. Avoid ``with sqlite3.connect(...)`` blocks or
+  explicit ``close()`` calls when pooling is enabled.
 """
 
 import os, sqlite3, threading, contextlib, atexit

--- a/tests/test_sqlite_pool.py
+++ b/tests/test_sqlite_pool.py
@@ -1,0 +1,43 @@
+import sqlite3
+import threading
+
+from src.codex.db import sqlite_patch
+
+
+def test_sqlite_pool_allows_concurrent_writes(tmp_path, monkeypatch):
+    """Enable CODEX_SQLITE_POOL and perform concurrent writes.
+
+    The pooling layer should allow multiple threads to reuse a single connection
+    per thread without raising database locked errors.
+    """
+
+    db = tmp_path / "pool.db"
+    monkeypatch.setenv("CODEX_SQLITE_POOL", "1")
+    sqlite_patch.auto_enable_from_env()
+
+    try:
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE t (x INTEGER)")
+        conn.commit()
+
+        def worker(n):
+            for _ in range(n):
+                c = sqlite3.connect(str(db))
+                c.execute("INSERT INTO t(x) VALUES (1)")
+                c.commit()
+
+        threads = [threading.Thread(target=worker, args=(20,)) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # one main thread connection + 5 worker threads
+        assert len(sqlite_patch._CONN_POOL) == 6
+
+        total = sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM t").fetchone()[0]
+        assert total == 100
+    finally:
+        sqlite_patch.disable_pooling()
+        sqlite_patch._close_all()
+


### PR DESCRIPTION
## Summary
- document CODEX_SQLITE_POOL usage and thread-safety limitations
- note per-thread caching and close() behavior in sqlite patch module
- add unit test enabling CODEX_SQLITE_POOL and performing concurrent writes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a46e9e075483318b9bf5037a935381