### PR TITLE
docs: add agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS
+
+This document provides guidelines for contributors and automated agents working in this repository. Update it as conventions evolve.
+
+## Environment variables
+
+These variables control runtime configuration and logging:
+
+- `CODEX_ENV_PYTHON_VERSION`, `CODEX_ENV_NODE_VERSION`, `CODEX_ENV_RUST_VERSION`, `CODEX_ENV_GO_VERSION`, `CODEX_ENV_SWIFT_VERSION` – select language versions during environment setup.
+- `CODEX_SESSION_ID` – identifier for a logical session. Set to group log events.
+- `CODEX_SESSION_LOG_DIR` – directory for session log files (defaults to `.codex/sessions`).
+- `CODEX_LOG_DB_PATH` / `CODEX_DB_PATH` – path to the SQLite database used by logging tools.
+- `CODEX_SQLITE_POOL` – set to `1` to enable per-session SQLite connection pooling.
+
+## Logging roles
+
+Logging utilities expect roles from the set:
+
+- `system`
+- `user`
+- `assistant`
+- `tool`
+
+Use these when recording conversation or session events.
+
+## Testing expectations
+
+Before committing, run all checks locally:
+
+```bash
+pre-commit run --all-files
+pytest
+```
+
+## Tool usage
+
+Common CLI entry points provided by this repository:
+
+- `python -m codex.logging.session_logger` – record session events.
+- `python -m codex.logging.viewer` – view session logs.
+- `python -m codex.logging.query_logs` – search conversation transcripts.
+
+Keep this document updated as conventions evolve.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository is intended to help developers cutomize environments in Codex, b
 
 For more details on environment setup, see [OpenAI Codex](http://platform.openai.com/docs/codex).
 
+For environment variables, logging roles, testing expectations, and tool usage, see [AGENTS.md](AGENTS.md).
+
 ## Usage
 
 The Docker image is available at:


### PR DESCRIPTION
## Summary
- document environment variables, logging roles, testing, and tooling in `AGENTS.md`
- reference the new guidance from `README`

## Testing
- `pre-commit run --files README.md AGENTS.md`
- `pre-commit run --all-files` *(fails: Duplicate module named "codex_workflow")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a47354b75c8331a69857516b98a7c8