### PR TITLE
feat: mark auto-modified files

### DIFF
--- a/tools/apply_pyproject_packaging.py
+++ b/tools/apply_pyproject_packaging.py
@@ -33,6 +33,9 @@ DO_NOT_ACTIVATE_GITHUB_ACTIONS = True
 
 errors = []
 
+AUTO_MARKER = "# [CODEX-AUTO]"
+FORCE_FLAG = "--force" in sys.argv
+
 
 def now_ts() -> float:
     return time.time()
@@ -92,6 +95,17 @@ def read_text(p: Path) -> str:
 
 def write_text(p: Path, text: str):
     p.parent.mkdir(parents=True, exist_ok=True)
+    if not FORCE_FLAG and p.exists():
+        existing = p.read_text(encoding="utf-8")
+        if AUTO_MARKER in existing:
+            print(f"skip {p} (has {AUTO_MARKER})", file=sys.stderr)
+            return
+    if AUTO_MARKER not in text:
+        lines = text.splitlines(keepends=True)
+        if lines and lines[0].startswith("#!"):
+            text = lines[0] + AUTO_MARKER + "\n" + "".join(lines[1:])
+        else:
+            text = AUTO_MARKER + "\n" + "".join(lines)
     p.write_text(text, encoding="utf-8")
 
 

--- a/tools/codex_patch_session_logging.py
+++ b/tools/codex_patch_session_logging.py
@@ -39,6 +39,9 @@ TARGET_REL = "tests/test_session_logging.py"
 TARGET = os.path.join(REPO_ROOT, TARGET_REL)
 FLAGS_ENV = os.path.join(CODEX_DIR, "flags.env")
 
+AUTO_MARKER = "# [CODEX-AUTO]"
+FORCE_FLAG = "--force" in sys.argv
+
 os.makedirs(CODEX_DIR, exist_ok=True)
 
 CHANGE_LOG = os.path.join(CODEX_DIR, "change_log.md")
@@ -60,6 +63,17 @@ def read_text(p: str) -> str:
 
 
 def write_text(p: str, s: str) -> None:
+    if not FORCE_FLAG and os.path.exists(p):
+        existing = read_text(p)
+        if AUTO_MARKER in existing:
+            print(f"skip {p} (has {AUTO_MARKER})", file=sys.stderr)
+            return
+    if AUTO_MARKER not in s:
+        lines = s.splitlines(keepends=True)
+        if lines and lines[0].startswith("#!"):
+            s = lines[0] + AUTO_MARKER + "\n" + "".join(lines[1:])
+        else:
+            s = AUTO_MARKER + "\n" + "".join(lines)
     with open(p, "w", encoding="utf-8") as f:
         f.write(s)
 

--- a/tools/codex_workflow.py
+++ b/tools/codex_workflow.py
@@ -17,6 +17,8 @@ from datetime import datetime
 from pathlib import Path
 
 # ---------- Utilities ----------
+AUTO_MARKER = "# [CODEX-AUTO]"
+FORCE_FLAG = "--force" in sys.argv
 
 def repo_root() -> Path:
     try:
@@ -44,6 +46,17 @@ def read_text(p: Path) -> str:
 
 def write_text(p: Path, content: str):
     p.parent.mkdir(parents=True, exist_ok=True)
+    if not FORCE_FLAG and p.exists():
+        existing = p.read_text(encoding="utf-8")
+        if AUTO_MARKER in existing:
+            print(f"skip {p} (has {AUTO_MARKER})", file=sys.stderr)
+            return
+    if AUTO_MARKER not in content:
+        lines = content.splitlines(keepends=True)
+        if lines and lines[0].startswith("#!"):
+            content = lines[0] + AUTO_MARKER + "\n" + "".join(lines[1:])
+        else:
+            content = AUTO_MARKER + "\n" + "".join(lines)
     p.write_text(content, encoding="utf-8")
 
 def chmod_x(p: Path):


### PR DESCRIPTION
## Summary
- add CODEX-AUTO markers and force flag checks for auto-modifying scripts

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5819c303c833187e72340ca0e808b