### PR TITLE
feat: add train-all pipeline command

### DIFF
--- a/src/codex_ml/__init__.py
+++ b/src/codex_ml/__init__.py
@@ -1,0 +1,19 @@
+"""Minimal training pipeline stubs for Codex CLI."""
+
+from .pipeline import run_codex_pipeline
+from .config import (
+    TrainingWeights,
+    PretrainingConfig,
+    SFTConfig,
+    RLHFConfig,
+    ValidationThresholds,
+)
+
+__all__ = [
+    "run_codex_pipeline",
+    "TrainingWeights",
+    "PretrainingConfig",
+    "SFTConfig",
+    "RLHFConfig",
+    "ValidationThresholds",
+]

--- a/src/codex_ml/config.py
+++ b/src/codex_ml/config.py
@@ -1,0 +1,48 @@
+"""Configuration dataclasses for the Codex training pipeline."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TrainingWeights:
+    """Weights controlling relative importance of training stages."""
+
+    alpha: float
+    beta: float
+    gamma: float
+
+
+@dataclass
+class PretrainingConfig:
+    """Settings for the pretraining stage."""
+
+    model_size: str
+    context_length: int
+
+
+@dataclass
+class SFTConfig:
+    """Settings for supervised fine-tuning."""
+
+    batch_size: int
+    learning_rate: float
+    epochs: int
+
+
+@dataclass
+class RLHFConfig:
+    """Settings for the RLHF stage."""
+
+    algorithm: str
+    kl_penalty: float
+    ppo_epochs: int
+
+
+@dataclass
+class ValidationThresholds:
+    """Metrics expected from the validation step."""
+
+    syntax_ok: float
+    logic_ok: float
+    security_ok: float
+    perf_ok: float

--- a/src/codex_ml/pipeline.py
+++ b/src/codex_ml/pipeline.py
@@ -1,0 +1,77 @@
+"""Fallback-friendly Codex training pipeline."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional, Sequence, Tuple
+import os
+
+from .config import (
+    TrainingWeights,
+    PretrainingConfig,
+    SFTConfig,
+    RLHFConfig,
+    ValidationThresholds,
+)
+
+
+def run_codex_pipeline(
+    *,
+    corpus: Sequence[str],
+    demos: Sequence[Dict[str, str]],
+    pairwise_prefs: Sequence[Tuple[str, str, str, int]],
+    weights: TrainingWeights,
+    pre_cfg: PretrainingConfig,
+    sft_cfg: SFTConfig,
+    rlhf_cfg: RLHFConfig,
+    val_t: ValidationThresholds,
+    synth_prompts: Optional[Iterable[str]] = None,
+) -> Dict[str, Any]:
+    """Run the Codex training pipeline.
+
+    This is a stub implementation that returns synthetic metrics when
+    ``CODEX_FALLBACK`` is enabled. If fallback is disabled, a
+    ``NotImplementedError`` is raised to signal missing real
+    implementations.
+    """
+
+    fallback = os.getenv("CODEX_FALLBACK", "1") == "1"
+    if not fallback:
+        raise NotImplementedError("Real training pipeline not implemented")
+
+    summary = {
+        "pretraining_tokens": sum(len(x) for x in corpus),
+        "sft_examples": len(list(demos)),
+        "rlhf_pairs": len(list(pairwise_prefs)),
+        "weights": {
+            "alpha": weights.alpha,
+            "beta": weights.beta,
+            "gamma": weights.gamma,
+        },
+        "config": {
+            "pretraining": {
+                "model_size": pre_cfg.model_size,
+                "context_length": pre_cfg.context_length,
+            },
+            "sft": {
+                "batch_size": sft_cfg.batch_size,
+                "learning_rate": sft_cfg.learning_rate,
+                "epochs": sft_cfg.epochs,
+            },
+            "rlhf": {
+                "algorithm": rlhf_cfg.algorithm,
+                "kl_penalty": rlhf_cfg.kl_penalty,
+                "ppo_epochs": rlhf_cfg.ppo_epochs,
+            },
+            "validation": {
+                "syntax_ok": val_t.syntax_ok,
+                "logic_ok": val_t.logic_ok,
+                "security_ok": val_t.security_ok,
+                "perf_ok": val_t.perf_ok,
+            },
+        },
+    }
+
+    if synth_prompts is not None:
+        summary["synth_prompts"] = list(synth_prompts)
+
+    return summary

--- a/tools/codex_cli.py
+++ b/tools/codex_cli.py
@@ -8,6 +8,18 @@ import subprocess  # nosec B404
 import sys
 import time
 
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "src"))
+
+from codex_ml.config import (  # noqa: E402
+    PretrainingConfig,
+    RLHFConfig,
+    SFTConfig,
+    TrainingWeights,
+    ValidationThresholds,
+)
+from codex_ml.pipeline import run_codex_pipeline  # noqa: E402
+
 LOG_PATH = pathlib.Path(os.getenv("CODEX_LOG_DB_PATH", ".codex/action_log.ndjson"))
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
@@ -61,12 +73,80 @@ def cmd_audit() -> int:
     return rc
 
 
+def cmd_train_all(fallback: bool, print_summary: bool) -> int:
+    if fallback:
+        os.environ["CODEX_FALLBACK"] = "1"
+    else:
+        os.environ["CODEX_FALLBACK"] = "0"
+
+    corpus = ["def add(a,b): return a+b", "SELECT * FROM t;"]
+    demos = [
+        {"prompt": "Write a CLI", "completion": "argparse ..."},
+        {"prompt": "Gzip a folder", "completion": "tar -czf ..."},
+    ]
+    pairwise_prefs = [
+        ("sum", "def add(a,b): return a+b", "def add(a,b): return a-b", 1),
+        ("sql", "SELECT * FROM users;", "DROP TABLE users;", 1),
+    ]
+
+    try:
+        summary = run_codex_pipeline(
+            corpus=corpus,
+            demos=demos,
+            pairwise_prefs=pairwise_prefs,
+            weights=TrainingWeights(alpha=1.0, beta=1.2, gamma=0.05),
+            pre_cfg=PretrainingConfig(model_size="placeholder", context_length=4096),
+            sft_cfg=SFTConfig(batch_size=32, learning_rate=5e-6, epochs=3),
+            rlhf_cfg=RLHFConfig(algorithm="PPO", kl_penalty=0.1, ppo_epochs=4),
+            val_t=ValidationThresholds(
+                syntax_ok=0.98, logic_ok=0.92, security_ok=1.0, perf_ok=0.85
+            ),
+            synth_prompts=None,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        log("train-all", "fail", str(exc))
+        return 1
+
+    if print_summary:
+        print(json.dumps(summary, indent=2))
+
+    log("train-all", "ok")
+    return 0
+
+
 def main() -> None:
     parser = argparse.ArgumentParser("codex-cli")
     sub = parser.add_subparsers(dest="cmd", required=True)
     sub.add_parser("lint")
     sub.add_parser("test")
     sub.add_parser("audit")
+    p_train = sub.add_parser("train-all")
+    p_train.add_argument(
+        "--fallback",
+        dest="fallback",
+        action="store_true",
+        default=True,
+        help="Enable fallback logic via CODEX_FALLBACK (default: enabled).",
+    )
+    p_train.add_argument(
+        "--no-fallback",
+        dest="fallback",
+        action="store_false",
+        help="Disable fallback logic via CODEX_FALLBACK.",
+    )
+    p_train.add_argument(
+        "--print-summary",
+        dest="print_summary",
+        action="store_true",
+        default=True,
+        help="Print JSON summary for dashboards/CI.",
+    )
+    p_train.add_argument(
+        "--no-print-summary",
+        dest="print_summary",
+        action="store_false",
+        help="Suppress JSON summary output.",
+    )
     args = parser.parse_args()
     if args.cmd == "lint":
         sys.exit(cmd_lint())
@@ -74,6 +154,8 @@ def main() -> None:
         sys.exit(cmd_test())
     if args.cmd == "audit":
         sys.exit(cmd_audit())
+    if args.cmd == "train-all":
+        sys.exit(cmd_train_all(args.fallback, args.print_summary))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `train-all` subcommand to codex CLI for Pretraining→SFT→RLHF→Validation
- include stub `codex_ml` package with configs and fallback pipeline

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaca70530c833192b53b8b20de6d8b