### PR TITLE
Ensure deterministic seeding across symbolic pipeline

### DIFF
--- a/documentation/codex_symbolic_pipeline.py
+++ b/documentation/codex_symbolic_pipeline.py
@@ -13,6 +13,7 @@
 #   - SFT aligns with curated demonstrations D_code.
 #   - RLHF optimizes policy against a learned Reward Model (e.g., PPO).
 #   - Ω(M) can encode safety/regularization terms.
+#   - Deterministic seeds default to 0 for reproducibility.
 # ---------------------------------------------------------------
 
 from __future__ import annotations
@@ -40,6 +41,7 @@ class PretrainCfg:
     objective: str = "next_token_prediction"
     lr: float = 1e-4
     epochs: int = 1
+    seed: int = 0
 
 
 @dataclass
@@ -47,6 +49,7 @@ class SFTCfg:
     lr: float = 5e-6
     epochs: int = 3
     batch_size: int = 32
+    seed: int = 0
 
 
 @dataclass
@@ -55,6 +58,7 @@ class RLHFCfg:
     ppo_clip: float = 0.2
     kl_penalty: float = 0.1
     epochs: int = 4
+    seed: int = 0
 
 
 # ----------------------------- Handles ----------------------------
@@ -144,8 +148,9 @@ def regularizer(model: ModelHandle) -> float:
     """
     Ω(M): safety/regularization proxy (e.g., KL to a reference model, policy entropy control).
     """
-    # Toy: small constant with mild jitter
-    return 0.05 + 0.01 * random.random()
+    # Toy: small constant with mild jitter, deterministically seeded
+    rng = random.Random(model.meta.get("seed", 0))
+    return 0.05 + 0.01 * rng.random()
 
 
 def objective_U(

--- a/documentation/codex_symbolic_training_summary.md
+++ b/documentation/codex_symbolic_training_summary.md
@@ -45,6 +45,7 @@ Demonstrations ($D_{\text{demos}}$) and preference pairs ($D_{\text{prefs}}$) ar
 
 ### Notes specific to Codex
 
+* A lightweight reference implementation mirrors this pipeline with deterministic seeding (default ``0``) so runs are reproducible without manual configuration.
 * Codex is an OpenAI coding agent/product line built on our most capable models; its training lineage follows the Pretraining → SFT → RLHF paradigm used across deployed assistants. [^5]
 
 [^1]: [Introducing ChatGPT](https://openai.com/index/chatgpt/?utm_source=chatgpt.com)

--- a/src/codex_ml/symbolic_pipeline.py
+++ b/src/codex_ml/symbolic_pipeline.py
@@ -14,7 +14,8 @@ The components are intentionally lightweight and rely only on the Python
 standard library so that the tests run quickly.  Nevertheless, the code mirrors
 the structure of real world systems: tokenisation, batching, gradient updates
 and evaluation metrics are implemented for each stage.  Deterministic seeding is
-used throughout to guarantee reproducible outputs.
+used throughout to guarantee reproducible outputs; each configuration defaults
+to ``seed=0`` so runs are reproducible without manual seeding.
 """
 
 from __future__ import annotations
@@ -66,7 +67,7 @@ class PretrainCfg:
     objective: str = "next_token_prediction"
     lr: float = 1e-2
     epochs: int = 1
-    seed: int | None = None
+    seed: int = 0
 
     def __post_init__(self) -> None:  # pragma: no cover - simple validation
         if self.context_len <= 0 or self.lr <= 0 or self.epochs <= 0:
@@ -78,7 +79,7 @@ class SFTCfg:
     lr: float = 1e-2
     epochs: int = 1
     batch_size: int = 32
-    seed: int | None = None
+    seed: int = 0
 
     def __post_init__(self) -> None:  # pragma: no cover - simple validation
         if self.lr <= 0 or self.epochs <= 0 or self.batch_size <= 0:
@@ -92,7 +93,7 @@ class RLHFCfg:
     kl_penalty: float = 0.1
     epochs: int = 1
     lr: float = 1e-2
-    seed: int | None = None
+    seed: int = 0
 
     def __post_init__(self) -> None:  # pragma: no cover - simple validation
         if (

--- a/tests/test_symbolic_pipeline.py
+++ b/tests/test_symbolic_pipeline.py
@@ -26,9 +26,9 @@ def _basic_data():
 def test_pipeline_reproducible():
     corpus, demos, prefs = _basic_data()
     cfgs = dict(
-        pre_cfg=PretrainCfg(seed=0),
-        sft_cfg=SFTCfg(seed=0, batch_size=1),
-        rlhf_cfg=RLHFCfg(seed=0),
+        pre_cfg=PretrainCfg(),
+        sft_cfg=SFTCfg(batch_size=1),
+        rlhf_cfg=RLHFCfg(),
         w=Weights(),
     )
     summary1 = run_codex_symbolic_pipeline(
@@ -56,8 +56,8 @@ def test_invalid_config():
 
 def test_reward_model_accuracy_and_loss():
     corpus, demos, prefs = _basic_data()
-    model = pretrain(corpus, PretrainCfg(seed=0))
-    model = sft(model, demos, SFTCfg(seed=0, batch_size=1))
+    model = pretrain(corpus, PretrainCfg())
+    model = sft(model, demos, SFTCfg(batch_size=1))
     rm = train_reward_model(prefs, model)
     assert rm.meta["accuracy"] == 1.0
     computed = loss_sft(model, demos)
@@ -66,24 +66,24 @@ def test_reward_model_accuracy_and_loss():
 
 
 def test_sft_empty_demos_raises():
-    model = pretrain(["a"], PretrainCfg(seed=0))
+    model = pretrain(["a"], PretrainCfg())
     with pytest.raises(ValueError):
-        sft(model, [], SFTCfg(seed=0))
+        sft(model, [], SFTCfg())
 
 
 def test_train_reward_model_empty_prefs_raises():
-    model = pretrain(["a"], PretrainCfg(seed=0))
+    model = pretrain(["a"], PretrainCfg())
     with pytest.raises(ValueError):
         train_reward_model([], model)
 
 
 def test_rlhf_missing_prefs_raises():
-    model = pretrain(["a"], PretrainCfg(seed=0))
-    model = sft(model, [{"prompt": "p", "completion": "a"}], SFTCfg(seed=0))
+    model = pretrain(["a"], PretrainCfg())
+    model = sft(model, [{"prompt": "p", "completion": "a"}], SFTCfg())
     rm = train_reward_model([("p", "a", "b", 1)], model)
     rm.meta.pop("prefs")
     with pytest.raises(ValueError):
-        rlhf_ppo(model, rm, RLHFCfg(seed=0))
+        rlhf_ppo(model, rm, RLHFCfg())
 
 
 def test_rlhf_cfg_invalid():
@@ -93,11 +93,11 @@ def test_rlhf_cfg_invalid():
 
 def test_rlhf_deterministic():
     corpus, demos, prefs = _basic_data()
-    M0a = pretrain(corpus, PretrainCfg(seed=0))
-    M0b = pretrain(corpus, PretrainCfg(seed=0))
-    M1a = sft(M0a, demos, SFTCfg(seed=0, batch_size=1))
-    M1b = sft(M0b, demos, SFTCfg(seed=0, batch_size=1))
+    M0a = pretrain(corpus, PretrainCfg())
+    M0b = pretrain(corpus, PretrainCfg())
+    M1a = sft(M0a, demos, SFTCfg(batch_size=1))
+    M1b = sft(M0b, demos, SFTCfg(batch_size=1))
     rm = train_reward_model(prefs, M1a)
-    M2a = rlhf_ppo(M1a, rm, RLHFCfg(seed=0))
-    M2b = rlhf_ppo(M1b, rm, RLHFCfg(seed=0))
+    M2a = rlhf_ppo(M1a, rm, RLHFCfg())
+    M2b = rlhf_ppo(M1b, rm, RLHFCfg())
     assert M2a.meta["token_probs"] == M2b.meta["token_probs"]


### PR DESCRIPTION
## Summary
- default `seed=0` in pipeline configs for reproducible runs without manual seeding
- document deterministic behaviour and update examples
- adjust tests to rely on built-in seeding

## Testing
- ⚠️ `pre-commit run --files documentation/codex_symbolic_training_summary.md documentation/codex_symbolic_pipeline.py src/codex_ml/symbolic_pipeline.py tests/test_symbolic_pipeline.py` (failed: semgrep environment initialization hung)
- ✅ `pytest tests/test_symbolic_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab3e37d3908331a517964f6611fb4e