### PR TITLE
Disable push/PR triggers in workflows

### DIFF
--- a/.codex/action_log.ndjson
+++ b/.codex/action_log.ndjson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36a5edea8d6e800882771dd2362215e0d30d5d51ee9eb960fcc8097c54d12bc6
+oid sha256:e0ce60f1e4d11bf7d569ecd5a31565d21bf3056f2f463dc0fdee6085fb36cb51
 size 368

--- a/.codex/results.md
+++ b/.codex/results.md
@@ -4,6 +4,9 @@
 - Redundant files: []
 - Files changed: 0
 
+## Hard Constraint
+- `.github/workflows` must not use triggers such as `on: push` or `pull_request`; workflows run only within the Codex environment or other ephemeral setups.
+
 ## mypy
 ```
 tests/_codex_introspect.py: error: Source file found twice under different module names: "_codex_introspect" and "tests._codex_introspect"

--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -1,8 +1,6 @@
 name: codex-ci
 on:
   workflow_dispatch: {}
-  pull_request:
-    types: [opened, synchronize, labeled]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codex-self-hosted-ci.yml
+++ b/.github/workflows/codex-self-hosted-ci.yml
@@ -1,8 +1,7 @@
 name: CI
 
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codex-self-manage.yml
+++ b/.github/workflows/codex-self-manage.yml
@@ -2,8 +2,6 @@ name: codex-self-manage
 
 on:
   workflow_dispatch: {}
-  pull_request:
-    types: [opened, synchronize, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,7 +9,6 @@ concurrency:
 
 jobs:
   ci:
-    if: github.event_name == 'workflow_dispatch' || contains(join(fromJson(toJson(github.event.pull_request.labels)).*.name, ' '), 'codex-ci')
     runs-on: [self-hosted, linux, codex]
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Ensure workflow files only trigger via `workflow_dispatch`
- Record hard constraint about manual workflows in `.codex/results.md`

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa93363c60833181756054ddedcfe7