### PR TITLE
Add NDJSON importer and DB-backed session hooks

### DIFF
--- a/documentation/end_to_end_logging.md
+++ b/documentation/end_to_end_logging.md
@@ -23,6 +23,29 @@ $env:CODEX_SESSION_ID = [guid]::NewGuid().ToString()
 $env:CODEX_LOG_DB_PATH = (Join-Path (Get-Location) ".codex/session_logs.db")
 ```
 
+## NDJSON as Canonical Source
+
+Session hooks write newline-delimited JSON files under
+``.codex/sessions/<SESSION_ID>.ndjson``.  These files are treated as the
+authoritative record of events.  A separate importer synchronizes the NDJSON
+into the SQLite ``session_events`` table so tools that expect a database view
+remain functional.
+
+Run the importer after sessions complete:
+
+```bash
+codex-import-ndjson --session "$CODEX_SESSION_ID"
+```
+
+To ingest all sessions in the log directory:
+
+```bash
+codex-import-ndjson --all
+```
+
+The importer tracks a ``session_ingest_watermark`` for each session to avoid
+duplicating already processed lines.
+
 ## 2) Quick Start
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,6 @@ include = ["codex*"]
 [project.optional-dependencies]
 cli = ["typer>=0.9", "rich>=13"]
 dev = ["ruff>=0.5", "pytest>=7"]
+
+[project.scripts]
+codex-import-ndjson = "codex.logging.import_ndjson:main"

--- a/src/codex/logging/import_ndjson.py
+++ b/src/codex/logging/import_ndjson.py
@@ -1,0 +1,189 @@
+"""Import session NDJSON logs into the SQLite session_events table.
+
+This module treats ``.codex/sessions/<SESSION_ID>.ndjson`` files as the
+canonical log source and synchronizes them into ``session_events`` rows.
+Each line in the NDJSON file is assigned a 1-based ``seq`` number; rows are
+upserted with a uniqueness constraint on ``(session_id, seq)``.  A companion
+table ``session_ingest_watermark`` tracks the highest ingested sequence per
+session so repeated imports are idempotent.
+
+The importer stores:
+
+* ``session_events(session_id TEXT, seq INTEGER, ts REAL, role TEXT, message TEXT)``
+* ``session_ingest_watermark(session_id TEXT PRIMARY KEY, seq INTEGER)``
+
+Example CLI usage::
+
+    codex-import-ndjson --session S123
+    codex-import-ndjson --all
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from .config import DEFAULT_LOG_DB
+
+
+def _default_log_dir() -> Path:
+    return Path(os.getenv("CODEX_SESSION_LOG_DIR", ".codex/sessions")).expanduser()
+
+
+def _db_path(override: str | None = None) -> Path:
+    env = override or os.getenv("CODEX_LOG_DB_PATH") or os.getenv("CODEX_DB_PATH")
+    if env:
+        return Path(env).expanduser().resolve()
+    return DEFAULT_LOG_DB.expanduser().resolve()
+
+
+def _init_db(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS session_events (
+            session_id TEXT NOT NULL,
+            ts REAL,
+            role TEXT,
+            message TEXT
+        )
+        """
+    )
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(session_events)")]
+    if "seq" not in cols:
+        conn.execute("ALTER TABLE session_events ADD COLUMN seq INTEGER")
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS session_events_session_seq_idx ON session_events(session_id, seq)"
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS session_ingest_watermark (
+            session_id TEXT PRIMARY KEY,
+            seq INTEGER NOT NULL
+        )
+        """
+    )
+
+
+def _parse_ts(ts: str | None) -> float | None:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return None
+
+
+def import_session(
+    session_id: str,
+    log_dir: Path | None = None,
+    db_path: Path | str | None = None,
+) -> int:
+    """Import a single session's NDJSON log into SQLite.
+
+    Returns the number of new rows inserted.
+    """
+
+    log_dir = (log_dir or _default_log_dir()).expanduser().resolve()
+    ndjson_path = log_dir / f"{session_id}.ndjson"
+    if not ndjson_path.exists():
+        raise FileNotFoundError(ndjson_path)
+
+    db_path = _db_path(str(db_path) if db_path else None)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        _init_db(conn)
+        cur = conn.execute(
+            "SELECT seq FROM session_ingest_watermark WHERE session_id=?",
+            (session_id,),
+        )
+        row = cur.fetchone()
+        watermark = row[0] if row else 0
+
+        last_seq = watermark
+        inserted = 0
+        with ndjson_path.open(encoding="utf-8") as f:
+            for seq, line in enumerate(f, start=1):
+                if not line.strip() or seq <= watermark:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                ts = _parse_ts(obj.get("ts"))
+                role = obj.get("role") or "system"
+                message = obj.get("message") or obj.get("type") or ""
+                conn.execute(
+                    """
+                    INSERT INTO session_events(session_id, seq, ts, role, message)
+                    VALUES(?,?,?,?,?)
+                    ON CONFLICT(session_id, seq) DO UPDATE SET
+                        ts=excluded.ts,
+                        role=excluded.role,
+                        message=excluded.message
+                    """,
+                    (session_id, seq, ts, role, message),
+                )
+                inserted += 1
+                last_seq = seq
+
+        if last_seq > watermark:
+            conn.execute(
+                """
+                INSERT INTO session_ingest_watermark(session_id, seq)
+                VALUES(?,?)
+                ON CONFLICT(session_id) DO UPDATE SET seq=excluded.seq
+                """,
+                (session_id, last_seq),
+            )
+        conn.commit()
+        return inserted
+    finally:
+        conn.close()
+
+
+def import_all(log_dir: Path | None = None, db_path: Path | str | None = None) -> Dict[str, int]:
+    """Import all ``*.ndjson`` files found under ``log_dir``."""
+
+    log_dir = (log_dir or _default_log_dir()).expanduser().resolve()
+    results: Dict[str, int] = {}
+    for p in sorted(log_dir.glob("*.ndjson")):
+        sid = p.stem
+        results[sid] = import_session(sid, log_dir=log_dir, db_path=db_path)
+    return results
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Import session NDJSON logs into session_events",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--session", help="Session ID to import")
+    group.add_argument("--all", action="store_true", help="Import all sessions")
+    parser.add_argument("--log-dir", help="Directory containing NDJSON logs")
+    parser.add_argument("--db", help="Path to SQLite DB")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.session:
+        import_session(args.session, log_dir=args.log_dir, db_path=args.db)
+    else:
+        import_all(log_dir=args.log_dir, db_path=args.db)
+    return 0
+
+
+if __name__ == "__main__":
+    session_ctx: Optional[Any]
+    try:
+        from .session_hooks import session as session_ctx
+    except Exception:  # pragma: no cover - helper optional
+        session_ctx = None
+    if session_ctx:
+        with session_ctx(sys.argv):
+            raise SystemExit(main())
+    raise SystemExit(main())
+

--- a/tests/test_import_ndjson.py
+++ b/tests/test_import_ndjson.py
@@ -1,0 +1,62 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from codex.logging import import_ndjson
+
+
+def _write_ndjson(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for obj in events:
+            f.write(json.dumps(obj) + "\n")
+
+
+def test_import_session_and_watermark(tmp_path, monkeypatch):
+    session_id = "S1"
+    sessions_dir = tmp_path / ".codex" / "sessions"
+    ndjson_file = sessions_dir / f"{session_id}.ndjson"
+    events = [
+        {"ts": "2024-01-01T00:00:00Z", "type": "session_start", "session_id": session_id},
+        {"ts": "2024-01-01T00:00:01Z", "type": "session_end", "session_id": session_id},
+    ]
+    _write_ndjson(ndjson_file, events)
+
+    db_path = tmp_path / "session.db"
+    monkeypatch.setenv("CODEX_SESSION_LOG_DIR", str(sessions_dir))
+    monkeypatch.setenv("CODEX_LOG_DB_PATH", str(db_path))
+
+    # first import
+    inserted = import_ndjson.import_session(session_id)
+    assert inserted == 2
+
+    # re-import should be idempotent
+    inserted = import_ndjson.import_session(session_id)
+    assert inserted == 0
+
+    # append new event and re-import
+    with ndjson_file.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"ts": "2024-01-01T00:00:02Z", "role": "user", "message": "hi"}) + "\n")
+    inserted = import_ndjson.import_session(session_id)
+    assert inserted == 1
+
+    con = sqlite3.connect(str(db_path))
+    try:
+        rows = list(
+            con.execute(
+                "SELECT session_id, seq, message FROM session_events ORDER BY seq"
+            )
+        )
+        assert rows == [
+            (session_id, 1, "session_start"),
+            (session_id, 2, "session_end"),
+            (session_id, 3, "hi"),
+        ]
+        wm = con.execute(
+            "SELECT seq FROM session_ingest_watermark WHERE session_id=?",
+            (session_id,),
+        ).fetchone()[0]
+        assert wm == 3
+    finally:
+        con.close()
+


### PR DESCRIPTION
## Summary
- log shell and Python session hooks to the SQLite database using `session_logger.log_event`
- add `codex.logging.import_ndjson` module and `codex-import-ndjson` CLI for importing session NDJSON into SQLite with watermarks
- document NDJSON as canonical log source and expose new import workflow

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a56b9a755c83319e7dbe07bc8ba53c