### PR TITLE
Ensure session logs use timezone-aware timestamps

### DIFF
--- a/scripts/session_hooks.sh
+++ b/scripts/session_hooks.sh
@@ -38,7 +38,7 @@ log_dir = pathlib.Path(sys.argv[1])
 sid = sys.argv[2]
 cwd = sys.argv[3]
 argv = list(sys.argv[4:])
-ts = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 log_dir.mkdir(parents=True, exist_ok=True)
 meta = log_dir / f"{sid}.meta"
 meta.write_text(f"{ts} session_start {sid}\n", encoding="utf-8")
@@ -66,7 +66,7 @@ log_dir = pathlib.Path(sys.argv[1])
 sid = sys.argv[2]
 exit_code = int(sys.argv[3])
 duration = int(sys.argv[4])
-ts = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 ndjson = log_dir / f"{sid}.ndjson"
 ndjson.parent.mkdir(parents=True, exist_ok=True)
 line = json.dumps({"ts": ts, "type": "session_end", "session_id": sid, "exit_code": exit_code, "duration_s": duration})

--- a/src/codex/logging/session_hooks.py
+++ b/src/codex/logging/session_hooks.py
@@ -67,7 +67,7 @@ def _log_path(name: str) -> pathlib.Path:
 
 def _now() -> str:
     """Return current UTC time in ISO-8601 Zulu format."""
-    return datetime.utcnow().replace(tzinfo=UTC).isoformat().replace("+00:00", "Z")
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _session_id() -> str:

--- a/tests/test_session_hooks.py
+++ b/tests/test_session_hooks.py
@@ -5,6 +5,9 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timezone
+
+from codex.logging import session_hooks
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SHELL_HELPER = ROOT / "scripts" / "session_logging.sh"
@@ -115,6 +118,13 @@ class TestPythonSessionHooks(unittest.TestCase):
             self.assertFalse(
                 (root / "sub" / "logs").exists(), "logdir should not depend on cwd"
             )
+
+    def test_now_returns_zulu_timestamp(self):
+        ts = session_hooks._now()
+        self.assertTrue(ts.endswith("Z"))
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        self.assertIsNotNone(dt.tzinfo)
+        self.assertEqual(dt.tzinfo, timezone.utc)
 
 
 if __name__ == "__main__":

--- a/tools/codex_patch_session_logging.py
+++ b/tools/codex_patch_session_logging.py
@@ -21,13 +21,18 @@ import os
 import re
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 
-REPO_ROOT = subprocess.run(
-    ["git", "rev-parse", "--show-toplevel"],
-    stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True
-).stdout.strip() or os.getcwd()
+REPO_ROOT = (
+    subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    ).stdout.strip()
+    or os.getcwd()
+)
 
 CODEX_DIR = os.path.join(REPO_ROOT, ".codex")
 TARGET_REL = "tests/test_session_logging.py"
@@ -42,27 +47,41 @@ RESULTS = os.path.join(CODEX_DIR, "results.md")
 
 # ---------- utilities ----------
 
+
 def now_iso() -> str:
-    return datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    return (
+        datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+
 
 def read_text(p: str) -> str:
     with open(p, "r", encoding="utf-8") as f:
         return f.read()
 
+
 def write_text(p: str, s: str) -> None:
     with open(p, "w", encoding="utf-8") as f:
         f.write(s)
+
 
 def append(path: str, text: str) -> None:
     with open(path, "a", encoding="utf-8") as f:
         f.write(text)
 
+
 def run_ok(cmd: List[str]) -> Tuple[bool, str]:
     try:
-        cp = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
+        cp = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
         return (cp.returncode == 0, cp.stdout)
     except Exception as e:
         return (False, f"{type(e).__name__}: {e}")
+
 
 def log_error(step: str, desc: str, err: str, ctx: str) -> None:
     """Write ChatGPT-5 formatted question to console + ndjson."""
@@ -80,26 +99,37 @@ def log_error(step: str, desc: str, err: str, ctx: str) -> None:
         "description": desc,
         "error": err,
         "context": ctx,
-        "question_for_chatgpt5": block
+        "question_for_chatgpt5": block,
     }
     append(ERRORS, json.dumps(entry) + "\n")
 
-def add_change(file_path: str, action: str, rationale: str, before: str, after: str) -> None:
-    diff = "\n".join(difflib.unified_diff(
-        before.splitlines(), after.splitlines(),
-        fromfile=f"a/{file_path}", tofile=f"b/{file_path}", lineterm=""
-    ))
-    append(CHANGE_LOG,
-           f"\n## {now_iso()} — {action}\n"
-           f"**File:** `{file_path}`\n"
-           f"**Rationale:** {rationale}\n\n"
-           f"```diff\n{diff}\n```\n")
+
+def add_change(
+    file_path: str, action: str, rationale: str, before: str, after: str
+) -> None:
+    diff = "\n".join(
+        difflib.unified_diff(
+            before.splitlines(),
+            after.splitlines(),
+            fromfile=f"a/{file_path}",
+            tofile=f"b/{file_path}",
+            lineterm="",
+        )
+    )
+    append(
+        CHANGE_LOG,
+        f"\n## {now_iso()} — {action}\n"
+        f"**File:** `{file_path}`\n"
+        f"**Rationale:** {rationale}\n\n"
+        f"```diff\n{diff}\n```\n",
+    )
+
 
 def ensure_import(module: str, src: str) -> Tuple[str, bool]:
     """Idempotently ensure `import module` exists; insert below top shebang/future/comments."""
-    if re.search(rf'^\s*import\s+{re.escape(module)}\b', src, re.M):
+    if re.search(rf"^\s*import\s+{re.escape(module)}\b", src, re.M):
         return src, False
-    if re.search(rf'^\s*from\s+{re.escape(module)}\b', src, re.M):
+    if re.search(rf"^\s*from\s+{re.escape(module)}\b", src, re.M):
         return src, False
 
     lines = src.splitlines()
@@ -124,12 +154,13 @@ def ensure_import(module: str, src: str) -> Tuple[str, bool]:
     new_lines = lines[:insert_idx] + [f"import {module}"] + lines[insert_idx:]
     return "\n".join(new_lines) + ("\n" if not src.endswith("\n") else ""), True
 
+
 # ---------- patch logic ----------
 
 EXC_PASS_PATTERN = re.compile(
-    r'(^[ \t]*)except\s+Exception(?:\s+as\s+\w+)?\s*:\s*\n'
-    r'([ \t]*)pass\b',
-    flags=re.M
+    r"(^[ \t]*)except\s+Exception(?:\s+as\s+\w+)?\s*:\s*\n"
+    r"([ \t]*)pass\b",
+    flags=re.M,
 )
 
 REPLACEMENT_TEMPLATE = """{indent}except Exception as e:
@@ -138,7 +169,10 @@ REPLACEMENT_TEMPLATE = """{indent}except Exception as e:
 {indent2}    pytest.skip(f"Required session logging hook not available: {{e!r}}")
 {indent2}pytest.fail(f"Session logging hook failed: {{e!r}}")"""
 
-def patch_except_pass(src: str, prefer_range: Optional[Tuple[int,int]]=None) -> Tuple[str, bool, str]:
+
+def patch_except_pass(
+    src: str, prefer_range: Optional[Tuple[int, int]] = None
+) -> Tuple[str, bool, str]:
     matches = list(EXC_PASS_PATTERN.finditer(src))
     if not matches:
         return src, False, "No `except Exception: pass` pattern found."
@@ -149,6 +183,7 @@ def patch_except_pass(src: str, prefer_range: Optional[Tuple[int,int]]=None) -> 
         line_starts = [0]
         for m in re.finditer(r"\n", src):
             line_starts.append(m.end())
+
         def line_no(pos: int) -> int:
             ln = 1
             for i, st in enumerate(line_starts):
@@ -156,6 +191,7 @@ def patch_except_pass(src: str, prefer_range: Optional[Tuple[int,int]]=None) -> 
                     break
                 ln = i + 1
             return ln
+
         for m in matches:
             ln = line_no(m.start())
             if start_l <= ln <= end_l:
@@ -167,24 +203,34 @@ def patch_except_pass(src: str, prefer_range: Optional[Tuple[int,int]]=None) -> 
     indent = chosen.group(1)
     indent2 = chosen.group(2) if chosen.group(2) else indent + "    "
     replacement = REPLACEMENT_TEMPLATE.format(indent=indent, indent2=indent2)
-    new_src = src[:chosen.start()] + replacement + src[chosen.end():]
+    new_src = src[: chosen.start()] + replacement + src[chosen.end() :]
     return new_src, True, "Patched `except Exception: pass` with logging + skip/fail."
 
+
 # ---------- main workflow ----------
+
 
 @dataclasses.dataclass
 class Outcome:
     errors: List[str] = dataclasses.field(default_factory=list)
     changes: int = 0
 
+
 def main() -> int:
     ok, out = run_ok(["git", "status", "--porcelain"])
     if not ok:
-        log_error("1.1", "Check clean working state", out, "git status --porcelain failed")
+        log_error(
+            "1.1", "Check clean working state", out, "git status --porcelain failed"
+        )
     elif out.strip():
-        log_error("1.1", "Uncommitted changes present", out.strip(), "Proceeding best-effort per instructions")
+        log_error(
+            "1.1",
+            "Uncommitted changes present",
+            out.strip(),
+            "Proceeding best-effort per instructions",
+        )
 
-    append(FLAGS_ENV, f"DO_NOT_ACTIVATE_GITHUB_ACTIONS=true\n")
+    append(FLAGS_ENV, "DO_NOT_ACTIVATE_GITHUB_ACTIONS=true\n")
 
     outcome = Outcome()
 
@@ -222,30 +268,53 @@ def main() -> int:
             )
             add_change(TARGET_REL, "Patch except-pass", rationale, before, patched)
             if imp_logging or imp_pytest:
-                add_change(TARGET_REL, "Ensure imports", "Added missing imports for logging/pytest", after, patched)
+                add_change(
+                    TARGET_REL,
+                    "Ensure imports",
+                    "Added missing imports for logging/pytest",
+                    after,
+                    patched,
+                )
         else:
             log_error("3.2", "Patch except-pass", msg, TARGET)
 
     except Exception as e:
         log_error("3.2", "Apply patch", f"{type(e).__name__}: {e}", TARGET)
 
-    ok, out = run_ok([sys.executable, "-c", "import importlib, sys; importlib.import_module('pytest'); print('pytest-ok')"])
+    ok, out = run_ok(
+        [
+            sys.executable,
+            "-c",
+            "import importlib, sys; importlib.import_module('pytest'); print('pytest-ok')",
+        ]
+    )
     if ok and "pytest-ok" in out:
         _ok, _out = run_ok(["pytest", "--collect-only", "-q"])
         if not _ok:
             log_error("3.4", "Pytest collection", _out, "pytest --collect-only -q")
 
-    append(CHANGE_LOG, "\n## Pruning\nNo pruning performed; construction succeeded without duplication or unsafe paths.\n")
+    append(
+        CHANGE_LOG,
+        "\n## Pruning\nNo pruning performed; construction succeeded without duplication or unsafe paths.\n",
+    )
 
     results = []
     if outcome.changes:
-        results.append(f"- Patched `{TARGET_REL}` to replace `except Exception: pass` with logging + skip/fail.")
+        results.append(
+            f"- Patched `{TARGET_REL}` to replace `except Exception: pass` with logging + skip/fail."
+        )
     else:
         results.append(f"- No patch applied to `{TARGET_REL}` (pattern not found).")
-    results.append("- Ensured `import logging` and `import pytest` presence (idempotent).")
+    results.append(
+        "- Ensured `import logging` and `import pytest` presence (idempotent)."
+    )
     results.append("- Recorded diffs in `.codex/change_log.md`.")
-    results.append("- Captured any errors in `.codex/errors.ndjson` (ChatGPT-5 format).")
-    results.append("- Constraint observed: **DO NOT ACTIVATE ANY GitHub Actions files.**")
+    results.append(
+        "- Captured any errors in `.codex/errors.ndjson` (ChatGPT-5 format)."
+    )
+    results.append(
+        "- Constraint observed: **DO NOT ACTIVATE ANY GitHub Actions files.**"
+    )
 
     append(RESULTS, "# Results Summary\n" + "\n".join(results) + "\n")
     append(RESULTS, "\n**DO NOT ACTIVATE ANY GitHub Actions files.**\n")
@@ -253,7 +322,10 @@ def main() -> int:
     has_errors = os.path.isfile(ERRORS) and os.path.getsize(ERRORS) > 0
     return 1 if has_errors else 0
 
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Codex workflow for session logging test patch.")
+    parser = argparse.ArgumentParser(
+        description="Codex workflow for session logging test patch."
+    )
     _ = parser.parse_args()
     sys.exit(main())

--- a/tools/codex_precommit_bootstrap.py
+++ b/tools/codex_precommit_bootstrap.py
@@ -27,7 +27,7 @@ import re
 import subprocess
 import sys
 import textwrap
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_BRANCH_EXPECTED = "0B_base_"
@@ -59,7 +59,7 @@ def sh(cmd: list[str]) -> tuple[int, str, str]:
 def log_change(path: Path, action: str, rationale: str, before: str, after: str):
     CODEX_DIR.mkdir(parents=True, exist_ok=True)
     CHANGE_LOG.parent.mkdir(parents=True, exist_ok=True)
-    ts = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    ts = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
     diff = ""
     if before is None:
         diff = f"*created* {path}"
@@ -85,7 +85,11 @@ def log_change(path: Path, action: str, rationale: str, before: str, after: str)
 def log_error(step_num_desc: str, error_message: str, context: str):
     CODEX_DIR.mkdir(parents=True, exist_ok=True)
     entry = {
-        "ts": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "ts": (
+            datetime.now(timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
+        ),
         "step": step_num_desc,
         "error": error_message,
         "context": context,

--- a/tools/codex_workflow.py
+++ b/tools/codex_workflow.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import sys
 import textwrap
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(
@@ -33,7 +33,7 @@ UNRESOLVED = False
 
 
 def now():
-    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def ensure_dirs():

--- a/tools/codex_workflow.sh
+++ b/tools/codex_workflow.sh
@@ -188,7 +188,7 @@ def _log_path(name: str) -> pathlib.Path:
     return LOG_DIR / name
 
 def _now():
-    return dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc).isoformat().replace("+00:00","Z")
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00","Z")
 
 def _session_id():
     sid = os.environ.get("CODEX_SESSION_ID")

--- a/tools/unify_logging_canonical.py
+++ b/tools/unify_logging_canonical.py
@@ -2,9 +2,15 @@
 # tools/unify_logging_canonical.py
 # Purpose: Make src/codex/logging canonical, wrap/retire legacy modules, normalize imports, and document everything.
 
-import os, sys, re, json, subprocess, hashlib, datetime, shutil
+import datetime
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
 from pathlib import Path
-from typing import List, Tuple, Dict
+from typing import Dict, List, Tuple
 
 # ---------------------------
 # Config / Constraints
@@ -16,14 +22,28 @@ ERRORS_NDJSON = CODEX_DIR / "errors.ndjson"
 RESULTS_MD = CODEX_DIR / "results.md"
 
 DO_NOT_ACTIVATE_GITHUB_ACTIONS = True
-SKIP_DIRS = {".git", ".venv", "venv", "__pycache__", ".mypy_cache", ".ruff_cache", ".pytest_cache"}
+SKIP_DIRS = {
+    ".git",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+}
 if DO_NOT_ACTIVATE_GITHUB_ACTIONS:
     SKIP_DIRS |= {".github", ".github/workflows"}
 
 CANONICAL_DIR = REPO_ROOT / "src" / "codex" / "logging"
 LEGACY_WRAPPERS = {
-    REPO_ROOT / "codex" / "logging" / "session_logger.py": "src.codex.logging.session_logger",
-    REPO_ROOT / "codex" / "logging" / "session_query.py": "src.codex.logging.query_logs",  # maps "session_query" -> "query_logs"
+    REPO_ROOT
+    / "codex"
+    / "logging"
+    / "session_logger.py": "src.codex.logging.session_logger",
+    REPO_ROOT
+    / "codex"
+    / "logging"
+    / "session_query.py": "src.codex.logging.query_logs",  # maps "session_query" -> "query_logs"
 }
 
 # Patterns for import normalization
@@ -35,22 +55,35 @@ IMPORT_PATTERNS = [
 ]
 # CLI/module invocations in docs
 DOC_PATTERNS = [
-    (re.compile(r"\bpython(?:3)?\s+-m\s+codex\.logging\."), "python -m src.codex.logging."),
+    (
+        re.compile(r"\bpython(?:3)?\s+-m\s+codex\.logging\."),
+        "python -m src.codex.logging.",
+    ),
 ]
 
 # ---------------------------
 # Utilities
 # ---------------------------
 
+
 def now_iso() -> str:
-    return datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
 
 def sh(cmd: List[str]) -> Tuple[int, str, str]:
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     out, err = p.communicate()
     return p.returncode, out, err
 
-def record_change(path: Path, action: str, rationale: str, before: str = "", after: str = "") -> None:
+
+def record_change(
+    path: Path, action: str, rationale: str, before: str = "", after: str = ""
+) -> None:
     CODEX_DIR.mkdir(parents=True, exist_ok=True)
     CHANGE_LOG.touch(exist_ok=True)
     with CHANGE_LOG.open("a", encoding="utf-8") as f:
@@ -69,10 +102,12 @@ def record_change(path: Path, action: str, rationale: str, before: str = "", aft
             f.write(out[:8000])
             f.write("\n```\n")
 
+
 def hash_preview(s: str) -> str:
     h = hashlib.sha256(s.encode("utf-8")).hexdigest()[:12]
     preview = s.splitlines()[0] if s else ""
     return f"sha256:{h} :: {preview[:200]}"
+
 
 def append_error(step: str, desc: str, message: str, context: str) -> None:
     CODEX_DIR.mkdir(parents=True, exist_ok=True)
@@ -97,14 +132,23 @@ def append_error(step: str, desc: str, message: str, context: str) -> None:
     # Echo to console as required
     print(question_block, file=sys.stderr)
 
+
 def ensure_clean_worktree() -> None:
     rc, out, err = sh(["git", "status", "--porcelain"])
     if rc != 0:
-        append_error("1.1", "Verify clean worktree", err.strip() or out.strip(), "git status failed")
+        append_error(
+            "1.1",
+            "Verify clean worktree",
+            err.strip() or out.strip(),
+            "git status failed",
+        )
         sys.exit(1)
     if out.strip():
-        append_error("1.1", "Verify clean worktree", "Working tree is not clean", out.strip())
+        append_error(
+            "1.1", "Verify clean worktree", "Working tree is not clean", out.strip()
+        )
         sys.exit(1)
+
 
 def load_readmes() -> None:
     for p in [REPO_ROOT / "README.md", REPO_ROOT / "README_UPDATED.md"]:
@@ -113,6 +157,7 @@ def load_readmes() -> None:
                 _ = p.read_text(encoding="utf-8")
             except Exception as e:
                 append_error("1.2", f"Read {p.name}", str(e), str(p))
+
 
 def build_inventory() -> List[Path]:
     collected = []
@@ -125,12 +170,14 @@ def build_inventory() -> List[Path]:
             collected.append(root_p / fn)
     return collected
 
+
 def write_header_logs() -> None:
     CODEX_DIR.mkdir(parents=True, exist_ok=True)
     if not CHANGE_LOG.exists():
         CHANGE_LOG.write_text("# Change Log\n", encoding="utf-8")
     if not ERRORS_NDJSON.exists():
         ERRORS_NDJSON.write_text("", encoding="utf-8")
+
 
 def make_wrapper(path: Path, target_module: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -148,8 +195,14 @@ def make_wrapper(path: Path, target_module: str) -> None:
             before = "<unreadable>"
     path.write_text(content, encoding="utf-8")
     after = hash_preview(content)
-    record_change(path, "CREATE_WRAPPER" if not before else "REPLACE_WITH_WRAPPER",
-                  f"Legacy -> canonical re-export ({target_module})", before, after)
+    record_change(
+        path,
+        "CREATE_WRAPPER" if not before else "REPLACE_WITH_WRAPPER",
+        f"Legacy -> canonical re-export ({target_module})",
+        before,
+        after,
+    )
+
 
 def normalize_file_text(path: Path) -> Tuple[bool, str, str]:
     try:
@@ -167,13 +220,18 @@ def normalize_file_text(path: Path) -> Tuple[bool, str, str]:
     if changed:
         try:
             path.write_text(txt, encoding="utf-8")
-            record_change(path, "MODIFY_IMPORTS/DOCS",
-                          "Normalize imports to src.codex.logging and CLI invocations",
-                          hash_preview(before), hash_preview(txt))
+            record_change(
+                path,
+                "MODIFY_IMPORTS/DOCS",
+                "Normalize imports to src.codex.logging and CLI invocations",
+                hash_preview(before),
+                hash_preview(txt),
+            )
         except Exception as e:
             append_error("3.3", f"Write normalized file: {path}", str(e), str(path))
             return False, before, before
     return changed, before, txt
+
 
 def normalize_imports_across_repo(inventory: List[Path]) -> int:
     changes = 0
@@ -187,6 +245,7 @@ def normalize_imports_across_repo(inventory: List[Path]) -> int:
             changes += 1
     return changes
 
+
 def smoke_checks() -> None:
     # Minimal import checks
     def try_import(mod: str, step: str):
@@ -197,16 +256,21 @@ def smoke_checks() -> None:
 
     try_import("src.codex.logging", "3.4")
     # common submodules often referenced in README
-    for sub in ("src.codex.logging.viewer", "src.codex.logging.query_logs", "src.codex.logging.export"):
+    for sub in (
+        "src.codex.logging.viewer",
+        "src.codex.logging.query_logs",
+        "src.codex.logging.export",
+    ):
         try_import(sub, "3.4")
+
 
 def write_results_summary(changed_count: int, wrappers: Dict[str, str]) -> None:
     lines = []
     lines.append("# Results Summary")
     lines.append("")
     lines.append("## Implemented")
-    lines.append(f"- Canonical package: `src/codex/logging/`")
-    lines.append(f"- Wrappers created/replaced:")
+    lines.append("- Canonical package: `src/codex/logging/`")
+    lines.append("- Wrappers created/replaced:")
     for k, v in wrappers.items():
         lines.append(f"  - `{Path(k).as_posix()}` → `from {v} import *`")
     lines.append(f"- Files normalized (imports/docs): {changed_count}")
@@ -215,12 +279,15 @@ def write_results_summary(changed_count: int, wrappers: Dict[str, str]) -> None:
     lines.append("- None removed in this pass (wrappers retained for back-compat).")
     lines.append("")
     lines.append("## Next Steps")
-    lines.append("- After downstream consumers migrate to `src.codex.logging.*`, consider deleting legacy wrappers.")
+    lines.append(
+        "- After downstream consumers migrate to `src.codex.logging.*`, consider deleting legacy wrappers."
+    )
     lines.append("")
     lines.append("## Important")
     lines.append("**DO NOT ACTIVATE ANY GitHub Actions files.**")
     CODEX_DIR.mkdir(parents=True, exist_ok=True)
     RESULTS_MD.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
 
 def main() -> int:
     write_header_logs()
@@ -236,8 +303,12 @@ def main() -> int:
 
     # Sanity: canonical dir present
     if not CANONICAL_DIR.exists():
-        append_error("2.2", "Locate canonical src/codex/logging", "Canonical directory not found",
-                     str(CANONICAL_DIR))
+        append_error(
+            "2.2",
+            "Locate canonical src/codex/logging",
+            "Canonical directory not found",
+            str(CANONICAL_DIR),
+        )
         # Stop — we cannot safely proceed
         return 1
 
@@ -250,8 +321,12 @@ def main() -> int:
         expected = CANONICAL_DIR / target_hint
         if not expected.exists():
             # Not fatal for session_logger; many repos provide it. Log and continue (we may still normalize imports).
-            append_error("3.2", f"Check canonical module: {target_module}",
-                         "Expected canonical module file not found", f"Expected {expected}")
+            append_error(
+                "3.2",
+                f"Check canonical module: {target_module}",
+                "Expected canonical module file not found",
+                f"Expected {expected}",
+            )
             # Do NOT create a shim if target cannot be located
             continue
         make_wrapper(legacy_path, target_module)
@@ -271,6 +346,7 @@ def main() -> int:
         # If any lines exist with content, exit non-zero
         return 1
     return 0
+
 
 if __name__ == "__main__":
     rc = main()


### PR DESCRIPTION
## Summary
- use `datetime.now(UTC)` in session hooks
- update shell and tool snippets to `datetime.now(timezone.utc)`
- test session hook timestamps for Z-suffix and timezone awareness

## Testing
- `pre-commit run --files scripts/session_hooks.sh src/codex/logging/session_hooks.py tests/test_session_hooks.py tools/codex_logging_workflow.py tools/codex_patch_session_logging.py tools/codex_precommit_bootstrap.py tools/codex_sqlite_align.py tools/codex_workflow.py tools/codex_workflow.sh tools/unify_logging_canonical.py` *(fails: E501 line too long; mypy errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a476b47b788331a25d6ecdfe30d3e3