### PR TITLE
Add local CI script for pre-commit, tests, and build

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ pre-commit run --all-files
 pytest -q
 ```
 
+Alternatively, run `./ci_local.sh` to execute these checks along with a local build step.
+
 These same commands run in CI; see the workflow definition in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (read-only).
 
 ## Testing

--- a/ci_local.sh
+++ b/ci_local.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pre-commit run --all-files
+pytest
+python -m build -n


### PR DESCRIPTION
## Summary
- add `ci_local.sh` to run pre-commit, pytest, and a non-isolated build
- document `ci_local.sh` usage in README

## Testing
- `pre-commit run --all-files`
- `pytest`
- `./ci_local.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a5818fe3a083318125f140c29c3d18