### PR TITLE
Implement PPO clipping and expand symbolic pipeline tests

### DIFF
--- a/src/codex_ml/symbolic_pipeline.py
+++ b/src/codex_ml/symbolic_pipeline.py
@@ -270,8 +270,10 @@ def rlhf_ppo(model: ModelHandle, rm: RewardModelHandle, cfg: RLHFCfg) -> ModelHa
             rewards.append(r)
             baseline = sum(rewards) / len(rewards)
             adv = r - baseline - cfg.kl_penalty * kl_divergence(token_probs, base_probs)
+            ratio = math.exp(cfg.lr * adv)
+            clipped = max(1 - cfg.ppo_clip, min(1 + cfg.ppo_clip, ratio))
             for t in completion:
-                token_probs[t] *= math.exp(cfg.lr * adv)
+                token_probs[t] *= clipped
             total = sum(token_probs.values())
             for k in token_probs:
                 token_probs[k] /= total

--- a/tests/test_symbolic_pipeline.py
+++ b/tests/test_symbolic_pipeline.py
@@ -9,6 +9,7 @@ from codex_ml.symbolic_pipeline import (
     Weights,
     loss_sft,
     pretrain,
+    rlhf_ppo,
     run_codex_symbolic_pipeline,
     sft,
     train_reward_model,
@@ -62,3 +63,41 @@ def test_reward_model_accuracy_and_loss():
     computed = loss_sft(model, demos)
     manual = -sum(math.log(model.meta["token_probs"][t]) for t in ["a", "b"]) / 2
     assert math.isclose(computed, manual)
+
+
+def test_sft_empty_demos_raises():
+    model = pretrain(["a"], PretrainCfg(seed=0))
+    with pytest.raises(ValueError):
+        sft(model, [], SFTCfg(seed=0))
+
+
+def test_train_reward_model_empty_prefs_raises():
+    model = pretrain(["a"], PretrainCfg(seed=0))
+    with pytest.raises(ValueError):
+        train_reward_model([], model)
+
+
+def test_rlhf_missing_prefs_raises():
+    model = pretrain(["a"], PretrainCfg(seed=0))
+    model = sft(model, [{"prompt": "p", "completion": "a"}], SFTCfg(seed=0))
+    rm = train_reward_model([("p", "a", "b", 1)], model)
+    rm.meta.pop("prefs")
+    with pytest.raises(ValueError):
+        rlhf_ppo(model, rm, RLHFCfg(seed=0))
+
+
+def test_rlhf_cfg_invalid():
+    with pytest.raises(ValueError):
+        RLHFCfg(ppo_clip=-0.1)
+
+
+def test_rlhf_deterministic():
+    corpus, demos, prefs = _basic_data()
+    M0a = pretrain(corpus, PretrainCfg(seed=0))
+    M0b = pretrain(corpus, PretrainCfg(seed=0))
+    M1a = sft(M0a, demos, SFTCfg(seed=0, batch_size=1))
+    M1b = sft(M0b, demos, SFTCfg(seed=0, batch_size=1))
+    rm = train_reward_model(prefs, M1a)
+    M2a = rlhf_ppo(M1a, rm, RLHFCfg(seed=0))
+    M2b = rlhf_ppo(M1b, rm, RLHFCfg(seed=0))
+    assert M2a.meta["token_probs"] == M2b.meta["token_probs"]


### PR DESCRIPTION
## Summary
- incorporate PPO clipping into `rlhf_ppo` and apply advantages with KL regularization
- add extensive tests for SFT, reward model, and RLHF edge cases and determinism

## Testing
- `pytest`
- `pre-commit run --all-files` *(fails: repository hook semgrep environment init)*

------
https://chatgpt.com/codex/tasks/task_e_68ab39818ce4833198dff6ab8de9b4b9