### PR TITLE
feat: allow GHCR login via GitHub token

### DIFF
--- a/scripts/deep_research_task_process.py
+++ b/scripts/deep_research_task_process.py
@@ -487,6 +487,11 @@ def _task_unify_ci() -> None:
     ci_content = f"""name: CI
 on:
   workflow_dispatch:
+    inputs:
+      use-ghcr-token:
+        description: 'Use GITHUB_TOKEN for GHCR auth when GHCR_PAT is absent'
+        required: false
+        default: 'false'
   pull_request:
     branches: [main]
     paths-ignore:
@@ -505,9 +510,9 @@ jobs:
       - name: Build Docker image
         run: docker build -t ghcr.io/{GITHUB_ORG}/{GITHUB_REPO}:latest .
       - name: Push Docker image
-        if: ${{{{ github.event_name == 'workflow_dispatch' && secrets.GHCR_PAT != '' }}}}
+        if: ${{{{ github.event_name == 'workflow_dispatch' && (secrets.GHCR_PAT != '' || github.event.inputs.use-ghcr-token == 'true') }}}}
         env:
-          CR_PAT: ${{{{ secrets.GHCR_PAT }}}}
+          CR_PAT: ${{{{ secrets.GHCR_PAT != '' && secrets.GHCR_PAT || github.token }}}}
         run: |
           echo "$CR_PAT" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
           docker push ghcr.io/{GITHUB_ORG}/{GITHUB_REPO}:latest


### PR DESCRIPTION
## Summary
- allow CI workflow to authenticate to GHCR via GitHub token when GHCR_PAT is not provided
- add workflow dispatch input `use-ghcr-token` to toggle alternate authentication

## Testing
- `pre-commit run --all-files` *(fails: Username for 'https://github.com')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa05709c28833182e042565eeb212c