### PR TITLE
Use default logging DB path when env var missing

### DIFF
--- a/tests/test_log_adapters.py
+++ b/tests/test_log_adapters.py
@@ -9,12 +9,18 @@ def _count(db: Path) -> int:
         return conn.execute("SELECT COUNT(*) FROM app_log").fetchone()[0]
 
 
-def test_log_message_writes_to_explicit_and_env_db(tmp_path, monkeypatch):
+def test_log_message_writes_to_env_and_default_db(tmp_path, monkeypatch):
     env_db = tmp_path / "env.db"
+    env_db.parent.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("CODEX_LOG_DB_PATH", str(env_db))
-    log_message("via-env")
+    used_env = log_message("via-env")
+    assert used_env == env_db
     assert _count(env_db) == 1
 
-    explicit_db = tmp_path / "explicit.db"
-    log_message("via-explicit", db_path=explicit_db)
-    assert _count(explicit_db) == 1
+    monkeypatch.delenv("CODEX_LOG_DB_PATH", raising=False)
+    monkeypatch.chdir(tmp_path)
+    default_db = tmp_path / ".codex" / "session_logs.db"
+    default_db.parent.mkdir(parents=True, exist_ok=True)
+    used_default = log_message("via-default")
+    assert used_default.resolve() == default_db.resolve()
+    assert _count(default_db) == 1


### PR DESCRIPTION
## Summary
- fallback to `.codex/session_logs.db` when `CODEX_LOG_DB_PATH` is unset
- return the resolved path from `log_event` and `log_message`
- verify environment and default path behaviors for log adapters

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a480a91f7083318ce9843c5d9b10af