### PR TITLE
Fix reward preference tuple typing

### DIFF
--- a/documentation/codex_symbolic_pipeline.py
+++ b/documentation/codex_symbolic_pipeline.py
@@ -98,7 +98,7 @@ def sft(model: ModelHandle, demos: List[Dict[str, Any]], cfg: SFTCfg) -> ModelHa
 
 
 def train_reward_model(
-    prefs: List[Tuple[str, str, int]], base: ModelHandle
+    prefs: List[Tuple[str, str, str, int]], base: ModelHandle
 ) -> RewardModelHandle:
     """
     Reward-Model training from pairwise preferences:
@@ -164,7 +164,7 @@ def run_codex_symbolic_pipeline(
     *,
     corpus: List[str],
     demos: List[Dict[str, Any]],
-    prefs: List[Tuple[str, str, int]],
+    prefs: List[Tuple[str, str, str, int]],
     w: Weights = Weights(),
     pre_cfg: PretrainCfg = PretrainCfg(),
     sft_cfg: SFTCfg = SFTCfg(),

--- a/src/codex_ml/symbolic_pipeline.py
+++ b/src/codex_ml/symbolic_pipeline.py
@@ -97,7 +97,7 @@ def sft(model: ModelHandle, demos: List[Dict[str, Any]], cfg: SFTCfg) -> ModelHa
 
 
 def train_reward_model(
-    prefs: List[Tuple[str, str, int]], base: ModelHandle
+    prefs: List[Tuple[str, str, str, int]], base: ModelHandle
 ) -> RewardModelHandle:
     """
     Reward-Model training from pairwise preferences:
@@ -163,7 +163,7 @@ def run_codex_symbolic_pipeline(
     *,
     corpus: List[str],
     demos: List[Dict[str, Any]],
-    prefs: List[Tuple[str, str, int]],
+    prefs: List[Tuple[str, str, str, int]],
     w: Weights = Weights(),
     pre_cfg: PretrainCfg = PretrainCfg(),
     sft_cfg: SFTCfg = SFTCfg(),


### PR DESCRIPTION
## Summary
- fix reward model preference tuple annotations
- update pipeline orchestrator to accept full preference tuples

## Testing
- `pre-commit run --files documentation/codex_symbolic_pipeline.py src/codex_ml/symbolic_pipeline.py`
- `pytest tests/test_symbolic_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab2f477878833180c879ef10628d83