### PR TITLE
docs: add symbolic training summary

### DIFF
--- a/documentation/codex_symbolic_training_summary.md
+++ b/documentation/codex_symbolic_training_summary.md
@@ -1,0 +1,56 @@
+# ChatGPT Codex — Symbolic Training Summary
+
+This document summarizes the high-level training trajectory for ChatGPT Codex using symbolic notation. It consolidates the core stages—pretraining, supervised fine-tuning, and reinforcement learning from human feedback (RLHF)—and sketches the data and objective flow.
+
+## Stages
+
+1. **Pretraining** – Large-scale next-token prediction on mixed code and text corpora to learn general coding fluency. [^1] [^2]
+2. **Supervised Fine-Tuning (SFT)** – Aligns the pretrained model with curated demonstrations of coding tasks, fixes, and explanations. [^1]
+3. **RLHF (Policy Optimization)** – A reward model, trained on human preference comparisons, guides a policy optimization step (e.g., PPO) to produce the deployed assistant. Rule-based rewards can be mixed in for safety constraints. [^3] [^4]
+
+## Symbolic Pipeline
+
+```
+Let M₀ = Base Codex (pretrained)
+Codex:
+  M₀ — SFT(curated code demos) → M₁ — RLHF(reward model, PPO) → M₂ (deployed utility)
+```
+
+Here the reward model is derived from human preference pairs and scores candidate outputs. [^3]
+
+## Objective (schematic)
+
+$$
+\min_{M}\; \mathcal{L}(M)
+= \alpha\,\mathcal{L}_{\text{SFT}}(M; D_{\text{code}})\;+\;
+  \beta\,\mathcal{L}_{\text{RLHF}}(M; R)\;+\;
+  \gamma\,\Omega(M)
+$$
+
+- $\mathcal{L}_{\text{SFT}}$: supervised loss on curated coding data
+- $\mathcal{L}_{\text{RLHF}}$: preference-based reward optimization (e.g., PPO with a learned RM)
+- $\Omega(M)$: regularizers or safety constraints (may include rule-based rewards)
+- $\alpha,\beta,\gamma$: phase weights [^3] [^4]
+
+## Data and Feedback Flow
+
+$$
+\begin{aligned}
+&\textbf{Pretraining:}& \text{Corpora}_{\text{text,code}} \;\rightarrow\; M_0 \\
+&\textbf{SFT:}& (M_0, D_{\text{demos}}) \;\xrightarrow{\text{supervised}}\; M_1 \\
+&\textbf{RM training:}& D_{\text{prefs}}=(x, y_A, y_B, \ell)\;\rightarrow\; \text{RewardModel} \\
+&\textbf{RLHF:}& (M_1,\text{RewardModel}) \;\xrightarrow{\text{PPO}}\; M_2
+\end{aligned}
+$$
+
+Human labelers supply demonstration data $D_{\text{demos}}$ and preference pairs $D_{\text{prefs}}$. The reward model predicts preferred outputs, and PPO optimizes the policy against that model while optionally incorporating rule-based safety rewards. [^3] [^4]
+
+## Notes on Codex
+
+OpenAI Codex is a product line of coding assistants built on this training lineage, which follows the pretraining → SFT → RLHF paradigm. [^5]
+
+[^1]: [Introducing ChatGPT](https://openai.com/index/chatgpt/?utm_source=chatgpt.com)
+[^2]: [GPT-4 Technical Report](https://cdn.openai.com/papers/gpt-4.pdf?utm_source=chatgpt.com)
+[^3]: [Aligning language models to follow instructions](https://openai.com/index/instruction-following/?utm_source=chatgpt.com)
+[^4]: [Training language models to follow instructions with human feedback](https://cdn.openai.com/papers/Training_language_models_to_follow_instructions_with_human_feedback.pdf?utm_source=chatgpt.com)
+[^5]: [OpenAI Codex](https://openai.com/codex/?utm_source=chatgpt.com)


### PR DESCRIPTION
## Summary
- document ChatGPT Codex's pretraining, SFT, and RLHF stages using symbolic notation
- outline objective function and data flow

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aacce3397483319a550a2eb497c780