### PR TITLE
docs: add codex pipeline scaffold

### DIFF
--- a/documentation/codex_pipeline_scaffold.md
+++ b/documentation/codex_pipeline_scaffold.md
@@ -1,0 +1,87 @@
+# Codex Training Pipeline Scaffold
+
+This document describes the Codex training pipeline in a form ready for incremental implementation. Each stage contains sample prompts for Codex and pseudocode skeletons that developers can expand.
+
+## Stage 1: Pretraining
+
+**Iterative Prompt**
+```
+You are building the base Codex model.
+1. Load mixed text and code corpora.
+2. Tokenize and batch the data.
+3. Train a transformer model with next-token prediction.
+Provide Python functions for data loading and training loops.
+```
+
+**Pseudocode**
+```python
+# Initialize base model M0
+model = TransformerModel(config)
+
+# Pretraining loop
+for batch in pretraining_corpus:
+    tokens = tokenize(batch)
+    loss = model.loss(tokens)
+    model.update(loss)
+```
+
+## Stage 2: Supervised Fine-Tuning (SFT)
+
+**Iterative Prompt**
+```
+You are fine-tuning the pretrained model on curated examples.
+1. Accept prompt/response pairs of coding tasks.
+2. Optimize the model with teacher-forcing.
+3. Save the fine-tuned weights as M1.
+Implement the fine-tuning loop and evaluation hooks.
+```
+
+**Pseudocode**
+```python
+# Load pretrained weights
+model = load_weights(M0_path)
+
+for prompt, solution in sft_dataset:
+    tokens = tokenize(prompt + solution)
+    loss = model.loss(tokens)
+    model.update(loss)
+
+save_weights(model, M1_path)
+```
+
+## Stage 3: Reinforcement Learning from Human Feedback (RLHF)
+
+**Iterative Prompt**
+```
+You are aligning model behavior with human preferences.
+1. Collect preference pairs comparing model outputs.
+2. Train a reward model R from the preferences.
+3. Optimize the policy model M1 using PPO to maximize R.
+Return the improved model M2.
+```
+
+**Pseudocode**
+```python
+# Train reward model
+reward_model = RewardModel(train_preferences)
+
+# RLHF optimization
+policy = load_weights(M1_path)
+for step in range(rl_steps):
+    prompts = sample_prompts()
+    responses = policy.generate(prompts)
+    rewards = reward_model.score(prompts, responses)
+    policy = ppo_update(policy, prompts, responses, rewards)
+
+save_weights(policy, M2_path)
+```
+
+## Utility Equation
+The combined utility of a model \(M\) during training can be expressed as:
+\[
+U(M) = \alpha \cdot \mathcal{L}_{\text{SFT}}(M; D) + \beta \cdot \mathcal{L}_{\text{RLHF}}(M; R) + \gamma \cdot \Omega(M)
+\]
+where \(\mathcal{L}_{\text{SFT}}\) is the supervised loss, \(\mathcal{L}_{\text{RLHF}}\) is the reward optimization term, and \(\Omega(M)\) captures regularization.
+
+## Summary
+Following this scaffold enables a developer or Codex-driven workflow to implement the full training pipeline: pretraining (M0), supervised fine-tuning (M1), and RLHF optimization (M2).


### PR DESCRIPTION
## Summary
- outline Codex training pipeline with prompts and pseudocode for pretraining, SFT, and RLHF

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac1a55804833197c2fcf9b27ff115