### PR TITLE
chore: remove placeholder ingestion test

### DIFF
--- a/documentation/codex_setup_integration.md
+++ b/documentation/codex_setup_integration.md
@@ -12,7 +12,7 @@ The `./codex_setup.py` script has multi-phase repository augmentation: inventory
 | 2 | Mapping | Path resolution | Completed | Key targets (ingestion, workflows, logging modules) mapped |
 | 2 | Existence Checks | viewer.py, session_logger.py, pre-commit config | Conditional logging | Missing files trigger question prompts to stderr |
 | 3.1 | Ingestion | Scaffold `Ingestor` | Created | Placeholder NotImplementedError |
-| 3.2 | Tests | Placeholder ingestion test | Created | Skipped via pytest.skip |
+| 3.2 | Tests | Encoding ingestion tests | Added | Validates text readers accept encoding |
 | 3.3 | Docs | Ingestion README | Created | Basic module intent |
 | 3.4 | CI | Unified workflows | Created / replaced | ci.yml with build + verify jobs; old disabled build removed if present |
 | 3.5 | Contributing | Update guide | Edited | Added mypy, secret scanning guidance, removed obsolete warnings |
@@ -35,7 +35,7 @@ The `./codex_setup.py` script has multi-phase repository augmentation: inventory
 | .codex/results.md | Log | Execution summary & next steps |
 | .codex/inventory.json | Data | Repository file inventory |
 | src/ingestion/__init__.py | Code | Ingestor scaffold |
-| tests/test_ingestion_placeholder.py | Test | Placeholder skipped test |
+| tests/test_ingestion_encoding_coverage.py | Test | Ensures text readers expose `encoding` parameter |
 | src/ingestion/README.md | Doc | Module intent |
 | .github/workflows/ci.yml | CI | Unified workflow |
 | CONTRIBUTING.md | Doc | Updated contributor guidance |

--- a/scripts/deep_research_task_process.py
+++ b/scripts/deep_research_task_process.py
@@ -134,7 +134,6 @@ INVENTORY_JSON = CODEX_DIR / "inventory.json"
 # Target repository artifacts
 INGESTION_DIR = REPO_ROOT / "src" / "ingestion"
 INGESTOR_PY = INGESTION_DIR / "__init__.py"
-TEST_INGESTION = REPO_ROOT / "tests" / "test_ingestion_placeholder.py"
 INGESTION_README = INGESTION_DIR / "README.md"
 PRECOMMIT_CFG = REPO_ROOT / ".pre-commit-config.yaml"
 CONTRIBUTING_MD = REPO_ROOT / "CONTRIBUTING.md"

--- a/tests/test_ingestion_placeholder.py
+++ b/tests/test_ingestion_placeholder.py
@@ -1,3 +1,0 @@
-import pytest
-
-pytest.skip("Ingestor not implemented yet", allow_module_level=True)


### PR DESCRIPTION
## Summary
- remove unused placeholder ingestion test
- document encoding-based ingestion coverage
- drop stale placeholder test reference from repo maintenance script

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_ingestion_*`


------
https://chatgpt.com/codex/tasks/task_e_68aa7ac3e9f88331a0949a18ad85b5d0