### PR TITLE
Use conversation_logger in end-to-end demo

### DIFF
--- a/documentation/end_to_end_logging.md
+++ b/documentation/end_to_end_logging.md
@@ -61,3 +61,9 @@ Options:
 * `--tail` (show latest N rows)
 
 > **Compliance:** DO NOT ACTIVATE ANY GitHub Actions files.
+
+## Example Script
+
+The repository includes [`scripts/codex_end_to_end.py`](../scripts/codex_end_to_end.py),
+which records a short conversation with `conversation_logger` and then queries
+the transcript using `codex.logging.query_logs`.

--- a/scripts/codex_end_to_end.py
+++ b/scripts/codex_end_to_end.py
@@ -2,8 +2,8 @@
 """Minimal end-to-end logging demonstration.
 
 This script simulates a small chat session. It writes start, user, assistant
-and end events via ``session_logger`` and then queries the transcript using the
-``query_logs`` CLI. The script exits non-zero if any step fails.
+and end events via ``conversation_logger`` and then queries the transcript using
+the ``query_logs`` CLI. The script exits non-zero if any step fails.
 """
 
 from __future__ import annotations
@@ -13,16 +13,15 @@ import sys
 import uuid
 from pathlib import Path
 
-from src.codex.logging.session_logger import log_event
+from src.codex.logging import conversation_logger as cl
 
 
-def main() -> int:
-    session_id = f"demo-{uuid.uuid4()}"
-    db = Path(".codex") / "session_logs.db"
-    log_event(session_id, "system", "session_start", db_path=db)
-    log_event(session_id, "user", "hello", db_path=db)
-    log_event(session_id, "assistant", "hi there", db_path=db)
-    log_event(session_id, "system", "session_end", db_path=db)
+def _log_and_query(session_id: str, db: Path) -> str:
+    """Log a short exchange and return the query_logs output."""
+    cl.start_session(session_id, db_path=str(db))
+    cl.log_message(session_id, "user", "hello", db_path=str(db))
+    cl.log_message(session_id, "assistant", "hi there", db_path=str(db))
+    cl.end_session(session_id, db_path=str(db))
 
     cmd = [
         sys.executable,
@@ -37,9 +36,19 @@ def main() -> int:
     ]
     cp = subprocess.run(cmd, capture_output=True, text=True)
     if cp.returncode != 0:
-        sys.stderr.write(cp.stderr)
-        return cp.returncode
-    print(cp.stdout)
+        raise RuntimeError(cp.stderr)
+    return cp.stdout
+
+
+def main() -> int:
+    session_id = f"demo-{uuid.uuid4()}"
+    db = Path(".codex") / "session_logs.db"
+    try:
+        output = _log_and_query(session_id, db)
+    except Exception as exc:  # pragma: no cover - CLI demo
+        sys.stderr.write(f"{exc}\n")
+        return 1
+    print(output)
     return 0
 
 


### PR DESCRIPTION
## Summary
- add `_log_and_query` helper using `conversation_logger` to record and query a short session
- document `scripts/codex_end_to_end.py` in end-to-end logging guide

## Testing
- `pre-commit run --all-files`
- `pytest scripts/test_codex_end_to_end.py` *(fails: file or directory not found: scripts/test_codex_end_to_end.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a56bad889083318c7d40576f7d1f6f