### PR TITLE
Add shell session hooks with exit-code aware logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,11 @@ def handle_user_message(prompt: str) -> str:
 
 Lightweight helpers capture shell and Python entry sessions as NDJSON lines:
 
-- `scripts/session_logging.sh` – provides `codex_session_start` / `codex_session_end`
+- `scripts/session_hooks.sh` – shell functions `codex_session_start` / `codex_session_end`
+  backed by Python logging.  Each Python invocation is checked and failures are
+  reported to `stderr`.
+- `scripts/session_logging.sh` – backwards-compatible wrapper sourcing
+  `session_hooks.sh`.
 - `src/codex/logging/session_hooks.py` – Python context manager emitting start/end events
 
 Logs are written under `.codex/sessions/<SESSION_ID>.ndjson` and exercised via `tests/test_session_hooks.py`.

--- a/documentation/session_hooks_shell.md
+++ b/documentation/session_hooks_shell.md
@@ -1,0 +1,25 @@
+# Shell Session Hooks
+
+The `scripts/session_hooks.sh` script exposes two functions for lightweight
+session logging:
+
+- `codex_session_start [args…]` – record the start of a shell session.
+- `codex_session_end [exit_code]` – record the end of a session and exit code.
+
+Both functions rely on a small Python snippet to append newline-delimited JSON
+entries to the directory indicated by `CODEX_SESSION_LOG_DIR` (default
+`.codex/sessions`). After each Python call the script checks the exit status. If
+logging fails, an error message is written to `stderr` but the calling shell
+continues.
+
+Example:
+
+```bash
+. scripts/session_hooks.sh
+codex_session_start "my-cli" "$@"
+trap 'codex_session_end $?' EXIT
+```
+
+The start hook stores the current time so that the end hook can compute and
+record the session duration in seconds. Both hooks are best-effort and will not
+abort the main script when logging errors occur.

--- a/scripts/session_hooks.sh
+++ b/scripts/session_hooks.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Shell session hooks that log start/end events via Python.
+# Captures exit codes from Python logging calls and reports failures.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Ensure log dir env var is exported so Python can read it
+: "${CODEX_SESSION_LOG_DIR:=.codex/sessions}"
+export CODEX_SESSION_LOG_DIR
+CODEX_SESSION_LOG_DIR="$(python - <<'PY'
+import os, pathlib
+print(pathlib.Path(os.environ['CODEX_SESSION_LOG_DIR']).expanduser().resolve())
+PY
+)"
+py_status=$?
+if [[ $py_status -ne 0 ]]; then
+  echo "codex session hooks: failed to resolve log dir (exit $py_status)" >&2
+fi
+mkdir -p "$CODEX_SESSION_LOG_DIR"
+
+codex__uuid() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+  else
+    printf "sess-%s-%s" "$(date +%s)" "$RANDOM"
+  fi
+}
+
+codex_session_start() {
+  : "${CODEX_SESSION_ID:=$(codex__uuid)}"
+  export CODEX_SESSION_ID
+  export CODEX_SESSION_START_EPOCH="$(date -u +%s)"
+  python - "$CODEX_SESSION_LOG_DIR" "$CODEX_SESSION_ID" "$PWD" "$@" <<'PY'
+import json, os, pathlib, sys
+from datetime import datetime, timezone
+log_dir = pathlib.Path(sys.argv[1])
+sid = sys.argv[2]
+cwd = sys.argv[3]
+argv = list(sys.argv[4:])
+ts = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+log_dir.mkdir(parents=True, exist_ok=True)
+meta = log_dir / f"{sid}.meta"
+meta.write_text(f"{ts} session_start {sid}\n", encoding="utf-8")
+ndjson = log_dir / f"{sid}.ndjson"
+line = json.dumps({"ts": ts, "type": "session_start", "session_id": sid, "cwd": cwd, "argv": argv})
+with ndjson.open("a", encoding="utf-8") as f:
+    f.write(line + "\n")
+PY
+  status=$?
+  if [[ $status -ne 0 ]]; then
+    echo "codex_session_start: logging failed with exit code $status" >&2
+  fi
+}
+
+codex_session_end() {
+  local exit_code="${1:-0}"
+  : "${CODEX_SESSION_ID:?missing session id}"
+  local now_epoch="$(date -u +%s)"
+  local start_epoch="${CODEX_SESSION_START_EPOCH:-$now_epoch}"
+  local duration="$(( now_epoch - start_epoch ))"
+  python - "$CODEX_SESSION_LOG_DIR" "$CODEX_SESSION_ID" "$exit_code" "$duration" <<'PY'
+import json, pathlib, sys
+from datetime import datetime, timezone
+log_dir = pathlib.Path(sys.argv[1])
+sid = sys.argv[2]
+exit_code = int(sys.argv[3])
+duration = int(sys.argv[4])
+ts = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+ndjson = log_dir / f"{sid}.ndjson"
+ndjson.parent.mkdir(parents=True, exist_ok=True)
+line = json.dumps({"ts": ts, "type": "session_end", "session_id": sid, "exit_code": exit_code, "duration_s": duration})
+with ndjson.open("a", encoding="utf-8") as f:
+    f.write(line + "\n")
+PY
+  status=$?
+  if [[ $status -ne 0 ]]; then
+    echo "codex_session_end: logging failed with exit code $status" >&2
+  fi
+}

--- a/scripts/session_logging.sh
+++ b/scripts/session_logging.sh
@@ -1,59 +1,7 @@
 #!/usr/bin/env bash
-# Session logging helper (Shell)
+# Backwards compatibility wrapper for session logging.
+# Sources session_hooks.sh which implements the actual logic.
 set -euo pipefail
-
-: "${CODEX_SESSION_LOG_DIR:=.codex/sessions}"
-CODEX_SESSION_LOG_DIR="$(python - <<'PY'
-import os, pathlib
-print(pathlib.Path(os.environ['CODEX_SESSION_LOG_DIR']).expanduser().resolve())
-PY
-)"
-mkdir -p "$CODEX_SESSION_LOG_DIR"
-
-codex__timestamp() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
-
-codex__log_file() {
-  [[ -d "$CODEX_SESSION_LOG_DIR" ]] || mkdir -p "$CODEX_SESSION_LOG_DIR"
-  printf '%s/%s' "$CODEX_SESSION_LOG_DIR" "$1"
-}
-
-codex__uuid() {
-  if command -v uuidgen >/dev/null 2>&1; then
-    uuidgen | tr '[:upper:]' '[:lower:]'
-  else
-    printf "sess-%s-%s" "$(date +%s)" "$RANDOM"
-  fi
-}
-
-codex_session_start() {
-  : "${CODEX_SESSION_ID:=$(codex__uuid)}"
-  export CODEX_SESSION_ID
-  echo "$(codex__timestamp) session_start $CODEX_SESSION_ID" > "$(codex__log_file "${CODEX_SESSION_ID}.meta")"
-  {
-    printf '{"ts":"%s","type":"session_start","session_id":"%s","cwd":"%s","argv":[' "$(codex__timestamp)" "$CODEX_SESSION_ID" "$PWD"
-    first=1
-    for a in "$@"; do
-      if [[ $first -eq 1 ]]; then first=0; else printf ","; fi
-      printf '%s' "\"${a//\"/\\\"}\""
-    done
-    printf "]}\n"
-  } >> "$(codex__log_file "${CODEX_SESSION_ID}.ndjson")"
-}
-
-codex_session_end() {
-  local exit_code="${1:-0}"
-  : "${CODEX_SESSION_ID:?missing session id}"
-  local start_line
-  start_line="$(head -n1 "$(codex__log_file "${CODEX_SESSION_ID}.meta")" 2>/dev/null || true)"
-  local duration=""
-  if [[ -n "$start_line" ]]; then
-    local start_epoch
-    start_epoch="$(date -u -d "$(echo "$start_line" | awk '{print $1}')" +%s 2>/dev/null || date +%s)"
-    local now_epoch
-    now_epoch="$(date -u +%s)"
-    duration="$(( now_epoch - start_epoch ))"
-  fi
-  printf '{"ts":"%s","type":"session_end","session_id":"%s","exit_code":%s,"duration_s":%s}\n' \
-    "$(codex__timestamp)" "$CODEX_SESSION_ID" "$exit_code" "${duration:-null}" \
-    >> "$(codex__log_file "${CODEX_SESSION_ID}.ndjson")"
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./session_hooks.sh
+. "$SCRIPT_DIR/session_hooks.sh"

--- a/tests/test_session_logging.py
+++ b/tests/test_session_logging.py
@@ -81,6 +81,7 @@ def test_context_manager_emits_start_end(tmp_path, monkeypatch):
     used = None
     try:
         if hooks:
+            importlib.reload(hooks)
             # Accept multiple possible exports: session(), session_scope(), or Context()
             cm = None
             for name in ["session", "session_scope", "SessionContext", "context"]:


### PR DESCRIPTION
## Summary
- add `session_hooks.sh` that logs start/end via Python and reports failures
- wrap existing `session_logging.sh` to source new hooks
- document shell hook behavior and error handling
- reload session hook module in tests for accurate log directories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a46e9c3db48331bae952611f7cf9a5