### PR TITLE
Implement file-based ingestion and tests

### DIFF
--- a/src/ingestion/README.md
+++ b/src/ingestion/README.md
@@ -1,3 +1,24 @@
 # Ingestion Module
 
-This module is intended for data ingestion functionality. The `Ingestor` class is currently a placeholder and will be implemented in the future.
+Provides a minimal :class:`Ingestor` utility for reading text from files. The
+current implementation focuses solely on filesystem paths and is designed to be
+extended with additional data sources in the future.
+
+## Usage
+
+```python
+from ingestion import Ingestor
+
+ingestor = Ingestor()
+text = ingestor.ingest("path/to/file.txt")
+```
+
+## Expected Errors
+
+- `FileNotFoundError` – raised when the supplied path does not exist or is not
+  a file.
+
+## Future Extensions
+
+Potential future work includes support for streaming sources, remote URLs, or
+data validation hooks.

--- a/src/ingestion/__init__.py
+++ b/src/ingestion/__init__.py
@@ -1,15 +1,41 @@
-"""
-Ingestion module scaffold.
+"""Basic file ingestion utilities.
 
-This module defines the `Ingestor` class for future data ingestion functionality.
+This module defines the :class:`Ingestor` class which provides a small helper
+for reading textual data from files.  The implementation is intentionally
+minimal and serves as a starting point for future ingestion features.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Union
+
 
 class Ingestor:
-    """Placeholder ingestor class for data ingestion."""
+    """Simple ingestor that reads text from files."""
 
-    def ingest(self, source: str) -> None:
-        """Ingest data from the given source. (To be implemented)"""
-        raise NotImplementedError("Ingestor.ingest is not implemented yet")
+    def ingest(self, path: Union[str, Path]) -> str:
+        """Read and return text content from a file.
+
+        Parameters
+        ----------
+        path:
+            Filesystem path to a text file.
+
+        Returns
+        -------
+        str
+            The textual contents of the file.
+
+        Raises
+        ------
+        FileNotFoundError
+            If ``path`` does not exist or is not a regular file.
+        OSError
+            If the file exists but cannot be read.
+        """
+
+        file_path = Path(path)
+        if not file_path.is_file():
+            raise FileNotFoundError(f"No such file: {file_path}")
+        return file_path.read_text()

--- a/tests/test_ingestion_io.py
+++ b/tests/test_ingestion_io.py
@@ -1,0 +1,27 @@
+"""Tests for file-based ingestion."""
+
+from pathlib import Path
+
+import pytest
+
+from ingestion import Ingestor
+
+
+def test_ingest_reads_file(tmp_path: Path) -> None:
+    """Ingestor.ingest should return the contents of a text file."""
+
+    file_path = tmp_path / "example.txt"
+    file_path.write_text("hello world")
+
+    ingestor = Ingestor()
+    assert ingestor.ingest(file_path) == "hello world"
+
+
+def test_ingest_missing_file(tmp_path: Path) -> None:
+    """Ingestor.ingest should raise FileNotFoundError for missing files."""
+
+    missing_path = tmp_path / "missing.txt"
+    ingestor = Ingestor()
+
+    with pytest.raises(FileNotFoundError):
+        ingestor.ingest(missing_path)


### PR DESCRIPTION
## Summary
- implement `Ingestor.ingest` to read text from file paths
- document ingestion usage, errors, and future extensions
- add tests covering successful reads and missing files

## Testing
- `ruff check src/ingestion/__init__.py tests/test_ingestion_io.py`
- `python -m black --check src/ingestion/__init__.py tests/test_ingestion_io.py`
- `pytest -q`
- ⚠️ `pre-commit run --all-files` *(failed: Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_e_68a76b46a64483319edd77c1ffc094a0