### PR TITLE
refactor: streamline chat logging

### DIFF
--- a/README_UPDATED.md
+++ b/README_UPDATED.md
@@ -97,6 +97,13 @@ from src.codex.logging.session_logger import SessionLogger
 with SessionLogger("demo-session") as log:
     log.log_message("user", "Hello")
 ```
+```python
+# Or use ChatSession which logs each message once via log_event
+from src.codex.chat import ChatSession
+
+with ChatSession("demo-session") as chat:
+    chat.log_user("Hello")
+    chat.log_assistant("Hi there")
 ```
 
 ### Querying

--- a/src/codex/chat.py
+++ b/src/codex/chat.py
@@ -1,10 +1,17 @@
-"""Simple chat session helper that logs messages via SessionLogger.
+"""Simple chat session helper that logs messages via ``log_event``.
 
 This module provides a ``ChatSession`` context manager that initializes
-``SessionLogger`` on entry, captures user and assistant messages, and ensures
+``SessionLogger`` on entry, records user and assistant messages, and ensures
 the session is closed on exit. The current session ID is propagated via the
 ``CODEX_SESSION_ID`` environment variable so that other components can access it
 consistently.
+
+Example
+-------
+>>> from src.codex.chat import ChatSession
+>>> with ChatSession("demo") as chat:
+...     chat.log_user("hi")
+...     chat.log_assistant("hello")
 """
 
 from __future__ import annotations
@@ -14,7 +21,6 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
-from src.codex.logging import conversation_logger as _cl
 from src.codex.logging.session_logger import log_event
 
 
@@ -49,7 +55,6 @@ class ChatSession:
         role = "user"
         db = self.db_path
         path = Path(db) if db else None
-        _cl.log_message(self.session_id, role, message, db_path=db)
         log_event(self.session_id, role, message, db_path=path)
 
     def log_assistant(self, message: str) -> None:
@@ -57,7 +62,6 @@ class ChatSession:
         role = "assistant"
         db = self.db_path
         path = Path(db) if db else None
-        _cl.log_message(self.session_id, role, message, db_path=db)
         log_event(self.session_id, role, message, db_path=path)
 
     def __exit__(self, exc_type, exc, tb) -> None:

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -22,7 +22,7 @@ def test_chat_session_logs_and_env(tmp_path, monkeypatch):
         assert os.getenv("CODEX_SESSION_ID") == "env-session"
         chat.log_user("hi")
         chat.log_assistant("yo")
-    assert _count(db) == 6
+    assert _count(db) == 4
     assert os.getenv("CODEX_SESSION_ID") is None
 
 


### PR DESCRIPTION
## Summary
- simplify ChatSession to log messages only via `log_event`
- adjust chat session tests to expect four events
- document ChatSession usage with single logging call

## Testing
- `pre-commit run --files README_UPDATED.md src/codex/chat.py tests/test_chat_session.py` *(failed: local-pytest modified files; reran with skip)*
- `SKIP=local-pytest pre-commit run --files README_UPDATED.md src/codex/chat.py tests/test_chat_session.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a61271ddb08331852fa988b4169966