### PR TITLE
Format long SQL string in test for Ruff compliance

### DIFF
--- a/tests/test_query_logs_tail.py
+++ b/tests/test_query_logs_tail.py
@@ -8,7 +8,14 @@ def test_tail_option(tmp_path):
     db = tmp_path / "events.sqlite"
     con = sqlite3.connect(str(db))
     con.execute(
-        "CREATE TABLE session_events(session_id TEXT, timestamp TEXT, role TEXT, message TEXT)"
+        """
+        CREATE TABLE session_events(
+            session_id TEXT,
+            timestamp TEXT,
+            role TEXT,
+            message TEXT
+        )
+        """
     )
     con.executemany(
         "INSERT INTO session_events VALUES (?,?,?,?)",


### PR DESCRIPTION
## Summary
- wrap session_events table creation string in test for line-length compliance

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ec54068c83319062f70dbfa91b27