### PR TITLE
sanitise sqlite pragma table names

### DIFF
--- a/tests/test_db_utils_table_name.py
+++ b/tests/test_db_utils_table_name.py
@@ -1,8 +1,10 @@
-"""Tests for database utility table-name inference."""
+"""Tests for database utility table-name inference and sanitization."""
 
 import sqlite3
 
-from src.codex.logging.db_utils import infer_probable_table
+import pytest
+
+from src.codex.logging.db_utils import get_columns, infer_probable_table
 
 
 def test_db_utils_table_name() -> None:
@@ -13,3 +15,12 @@ def test_db_utils_table_name() -> None:
     con.execute("CREATE TABLE session_events (session_id TEXT, message TEXT)")
     table = infer_probable_table(con)
     assert table == "session_events"
+
+
+def test_get_columns_rejects_invalid_name() -> None:
+    con = sqlite3.connect(":memory:")
+    try:
+        with pytest.raises(ValueError):
+            get_columns(con, "bad;DROP TABLE other;")
+    finally:
+        con.close()


### PR DESCRIPTION
## Summary
- validate SQLite table names before PRAGMA queries to avoid injection
- add sanitization helpers in logging utilities and session query
- cover invalid table names with tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaa3ddc2d88331a40da8abcc4c7c3b