### PR TITLE
Add symbolic RLHF pipeline scaffold

### DIFF
--- a/documentation/codex_symbolic_pipeline.py
+++ b/documentation/codex_symbolic_pipeline.py
@@ -1,0 +1,235 @@
+# ================================================================
+# ChatGPT Codex — Pseudocode Scaffold (mirrors symbolic objective)
+# ================================================================
+# Symbolic pipeline:
+#   Let M0 = Base Codex (pretrained on text+code)
+#   M0 — SFT(curated demos) → M1 — RLHF(reward model, PPO) → M2 (Final)
+#
+# Objective (schematic):
+#   U(M) = α·L_SFT(M; D_code) + β·L_RLHF(M; R) + γ·Ω(M)
+#
+# Notes:
+#   - Pretraining creates M0 (foundation).
+#   - SFT aligns with curated demonstrations D_code.
+#   - RLHF optimizes policy against a learned Reward Model (e.g., PPO).
+#   - Ω(M) can encode safety/regularization terms.
+# ---------------------------------------------------------------
+
+from __future__ import annotations
+
+import json
+import math
+import random
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple
+
+# ----------------------------- Config -----------------------------
+
+
+@dataclass
+class Weights:
+    alpha: float = 1.0  # weight for SFT loss
+    beta: float = 1.0  # weight for RLHF term
+    gamma: float = 0.1  # weight for regularization
+
+
+@dataclass
+class PretrainCfg:
+    context_len: int = 4096
+    objective: str = "next_token_prediction"
+    lr: float = 1e-4
+    epochs: int = 1
+
+
+@dataclass
+class SFTCfg:
+    lr: float = 5e-6
+    epochs: int = 3
+    batch_size: int = 32
+
+
+@dataclass
+class RLHFCfg:
+    algo: str = "PPO"
+    ppo_clip: float = 0.2
+    kl_penalty: float = 0.1
+    epochs: int = 4
+
+
+# ----------------------------- Handles ----------------------------
+
+
+@dataclass
+class ModelHandle:
+    name: str
+    stage: str
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RewardModelHandle:
+    name: str
+    base_model: str
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+# --------------------------- Primitives ---------------------------
+
+
+def pretrain(corpus: List[str], cfg: PretrainCfg) -> ModelHandle:
+    """
+    Pretraining stub → M0
+    Returns a base model handle with token stats; bind to real trainer as needed.
+    """
+    tokens = sum(len(t) for t in corpus)
+    time.sleep(0.01)
+    return ModelHandle(
+        "Codex-Base", "M0.Pretrained", {"tokens_seen": tokens, **cfg.__dict__}
+    )
+
+
+def sft(model: ModelHandle, demos: List[Dict[str, Any]], cfg: SFTCfg) -> ModelHandle:
+    """
+    Supervised Fine-Tuning → M1
+    """
+    time.sleep(0.01)
+    return ModelHandle(model.name, "M1.SFT", {"samples": len(demos), **cfg.__dict__})
+
+
+def train_reward_model(
+    prefs: List[Tuple[str, str, int]], base: ModelHandle
+) -> RewardModelHandle:
+    """
+    Reward-Model training from pairwise preferences:
+    Each tuple: (prompt, completion_A, completion_B, label ∈ {0,1} for A preferred)
+    """
+    time.sleep(0.01)
+    return RewardModelHandle("RM-Codex", base.name, {"pairs": len(prefs)})
+
+
+def rlhf_ppo(model: ModelHandle, rm: RewardModelHandle, cfg: RLHFCfg) -> ModelHandle:
+    """
+    RLHF stage via PPO → M2
+    """
+    time.sleep(0.01)
+    return ModelHandle(model.name, "M2.RLHF", {"rm": rm.name, **cfg.__dict__})
+
+
+# ---------------------------- Loss Terms --------------------------
+
+
+def loss_sft(model: ModelHandle, demos: List[Dict[str, Any]]) -> float:
+    """
+    Placeholder supervised loss L_SFT(M; D_code).
+    Lower is better. Replace with real evaluation.
+    """
+    # Toy: inverse with log on sample count
+    n = max(1, len(demos))
+    return 1.0 / math.log1p(n)
+
+
+def loss_rlhf(model: ModelHandle, rm: RewardModelHandle) -> float:
+    """
+    Placeholder RLHF term L_RLHF(M; R).
+    Interpret lower as better (negative reward / regret proxy).
+    Replace with PPO rollout evaluation against reward model.
+    """
+    # Toy: decreases as 'epochs' increase in RLHFCfg, if present
+    steps = model.meta.get("epochs", 1)
+    return 1.0 / (1.0 + steps)
+
+
+def regularizer(model: ModelHandle) -> float:
+    """
+    Ω(M): safety/regularization proxy (e.g., KL to a reference model, policy entropy control).
+    """
+    # Toy: small constant with mild jitter
+    return 0.05 + 0.01 * random.random()
+
+
+def objective_U(
+    alpha: float, beta: float, gamma: float, Lsft: float, Lrlhf: float, Omega: float
+) -> float:
+    """
+    U(M) = α·L_SFT + β·L_RLHF + γ·Ω
+    """
+    return alpha * Lsft + beta * Lrlhf + gamma * Omega
+
+
+# --------------------------- Orchestration ------------------------
+
+
+def run_codex_symbolic_pipeline(
+    *,
+    corpus: List[str],
+    demos: List[Dict[str, Any]],
+    prefs: List[Tuple[str, str, int]],
+    w: Weights = Weights(),
+    pre_cfg: PretrainCfg = PretrainCfg(),
+    sft_cfg: SFTCfg = SFTCfg(),
+    rlhf_cfg: RLHFCfg = RLHFCfg(),
+) -> Dict[str, Any]:
+    """
+    Mirrors symbolic math exactly:
+      M0 = pretrain(corpus)
+      M1 = sft(M0, demos)
+      RM = train_reward_model(prefs, M1)
+      M2 = rlhf_ppo(M1, RM)
+      U(M2) = α·L_SFT(M2; D_code) + β·L_RLHF(M2; R) + γ·Ω(M2)
+    """
+    # Stages
+    M0 = pretrain(corpus, pre_cfg)
+    M1 = sft(M0, demos, sft_cfg)
+    RM = train_reward_model(prefs, M1)
+    M2 = rlhf_ppo(M1, RM, rlhf_cfg)
+
+    # Losses & Objective
+    Lsft = loss_sft(M2, demos)
+    Lrl = loss_rlhf(M2, RM)
+    Om = regularizer(M2)
+    U = objective_U(w.alpha, w.beta, w.gamma, Lsft, Lrl, Om)
+
+    return {
+        "symbolic": "M0 — SFT → M1 — RLHF(PPO) → M2;  U = α·L_SFT + β·L_RLHF + γ·Ω",
+        "weights": w.__dict__,
+        "handles": {
+            "M0": M0.__dict__,
+            "M1": M1.__dict__,
+            "RM": RM.__dict__,
+            "M2": M2.__dict__,
+        },
+        "losses": {"L_SFT": Lsft, "L_RLHF": Lrl, "Omega": Om},
+        "objective_U": U,
+    }
+
+
+# --------------------------- Example Run --------------------------
+
+if __name__ == "__main__":
+    toy_corpus = ["def add(a,b): return a+b", "SELECT * FROM users;", "# docs..."]
+    toy_demos = [
+        {
+            "prompt": "Write a CLI that echoes input",
+            "completion": "argparse-based CLI ...",
+        },
+        {
+            "prompt": "Create a Bash script to gzip a folder",
+            "completion": "tar -czf ...",
+        },
+    ]
+    toy_prefs = [
+        ("sum", "def add(a,b): return a+b", "def add(a,b): return a-b", 1),
+        ("sql", "SELECT * FROM users;", "DROP TABLE users;", 1),
+    ]
+
+    summary = run_codex_symbolic_pipeline(
+        corpus=toy_corpus,
+        demos=toy_demos,
+        prefs=toy_prefs,
+        w=Weights(alpha=1.0, beta=1.2, gamma=0.05),
+        pre_cfg=PretrainCfg(context_len=4096, lr=1e-4, epochs=1),
+        sft_cfg=SFTCfg(lr=5e-6, epochs=3, batch_size=32),
+        rlhf_cfg=RLHFCfg(algo="PPO", ppo_clip=0.2, kl_penalty=0.1, epochs=4),
+    )
+    print(json.dumps(summary, indent=2))


### PR DESCRIPTION
## Summary
- add a `codex_symbolic_pipeline.py` example demonstrating a pretrain→SFT→RLHF(PPO) flow with an explicit U(M)=α·L_SFT+β·L_RLHF+γ·Ω objective

## Testing
- `pre-commit run --files documentation/codex_symbolic_pipeline.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aacdcb8ecc83319d25b6ae2b872e41