### PR TITLE
Add training pipeline command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ select = ["E", "F", "I"]
 ignore = ["E501"]
 
 [tool.ruff.lint.isort]
-known-first-party = ["codex"]
+known-first-party = ["codex", "codex_ml"]
 
 [tool.black]
 line-length = 88
@@ -46,3 +46,4 @@ dev = ["ruff>=0.5", "pytest>=7", "duckdb>=1.0"]
 
 [project.scripts]
 codex-import-ndjson = "codex.logging.import_ndjson:main"
+codex = "tools.codex_cli:codex"

--- a/src/codex_ml/__init__.py
+++ b/src/codex_ml/__init__.py
@@ -1,0 +1,20 @@
+"""Minimal training utilities for the Codex CLI."""
+
+from .pipeline import run_codex_pipeline
+from .config import (
+    TrainingWeights,
+    PretrainingConfig,
+    SFTConfig,
+    RLHFConfig,
+    ValidationThresholds,
+)
+
+__all__ = [
+    "run_codex_pipeline",
+    "TrainingWeights",
+    "PretrainingConfig",
+    "SFTConfig",
+    "RLHFConfig",
+    "ValidationThresholds",
+]
+

--- a/src/codex_ml/config.py
+++ b/src/codex_ml/config.py
@@ -1,0 +1,39 @@
+"""Configuration dataclasses for the Codex training pipeline."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TrainingWeights:
+    alpha: float
+    beta: float
+    gamma: float
+
+
+@dataclass
+class PretrainingConfig:
+    model_size: str
+    context_length: int
+
+
+@dataclass
+class SFTConfig:
+    batch_size: int
+    learning_rate: float
+    epochs: int
+
+
+@dataclass
+class RLHFConfig:
+    algorithm: str
+    kl_penalty: float
+    ppo_epochs: int
+
+
+@dataclass
+class ValidationThresholds:
+    syntax_ok: float
+    logic_ok: float
+    security_ok: float
+    perf_ok: float
+

--- a/src/codex_ml/pipeline.py
+++ b/src/codex_ml/pipeline.py
@@ -1,0 +1,43 @@
+"""Fallback pipeline implementation for the Codex training CLI."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Iterable, Optional, Sequence
+
+from .config import (
+    TrainingWeights,
+    PretrainingConfig,
+    SFTConfig,
+    RLHFConfig,
+    ValidationThresholds,
+)
+
+
+def run_codex_pipeline(
+    *,
+    corpus: Sequence[str],
+    demos: Sequence[dict[str, str]],
+    pairwise_prefs: Sequence[tuple[str, str, str, int]],
+    weights: TrainingWeights,
+    pre_cfg: PretrainingConfig,
+    sft_cfg: SFTConfig,
+    rlhf_cfg: RLHFConfig,
+    val_t: ValidationThresholds,
+    synth_prompts: Optional[Iterable[str]] = None,
+) -> dict[str, Any]:
+    """Run the training pipeline or return synthetic metrics in fallback mode."""
+
+    if os.getenv("CODEX_FALLBACK") == "1":
+        return {
+            "pretraining": {
+                "status": "fallback",
+                "tokens": sum(len(c) for c in corpus),
+            },
+            "sft": {"status": "fallback", "demos": len(demos)},
+            "rlhf": {"status": "fallback", "pairs": len(pairwise_prefs)},
+            "validation": {"status": "fallback", "thresholds": val_t.__dict__},
+        }
+
+    raise NotImplementedError("Real training pipeline is not implemented")
+

--- a/tools/codex_cli.py
+++ b/tools/codex_cli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-import argparse
+"""Utility CLI for linting, testing, and training pipelines."""
+
 import json
 import os
 import pathlib
@@ -7,6 +8,22 @@ import shutil
 import subprocess  # nosec B404
 import sys
 import time
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import click  # noqa: E402
+
+from codex_ml.config import (  # noqa: E402
+    PretrainingConfig,
+    RLHFConfig,
+    SFTConfig,
+    TrainingWeights,
+    ValidationThresholds,
+)
+from codex_ml.pipeline import run_codex_pipeline  # noqa: E402
 
 LOG_PATH = pathlib.Path(os.getenv("CODEX_LOG_DB_PATH", ".codex/action_log.ndjson"))
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -16,12 +33,16 @@ SKIP_TESTS = os.getenv("CODEX_CLI_SKIP_TESTS") == "1"
 
 
 def log(event: str, status: str, detail: str = "") -> None:
+    """Append an event record to the log file."""
+
     rec = {"ts": time.time(), "event": event, "status": status, "detail": detail}
     with LOG_PATH.open("a", encoding="utf-8") as f:
         f.write(json.dumps(rec) + "\n")
 
 
 def run(cmd: list[str]) -> int:
+    """Run a command and return its exit code."""
+
     try:
         exe = shutil.which(cmd[0])
         if exe is None:
@@ -34,6 +55,8 @@ def run(cmd: list[str]) -> int:
 
 
 def cmd_lint() -> int:
+    """Run pre-commit hooks."""
+
     if SKIP_PRECOMMIT:
         rc = 0
     else:
@@ -43,6 +66,8 @@ def cmd_lint() -> int:
 
 
 def cmd_test() -> int:
+    """Run tests."""
+
     if SKIP_TESTS:
         rc = 0
     else:
@@ -52,6 +77,8 @@ def cmd_test() -> int:
 
 
 def cmd_audit() -> int:
+    """Run lint and tests."""
+
     rc = 0
     if not SKIP_PRECOMMIT:
         rc |= run(["pre-commit", "run", "--all-files"])
@@ -61,20 +88,82 @@ def cmd_audit() -> int:
     return rc
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser("codex-cli")
-    sub = parser.add_subparsers(dest="cmd", required=True)
-    sub.add_parser("lint")
-    sub.add_parser("test")
-    sub.add_parser("audit")
-    args = parser.parse_args()
-    if args.cmd == "lint":
-        sys.exit(cmd_lint())
-    if args.cmd == "test":
-        sys.exit(cmd_test())
-    if args.cmd == "audit":
-        sys.exit(cmd_audit())
+@click.group()
+def codex() -> None:
+    """Codex utility CLI."""
+
+
+@codex.command("lint")
+def lint_cmd() -> None:
+    """Run pre-commit hooks."""
+
+    raise SystemExit(cmd_lint())
+
+
+@codex.command("test")
+def test_cmd() -> None:
+    """Run tests."""
+
+    raise SystemExit(cmd_test())
+
+
+@codex.command("audit")
+def audit_cmd() -> None:
+    """Run lint and tests."""
+
+    raise SystemExit(cmd_audit())
+
+
+@click.command("train-all")
+@click.option(
+    "--fallback/--no-fallback",
+    default=True,
+    help="Enable fallback logic via CODEX_FALLBACK (default: enabled).",
+)
+@click.option(
+    "--print-summary",
+    is_flag=True,
+    default=True,
+    help="Print JSON summary for dashboards/CI.",
+)
+def train_all(fallback: bool, print_summary: bool) -> None:
+    """Run the full training pipeline with optional fallbacks."""
+
+    if fallback:
+        os.environ["CODEX_FALLBACK"] = "1"
+    else:
+        os.environ["CODEX_FALLBACK"] = "0"
+
+    corpus = ["def add(a,b): return a+b", "SELECT * FROM t;"]
+    demos = [
+        {"prompt": "Write a CLI", "completion": "argparse ..."},
+        {"prompt": "Gzip a folder", "completion": "tar -czf ..."},
+    ]
+    pairwise_prefs = [
+        ("sum", "def add(a,b): return a+b", "def add(a,b): return a-b", 1),
+        ("sql", "SELECT * FROM users;", "DROP TABLE users;", 1),
+    ]
+
+    summary = run_codex_pipeline(
+        corpus=corpus,
+        demos=demos,
+        pairwise_prefs=pairwise_prefs,
+        weights=TrainingWeights(alpha=1.0, beta=1.2, gamma=0.05),
+        pre_cfg=PretrainingConfig(model_size="placeholder", context_length=4096),
+        sft_cfg=SFTConfig(batch_size=32, learning_rate=5e-6, epochs=3),
+        rlhf_cfg=RLHFConfig(algorithm="PPO", kl_penalty=0.1, ppo_epochs=4),
+        val_t=ValidationThresholds(
+            syntax_ok=0.98, logic_ok=0.92, security_ok=1.0, perf_ok=0.85
+        ),
+        synth_prompts=None,
+    )
+
+    if print_summary:
+        click.echo(json.dumps(summary, indent=2))
+
+
+codex.add_command(train_all)
 
 
 if __name__ == "__main__":
-    main()
+    codex()


### PR DESCRIPTION
## Summary
- refactor tools/codex_cli.py to use Click and expose new `train-all` command
- add minimal `codex_ml` package with training configs and fallback pipeline
- register CLI entry point and update lint config

## Testing
- `python -m pre_commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aac75e04608331bed267f3f5684d66