### PR TITLE
Add CLI tests and refine chat session expectations

### DIFF
--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -18,11 +18,13 @@ def _count(db):
 def test_chat_session_logs_and_env(tmp_path, monkeypatch):
     db = tmp_path / "chat.db"
     monkeypatch.delenv("CODEX_SESSION_ID", raising=False)
+    messages = ["hi", "yo"]
     with ChatSession(session_id="env-session", db_path=str(db)) as chat:
         assert os.getenv("CODEX_SESSION_ID") == "env-session"
-        chat.log_user("hi")
-        chat.log_assistant("yo")
-    assert _count(db) == 4
+        chat.log_user(messages[0])
+        chat.log_assistant(messages[1])
+    expected_rows = 2 + len(messages)  # start/end + one per message
+    assert _count(db) == expected_rows
     assert os.getenv("CODEX_SESSION_ID") is None
 
 

--- a/tests/test_import_ndjson_cli.py
+++ b/tests/test_import_ndjson_cli.py
@@ -1,0 +1,57 @@
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_ndjson(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for obj in events:
+            f.write(json.dumps(obj) + "\n")
+
+
+def _run_cli(cmd: list[str], log_dir: Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    src_dir = Path(__file__).resolve().parents[1] / "src"
+    env["PYTHONPATH"] = os.pathsep.join([str(src_dir), env.get("PYTHONPATH", "")])
+    env["CODEX_SESSION_LOG_DIR"] = str(log_dir)
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+
+def test_import_ndjson_cli_idempotent(tmp_path: Path):
+    session_id = "S-cli"
+    log_dir = tmp_path / "logs"
+    ndjson_file = log_dir / f"{session_id}.ndjson"
+    events = [
+        {"ts": "2024-01-01T00:00:00Z", "role": "user", "message": "hi"},
+        {"ts": "2024-01-01T00:00:01Z", "role": "assistant", "message": "yo"},
+    ]
+    _write_ndjson(ndjson_file, events)
+    db_path = tmp_path / "events.db"
+
+    cmd_base = ["codex-import-ndjson"]
+    if shutil.which("codex-import-ndjson") is None:
+        cmd_base = [sys.executable, "-m", "codex.logging.import_ndjson"]
+    cmd = cmd_base + ["--session", session_id, "--db", str(db_path)]
+
+    proc = _run_cli(cmd, log_dir)
+    assert proc.returncode == 0, proc.stderr
+    with sqlite3.connect(db_path) as con:
+        count = con.execute(
+            "SELECT COUNT(*) FROM session_events WHERE session_id=?",
+            (session_id,),
+        ).fetchone()[0]
+    assert count == len(events)
+
+    proc2 = _run_cli(cmd, log_dir)
+    assert proc2.returncode == 0, proc2.stderr
+    with sqlite3.connect(db_path) as con:
+        count2 = con.execute(
+            "SELECT COUNT(*) FROM session_events WHERE session_id=?",
+            (session_id,),
+        ).fetchone()[0]
+    assert count2 == len(events)

--- a/tests/test_session_query_cli.py
+++ b/tests/test_session_query_cli.py
@@ -1,0 +1,40 @@
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_session_query_cli(tmp_path):
+    db = tmp_path / "events.db"
+    con = sqlite3.connect(str(db))
+    con.execute(
+        "CREATE TABLE session_events(timestamp TEXT, session_id TEXT, role TEXT, message TEXT)"
+    )
+    rows = [
+        ("2025-01-01T00:00:00Z", "S1", "user", "hi"),
+        ("2025-01-01T00:00:01Z", "S1", "assistant", "yo"),
+    ]
+    con.executemany("INSERT INTO session_events VALUES (?,?,?,?)", rows)
+    con.commit()
+    con.close()
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "codex.logging.session_query",
+        "--session-id",
+        "S1",
+        "--db",
+        str(db),
+    ]
+    env = os.environ.copy()
+    src_dir = Path(__file__).resolve().parents[1] / "src"
+    env["PYTHONPATH"] = os.pathsep.join([str(src_dir), env.get("PYTHONPATH", "")])
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    assert proc.returncode == 0, proc.stderr
+    lines = proc.stdout.strip().splitlines()
+    assert lines[0].split("\t") == ["timestamp", "session_id", "role", "message"]
+    assert lines[1].endswith("\thi")
+    assert lines[2].endswith("\tyo")
+    assert len(lines) == 3


### PR DESCRIPTION
## Summary
- test codex-import-ndjson CLI and idempotent ingestion
- verify session_query CLI outputs expected rows
- tighten ChatSession log count expectations

## Testing
- `pre-commit run --all-files` *(fails: files were modified by local-pytest)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62790955083319de6da8fd6a66d67