### PR TITLE
Add Codex setup utility and log documentation

### DIFF
--- a/.codex/change_log.md
+++ b/.codex/change_log.md
@@ -12665,3 +12665,6 @@ index a128dd0..39c53ae 100644
 +    ):
 +        return ingest(path, encoding=encoding, chunk_size=chunk_size)
 ```
+- 2025-08-21T23:17:38Z Initialized/verified .codex/ and log files (append-only guarantees).
+
+- 2025-08-21T23:34:11Z Document Codex scripts in README

--- a/.codex/errors.ndjson
+++ b/.codex/errors.ndjson
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:642d2214fb527037f04d43a41bcbf94e331fd74c3cd49f93f0a2174d7b773e9d
-size 1751

--- a/.codex/results.md
+++ b/.codex/results.md
@@ -208,3 +208,8 @@ Exit code: 0
 
 ## Final Notes
 - **DO NOT ACTIVATE ANY GitHub Actions files.**
+
+## 2025-08-21T23:17:38Z — Setup Summary
+Initialized .codex and seeded files.
+
+- 2025-08-21T23:34:15Z Documented Codex scripts section in README

--- a/README.md
+++ b/README.md
@@ -466,3 +466,13 @@ View the snapshot in your browser with [Datasette Lite](https://lite.datasette.i
 `ingestion.ingest` and its `Ingestor.ingest` shim now accept an optional
 `encoding` argument. Pass `"auto"` to trigger best-effort autodetection or
 specify an explicit codec (default `"utf-8"`).
+
+## Codex Logs
+- `.codex/change_log.md`: human-readable changes
+- `.codex/errors.ndjson`: NDJSON (one JSON object per line)
+- `.codex/results.md`: summaries/results
+
+## Codex Scripts
+- `codex_setup.py`: initialize and manage append-only logs under `.codex/`
+- `codex_script.py`: sample CLI demonstrating safe file patching and tool validations
+- `codex_workflow.py`: end-to-end workflow performing best-effort edits and logging

--- a/codex_setup.py
+++ b/codex_setup.py
@@ -1,379 +1,257 @@
-import os, sys, json, re, subprocess
-from pathlib import Path
-from datetime import datetime
+#!/usr/bin/env python3
+"""
+Codex .codex/ bootstrapper & append-only writer.
 
-# Phase 1: Preparation – setup paths, ensure logs, check clean state, initial inventory
-REPO_ROOT = Path(__file__).resolve().parent  # assume script placed at repo root
+- Creates `.codex/` and seeds:
+  - change_log.md       -> "# Codex Change Log"
+  - errors.ndjson       -> (empty, NDJSON/JSON Lines)
+  - results.md          -> "# Codex Results"
+- Guarantees append-only behavior:
+  - Prefers POSIX O_APPEND for atomic appends (multi-process safe) [open(2)].
+  - Falls back to text append mode "a" cross-platform.
+
+Refs:
+- NDJSON / JSON Lines: jsonlines.org, ndjson-spec (newline-delimited JSON).
+- Append-only semantics: POSIX O_APPEND (open(2)).
+
+DO NOT ACTIVATE ANY GitHub Actions files. ALL GitHub Action.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path.cwd()
 CODEX_DIR = REPO_ROOT / ".codex"
 CHANGE_LOG = CODEX_DIR / "change_log.md"
-ERRORS_LOG = CODEX_DIR / "errors.ndjson"
-RESULTS_LOG = CODEX_DIR / "results.md"
-INVENTORY_JSON = CODEX_DIR / "inventory.json"
+ERRORS_NDJSON = CODEX_DIR / "errors.ndjson"
+RESULTS_MD = CODEX_DIR / "results.md"
+README_MD = REPO_ROOT / "README.md"
+
 
 def now_iso() -> str:
-    """Current UTC timestamp in ISO-8601 format (Z)."""
     return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
 
-# Ensure .codex directory and log files exist
-CODEX_DIR.mkdir(parents=True, exist_ok=True)
-if not CHANGE_LOG.exists():
-    CHANGE_LOG.write_text("# Codex Change Log\n\n", encoding="utf-8")
-if not ERRORS_LOG.exists():
-    ERRORS_LOG.write_text("", encoding="utf-8")
-if not RESULTS_LOG.exists():
-    RESULTS_LOG.write_text("", encoding="utf-8")
 
-# Check for clean git working tree (best-effort)
-try:
-    dirty_status = subprocess.check_output(["git", "status", "--porcelain"], cwd=str(REPO_ROOT))
-    dirty = dirty_status.decode().strip()
-except Exception as e:
-    dirty = ""
-    # Record error but continue
-    msg = f"git status failed: {e}"
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "1: Preparation - git status", "error": msg, "context": "Ensure Git repository is initialized"}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [1: Preparation - git status], encountered the following error:\n{msg}\nContext: Ensure Git repository is initialized\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
-if dirty:
-    # Log error and continue without aborting
-    msg = "Working tree is not clean (uncommitted changes present)"
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "1: Preparation - clean check", "error": msg, "context": dirty}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [1: Preparation - clean check], encountered the following error:\n{msg}\nContext: {dirty}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
+def _posix_append_bytes(path: Path, data: bytes) -> None:
+    """
+    POSIX-safe append using O_APPEND for atomic end-of-file writes.
+    Falls back to text append if O_APPEND not available.
+    """
+    flags = getattr(os, "O_APPEND", None)
+    if flags is None or os.name == "nt":
+        # Fallback: text append (not guaranteed atomic across processes)
+        with open(path, "ab") as f:
+            f.write(data)
+        return
+    # POSIX path
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
 
-# Build initial inventory of files
-items = []
-for p in REPO_ROOT.rglob("*"):
-    if p.is_file() and ".git" not in p.parts:
-        rel_path = str(p.relative_to(REPO_ROOT))
-        try:
-            size = p.stat().st_size
-        except Exception:
-            size = 0
-        # Classify role
-        ext = p.suffix.lower()
-        if ext in {".py", ".sh", ".js", ".ts", ".tsx", ".jsx", ".sql"}:
-            role = "code"
-        elif ext in {".md", ".rst"}:
-            role = "doc"
-        elif "pre-commit" in p.name or ext in {".yml", ".yaml", ".toml", ".ini"}:
-            role = "config"
-        else:
-            role = "asset"
-        # Compute SHA-256 if possible (ignore decode errors)
-        try:
-            text = p.read_text(encoding="utf-8", errors="ignore")
-            import hashlib
-            sha_val = hashlib.sha256(text.encode("utf-8")).hexdigest()
-        except Exception:
-            sha_val = None
-        items.append({"path": rel_path, "size": size, "role": role, "sha256": sha_val})
-INVENTORY_JSON.write_text(json.dumps(items, indent=2), encoding="utf-8")
 
-# Phase 2: Search & Mapping – locate files and prepare modification plan
-# Define file paths for modifications
-INGESTION_DIR = REPO_ROOT / "src" / "ingestion"
-INGESTOR_PY = INGESTION_DIR / "__init__.py"
-TEST_INGESTION = REPO_ROOT / "tests" / "test_ingestion_placeholder.py"
-INGESTION_README = REPO_ROOT / "src" / "ingestion" / "README.md"
-PRECOMMIT_CFG = REPO_ROOT / ".pre-commit-config.yaml"
-CONTRIBUTING_MD = REPO_ROOT / "CONTRIBUTING.md"
-README_MD = REPO_ROOT / "README.md"
-SESSION_LOGGER_PY = REPO_ROOT / "src" / "codex" / "logging" / "session_logger.py"
-VIEWER_PY = REPO_ROOT / "src" / "codex" / "logging" / "viewer.py"
-CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
-BUILD_WORKFLOW_DISABLED = REPO_ROOT / ".github" / "workflows" / "build-image.yml.disabled"
+def append_line(path: Path, line: str) -> None:
+    if not line.endswith("\n"):
+        line += "\n"
+    _posix_append_bytes(path, line.encode("utf-8"))
 
-# Check existence of key files (report if missing)
-if not VIEWER_PY.exists():
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "2: Locate viewer.py", "error": "File not found", "context": str(VIEWER_PY)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [2: Search & Mapping - locate viewer.py], encountered the following error:\nFile not found\nContext: {VIEWER_PY}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
-if not SESSION_LOGGER_PY.exists():
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "2: Locate session_logger.py", "error": "File not found", "context": str(SESSION_LOGGER_PY)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [2: Search & Mapping - locate session_logger.py], encountered the following error:\nFile not found\nContext: {SESSION_LOGGER_PY}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
-if not PRECOMMIT_CFG.exists():
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "2: Locate pre-commit config", "error": "File not found", "context": str(PRECOMMIT_CFG)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [2: Search & Mapping - locate pre-commit config], encountered the following error:\nFile not found\nContext: {PRECOMMIT_CFG}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
-# The ingestion directory may not exist yet (we will create it), no need to log error for that.
-if not (REPO_ROOT / ".github" / "workflows").exists():
-    (REPO_ROOT / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
-if not BUILD_WORKFLOW_DISABLED.exists():
-    # If build-image disabled workflow is missing, still proceed (maybe already unified or not present)
-    pass
 
-# Phase 3: Best-Effort Construction – implement tasks step by step
-
-# --- Create src/ingestion/ scaffold with Ingestor class
-try:
-    INGESTION_DIR.mkdir(parents=True, exist_ok=True)
-    ingestor_code = '''"""
-Ingestion module scaffold.
-
-This module defines the `Ingestor` class for future data ingestion functionality.
-"""
-class Ingestor:
-    """Placeholder ingestor class for data ingestion."""
-    def ingest(self, source: str) -> None:
-        """Ingest data from the given source. (To be implemented)"""
-        raise NotImplementedError("Ingestor.ingest is not implemented yet")
-'''
-before = INGESTOR_PY.read_text(encoding="utf-8") if INGESTOR_PY.exists() else ""
-    INGESTOR_PY.write_text(ingestor_code, encoding="utf-8")
-    # Log file creation
-    diff = "\n".join(list(re.sub("^", "", line) for line in ingestor_code.splitlines()))
-    CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {INGESTOR_PY.relative_to(REPO_ROOT)}\n- **Action:** {'edit' if before else 'create'}\n- **Rationale:** Add ingestion module scaffold\n```diff\n{diff}\n```\n\n")
-except Exception as e:
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.1: Ingestion scaffold", "error": str(e), "context": str(INGESTOR_PY)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.1: Ingestion scaffold], encountered the following error:\n{e}\nContext: file={INGESTOR_PY}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
-
-# --- Create tests/test_ingestion_placeholder.py (placeholder test)
-try:
-    TEST_INGESTION.parent.mkdir(parents=True, exist_ok=True)
-    test_content = '''import pytest
-pytest.skip("Ingestor not implemented yet", allow_module_level=True)
-'''
-    before = TEST_INGESTION.read_text(encoding="utf-8") if TEST_INGESTION.exists() else ""
-    TEST_INGESTION.write_text(test_content, encoding="utf-8")
-    diff = "\n".join(list(re.sub("^", "", line) for line in test_content.splitlines()))
-    CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {TEST_INGESTION.relative_to(REPO_ROOT)}\n- **Action:** {'edit' if before else 'create'}\n- **Rationale:** Add placeholder ingestion test\n```diff\n{diff}\n```\n\n")
-except Exception as e:
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.2: Ingestion test", "error": str(e), "context": str(TEST_INGESTION)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.2: Ingestion placeholder test], encountered the following error:\n{e}\nContext: file={TEST_INGESTION}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
-
-# --- Create src/ingestion/README.md (placeholder documentation)
-try:
-    readme_content = "# Ingestion Module\n\nThis module is intended for data ingestion functionality. The `Ingestor` class is currently a placeholder and will be implemented in the future.\n"
-    before = INGESTION_README.read_text(encoding="utf-8") if INGESTION_README.exists() else ""
-    INGESTION_README.write_text(readme_content, encoding="utf-8")
-    diff = "\n".join(list(re.sub("^", "", line) for line in readme_content.splitlines()))
-    CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {INGESTION_README.relative_to(REPO_ROOT)}\n- **Action:** {'edit' if before else 'create'}\n- **Rationale:** Add ingestion module README\n```diff\n{diff}\n```\n\n")
-except Exception as e:
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.3: Ingestion README", "error": str(e), "context": str(INGESTION_README)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.3: Ingestion README], encountered the following error:\n{e}\nContext: file={INGESTION_README}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
-
-# --- Ensure development tools run (ruff, mypy, pytest) – no code changes needed, just confirm environment
-# (No explicit code here; these checks will run in CI as configured. Any issues will surface in CI logs.)
-
-# --- Unify GitHub Action workflows into .github/workflows/ci.yml (include lint/type-check/tests, coverage, SAST, Docker build)
-try:
-    # Read existing CI workflow (if any) and disabled build-image workflow
-    base_ci = CI_WORKFLOW.read_text(encoding="utf-8") if CI_WORKFLOW.exists() else ""
-    build_img = BUILD_WORKFLOW_DISABLED.read_text(encoding="utf-8") if BUILD_WORKFLOW_DISABLED.exists() else ""
-    # Compose unified CI workflow content
-    ci_content = """name: CI\non:\n  workflow_dispatch:\njobs:\n  build-image:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v3\n      - name: Build Docker image\n        run: docker build -t ghcr.io/openai/codex-universal:latest .\n      - name: Push Docker image\n        env:\n          CR_PAT: ${{ secrets.GHCR_PAT }}\n        run: |\n          echo "$CR_PAT" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin\n          docker push ghcr.io/openai/codex-universal:latest\n\n  verify:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v3\n      - name: Set up Python\n        uses: actions/setup-python@v4\n        with:\n          python-version: 3.11\n      - name: Install dependencies\n        run: pip install pre-commit pytest pytest-cov click\n      - name: Run linters and tests\n        run: |\n          pre-commit run --all-files\n          pytest -q --cov=src --cov-report=html:htmlcov\n      - name: Upload coverage report\n        if: always()\n        uses: actions/upload-artifact@v3\n        with:\n          name: coverage-html\n          path: htmlcov/\n"""
-before = base_ci
-    CI_WORKFLOW.write_text(ci_content, encoding="utf-8")
-    # Show diff of unified content (for change log, summarizing differences)
-    diff = "\n".join(list(re.sub("^", "", line) for line in ci_content.splitlines()))
-    CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {CI_WORKFLOW.relative_to(REPO_ROOT)}\n- **Action:** {'edit' if before else 'create'}\n- **Rationale:** Unify CI workflows (tests, lint, build-image) into single file\n```diff\n{diff}\n```\n\n")
-    # Remove old disabled workflow if present (cleanup)
-    if BUILD_WORKFLOW_DISABLED.exists():
-        BUILD_WORKFLOW_DISABLED.unlink()
-        CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {BUILD_WORKFLOW_DISABLED.relative_to(REPO_ROOT)}\n- **Action:** delete\n- **Rationale:** Remove obsolete workflow (merged into ci.yml)\n\n")
-except Exception as e:
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.4: Unify CI workflows", "error": str(e), "context": str(CI_WORKFLOW)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.4: Unify CI workflows], encountered the following error:\n{e}\nContext: target_file={CI_WORKFLOW}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
-
-# --- Update CONTRIBUTING.md (standard checks and remove GH Actions warning)
-try:
-    contrib_text = CONTRIBUTING_MD.read_text(encoding="utf-8")
-    # Insert mypy in the checks command list if not present
-    if "mypy" not in contrib_text:
-        contrib_text = contrib_text.replace("pre-commit run --all-files\npytest", "pre-commit run --all-files\nmypy .\npytest")
-    # Remove outdated instruction about not enabling GitHub Actions
-    contrib_text = re.sub(r"(?m)^Avoid enabling GitHub Actions.*(?:\n|$)", "", contrib_text)
-    # Add note about updating secrets baseline if needed
-    if ".secrets.baseline" not in contrib_text:
-        insert_idx = contrib_text.find("## Manual Validation")
-        extra_note = ("\nIf the secret scan (detect-secrets) fails due to a false positive (and no actual secret is present), update the baseline by running:\n"
-                      "```\n$ detect-secrets scan --baseline .secrets.baseline\n```\n")
-        if insert_idx != -1:
-            contrib_text = contrib_text[:insert_idx] + extra_note + contrib_text[insert_idx:]
-        else:
-            contrib_text += "\n" + extra_note
-    before = CONTRIBUTING_MD.read_text(encoding="utf-8")
-    CONTRIBUTING_MD.write_text(contrib_text, encoding="utf-8")
-    diff = "\n".join(list(re.sub("^", "", line) for line in contrib_text.splitlines()))
-    CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {CONTRIBUTING_MD.relative_to(REPO_ROOT)}\n- **Action:** edit\n- **Rationale:** Update contributing guide for new CI and secret scanning\n```diff\n{diff}\n```\n\n")
-except Exception as e:
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.5: Update CONTRIBUTING.md", "error": str(e), "context": str(CONTRIBUTING_MD)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.5: Update CONTRIBUTING.md], encountered the following error:\n{e}\nContext: file={CONTRIBUTING_MD}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
-
-# --- Refactor CLI using click (whitelist tasks, basic validation, add tests and docs)
-try:
-    # Define new CLI module content
-    cli_py = REPO_ROOT / "src" / "codex" / "cli.py"
-    cli_content = '''"""
-Unified CLI for codex, using click for subcommands and input validation.
-"""\n\nimport click\n\nALLOWED_TASKS = {\n    "ingest": lambda: print("Ingestion scaffold created (placeholder)."),\n    "ci": lambda: print("CI workflow unified."),\n    "pool-fix": lambda: print("SQLite connection pool fix applied."),\n}\n\n@click.group()\ndef cli():\n    """Codex CLI entry point."""\n    pass\n\n@cli.command("tasks")\ndef list_tasks():\n    """List allowed maintenance tasks."""\n    for task in ALLOWED_TASKS:\n        click.echo(task)\n\n@cli.command("run")\n@click.argument("task")\ndef run_task(task):\n    """Run a whitelisted maintenance task by name."""\n    if task not in ALLOWED_TASKS:\n        click.echo(f"Task '{task}' is not allowed.", err=True)\n        sys.exit(1)\n    # Execute the allowed task\n    ALLOWED_TASKS[task]()\n'''
-before = cli_py.read_text(encoding="utf-8") if cli_py.exists() else ""
-    cli_py.parent.mkdir(parents=True, exist_ok=True)
-    cli_py.write_text(cli_content, encoding="utf-8")
-    diff = "\n".join(list(re.sub("^", "", line) for line in cli_content.splitlines()))
-    CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {cli_py.relative_to(REPO_ROOT)}\n- **Action:** {'edit' if before else 'create'}\n- **Rationale:** Add unified CLI (click) with whitelisted commands\n```diff\n{diff}\n```\n\n")
-    # Add a basic test for CLI
-    test_cli_py = REPO_ROOT / "tests" / "test_cli.py"
-    cli_test_content = '''import importlib\nfrom click.testing import CliRunner\n\ncli_module = importlib.import_module("codex.cli")\n\ndef test_cli_list_tasks():\n    runner = CliRunner()\n    result = runner.invoke(cli_module.cli, ["tasks"])\n    assert result.exit_code == 0\n    out = result.output.strip().split()\n    # Should list at least one allowed task (e.g., "ingest")\n    assert "ingest" in out\n\ndef test_cli_run_invalid():\n    runner = CliRunner()\n    result = runner.invoke(cli_module.cli, ["run", "invalid_task"])\n    assert result.exit_code != 0\n    assert "not allowed" in result.output\n\ndef test_cli_run_valid():\n    runner = CliRunner()\n    result = runner.invoke(cli_module.cli, ["run", "ingest"])\n    assert result.exit_code == 0\n    assert "Ingestion" in result.output\n'''
-before_test_cli = test_cli_py.read_text(encoding="utf-8") if test_cli_py.exists() else ""
-    test_cli_py.parent.mkdir(parents=True, exist_ok=True)
-    test_cli_py.write_text(cli_test_content, encoding="utf-8")
-    diff2 = "\n".join(list(re.sub("^", "", line) for line in cli_test_content.splitlines()))
-    CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {test_cli_py.relative_to(REPO_ROOT)}\n- **Action:** {'edit' if before_test_cli else 'create'}\n- **Rationale:** Add CLI tests for whitelisted commands\n```diff\n{diff2}\n```\n\n")
-except Exception as e:
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.6: CLI refactor (click)", "error": str(e), "context": "codex/cli.py"}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.6: CLI refactor using click], encountered the following error:\n{e}\nContext: codex/cli.py\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
-
-# --- Fix SQLite connection pool (ensure connection closed on error in session_logger.py)
-try:
-    src_text = SESSION_LOGGER_PY.read_text(encoding="utf-8")
-    # Modify _fallback_log_event to add except block
-    pattern_try = r"(\n\s*try:\n\s*conn\.execute\([^)]*\)\n\s*conn\.commit\(\))"
-    if re.search(pattern_try, src_text):
-        # Insert except block before the finally:
-        new_code = "\1\n    except Exception as e:\n        if USE_POOL:\n            try:\n                conn.close()\n            except Exception:\n                pass\n            CONN_POOL.pop(key, None)\n        raise"
-        src_text = re.sub(pattern_try, new_code, src_text)
-    # Write back changes
-    before = SESSION_LOGGER_PY.read_text(encoding="utf-8")
-    SESSION_LOGGER_PY.write_text(src_text, encoding="utf-8")
-    diff = "\n".join(list(re.sub("^", "", line) for line in src_text.splitlines()))
-    CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {SESSION_LOGGER_PY.relative_to(REPO_ROOT)}\n- **Action:** edit\n- **Rationale:** Fix SQLite connection pool (close connection on exceptions)\n```diff\n{diff}\n```\n\n")
-except Exception as e:
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.7: SQLite pool fix", "error": str(e), "context": str(SESSION_LOGGER_PY)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.7: SQLite connection pool fix], encountered the following error:\n{e}\nContext: file={SESSION_LOGGER_PY}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
-
-# --- Ensure log_event is always executed in finally (SessionLogger.__exit__)
-try:
-    src_text = SESSION_LOGGER_PY.read_text(encoding="utf-8")
-    if "def __exit__" in src_text:
-        # Replace __exit__ method implementation with try/except
-        new_exit_impl = (
-            "def __exit__(self, exc_type, exc, tb) -> None:\n"
-            "        try:\n"
-            "            if exc_type is not None:\n"
-            "                log_event(self.session_id, \"system\", f\"session_end (exc={exc_type.__name__}: {exc})\", db_path=self.db_path)\n"
-            "            else:\n"
-            "                log_event(self.session_id, \"system\", \"session_end\", db_path=self.db_path)\n"
-            "        except Exception:\n"
-            "            import logging\n"
-            "            logging.exception(\"session_end DB log failed\")\n"
-            "        return False"
+def error_capture(step_no: str, step_desc: str, err_msg: str, ctx: str = "") -> None:
+    """Write error to NDJSON and print ChatGPT-5 research question."""
+    record = {
+        "ts": now_iso(),
+        "step": f"{step_no}: {step_desc}",
+        "error": err_msg,
+        "context": ctx,
+    }
+    try:
+        append_line(ERRORS_NDJSON, json.dumps(record, ensure_ascii=False))
+    finally:
+        sys.stderr.write(
+            f"Question for ChatGPT-5 {now_iso()}:\n"
+            f"While performing [{step_no}:{step_desc}], "
+            f"encountered the following error:\n"
+            f"{err_msg}\n"
+            f"Context: {ctx}\n"
+            "What are the possible causes, and how can this be resolved "
+            "while preserving intended functionality?\n"
         )
-        src_text = re.sub(r"def __exit__\(self, exc_type, exc, tb\):\s*?(\n\s*if exc:.*?session_end.*?else:.*?session_end.*?\))", new_exit_impl, src_text, flags=re.S)
-    before = SESSION_LOGGER_PY.read_text(encoding="utf-8")
-    SESSION_LOGGER_PY.write_text(src_text, encoding="utf-8")
-    diff = "\n".join(list(re.sub("^", "", line) for line in src_text.splitlines()))
-    CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {SESSION_LOGGER_PY.relative_to(REPO_ROOT)}\n- **Action:** edit\n- **Rationale:** Ensure log_event execution on context exit (handle exceptions safely)\n```diff\n{diff}\n```\n\n")
-except Exception as e:
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.8: log_event finally", "error": str(e), "context": str(SESSION_LOGGER_PY)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.8: log_event cleanup on finally], encountered the following error:\n{e}\nContext: file={SESSION_LOGGER_PY}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
 
-# --- Table name validation in viewer CLI (already implemented previously; verify exists)
-try:
-    viewer_src = VIEWER_PY.read_text(encoding="utf-8")
-    if "_validate_table_name" not in viewer_src or '--table' not in viewer_src:
-        # (Assume previous branch added this; if missing, log a warning)
-        ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.9: Table name validation", "error": "Validation code missing", "context": "viewer.py"}) + "\n")
-        sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.9: Table name validation], encountered the following issue:\nExpected validation logic not found in viewer.py.\nContext: viewer.py might be outdated.\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
-except Exception as e:
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.9: Table name validation", "error": str(e), "context": str(VIEWER_PY)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.9: Table name validation], encountered the following error:\n{e}\nContext: file={VIEWER_PY}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
 
-# --- Deduplication and Markdown verification in docs (no duplicate sections remain; no action needed)
-# (Documentation sections already pruned of duplicates; nothing to change here.)
+def init_codex_dir() -> None:
+    # Phase 1: Preparation
+    try:
+        CODEX_DIR.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        error_capture("1.1", "Create .codex/", str(e), f"path={CODEX_DIR}")
+        raise
 
-# --- Extend .pre-commit-config.yaml with Bandit and detect-secrets hooks
-try:
-    pc_content = PRECOMMIT_CFG.read_text(encoding="utf-8")
-    indent = "  "  # list items are 2-space indented under 'repos:'
-    bandit_block = '- repo: https://github.com/PyCQA/bandit\n  rev: 1.7.4\n  hooks:\n    - id: bandit\n      name: bandit-security-scan\n      args: ["-lll"]\n'
-    detect_block = '- repo: https://github.com/Yelp/detect-secrets\n  rev: v1.3.0\n  hooks:\n    - id: detect-secrets\n      name: detect-secrets-scan\n      args: ["--baseline", ".secrets.baseline"]\n'
-    if "repo: https://github.com/PyCQA/bandit" not in pc_content:
-        if not pc_content.endswith("\n"):
-            pc_content += "\n"
-        pc_content += indent + bandit_block.replace("\n", "\n" + indent)
-        if not pc_content.endswith("\n"):
-            pc_content += "\n"
-    if "repo: https://github.com/Yelp/detect-secrets" not in pc_content:
-        if not pc_content.endswith("\n"):
-            pc_content += "\n"
-        pc_content += indent + detect_block.replace("\n", "\n" + indent)
-        if not pc_content.endswith("\n"):
-            pc_content += "\n"
-    before = PRECOMMIT_CFG.read_text(encoding="utf-8")
-    PRECOMMIT_CFG.write_text(pc_content, encoding="utf-8")
-    diff = "\n".join(list(re.sub("^", "", line) for line in pc_content.splitlines()))
-    CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {PRECOMMIT_CFG.relative_to(REPO_ROOT)}\n- **Action:** edit\n- **Rationale:** Extend pre-commit hooks (Bandit & detect-secrets)\n```diff\n{diff}\n```\n\n")
-except Exception as e:
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.10: Extend pre-commit config", "error": str(e), "context": str(PRECOMMIT_CFG)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.10: .pre-commit-config.yaml extension], encountered the following error:\n{e}\nContext: file={PRECOMMIT_CFG}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
+    # Create/seed files (idempotent, never truncate)
+    try:
+        if not CHANGE_LOG.exists():
+            append_line(CHANGE_LOG, "# Codex Change Log")
+        if not ERRORS_NDJSON.exists():
+            ERRORS_NDJSON.touch()
+        if not RESULTS_MD.exists():
+            append_line(RESULTS_MD, "# Codex Results")
+    except Exception as e:
+        error_capture(
+            "1.2",
+            "Seed .codex files",
+            str(e),
+            "change_log.md, errors.ndjson, results.md",
+        )
+        raise
 
-# --- Generate .secrets.baseline using detect-secrets
-try:
-    baseline_path = REPO_ROOT / ".secrets.baseline"
-    # Run detect-secrets scan to generate baseline file
-    result = subprocess.run(["detect-secrets", "scan", "--baseline", str(baseline_path)], check=False, capture_output=True, text=True)
-    if result.returncode != 0:
-        raise RuntimeError(result.stderr.strip() or "detect-secrets scan failed")
-    baseline_content = baseline_path.read_text(encoding="utf-8")
-    before = ""  # no baseline existed before
-    diff = "\n".join(list(re.sub("^", "", line) for line in baseline_content.splitlines()))
-    CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {baseline_path.relative_to(REPO_ROOT)}\n- **Action:** create\n- **Rationale:** Generate detect-secrets baseline\n```diff\n{diff}\n```\n\n")
-except Exception as e:
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.11: Generate .secrets.baseline", "error": str(e), "context": ".secrets.baseline"}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.11: .secrets.baseline generation], encountered the following error:\n{e}\nContext: running detect-secrets\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
 
-# --- Update README.md documentation for secret scans
-try:
-    readme_text = README_MD.read_text(encoding="utf-8")
-    if "## Security Scanning" not in readme_text:
-        sec_section = ("\n## Security Scanning\n"
-                       "This project uses **Bandit** for static security analysis and **detect-secrets** for secret scanning.\n"
-                       "- **Bandit**: runs automatically via pre-commit to catch common security issues in code.\n"
-                       "- **Detect-Secrets**: uses a baseline file (`.secrets.baseline`) to track allowed secret patterns. If you add or modify credentials or keys in the code, update the baseline by running:\n"
-                       "```bash\n"
-                       "detect-secrets scan --baseline .secrets.baseline\n"
-                       "```\n"
-                       "Ensure no real secrets are committed; the baseline helps filter out false positives.\n")
-        # Insert the security section before the Logging Locations section
-        idx = readme_text.find("## Logging Locations")
-        if idx != -1:
-            readme_text = readme_text[:idx] + sec_section + readme_text[idx:]
-        else:
-            readme_text += sec_section
-    before = README_MD.read_text(encoding="utf-8")
-    README_MD.write_text(readme_text, encoding="utf-8")
-    diff = "\n".join(list(re.sub("^", "", line) for line in readme_text.splitlines()))
-    CHANGE_LOG.open("a", encoding="utf-8").write(f"### {now_iso()} — {README_MD.relative_to(REPO_ROOT)}\n- **Action:** edit\n- **Rationale:** Document security scanning (Bandit & detect-secrets) in README\n```diff\n{diff}\n```\n\n")
-except Exception as e:
-    ERRORS_LOG.open("a", encoding="utf-8").write(json.dumps({"ts": now_iso(), "step": "3.12: Update README for secret scans", "error": str(e), "context": str(README_MD)}) + "\n")
-    sys.stderr.write(f"Question for ChatGPT-5:\nWhile performing [3.12: README documentation for secret scans], encountered the following error:\n{e}\nContext: file={README_MD}\nWhat are the possible causes, and how can this be resolved while preserving intended functionality?\n\n")
+def update_readme_best_effort() -> None:
+    """Non-destructive: ensure README has a minimal 'Codex Logs' section."""
+    try:
+        if not README_MD.exists():
+            return
+        text = README_MD.read_text(encoding="utf-8", errors="ignore")
+        if "## Codex Logs" in text:
+            return
+        extra = (
+            "\n## Codex Logs\n"
+            "- `.codex/change_log.md`: human-readable changes\n"
+            "- `.codex/errors.ndjson`: NDJSON (one JSON object per line)\n"
+            "- `.codex/results.md`: summaries/results\n"
+        )
+        # Append (no truncation)
+        with open(README_MD, "a", encoding="utf-8") as f:
+            f.write(extra)
+    except Exception as e:
+        error_capture("2.1", "README best-effort update", str(e), f"readme={README_MD}")
 
-# Phase 4: Controlled Pruning – none of the planned features were dropped, except CLI tasks integrated as stubs (to avoid duplicate logic).
-# (No further code removal needed, all tasks implemented to best extent.)
 
-# Phase 5: Error Capture – handled inline in each try/except above by logging to errors.ndjson and printing questions for ChatGPT-5.
+def finalize_results(summary: str) -> None:
+    try:
+        append_line(
+            RESULTS_MD,
+            f"\n## {now_iso()} — Setup Summary\n{summary}",
+        )
+        append_line(
+            CHANGE_LOG,
+            (
+                f"- {now_iso()} Initialized/verified .codex/ and log files "
+                "(append-only guarantees)."
+            ),
+        )
+    except Exception as e:
+        error_capture(
+            "6.1",
+            "Finalize results",
+            str(e),
+            "write summaries to results.md & change_log.md",
+        )
 
-# Phase 6: Finalization – summarize results, potential gaps, and next steps in results.md
-results_lines = []
-results_lines.append(f"# Results Summary ({now_iso()})")
-results_lines.append("\n- **Implemented:**")
-results_lines.append("    - Ingestion module scaffold (`Ingestor` class, placeholder test, README).")
-results_lines.append("    - Unified GitHub Actions workflow (`ci.yml`) for lint, type-check, tests, coverage, and Docker image build.")
-results_lines.append("    - Enabled static analysis (Bandit) and secret scanning (detect-secrets) via pre-commit and CI.")
-results_lines.append("    - Updated contributor guidelines and README for new CI and security practices.")
-results_lines.append("    - Refactored CLI with `click` (whitelisted maintenance commands, with basic test).")
-results_lines.append("    - Fixed SQLite connection pooling (close on exceptions) and ensured log events always recorded on session exit.")
-results_lines.append("    - Enforced table name validation in log viewer CLI (regex for `--table`).")
-results_lines.append("\n- **Residual Gaps:**")
-results_lines.append("    - `Ingestor` class is not functional (placeholder for future implementation).")
-results_lines.append("    - CLI commands are stubs (need real linking to internal functions for full functionality).")
-results_lines.append("    - Any Bandit warnings should be reviewed; adjust code or ignore rules if necessary.")
-results_lines.append("    - The secret scanning baseline may require updates if new secrets-like patterns are added.")
-results_lines.append("\n- **Pruning:** No planned features were dropped. (Documentation duplicates were already resolved in an earlier step; none found to remove.)")
-results_lines.append("\n- **Next Steps:")
-results_lines.append("    - Implement ingestion logic in `Ingestor` and add real tests for it.")
-results_lines.append("    - Extend the click CLI to invoke actual maintenance functions (integrate with internal APIs).")
-results_lines.append("    - Monitor CI results; address any failing checks (fix code or update configurations).")
-results_lines.append("    - Periodically run `detect-secrets scan` to keep `.secrets.baseline` up to date as code evolves.")
-results_lines.append("\n**DO NOT ACTIVATE ANY GitHub Actions files** (workflow is present but runs only on manual dispatch by design).")
 
-RESULTS_LOG.write_text("\n".join(results_lines) + "\n", encoding="utf-8")
-print("Completed Deep Research Task script execution. Results and change log have been updated.")
+def verify() -> str:
+    """Return a small report with sizes and last line samples."""
+
+    def tail(path: Path, n=3) -> str:
+        if not path.exists():
+            return "(missing)"
+        try:
+            data = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+            return "\n".join(data[-n:])
+        except Exception as e:
+            return f"(error reading: {e})"
+
+    change_log_size = CHANGE_LOG.stat().st_size if CHANGE_LOG.exists() else 0
+    errors_size = ERRORS_NDJSON.stat().st_size if ERRORS_NDJSON.exists() else 0
+    results_size = RESULTS_MD.stat().st_size if RESULTS_MD.exists() else 0
+    report = [
+        f"Root: {REPO_ROOT}",
+        f".codex/: {CODEX_DIR.exists()}",
+        f"change_log.md: {CHANGE_LOG.exists()} size={change_log_size}",
+        f"errors.ndjson: {ERRORS_NDJSON.exists()} size={errors_size}",
+        f"results.md: {RESULTS_MD.exists()} size={results_size}",
+        "\n--- Tails ---",
+        "[change_log.md]",
+        tail(CHANGE_LOG),
+        "[errors.ndjson]",
+        tail(ERRORS_NDJSON),
+        "[results.md]",
+        tail(RESULTS_MD),
+        "\nNOTE: DO NOT ACTIVATE ANY GitHub Actions files. ALL GitHub Action.",
+    ]
+    return "\n".join(report)
+
+
+def append_demo_lines() -> None:
+    """Demonstrate append-only behavior with a sample entry in each file."""
+    try:
+        append_line(CHANGE_LOG, f"- {now_iso()} Demo change appended safely.")
+        append_line(
+            ERRORS_NDJSON,
+            json.dumps(
+                {"ts": now_iso(), "demo": True, "msg": "sample ndjson line"},
+                ensure_ascii=False,
+            ),
+        )
+        append_line(RESULTS_MD, f"- {now_iso()} Demo result appended safely.")
+    except Exception as e:
+        error_capture("3.1", "Append demo lines", str(e))
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Codex .codex/ bootstrapper")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("init", help="Create .codex/ and seed files (idempotent).")
+    sub.add_parser("verify", help="Print sizes and tails of .codex files.")
+    sub.add_parser("append-demo", help="Append one demo line to each file.")
+    append_p = sub.add_parser(
+        "append", help="Append a single line to change_log|errors|results"
+    )
+    append_p.add_argument("which", choices=["change_log", "errors", "results"])
+    append_p.add_argument("text", help="Text or JSON (for errors) to append")
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.cmd == "init":
+            init_codex_dir()
+            update_readme_best_effort()
+            finalize_results("Initialized .codex and seeded files.")
+        elif args.cmd == "verify":
+            init_codex_dir()
+            print(verify())
+        elif args.cmd == "append-demo":
+            init_codex_dir()
+            append_demo_lines()
+            print("Demo lines appended.")
+        elif args.cmd == "append":
+            init_codex_dir()
+            if args.which == "change_log":
+                append_line(CHANGE_LOG, args.text)
+            elif args.which == "errors":
+                # If user passes raw text, wrap into a JSON record with message
+                try:
+                    obj = json.loads(args.text)
+                except json.JSONDecodeError:
+                    obj = {"ts": now_iso(), "message": args.text}
+                append_line(ERRORS_NDJSON, json.dumps(obj, ensure_ascii=False))
+            else:
+                append_line(RESULTS_MD, args.text)
+            print(f"Appended to {args.which}.")
+        return 0
+    except KeyboardInterrupt:
+        error_capture("0.0", "Interrupted by user", "KeyboardInterrupt")
+        return 130
+    except Exception as e:
+        error_capture("0.1", "Unhandled exception", repr(e))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `codex_setup.py` CLI to bootstrap `.codex` logs with append-only safety
- document `.codex` log files and available Codex scripts in README
- seed `.codex` logs with initial summaries

## Testing
- `pre-commit run --all-files` *(fails: prompts for GitHub credentials)*
- `pytest`
- `python codex_setup.py verify`


------
https://chatgpt.com/codex/tasks/task_e_68a7a89aa3408331a6ed3c43cadff485