### PR TITLE
Add session query CLI test and refine chat session log expectations

### DIFF
--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -23,7 +23,7 @@ def test_chat_session_logs_and_env(tmp_path, monkeypatch):
         assert os.getenv("CODEX_SESSION_ID") == "env-session"
         chat.log_user(messages[0])
         chat.log_assistant(messages[1])
-    expected_rows = 2 + len(messages)  # start/end + one per message
+    expected_rows = len(messages) + 2  # 2 for start/end, one row per message
     assert _count(db) == expected_rows
     assert os.getenv("CODEX_SESSION_ID") is None
 


### PR DESCRIPTION
## Summary
- add test covering `codex.logging.session_query` CLI with a temporary SQLite database
- simplify chat session test to expect one database row per message plus start/end

## Testing
- `SKIP=end-of-file-fixer,local-pytest pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a62d84568c83319acc8505e7fbcad5