### PR TITLE
Group Codex session artifacts in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+# macOS Finder metadata
 .DS_Store
-.codex/session_logs.db
+
+# Codex session artifacts
 .codex/sessions/
 .codex/*.tmp
 *.sqlite
+.codex/session_logs.db


### PR DESCRIPTION
## Summary
- Clarify `.gitignore` by grouping Codex session logs and temp files under a descriptive section

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5817e58108331ac8c3c0d2da03a24