### PR TITLE
Adjust expected log record counts

### DIFF
--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -23,7 +23,7 @@ def test_chat_session_logs_and_env(tmp_path, monkeypatch):
         assert os.getenv("CODEX_SESSION_ID") == "env-session"
         chat.log_user(messages[0])
         chat.log_assistant(messages[1])
-    expected_rows = len(messages) + 2  # 2 for start/end, one row per message
+    expected_rows = 2 + len(messages)  # start/end plus one row per message
     assert _count(db) == expected_rows
     assert os.getenv("CODEX_SESSION_ID") is None
 

--- a/tests/test_conversation_logger.py
+++ b/tests/test_conversation_logger.py
@@ -15,8 +15,10 @@ def _count(db):
 def test_wrapper_logs_messages(tmp_path):
     db = tmp_path / "conv.db"
     sid = "wrapper-session"
+    messages = ["hi", "yo"]
     start_session(sid, db_path=str(db))
-    log_message(sid, "user", "hi", db_path=str(db))
-    log_message(sid, "assistant", "yo", db_path=str(db))
+    log_message(sid, "user", messages[0], db_path=str(db))
+    log_message(sid, "assistant", messages[1], db_path=str(db))
     end_session(sid, db_path=str(db))
-    assert _count(db) == 4
+    expected_rows = 2 + len(messages)  # start/end plus one row per message
+    assert _count(db) == expected_rows


### PR DESCRIPTION
## Summary
- align ChatSession test with start/end plus one entry per message
- compute expected row counts in conversation logger test

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a64157dde8833198a9efd4c51b7172