### PR TITLE
Add manual verification template and contributing reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+Thank you for improving `codex-universal`.
+
+## Getting Started
+
+This project accepts documentation updates and `.codex` artefacts. Before submitting a pull request, run the standard checks:
+
+```bash
+pre-commit run --all-files
+pytest
+```
+
+## Manual Validation
+
+When changes affect the snapshot database or related tooling, perform manual validation. Follow the [Manual Verification Template](documentation/manual_verification_template.md) and record the steps you completed (A1–A4, B1–B2, or C1) in your pull request description or issue.
+
+## Scope
+
+Avoid enabling GitHub Actions or adding non-documentation files unless explicitly requested. See [AGENTS.md](AGENTS.md) for full guidelines.

--- a/documentation/manual_verification_template.md
+++ b/documentation/manual_verification_template.md
@@ -1,0 +1,41 @@
+# Manual Verification Template
+
+Use these steps to manually validate `.artifacts/snippets.db` or its derivatives. Choose one of the options below and complete the associated steps.
+
+## Option A: SQLite CLI
+
+1. **A1** – Open the snapshot:
+   ```bash
+   sqlite3 .artifacts/snippets.db
+   ```
+2. **A2** – List available tables:
+   ```sql
+   .tables
+   ```
+3. **A3** – Run a sample query:
+   ```sql
+   SELECT * FROM snippet LIMIT 5;
+   ```
+4. **A4** – Reopen in immutable (read‑only) mode to confirm no writes:
+   ```bash
+   sqlite3 'file:.artifacts/snippets.db?immutable=1'
+   ```
+
+## Option B: DuckDB Parquet Export
+
+1. **B1** – Export the snapshot to Parquet:
+   ```bash
+   python tools/export_to_parquet.py
+   ```
+2. **B2** – Inspect a partition with DuckDB:
+   ```sql
+   SELECT * FROM read_parquet('parquet/snippet/id=1/*.parquet');
+   ```
+
+## Option C: Datasette Lite
+
+1. **C1** – Load the snapshot in Datasette Lite by passing a public URL:
+   ```
+   https://lite.datasette.io/?url=https://files.example.com/snippets.db
+   ```
+   The database runs entirely in the browser for ad‑hoc queries.


### PR DESCRIPTION
## Summary
- add manual verification template covering Options A, B, and C
- document manual validation requirement in CONTRIBUTING

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a60026cc2c8331a4d928d28794bc1c