### PR TITLE
Add Datasette Lite snapshot link

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,3 +420,5 @@ con = sqlite3.connect('file:snippets.db?immutable=1', uri=True)
 ```
 
 This prevents SQLite from creating journal files or writing to the database file.
+
+View the snapshot in your browser with [Datasette Lite](https://lite.datasette.io/?url=https://files.catbox.moe/zw7qio.db).

--- a/documentation/option_c_datasette_lite.md
+++ b/documentation/option_c_datasette_lite.md
@@ -1,0 +1,10 @@
+# Option C: Datasette Lite
+
+Host the `.artifacts/snippets.db` snapshot on a static file server that sends `Access-Control-Allow-Origin: *`.
+With the file available at a public URL, load it directly in the browser using [Datasette Lite](https://lite.datasette.io/):
+
+```
+https://lite.datasette.io/?url=https://files.catbox.moe/zw7qio.db
+```
+
+The page runs SQLite in WebAssembly and exposes the database through Datasette's interface for ad-hoc queries.


### PR DESCRIPTION
## Summary
- publish `.artifacts/snippets.db` to a CORS-enabled static host
- link to the hosted snapshot in README via Datasette Lite
- document Datasette Lite usage under `documentation/`

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5f8156b8c83319050e920dc61748b