### PR TITLE
feat: allow using CR_PAT for Docker push

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Alternatively, run `./ci_local.sh` to execute these checks along with a local bu
 
 These same commands run in CI; see the workflow definition in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (read-only).
 
+The `ci` workflow can also push Docker images to GHCR. When triggering it via **Run workflow**, set `use-cr-pat: true` to authenticate using the `CR_PAT` secret (a personal access token). If unset, the workflow falls back to `GHCR_PAT` or the default `GITHUB_TOKEN`.
+
 ### Codex Self-Manage (opt-in)
 This repository does not execute GitHub Actions automatically. To run checks in the cloud on demand:
 

--- a/scripts/deep_research_task_process.py
+++ b/scripts/deep_research_task_process.py
@@ -492,6 +492,10 @@ on:
         description: 'Use GITHUB_TOKEN for GHCR auth when GHCR_PAT is absent'
         required: false
         default: 'false'
+      use-cr-pat:
+        description: 'Use CR_PAT secret for GHCR auth when set'
+        required: false
+        default: 'false'
   pull_request:
     branches: [main]
     paths-ignore:
@@ -510,9 +514,9 @@ jobs:
       - name: Build Docker image
         run: docker build -t ghcr.io/{GITHUB_ORG}/{GITHUB_REPO}:latest .
       - name: Push Docker image
-        if: ${{{{ github.event_name == 'workflow_dispatch' && (secrets.GHCR_PAT != '' || github.event.inputs.use-ghcr-token == 'true') }}}}
+        if: ${{{{ github.event_name == 'workflow_dispatch' && (secrets.GHCR_PAT != '' || (github.event.inputs.use-cr-pat == 'true' && secrets.CR_PAT != '') || github.event.inputs.use-ghcr-token == 'true') }}}}
         env:
-          CR_PAT: ${{{{ secrets.GHCR_PAT != '' && secrets.GHCR_PAT || github.token }}}}
+          CR_PAT: ${{{{ secrets.GHCR_PAT != '' && secrets.GHCR_PAT || (github.event.inputs.use-cr-pat == 'true' && secrets.CR_PAT != '' && secrets.CR_PAT) || github.token }}}}
         run: |
           echo "$CR_PAT" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
           docker push ghcr.io/{GITHUB_ORG}/{GITHUB_REPO}:latest


### PR DESCRIPTION
## Summary
- support `use-cr-pat` workflow input to authenticate with `CR_PAT` secret
- document Docker push authentication options in README

## Testing
- ⚠️ `pre-commit run --all-files` *(failed: prompted for GitHub credentials)*
- ✅ `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa2ca8690483319a73ef86e611c369