### PR TITLE
feat: scaffold ingestion package

### DIFF
--- a/.codex/change_log.md
+++ b/.codex/change_log.md
@@ -10679,3 +10679,52 @@ index 80d2f41..ec056e7 100644
 +
  ## Usage
 ````
+
+## feat: scaffold ingestion package
+
+- **src/ingestion/__init__.py** — *add*
+  Rationale: Introduce placeholder Ingestor class for future data ingestion.
+```diff
++"""Ingestion package with placeholder class."""
++
++from __future__ import annotations
++
++
++class Ingestor:
++    """Placeholder class for data ingestion logic."""
++
++    def __init__(self) -> None:
++        """Initialize a new :class:`Ingestor` instance."""
++        # Placeholder implementation
++        pass
+```
+
+- **src/ingestion/README.md** — *add*
+  Rationale: Document ingestion package purpose and status.
+```diff
++# Ingestion Package
++
++The `ingestion` package will host data ingestion utilities.
++
++Currently, it contains a placeholder :class:`Ingestor` class defined in
++`__init__.py`. The class has no behavior yet but will be expanded to
++support various data ingestion pipelines.
++
++## Status
++
++This module is scaffolded and not yet functional. Future updates will
++implement ingestion logic and accompanying tests.
+```
+
+- **tests/test_ingestion_placeholder.py** — *add*
+  Rationale: Verify Ingestor class can be imported and instantiated.
+```diff
++from ingestion import Ingestor
++
++
++def test_ingestor_placeholder() -> None:
++    ingest = Ingestor()
++    assert isinstance(ingest, Ingestor)
++    assert Ingestor.__doc__ is not None
++    assert "placeholder" in Ingestor.__doc__.lower()
+```

--- a/.codex/mapping.md
+++ b/.codex/mapping.md
@@ -8,3 +8,10 @@
 - **T2:** Extract logic into reusable helper → `scripts/session_logging.sh`, `codex/logging/session_hooks.py`
 - **T3:** Source/import helper in launch scripts → `entrypoint.sh`, `scripts/smoke_query_logs.sh`, `src/codex/logging/*`
 - **T4:** Add regression test asserting start/end events → `tests/test_session_hooks.py`
+
+- **Scaffold ingestion package __init__ with Ingestor class** → ['src/ingestion/__init__.py']
+  Rationale: Define placeholder Ingestor class for future ingestion logic.
+- **Add ingestion README documentation** → ['src/ingestion/README.md']
+  Rationale: Document purpose and status of ingestion package.
+- **Add ingestion placeholder test** → ['tests/test_ingestion_placeholder.py']
+  Rationale: Ensure Ingestor can be imported and instantiated.

--- a/.codex/results.md
+++ b/.codex/results.md
@@ -61,3 +61,11 @@ local-pytest.............................................................Passed
 ### Test results (pytest)
 Exit code: 0
 48 passed, 2 skipped, 2 xfailed in 1.69s
+
+## Ingestion Scaffold
+- Clean working tree before commit: True
+- DO_NOT_ACTIVATE_GITHUB_ACTIONS sentinel present: True
+- Created `src/ingestion/__init__.py`, `src/ingestion/README.md`, and `tests/test_ingestion_placeholder.py`.
+- pre-commit run on new files: Passed
+- mypy on new files: Passed (global run reports duplicate module `codex_workflow`)
+- pytest: 66 passed, 2 skipped, 1 xfailed

--- a/src/ingestion/README.md
+++ b/src/ingestion/README.md
@@ -1,0 +1,12 @@
+# Ingestion Package
+
+The `ingestion` package will host data ingestion utilities.
+
+Currently, it contains a placeholder :class:`Ingestor` class defined in
+`__init__.py`. The class has no behavior yet but will be expanded to
+support various data ingestion pipelines.
+
+## Status
+
+This module is scaffolded and not yet functional. Future updates will
+implement ingestion logic and accompanying tests.

--- a/src/ingestion/__init__.py
+++ b/src/ingestion/__init__.py
@@ -1,0 +1,12 @@
+"""Ingestion package with placeholder class."""
+
+from __future__ import annotations
+
+
+class Ingestor:
+    """Placeholder class for data ingestion logic."""
+
+    def __init__(self) -> None:
+        """Initialize a new :class:`Ingestor` instance."""
+        # Placeholder implementation
+        pass

--- a/tests/test_ingestion_placeholder.py
+++ b/tests/test_ingestion_placeholder.py
@@ -1,0 +1,8 @@
+from ingestion import Ingestor
+
+
+def test_ingestor_placeholder() -> None:
+    ingest = Ingestor()
+    assert isinstance(ingest, Ingestor)
+    assert Ingestor.__doc__ is not None
+    assert "placeholder" in Ingestor.__doc__.lower()


### PR DESCRIPTION
## Summary
- add ingestion package with placeholder `Ingestor` class
- document ingestion module
- include basic ingestion placeholder test and update codex logs

## Testing
- `pre-commit run --files src/ingestion/__init__.py src/ingestion/README.md tests/test_ingestion_placeholder.py`
- `mypy --ignore-missing-imports src/ingestion/__init__.py tests/test_ingestion_placeholder.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6bdc9a8a483319df0679e16f6b6af