### PR TITLE
Add self-manage workflow and CLI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @Aries-Serpent
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+-
+
+## Testing
+- [ ] `pre-commit run --all-files`
+- [ ] `pytest -q`
+
+## Risks
+-
+
+## Rollback
+-
+

--- a/.github/workflows/codex-self-manage.yml
+++ b/.github/workflows/codex-self-manage.yml
@@ -1,0 +1,39 @@
+name: codex-self-manage
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    types: [opened, synchronize, labeled]
+
+jobs:
+  ci:
+    if: github.event_name == 'workflow_dispatch' || contains(join(fromJson(toJson(github.event.pull_request.labels)).*.name, ' '), 'codex-ci')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+      - name: Install project and tools
+        run: |
+          python -m pip install -U pip
+          pip install -e .
+          pip install pre-commit pytest coverage pip-audit
+      - name: Pre-commit
+        run: pre-commit run --all-files
+      - name: Tests
+        run: |
+          coverage run -m pytest -q
+          coverage xml
+      - name: Dependency audit
+        run: |
+          pip-audit -r requirements.txt || true
+          pip-audit || true
+      - name: Codex CLI audit
+        run: |
+          python tools/codex_cli.py audit || true

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 # Codex session artifacts
 .codex/sessions/
 .codex/*.tmp
+.codex/*.ndjson
 *.sqlite
 .codex/session_logs.db

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,9 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: mixed-line-ending
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+      - id: detect-private-key
 
   - repo: https://github.com/sqlfluff/sqlfluff
     rev: 3.4.2

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Alternatively, run `./ci_local.sh` to execute these checks along with a local bu
 
 These same commands run in CI; see the workflow definition in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (read-only).
 
+### Codex Self-Manage (opt-in)
+This repository does not execute GitHub Actions automatically. To run checks in the cloud on demand:
+
+1. Label a pull request with `codex-ci` **or** run the **codex-self-manage** workflow via **Run workflow**.
+2. The workflow runs `pre-commit`, `pytest` (with coverage), and `pip-audit`.
+3. Every run appends an NDJSON record to `.codex/action_log.ndjson` for traceability.
+
+Local one-shot:
+
+```bash
+python tools/codex_cli.py audit
+```
+
 ## Makefile
 
 Common tasks are provided via a simple `Makefile`:
@@ -61,7 +74,7 @@ make build   # python -m build
   scripts/run_coverage.sh
   ```
 
-> **Note:** DO NOT ACTIVATE ANY GitHub Actions files. This repository intentionally avoids enabling `.github/workflows/*` in this workflow.
+> **Note:** GitHub Actions are disabled by default. Use the `codex-self-manage` workflow or `python tools/codex_cli.py audit` for on-demand checks.
 
 ## Logging Locations
 

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+import sys
+
+
+def _run(args: list[str]) -> int:
+    env = os.environ.copy()
+    env["CODEX_CLI_SKIP"] = "1"
+    return subprocess.run([sys.executable, "tools/codex_cli.py", *args], env=env, check=False).returncode
+
+
+def test_cli_lint_smoke() -> None:
+    assert _run(["lint"]) == 0
+
+
+def test_cli_test_smoke() -> None:
+    assert _run(["test"]) == 0
+
+
+def test_cli_audit_smoke() -> None:
+    assert _run(["audit"]) == 0
+

--- a/tools/codex_cli.py
+++ b/tools/codex_cli.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Run lint/tests and log results for Codex self-management."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+
+LOG_PATH = pathlib.Path(os.getenv("CODEX_LOG_DB_PATH", ".codex/action_log.ndjson"))
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+LOG_PATH.touch(exist_ok=True)
+
+
+def log(event: str, status: str, detail: str | None = None) -> None:
+    rec = {"ts": time.time(), "event": event, "status": status}
+    if detail:
+        rec["detail"] = detail
+    with LOG_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec) + "\n")
+
+
+def run(cmd: list[str]) -> int:
+    if os.getenv("CODEX_CLI_SKIP") == "1":
+        return 0
+    return subprocess.run(cmd, check=False).returncode
+
+
+def cmd_lint() -> int:
+    rc = run(["pre-commit", "run", "--all-files"])
+    log("lint", "ok" if rc == 0 else "fail")
+    return rc
+
+
+def cmd_test() -> int:
+    rc = run(["pytest", "-q"])
+    log("test", "ok" if rc == 0 else "fail")
+    return rc
+
+
+def cmd_audit() -> int:
+    rc_lint = run(["pre-commit", "run", "--all-files"])
+    rc_test = run(["pytest", "-q"])
+    rc = rc_lint or rc_test
+    log("audit", "ok" if rc == 0 else "fail", "pre-commit+pytest")
+    return rc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="codex-cli")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("lint")
+    sub.add_parser("test")
+    sub.add_parser("audit")
+    args = parser.parse_args()
+
+    if args.cmd == "lint":
+        return cmd_lint()
+    if args.cmd == "test":
+        return cmd_test()
+    if args.cmd == "audit":
+        return cmd_audit()
+    parser.error("unknown command")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- add manual codex-self-manage GitHub workflow
- introduce codex_cli for on-demand lint/test logging
- tighten pre-commit hooks and add repo governance files

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a603bc35f48331bc0fc34875f7fc35