### PR TITLE
Add SQLite snippet snapshot builder and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,3 +409,14 @@ No code changes are required beyond importing `sqlite3` normally.
 - Calling `close()` on a pooled connection leaves it in a closed state within
   the pool. Avoid context managers like `with sqlite3.connect(...)` when pooling
   is enabled.
+
+## Immutable SQLite snapshots
+
+The script `tools/build_sqlite_snapshot.py` creates a small snapshot database under `.artifacts/snippets.db`. Open the snapshot in read-only mode using SQLite's immutable flag:
+
+```python
+import sqlite3
+con = sqlite3.connect('file:snippets.db?immutable=1', uri=True)
+```
+
+This prevents SQLite from creating journal files or writing to the database file.

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,26 @@
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+
+CREATE TABLE IF NOT EXISTS snippet (
+    id INTEGER PRIMARY KEY,
+    body TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS snippet_fts USING fts5(
+    body,
+    content='snippet',
+    content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS snippet_ai AFTER INSERT ON snippet BEGIN
+    INSERT INTO snippet_fts(rowid, body) VALUES (new.id, new.body);
+END;
+
+CREATE TRIGGER IF NOT EXISTS snippet_ad AFTER DELETE ON snippet BEGIN
+    INSERT INTO snippet_fts(snippet_fts, rowid, body) VALUES('delete', old.id, old.body);
+END;
+
+CREATE TRIGGER IF NOT EXISTS snippet_au AFTER UPDATE ON snippet BEGIN
+    INSERT INTO snippet_fts(snippet_fts, rowid, body) VALUES('delete', old.id, old.body);
+    INSERT INTO snippet_fts(rowid, body) VALUES(new.id, new.body);
+END;

--- a/tests/test_repo_option_a.py
+++ b/tests/test_repo_option_a.py
@@ -1,0 +1,25 @@
+import sqlite3
+
+import pytest
+
+from tools.build_sqlite_snapshot import ARTIFACT_DB, build_snapshot
+
+
+def test_build_snapshot_and_search_and_immutable():
+    if ARTIFACT_DB.exists():
+        ARTIFACT_DB.unlink()
+    build_snapshot()
+    assert ARTIFACT_DB.exists()
+    con = sqlite3.connect(ARTIFACT_DB)
+    try:
+        rows = con.execute(
+            "SELECT body FROM snippet_fts WHERE snippet_fts MATCH ?",
+            ("hello",),
+        ).fetchall()
+    finally:
+        con.close()
+    assert ("hello world",) in rows
+    con = sqlite3.connect(f"file:{ARTIFACT_DB}?immutable=1", uri=True)
+    with pytest.raises(sqlite3.OperationalError):
+        con.execute("INSERT INTO snippet(body) VALUES ('new')")
+    con.close()

--- a/tools/build_sqlite_snapshot.py
+++ b/tools/build_sqlite_snapshot.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "db" / "schema.sql"
+ARTIFACT_DB = ROOT / ".artifacts" / "snippets.db"
+
+SNIPPETS = [
+    {"body": "hello world"},
+    {"body": "goodbye world"},
+    {"body": "lorem ipsum"},
+]
+
+
+def build_snapshot(
+    db_path: Path = ARTIFACT_DB,
+    schema_path: Path = SCHEMA_PATH,
+    snippets: list[dict[str, str]] = SNIPPETS,
+) -> Path:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    if db_path.exists():
+        db_path.unlink()
+    con = sqlite3.connect(db_path)
+    try:
+        con.executescript(schema_path.read_text())
+        con.executemany(
+            "INSERT INTO snippet(body) VALUES (?)",
+            [(s["body"],) for s in snippets],
+        )
+        con.commit()
+    finally:
+        con.close()
+    return db_path
+
+
+if __name__ == "__main__":
+    build_snapshot()


### PR DESCRIPTION
## Summary
- add `db/schema.sql` with WAL, snippet table, FTS5 index, and triggers
- add `tools/build_sqlite_snapshot.py` to build `.artifacts/snippets.db`
- document immutable snapshot usage in README
- test snapshot build, FTS search, and immutable open

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5f0beb3f4833193e536acdca8abf6