### PR TITLE
Add sequence numbers and metadata to session logging

### DIFF
--- a/ci_local.sh
+++ b/ci_local.sh
@@ -4,3 +4,11 @@ set -euo pipefail
 pre-commit run --all-files
 pytest
 python -m build -n
+mypy src
+tmpdir=$(mktemp -d)
+python -m venv "$tmpdir/venv"
+. "$tmpdir/venv/bin/activate"
+pip install . >/dev/null
+python -c 'import codex'
+deactivate
+rm -rf "$tmpdir"

--- a/documentation/end_to_end_logging.md
+++ b/documentation/end_to_end_logging.md
@@ -4,7 +4,9 @@ This guide describes the environment variables and the start→message→end log
 
 ## 1) Environment
 
-* **CODEX_SESSION_ID**: A UUID tying multiple invocations together.
+* **CODEX_SESSION_ID**: A UUID tying multiple invocations together. When
+  generated via ``get_session_id()``, the value is persisted back to the
+  environment for the remainder of the process.
 * **CODEX_LOG_DB_PATH**: Path to a SQLite DB (or NDJSON) where events are stored.
 
 ### Shell Setup

--- a/documentation/manual_verification_template.md
+++ b/documentation/manual_verification_template.md
@@ -2,6 +2,8 @@
 
 Use these steps to manually validate `.artifacts/snippets.db` or its derivatives. Choose one of the options below and complete the associated steps.
 
+Automated helper: `python tools/verify_data_paths.py` runs Option A and B steps and prints a Datasette Lite URL for Option C.
+
 ## Option A: SQLite CLI
 
 1. **A1** – Open the snapshot:

--- a/src/codex/logging/db_utils.py
+++ b/src/codex/logging/db_utils.py
@@ -30,6 +30,7 @@ LIKELY_MAP = {
     "message": ["message", "content", "text", "body"],
     "level": ["level", "severity", "log_level"],
     "role": ["role", "speaker", "source"],
+    "metadata": ["metadata", "meta"],
 }
 
 

--- a/src/codex/logging/session_hooks.py
+++ b/src/codex/logging/session_hooks.py
@@ -41,6 +41,7 @@ except Exception:  # pragma: no cover - best effort fallback
         role: str,
         message: str,
         db_path: pathlib.Path | None = None,
+        meta: dict[str, Any] | None = None,
     ) -> Any:  # type: ignore[no-redef]
         return None
 

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -25,6 +25,15 @@ def test_chat_session_logs_and_env(tmp_path, monkeypatch):
         chat.log_assistant(messages[1])
     expected_rows = 2 + len(messages)  # start/end plus one row per message
     assert _count(db) == expected_rows
+    with sqlite3.connect(db) as c:
+        pairs = dict(
+            c.execute(
+                "SELECT message, COUNT(*) FROM session_events "
+                "WHERE message IN ('session_start','session_end') GROUP BY message"
+            )
+        )
+    assert pairs.get("session_start") == 1
+    assert pairs.get("session_end") == 1
     assert os.getenv("CODEX_SESSION_ID") is None
 
 

--- a/tests/test_codex_maintenance.py
+++ b/tests/test_codex_maintenance.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+
+def test_codex_maintenance_summary(tmp_path):
+    code = (
+        "import sys,tools.codex_maintenance as m;"
+        "m.TASKS=[('ok',[sys.executable,'-c','import sys;sys.exit(0)']),"
+        "('fail',[sys.executable,'-c','import sys;sys.exit(1)'])];"
+        "m.main()"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    out = proc.stdout
+    assert "- ok: success" in out
+    assert "- fail: failure" in out
+    assert proc.returncode != 0

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -13,10 +13,12 @@ def test_export_session(tmp_path, monkeypatch):
     with sqlite3.connect(db) as c:
         c.execute(
             "CREATE TABLE session_events("
-            "session_id TEXT, timestamp TEXT, role TEXT, message TEXT)"
+            "session_id TEXT, timestamp TEXT, role TEXT, "
+            "message TEXT, seq INTEGER, meta TEXT)"
         )
         c.executemany(
-            "INSERT INTO session_events VALUES (?,?,?,?)",
+            "INSERT INTO session_events(session_id, timestamp, role, message) "
+            "VALUES (?,?,?,?)",
             [
                 ("s1", "2024-01-01T00:00:00", "user", "hi"),
                 ("s1", "2024-01-01T00:01:00", "assistant", "hello"),

--- a/tests/test_import_ndjson_dedup.py
+++ b/tests/test_import_ndjson_dedup.py
@@ -1,0 +1,35 @@
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+from src.codex.logging import import_ndjson, session_hooks
+from src.codex.logging.session_hooks import session
+
+
+def test_importer_deduplicates_start_end(tmp_path, monkeypatch):
+    log_dir = tmp_path / "sessions"
+    db_path = tmp_path / "logs.db"
+    monkeypatch.setenv("CODEX_SESSION_LOG_DIR", str(log_dir))
+    monkeypatch.setenv("CODEX_LOG_DB_PATH", str(db_path))
+    monkeypatch.setattr(session_hooks, "LOG_DIR", log_dir)
+    session_hooks.LOG_DIR.mkdir(parents=True, exist_ok=True)
+    with session() as s:
+        sid = s.sid
+    # reimport should not duplicate start/end
+    count_before = sqlite3.connect(db_path).execute(
+        "SELECT COUNT(*) FROM session_events"
+    ).fetchone()[0]
+    import_ndjson.import_session(sid, log_dir=log_dir, db_path=db_path)
+    with sqlite3.connect(db_path) as con:
+        rows = con.execute(
+            "SELECT message, COUNT(*) FROM session_events WHERE message IN ('session_start','session_end') GROUP BY message"
+        ).fetchall()
+    pairs = dict(rows)
+    assert pairs.get("session_start") == 1
+    assert pairs.get("session_end") == 1
+    # ensure no extra rows created beyond original two
+    total = sqlite3.connect(db_path).execute(
+        "SELECT COUNT(*) FROM session_events"
+    ).fetchone()[0]
+    assert total == count_before

--- a/tests/test_ndjson_db_parity.py
+++ b/tests/test_ndjson_db_parity.py
@@ -1,0 +1,32 @@
+import json
+from datetime import datetime
+
+from src.codex.logging import import_ndjson, session_hooks
+from src.codex.logging.fetch_messages import fetch_messages
+from src.codex.logging.session_hooks import session
+
+
+def test_ndjson_matches_db(tmp_path, monkeypatch):
+    log_dir = tmp_path / "sessions"
+    db_path = tmp_path / "logs.db"
+    monkeypatch.setenv("CODEX_SESSION_LOG_DIR", str(log_dir))
+    monkeypatch.setenv("CODEX_LOG_DB_PATH", str(db_path))
+    monkeypatch.setattr(session_hooks, "LOG_DIR", log_dir)
+    session_hooks.LOG_DIR.mkdir(parents=True, exist_ok=True)
+    with session() as s:
+        sid = s.sid
+    ndjson = log_dir / f"{sid}.ndjson"
+    now = datetime.utcnow().isoformat() + "Z"
+    with ndjson.open("a", encoding="utf-8") as f:
+        f.write(json.dumps({"ts": now, "role": "user", "message": "hi"}) + "\n")
+        f.write(
+            json.dumps({"ts": now, "role": "assistant", "message": "yo"}) + "\n"
+        )
+    import_ndjson.import_session(sid, log_dir=log_dir, db_path=db_path)
+    with ndjson.open() as f:
+        lines = [json.loads(line) for line in f if line.strip()]
+    rows = fetch_messages(sid, db_path=db_path)
+    assert len(lines) == len(rows)
+    assert [r["message"] for r in rows] == [
+        l.get("message") or l.get("type") for l in lines
+    ]

--- a/tests/test_query_logs_tail.py
+++ b/tests/test_query_logs_tail.py
@@ -13,12 +13,15 @@ def test_tail_option(tmp_path):
             session_id TEXT,
             timestamp TEXT,
             role TEXT,
-            message TEXT
+            message TEXT,
+            seq INTEGER,
+            meta TEXT
         )
         """
     )
     con.executemany(
-        "INSERT INTO session_events VALUES (?,?,?,?)",
+        "INSERT INTO session_events(session_id, timestamp, role, message) "
+        "VALUES (?,?,?,?)",
         [
             ("S1", "2025-01-01T00:00:00Z", "user", "first"),
             ("S1", "2025-01-01T00:00:01Z", "assistant", "second"),

--- a/tests/test_session_logging.py
+++ b/tests/test_session_logging.py
@@ -224,7 +224,8 @@ def test_cli_query_returns_expected_rows(tmp_path, monkeypatch):
     cur = con.cursor()
     cur.execute(
         "CREATE TABLE session_events ("
-        "session_id TEXT, timestamp TEXT, role TEXT, message TEXT)"
+        "session_id TEXT, timestamp TEXT, role TEXT, message TEXT, "
+        "seq INTEGER, meta TEXT)"
     )
     con.commit()
     data = [
@@ -232,7 +233,11 @@ def test_cli_query_returns_expected_rows(tmp_path, monkeypatch):
         ("A", "2025-01-01T00:00:01Z", "assistant", "hey"),
         ("B", "2025-01-01T00:00:02Z", "user", "bye"),
     ]
-    cur.executemany("INSERT INTO session_events VALUES (?,?,?,?)", data)
+    cur.executemany(
+        "INSERT INTO session_events(session_id, timestamp, role, message) "
+        "VALUES (?,?,?,?)",
+        data,
+    )
     con.commit()
     con.close()
 

--- a/tests/test_session_query_cli.py
+++ b/tests/test_session_query_cli.py
@@ -10,10 +10,12 @@ def test_session_query_cli(tmp_path):
     with sqlite3.connect(db) as con:
         con.execute(
             "CREATE TABLE session_events("
-            "timestamp TEXT, session_id TEXT, role TEXT, message TEXT)"
+            "timestamp TEXT, session_id TEXT, role TEXT, "
+            "message TEXT, seq INTEGER, meta TEXT)"
         )
         con.executemany(
-            "INSERT INTO session_events VALUES (?,?,?,?)",
+            "INSERT INTO session_events(timestamp, session_id, role, message) "
+            "VALUES (?,?,?,?)",
             [
                 ("2025-01-01T00:00:00Z", "S1", "user", "hi"),
                 ("2025-01-01T00:00:01Z", "S1", "assistant", "yo"),

--- a/tests/test_session_query_smoke.py
+++ b/tests/test_session_query_smoke.py
@@ -18,10 +18,11 @@ def test_cli_smoke(tmp_path):
     con.execute(
         "CREATE TABLE session_events("  #
         "session_id TEXT, timestamp TEXT, "
-        "role TEXT, message TEXT)"
+        "role TEXT, message TEXT, seq INTEGER, meta TEXT)"
     )
     con.executemany(
-        "INSERT INTO session_events VALUES (?,?,?,?)",
+        "INSERT INTO session_events(session_id, timestamp, role, message) "
+        "VALUES (?,?,?,?)",
         [
             ("S1", "2025-01-01T00:00:00Z", "user", "hi"),
             ("S1", "2025-01-01T00:00:01Z", "assistant", "yo"),

--- a/tools/verify_data_paths.py
+++ b/tools/verify_data_paths.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Automate Option A/B data-path verification steps.
+
+Runs the snapshot builder and Parquet exporter, then prints a Datasette Lite URL
+for manual inspection (Option C).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    snap = ROOT / "tools" / "build_sqlite_snapshot.py"
+    parq = ROOT / "tools" / "export_to_parquet.py"
+    try:
+        subprocess.check_call([sys.executable, str(snap)])
+        subprocess.check_call([sys.executable, str(parq)])
+    except subprocess.CalledProcessError as exc:
+        print(f"Verification failed: {exc}")
+        return 1
+    db_path = ROOT / ".artifacts" / "snippets.db"
+    url = f"https://lite.datasette.io/?url={db_path.as_uri()}"
+    print("Datasette Lite URL:")
+    print(url)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- extend session logging schema with `seq` and `meta` columns and persist generated session IDs
- enhance NDJSON importer with SQLite pragmas, deduplication, and metadata upsert
- expose optional `--show-meta` in `query_logs` and expand local CI tooling

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a55e5a52148331bbe71f7b609a3a61