### PR TITLE
chore: fix formatting issues

### DIFF
--- a/.codex/action_log.ndjson
+++ b/.codex/action_log.ndjson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e0ce60f1e4d11bf7d569ecd5a31565d21bf3056f2f463dc0fdee6085fb36cb51
-size 368
+oid sha256:70db39525c611918fdb80af2611cff5bb934178cbebdb7c2ad88f50e0fb5f77b
+size 366

--- a/codex_workflow.py
+++ b/codex_workflow.py
@@ -66,7 +66,6 @@ def run(cmd: List[str]) -> Tuple[int, str, str]:
         return e.returncode, stdout, stderr
 
 
-
 def ensure_dirs():
     CODEX_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -298,7 +297,6 @@ def find_insert_index(src: str) -> int:
     while i < len(lines) and re.match(r"\s*from\s+__future__\s+import\s+", lines[i]):
         i += 1
     return sum(len(line) for line in lines[:i])
-
 
 
 def insert_import(src: str, name: str) -> str:

--- a/scripts/apply_session_logging_workflow.py
+++ b/scripts/apply_session_logging_workflow.py
@@ -23,7 +23,7 @@ except Exception:
     pass
 import textwrap
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 from codex.utils.subprocess import run
 


### PR DESCRIPTION
## Summary
- clean up blank line spacing in codex workflow helpers
- drop unused Optional import from session logging workflow script

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa9a5b15148331b363aaec69966848