### PR TITLE
Add user setup hook with logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ The following environment variables can be set to configure runtime installation
 | `CODEX_ENV_GO_VERSION`     | Go version to install      | `1.22.12`, `1.23.8`, `1.24.3`                    |                                                                      |
 | `CODEX_ENV_SWIFT_VERSION`  | Swift version to install   | `5.10`, `6.1`                                    |                                                                      |
 
+### Custom user setup
+
+If a shell script exists at `.codex/user_setup.sh`, it runs once after the environment is initialized. Override the location with `CODEX_USER_SETUP_PATH`. The sentinel `.codex/.user_setup.done` prevents reruns unless `CODEX_USER_SETUP_FORCE=1` is set. Output is written to `.codex/setup_logs/<timestamp>.log`.
+
+| Environment variable | Description |
+| -------------------- | ----------- |
+| `CODEX_USER_SETUP_PATH` | Path to the user setup script. Defaults to `.codex/user_setup.sh`. |
+| `CODEX_USER_SETUP_FORCE` | Run the user setup even if `.codex/.user_setup.done` exists. |
+
 ## What's included
 
 In addition to the packages specified in the table above, the following packages are also installed:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,5 +16,8 @@ echo "=================================="
 
 /opt/codex/setup_universal.sh
 
+. "$(dirname "$0")/setup.sh"
+run_user_setup
+
 echo "Environment ready. Dropping you into a bash shell."
 exec bash --login "$@"

--- a/src/codex/logging/import_ndjson.py
+++ b/src/codex/logging/import_ndjson.py
@@ -58,7 +58,8 @@ def _init_db(conn: sqlite3.Connection) -> None:
     if "seq" not in cols:
         conn.execute("ALTER TABLE session_events ADD COLUMN seq INTEGER")
     conn.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS session_events_session_seq_idx ON session_events(session_id, seq)"
+        "CREATE UNIQUE INDEX IF NOT EXISTS session_events_session_seq_idx "
+        "ON session_events(session_id, seq)"
     )
     conn.execute(
         """
@@ -147,7 +148,9 @@ def import_session(
         conn.close()
 
 
-def import_all(log_dir: Path | None = None, db_path: Path | str | None = None) -> Dict[str, int]:
+def import_all(
+    log_dir: Path | None = None, db_path: Path | str | None = None
+) -> Dict[str, int]:
     """Import all ``*.ndjson`` files found under ``log_dir``."""
 
     log_dir = (log_dir or _default_log_dir()).expanduser().resolve()
@@ -186,4 +189,3 @@ if __name__ == "__main__":
         with session_ctx(sys.argv):
             raise SystemExit(main())
     raise SystemExit(main())
-

--- a/tests/test_import_ndjson.py
+++ b/tests/test_import_ndjson.py
@@ -17,8 +17,16 @@ def test_import_session_and_watermark(tmp_path, monkeypatch):
     sessions_dir = tmp_path / ".codex" / "sessions"
     ndjson_file = sessions_dir / f"{session_id}.ndjson"
     events = [
-        {"ts": "2024-01-01T00:00:00Z", "type": "session_start", "session_id": session_id},
-        {"ts": "2024-01-01T00:00:01Z", "type": "session_end", "session_id": session_id},
+        {
+            "ts": "2024-01-01T00:00:00Z",
+            "type": "session_start",
+            "session_id": session_id,
+        },
+        {
+            "ts": "2024-01-01T00:00:01Z",
+            "type": "session_end",
+            "session_id": session_id,
+        },
     ]
     _write_ndjson(ndjson_file, events)
 
@@ -36,7 +44,16 @@ def test_import_session_and_watermark(tmp_path, monkeypatch):
 
     # append new event and re-import
     with ndjson_file.open("a", encoding="utf-8") as f:
-        f.write(json.dumps({"ts": "2024-01-01T00:00:02Z", "role": "user", "message": "hi"}) + "\n")
+        f.write(
+            json.dumps(
+                {
+                    "ts": "2024-01-01T00:00:02Z",
+                    "role": "user",
+                    "message": "hi",
+                }
+            )
+            + "\n"
+        )
     inserted = import_ndjson.import_session(session_id)
     assert inserted == 1
 
@@ -59,4 +76,3 @@ def test_import_session_and_watermark(tmp_path, monkeypatch):
         assert wm == 3
     finally:
         con.close()
-


### PR DESCRIPTION
## Summary
- run custom user setup script after environment init
- implement logging and sentinel guard for user setup
- document CODEX_USER_SETUP_PATH and CODEX_USER_SETUP_FORCE

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a57d7a05608331a4d43f0e28f507fd