### PR TITLE
feat: add encoding detection options to ingestion

### DIFF
--- a/src/ingestion/README.md
+++ b/src/ingestion/README.md
@@ -5,7 +5,8 @@ Utilities for reading text files.
 ## Parameters
 
 - `path: Union[str, Path]` – file to read.
-- `encoding: str = "utf-8"` – decoding used when opening the file.
+- `encoding: str = "utf-8"` – decoding used when opening the file. Pass
+  `"auto"` to attempt deterministic encoding detection.
 - `chunk_size: Optional[int] = None` – if `None`, returns the entire file as a
   single string; if a positive integer, yields chunks of at most that length.
 

--- a/src/ingestion/__init__.py
+++ b/src/ingestion/__init__.py
@@ -57,7 +57,9 @@ def ingest(
         raise FileNotFoundError(f"Path is a directory: {file_path}")
     if chunk_size is None:
         return file_path.read_text(
-            encoding=(encoding if encoding != "auto" else autodetect_encoding(file_path))
+            encoding=(
+                encoding if encoding != "auto" else autodetect_encoding(file_path)
+            )
         )
     if not isinstance(chunk_size, int) or chunk_size <= 0:
         raise ValueError("chunk_size must be a positive integer when provided")
@@ -65,7 +67,9 @@ def ingest(
     def _iter() -> Iterator[str]:
         with file_path.open(
             "r",
-            encoding=(encoding if encoding != "auto" else autodetect_encoding(file_path)),
+            encoding=(
+                encoding if encoding != "auto" else autodetect_encoding(file_path)
+            ),
         ) as fh:
             while True:
                 chunk = fh.read(chunk_size)

--- a/src/ingestion/csv_ingestor.py
+++ b/src/ingestion/csv_ingestor.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import List, Union
+
+from .encoding_detect import autodetect_encoding
+
+
+def load_csv(
+    path: Union[str, Path], *, encoding: str = "utf-8", **kwargs
+) -> List[list[str]]:
+    """Load CSV rows from ``path`` into a list.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path to a CSV file.
+    encoding:
+        Text encoding used to decode bytes. Pass ``"auto"`` to attempt
+        autodetection; defaults to ``"utf-8"``.
+    **kwargs:
+        Additional arguments forwarded to :func:`csv.reader`.
+    """
+    p = Path(path)
+    if encoding == "auto":
+        encoding = autodetect_encoding(p)
+    with p.open("r", encoding=encoding, newline="") as fh:
+        reader = csv.reader(fh, **kwargs)
+        return list(reader)

--- a/src/ingestion/encoding_detect.py
+++ b/src/ingestion/encoding_detect.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from pathlib import Path
 from typing import Optional, Union
 
@@ -13,7 +14,9 @@ except Exception:  # pragma: no cover
     _chardet = None
 
 
-def autodetect_encoding(path: Union[str, Path], default: str = "utf-8", sample_size: int = 131072) -> str:
+def autodetect_encoding(
+    path: Union[str, Path], default: str = "utf-8", sample_size: int = 131072
+) -> str:
     """Return best-effort text encoding for a file at *path*.
 
     Resolution order (deterministic): charset-normalizer → chardet → default.

--- a/src/ingestion/file_ingestor.py
+++ b/src/ingestion/file_ingestor.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+from .encoding_detect import autodetect_encoding
+
+
+def read_file(path: Union[str, Path], *, encoding: str = "utf-8") -> str:
+    """Return the contents of ``path`` decoded as text.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path to a text file.
+    encoding:
+        Text encoding used to decode bytes. Pass ``"auto"`` to attempt
+        autodetection; defaults to ``"utf-8"``.
+    """
+    p = Path(path)
+    if encoding == "auto":
+        encoding = autodetect_encoding(p)
+    return p.read_text(encoding=encoding)

--- a/src/ingestion/json_ingestor.py
+++ b/src/ingestion/json_ingestor.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Union
+
+from .encoding_detect import autodetect_encoding
+
+
+def load_json(path: Union[str, Path], *, encoding: str = "utf-8") -> Any:
+    """Load JSON data from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path to a JSON document.
+    encoding:
+        Text encoding used to decode bytes. Pass ``"auto"`` to attempt
+        autodetection; defaults to ``"utf-8"``.
+    """
+    p = Path(path)
+    if encoding == "auto":
+        encoding = autodetect_encoding(p)
+    with p.open("r", encoding=encoding) as fh:
+        return json.load(fh)

--- a/src/ingestion/utils.py
+++ b/src/ingestion/utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+from .encoding_detect import autodetect_encoding
+
+
+def read_text_file(path: Union[str, Path], *, encoding: str = "utf-8") -> str:
+    """Read a text file and return its content as a string.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path to the text file.
+    encoding:
+        Text encoding used to decode bytes. Pass ``"auto"`` to attempt
+        autodetection; defaults to ``"utf-8"``.
+    """
+    p = Path(path)
+    if encoding == "auto":
+        encoding = autodetect_encoding(p)
+    return p.read_text(encoding=encoding)


### PR DESCRIPTION
## Summary
- allow ingestion helpers to accept `encoding` with an `"auto"` option for detection
- add deterministic `autodetect_encoding` and wrappers for reading files, JSON, and CSV
- document automatic encoding selection in ingestion README

## Testing
- `pre-commit run --files src/ingestion/README.md src/ingestion/__init__.py src/ingestion/encoding_detect.py src/ingestion/file_ingestor.py src/ingestion/json_ingestor.py src/ingestion/csv_ingestor.py src/ingestion/utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa3e82515c8331abe355a94b6dbdbd