### PR TITLE
test: expand ingestion encoding coverage

### DIFF
--- a/tests/test_ingestion_auto_encoding.py
+++ b/tests/test_ingestion_auto_encoding.py
@@ -1,20 +1,21 @@
-import pytest
 from pathlib import Path
+import sys
 
-@pytest.mark.xfail(reason="Module path may differ; update imports if needed", strict=False, raises=Exception)
-def test_auto_detect_handles_cp1252(tmp_path: Path):
-    s = "café £"
-    p = tmp_path / "sample_cp1252.txt"
-    p.write_bytes(s.encode("cp1252"))
+import pytest
 
-    try:
-        from ingestion import Ingestor
-    except Exception:
-        try:
-            from src.ingestion import Ingestor
-        except Exception as e:
-            pytest.xfail(f"Cannot import Ingestor: {e}")
+ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
-    ing = Ingestor()
-    out = ing.ingest(p, encoding="auto")
-    assert "café" in out and "£" in out
+from ingestion import Ingestor
+
+ENCODINGS = ["iso-8859-1", "cp1252", "utf-16", "auto"]
+
+
+@pytest.mark.parametrize("enc", ENCODINGS[:-1])
+def test_auto_detect_handles_encodings(tmp_path: Path, enc: str) -> None:
+    text = "café £"
+    p = tmp_path / f"sample_{enc.replace('-', '')}.txt"
+    p.write_bytes(text.encode(enc))
+    out = Ingestor.ingest(p, encoding="auto")
+    assert out == text

--- a/tests/test_ingestion_encoding_coverage.py
+++ b/tests/test_ingestion_encoding_coverage.py
@@ -1,18 +1,26 @@
+"""Verify ingestion text readers expose an ``encoding`` parameter."""
+
 import ast
 from pathlib import Path
 
 READ_ATTRS = {("Path", "read_text"), ("", "read_text")}
 PANDAS_FUNCS = {"read_csv", "read_table", "read_json"}
 
+
 def _calls_text_readers(fn_node: ast.FunctionDef) -> bool:
     class Finder(ast.NodeVisitor):
         def __init__(self):
             self.uses_text_reader = False
+
         def visit_Call(self, node: ast.Call):
             if isinstance(node.func, ast.Attribute) and node.func.attr == "read_text":
                 self.uses_text_reader = True
             if isinstance(node.func, ast.Name) and node.func.id == "open":
-                if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant) and isinstance(node.args[1].value, str):
+                if (
+                    len(node.args) >= 2
+                    and isinstance(node.args[1], ast.Constant)
+                    and isinstance(node.args[1].value, str)
+                ):
                     if "b" not in node.args[1].value:
                         self.uses_text_reader = True
                 else:
@@ -20,15 +28,18 @@ def _calls_text_readers(fn_node: ast.FunctionDef) -> bool:
             if isinstance(node.func, ast.Attribute) and node.func.attr in PANDAS_FUNCS:
                 self.uses_text_reader = True
             return self.generic_visit(node)
+
     f = Finder()
     f.visit(fn_node)
     return f.uses_text_reader
+
 
 def _has_encoding_param(fn_node: ast.FunctionDef) -> bool:
     for arg in list(fn_node.args.args) + list(fn_node.args.kwonlyargs):
         if arg.arg == "encoding":
             return True
     return bool(fn_node.args.kwarg and fn_node.args.kwarg.arg)
+
 
 def test_all_text_readers_accept_encoding():
     root = Path(__file__).resolve().parents[1] / "src" / "ingestion"

--- a/tests/test_ingestion_encodings_matrix.py
+++ b/tests/test_ingestion_encodings_matrix.py
@@ -1,25 +1,23 @@
-import pytest
 from pathlib import Path
+import sys
 
-ENCODINGS = ["utf-8", "iso-8859-1", "cp1252", "utf-16", "auto"]
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ingestion import Ingestor
+
+ENCODINGS = ["iso-8859-1", "cp1252", "utf-16", "auto"]
+
 
 @pytest.mark.parametrize("enc", ENCODINGS)
-@pytest.mark.xfail(reason="Module path may differ; update imports if needed", strict=False, raises=Exception)
-def test_ingestion_encoding_matrix(tmp_path: Path, enc: str):
-    text_in = "café — Δ £"
+def test_ingestion_encoding_matrix(tmp_path: Path, enc: str) -> None:
+    text_in = "café £"
     file_enc = "cp1252" if enc == "auto" else enc
     f = tmp_path / f"sample_{file_enc.replace('-', '')}.txt"
     f.write_bytes(text_in.encode(file_enc))
-
-    try:
-        from ingestion import Ingestor
-    except Exception:
-        try:
-            from src.ingestion import Ingestor
-        except Exception as e:
-            pytest.xfail(f"Cannot import Ingestor: {e}")
-
-    ing = Ingestor()
-    out = ing.ingest(f, encoding=enc)
+    out = Ingestor.ingest(f, encoding=enc)
     assert isinstance(out, str)
-    assert "caf" in out and "£" in out
+    assert "café" in out and "£" in out

--- a/tests/test_ingestion_family_encoding.py
+++ b/tests/test_ingestion_family_encoding.py
@@ -1,41 +1,37 @@
-import pytest
+import json
 from pathlib import Path
+import sys
 
-ENCODINGS = ["iso-8859-1", "cp1252", "utf-16"]
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ingestion.file_ingestor import read_file
+from ingestion.json_ingestor import load_json
+from ingestion.csv_ingestor import load_csv
+from ingestion.utils import read_text_file
+
+ENCODINGS = ["iso-8859-1", "cp1252", "utf-16", "auto"]
+
 
 @pytest.mark.parametrize("enc", ENCODINGS)
-@pytest.mark.xfail(reason="Family modules may vary; update function names if different", strict=False, raises=Exception)
-def test_family_encoding_hooks(tmp_path: Path, enc: str):
-    s = "café £"
-    p = tmp_path / f"sample_{enc.replace('-', '')}.txt"
-    p.write_bytes(s.encode(enc))
+def test_family_encoding_hooks(tmp_path: Path, enc: str) -> None:
+    text = "café £"
+    file_enc = "cp1252" if enc == "auto" else enc
 
-    tried = 0
-    passed = 0
+    t = tmp_path / f"text_{file_enc}.txt"
+    t.write_text(text, encoding=file_enc)
 
-    candidates = [
-        ("ingestion.file_ingestor", "read_file"),
-        ("ingestion.json_ingestor", "load_json"),
-        ("ingestion.csv_ingestor", "load_csv"),
-        ("ingestion.utils", "read_text_file"),
-    ]
+    j = tmp_path / f"data_{file_enc}.json"
+    j.write_text(json.dumps({"msg": text}, ensure_ascii=False), encoding=file_enc)
 
-    for mod_name, fn_name in candidates:
-        try:
-            mod = __import__(mod_name, fromlist=[fn_name])
-            fn = getattr(mod, fn_name, None)
-            if callable(fn):
-                tried += 1
-                try:
-                    txt = fn(p, encoding=enc)
-                    if isinstance(txt, (str, bytes)):
-                        passed += 1
-                except Exception:
-                    pass
-        except Exception:
-            continue
+    c = tmp_path / f"data_{file_enc}.csv"
+    c.write_text(f"msg\n{text}\n", encoding=file_enc)
 
-    if tried == 0:
-        pytest.xfail("No ingestion family functions found; update candidate list for your repo structure")
-
-    assert passed >= 0
+    assert read_file(t, encoding=enc) == text
+    assert read_text_file(t, encoding=enc) == text
+    assert load_json(j, encoding=enc)["msg"] == text
+    rows = load_csv(c, encoding=enc)
+    assert rows == [["msg"], [text]]


### PR DESCRIPTION
## Summary
- prioritize chardet when auto-detecting text encodings
- exercise ingestion utilities across iso-8859-1, cp1252, utf-16, and auto detection
- document and enforce encoding coverage for ingestion readers

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_ingestion_encodings_matrix.py tests/test_ingestion_auto_encoding.py tests/test_ingestion_family_encoding.py tests/test_ingestion_encoding_coverage.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa478d519c8331b686b494af561dab