### PR TITLE
feat: add session logger sqlite connection pooling

### DIFF
--- a/src/codex/logging/config.py
+++ b/src/codex/logging/config.py
@@ -1,4 +1,12 @@
-"""Configuration defaults for Codex logging helpers."""
+"""Configuration defaults for Codex logging helpers.
+
+Environment variables:
+
+``CODEX_LOG_DB_PATH``
+    Override default SQLite path for session events.
+``CODEX_SQLITE_POOL``
+    If set to ``"1"``, reuse SQLite connections for logging.
+"""
 
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- reuse sqlite connections in `session_logger` when `CODEX_SQLITE_POOL=1`
- close pooled connections on process exit
- document `CODEX_SQLITE_POOL` in logging config

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5819047c08331b58613c1dc157e52