### PR TITLE
test: validate README SessionLogger example

### DIFF
--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -1,23 +1,26 @@
-from src.codex.logging.session_logger import fetch_messages, get_session_id, log_event
+import pathlib
+import re
+import sqlite3
 
 
-def generate_reply(prompt: str) -> str:
-    return f"echo:{prompt}"
-
-
-def test_readme_snippet(tmp_path, monkeypatch):
+def test_readme_session_logger_example(tmp_path, monkeypatch):
+    readme = pathlib.Path("README.md").read_text()
+    blocks = re.findall(r"```python\n(.*?)```", readme, re.DOTALL)
+    snippet = next(
+        b
+        for b in blocks
+        if "SessionLogger" in b and 'sl.log("assistant", "hello")' in b
+    )
     db = tmp_path / "session_logs.db"
     monkeypatch.setenv("CODEX_LOG_DB_PATH", str(db))
-    session_id = get_session_id()
-
-    def handle_user_message(prompt: str) -> str:
-        log_event(session_id, "user", prompt)
-        reply = generate_reply(prompt)
-        log_event(session_id, "assistant", reply)
-        return reply
-
-    out = handle_user_message("hi")
-    assert out == "echo:hi"
-    rows = fetch_messages(session_id, db_path=db)
-    messages = {r["message"] for r in rows}
-    assert "hi" in messages and "echo:hi" in messages
+    exec(snippet, {})
+    con = sqlite3.connect(db)
+    try:
+        rows = con.execute(
+            "SELECT role, message FROM session_events "
+            "WHERE session_id = ? AND role != 'system' ORDER BY ts",
+            ("demo",),
+        ).fetchall()
+    finally:
+        con.close()
+    assert rows == [("user", "hi"), ("assistant", "hello")]


### PR DESCRIPTION
## Summary
- test: execute README SessionLogger example and verify logged messages

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_readme_examples.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5817722a483318c24a6c2adccd996