### PR TITLE
Ensure session ID cleared on ChatSession exit

### DIFF
--- a/src/codex/chat.py
+++ b/src/codex/chat.py
@@ -75,9 +75,9 @@ class ChatSession:
         Returns:
             None. (The method does not suppress exceptions.)
         """
-        db = self.db_path
-        path = Path(db) if db else None
+        path = Path(self.db_path) if self.db_path else None
         try:
             log_event(self.session_id, "system", "session_end", db_path=path)
         finally:
+            # Always clear the session identifier regardless of logging outcome
             os.environ.pop("CODEX_SESSION_ID", None)

--- a/tests/test_chat_session_exit.py
+++ b/tests/test_chat_session_exit.py
@@ -19,3 +19,19 @@ def test_env_cleared_on_log_failure(monkeypatch):
             pass
 
     assert "CODEX_SESSION_ID" not in os.environ
+
+
+def test_env_cleared_when_body_and_log_fail(monkeypatch):
+    """Environment variable cleared if body and logging both fail."""
+
+    def boom(session_id, role, message, **kwargs):
+        if message == "session_end":
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("src.codex.chat.log_event", boom)
+
+    with pytest.raises(RuntimeError):
+        with ChatSession("boom"):
+            raise ValueError("inner")
+
+    assert "CODEX_SESSION_ID" not in os.environ


### PR DESCRIPTION
## Summary
- ensure `ChatSession.__exit__` always clears `CODEX_SESSION_ID` even if `log_event` fails
- add regression tests verifying env var removal when logging or body fails

## Testing
- `pre-commit run --files src/codex/chat.py tests/test_chat_session_exit.py`
- `pytest tests/test_chat_session_exit.py`

------
https://chatgpt.com/codex/tasks/task_e_68aa413de320833194bd58e9200bb95e