### PR TITLE
Test log adapters with explicit database path

### DIFF
--- a/tests/test_log_adapters.py
+++ b/tests/test_log_adapters.py
@@ -9,9 +9,10 @@ def test_log_adapters_write(tmp_path):
     la.log_message("another event", db_path=db)
     con = sqlite3.connect(str(db))
     cur = con.cursor()
-    cur.execute("SELECT level, message FROM app_log")
+    cur.execute("SELECT level, message, meta FROM app_log ORDER BY id")
     rows = cur.fetchall()
     con.close()
-    messages = [r[1] for r in rows]
-    assert "test event" in messages
-    assert "another event" in messages
+    assert rows == [
+        ("INFO", "test event", None),
+        ("INFO", "another event", None),
+    ]


### PR DESCRIPTION
## Summary
- Ensure `log_event` is invoked with a provided SQLite path
- Verify log entries are persisted with expected fields directly from the database

## Testing
- `pre-commit run --all-files` *(fails: ruff-format modified unrelated files)*
- `pre-commit run --files tests/test_log_adapters.py`
- `pytest tests/test_log_adapters.py`


------
https://chatgpt.com/codex/tasks/task_e_68a57d8aa22483319e8d3717203e32a4