### PR TITLE
Add pinned Codex CI workflow

### DIFF
--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -1,0 +1,38 @@
+name: codex-ci
+on:
+  workflow_dispatch: {}
+  pull_request:
+    types: [opened, synchronize, labeled]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  ci:
+    runs-on: [self-hosted, linux, codex]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.12'
+      - name: Cache pip
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-py-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          if [ -f pyproject.toml ]; then python -m pip install poetry; fi
+          if [ -f poetry.lock ]; then poetry install --no-interaction --no-ansi; fi
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
+        with:
+          extra_args: --all-files
+      - name: Run tests
+        run: pytest -q

--- a/PINNED_SHAS.md
+++ b/PINNED_SHAS.md
@@ -1,0 +1,23 @@
+# PINNED_SHAS.md
+
+Immutable pins for GitHub Actions used in the Codex CI workflow. Replace `<FULL_SHA>` placeholders in the workflow with these exact commit SHAs to ensure deterministic, secure builds.
+
+| Action | Purpose | Commit SHA |
+|---|---|---|
+| `actions/checkout` | Clone repository | `08eba0b27e820071cde6df949e0beb9ba4906955` |
+| `actions/setup-python` | Install Python | `a26af69be951a213d495a4c3e4e4022e16d87065` |
+| `actions/cache` | Dependency caching | `0400d5f644dc74513175e3cd8d07132dd4860809` |
+| `pre-commit/action` | Run pre-commit hooks | `2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd` |
+
+## How to Resolve the Latest Stable SHAs
+
+Using the GitHub REST API:
+
+```bash
+curl -fsSL https://api.github.com/repos/actions/checkout/git/refs/tags/v4 | jq -r '.object.sha'
+curl -fsSL https://api.github.com/repos/actions/setup-python/git/refs/tags/v5 | jq -r '.object.sha'
+curl -fsSL https://api.github.com/repos/actions/cache/git/refs/tags/v4 | jq -r '.object.sha'
+curl -fsSL https://api.github.com/repos/pre-commit/action/git/refs/tags/v3.0.1 | jq -r '.object.sha'
+```
+
+Review and update these pins quarterly or when security advisories are published.


### PR DESCRIPTION
## Summary
- add codex-ci workflow using pinned action commits
- document pinned action SHAs for checkout, setup-python, cache, and pre-commit action

## Testing
- `pre-commit run --all-files` *(fails: hook id local-pytest; AssertionError)*
- `pytest -q` *(fails: tests/test_session_logging.py::test_ndjson_and_db_alignment: AssertionError, tests/test_session_logging.py::test_context_manager_emits_start_end: AssertionError, tests/test_fetch_messages.py::test_fetch_messages[default_path]: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68a61d1b5fe88331aa95e4c4c8524aec