### PR TITLE
docs: explain entrypoint session logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ These same commands run in CI; see the workflow definition in [`.github/workflow
 - SQLite DB: `.codex/session_logs.db`
 - NDJSON sessions: `.codex/sessions/<SESSION_ID>.ndjson`
 
+## Entrypoint session logging
+
+`entrypoint.sh` sources [`scripts/session_logging.sh`](scripts/session_logging.sh) and calls
+`codex_session_start` when the container boots. A shell `trap` ensures
+`codex_session_end` runs on exit. Both functions append events to
+`.codex/sessions/<SESSION_ID>.ndjson`.
+
+Inspect a trace with `jq` or the bundled viewer:
+
+```bash
+jq '.' .codex/sessions/<SESSION_ID>.ndjson | less
+# or
+python -m codex.logging.viewer --session <SESSION_ID>
+```
+
 ## Usage
 
 The Docker image is available at:


### PR DESCRIPTION
## Summary
- document how entrypoint.sh uses codex_session_start/codex_session_end
- show how to inspect `.codex/sessions/<SESSION_ID>.ndjson`

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a581a3cc4883318281c3c616f48444