### PR TITLE
Add Makefile with common tasks and document usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: format lint test build
+
+format:
+	pre-commit run --all-files
+
+lint:
+	ruff src tests
+
+test:
+	pytest
+
+build:
+	python -m build

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ pytest -q
 
 These same commands run in CI; see the workflow definition in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (read-only).
 
+## Makefile
+
+Common tasks are provided via a simple `Makefile`:
+
+```bash
+make format  # pre-commit run --all-files
+make lint    # ruff src tests
+make test    # pytest
+make build   # python -m build
+```
+
 ## Testing
 
 ### Quick checks


### PR DESCRIPTION
## Summary
- add Makefile for format, lint, test, and build commands
- document Makefile usage in README

## Testing
- `python -m pre_commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5818b78fc8331be911568445fa7b9