### PR TITLE
chore: package test and tools modules for mypy

### DIFF
--- a/codex_workflow.py
+++ b/codex_workflow.py
@@ -66,7 +66,6 @@ def run(cmd: List[str]) -> Tuple[int, str, str]:
         return e.returncode, stdout, stderr
 
 
-
 def ensure_dirs():
     CODEX_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -298,7 +297,6 @@ def find_insert_index(src: str) -> int:
     while i < len(lines) and re.match(r"\s*from\s+__future__\s+import\s+", lines[i]):
         i += 1
     return sum(len(line) for line in lines[:i])
-
 
 
 def insert_import(src: str, name: str) -> str:

--- a/scripts/apply_session_logging_workflow.py
+++ b/scripts/apply_session_logging_workflow.py
@@ -23,7 +23,7 @@ except Exception:
     pass
 import textwrap
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 from codex.utils.subprocess import run
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package marker for mypy

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+# Tools package marker for mypy


### PR DESCRIPTION
## Summary
- mark `tests` and `tools` as packages to eliminate duplicate-module warnings
- format workflow scripts to satisfy pre-commit

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `mypy .` *(fails: Argument 2 to "fullmatch" has incompatible type "str | None"; expected "str" and others)*

------
https://chatgpt.com/codex/tasks/task_e_68aa985f53008331a292ab8f8be98ee1