### PR TITLE
Disable push/pull_request triggers for self-managed CI

### DIFF
--- a/.codex/results.md
+++ b/.codex/results.md
@@ -4,6 +4,9 @@
 - Redundant files: []
 - Files changed: 0
 
+## Hard Constraint
+- GitHub Actions must not trigger on `push` or `pull_request`; workflows run only within Codex-managed environments.
+
 ## mypy
 ```
 tests/_codex_introspect.py: error: Source file found twice under different module names: "_codex_introspect" and "tests._codex_introspect"

--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -1,8 +1,6 @@
 name: codex-ci
 on:
   workflow_dispatch: {}
-  pull_request:
-    types: [opened, synchronize, labeled]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codex-self-hosted-ci.yml
+++ b/.github/workflows/codex-self-hosted-ci.yml
@@ -1,8 +1,7 @@
 name: CI
 
 on:
-  push:
-  pull_request:
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codex-self-manage.yml
+++ b/.github/workflows/codex-self-manage.yml
@@ -2,8 +2,6 @@ name: codex-self-manage
 
 on:
   workflow_dispatch: {}
-  pull_request:
-    types: [opened, synchronize, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- remove `push` and `pull_request` triggers from self-managed GitHub Actions
- document Hard Constraint about not enabling push/pull_request triggers

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa93363c60833181756054ddedcfe7