### PR TITLE
chore: cleanup mapping documentation

### DIFF
--- a/.codex/mapping.md
+++ b/.codex/mapping.md
@@ -1,6 +1,6 @@
 # Mapping Table
 
-- **Instrument user/assistant exchanges** → ['/workspace/_codex_/tools/codex_logging_workflow.py', '/workspace/_codex_/src/codex/chat.py', '/workspace/_codex_/src/codex/logging/session_logger.py', '/workspace/_codex_/tests/test_session_logging.py', '/workspace/_codex_/src/codex/logging/conversation_logger.py', '/workspace/_codex_/src/codex/logging/query_logs.py', '/workspace/_codex_/tests/test_conversation_logger.py', '/workspace/_codex_/tests/test_export.py', '/workspace/_codex_/tests/test_chat_session.py']  
+- **Instrument user/assistant exchanges** → ['/workspace/_codex_/tools/codex_logging_workflow.py', '/workspace/_codex_/src/codex/chat.py', '/workspace/_codex_/src/codex/logging/session_logger.py', '/workspace/_codex_/tests/test_session_logging.py', '/workspace/_codex_/src/codex/logging/conversation_logger.py', '/workspace/_codex_/src/codex/logging/query_logs.py', '/workspace/_codex_/tests/test_conversation_logger.py', '/workspace/_codex_/tests/test_export.py', '/workspace/_codex_/tests/test_chat_session.py']
   Rationale: Keyword/heuristic scan for conversation handlers
 
 ## Session hook tasks


### PR DESCRIPTION
## Summary
- remove trailing whitespace from mapping table entry in `.codex/mapping.md`
- restore original action log pointer

## Testing
- `pre-commit run --files .codex/mapping.md --config .pre-commit-config-nosg.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa47e94c388331b711c93da4caaea1