### PR TITLE
chore: clean pytest artifacts in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,8 +42,8 @@ repos:
 
   - repo: local
     hooks:
-      - id: tox-tests
-        name: tox-tests
-        entry: bash -c "tox -q -e py && rm -rf .artifacts parquet && git show HEAD:.codex/action_log.ndjson > .codex/action_log.ndjson"
+      - id: local-pytest
+        name: local-pytest
+        entry: scripts/pre-commit-pytest.sh
         language: system
         pass_filenames: false

--- a/scripts/pre-commit-pytest.sh
+++ b/scripts/pre-commit-pytest.sh
@@ -9,4 +9,5 @@ cleanup() {
 }
 trap cleanup EXIT
 
-pytest -q
+export PYTHONDONTWRITEBYTECODE=1
+pytest -q -p no:cacheprovider


### PR DESCRIPTION
## Summary
- replace tox pre-commit hook with local-pytest using cleanup script
- prevent pytest artifacts by disabling cache and bytecode generation

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a61fdacdd083318a2bdf809d1fecae