### PR TITLE
Run tests in tox via pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@
 .codex/*.ndjson
 *.sqlite
 .codex/session_logs.db
+
+# Test artifacts
+.coverage
+.pytest_cache/
+**/__pycache__/
+.tox/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,6 @@ repos:
     hooks:
       - id: local-pytest
         name: local-pytest
-        entry: pytest -q
+        entry: scripts/pre-commit-pytest.sh
         language: system
         pass_filenames: false

--- a/scripts/pre-commit-pytest.sh
+++ b/scripts/pre-commit-pytest.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# temporary directory for isolated test run
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+    rm -f "$TMP_DIR/.coverage" .coverage 2>/dev/null || true
+    rm -rf "$TMP_DIR/.pytest_cache" .pytest_cache 2>/dev/null || true
+    find "$TMP_DIR" . -type d -name "__pycache__" -prune -exec rm -rf {} + 2>/dev/null || true
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+# copy repository excluding .git directory
+rsync -a --exclude '.git' . "$TMP_DIR"/
+
+(
+    cd "$TMP_DIR"
+    PYTHONDONTWRITEBYTECODE=1 COVERAGE_FILE=/tmp/coverage tox -q -e py
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py
+skipsdist = true
+
+[testenv]
+deps =
+    pytest
+    duckdb>=0.10
+commands = pytest -q --cache-clear


### PR DESCRIPTION
## Summary
- run tests in isolated temp dir via `scripts/pre-commit-pytest.sh`
- invoke tox `py` environment from pre-commit
- ignore test artifacts and tox build outputs

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6322ffb6883318b09d9b0bd55b481