### PR TITLE
Implement concrete losses in documentation pipeline

### DIFF
--- a/documentation/codex_symbolic_pipeline.py
+++ b/documentation/codex_symbolic_pipeline.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import json
 import math
 import random
-import time
+import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Tuple
 
@@ -80,79 +80,213 @@ class RewardModelHandle:
     meta: Dict[str, Any] = field(default_factory=dict)
 
 
+TOKEN_RE = re.compile(r"\w+|[^\s\w]", re.UNICODE)
+
+# Small constant used for numerical stability when taking logarithms.
+EPS = 1e-8
+
+
+def tokenize(text: str) -> List[str]:
+    """Split ``text`` into case-insensitive word/punctuation tokens."""
+
+    return TOKEN_RE.findall(text.lower())
+
+
+def kl_divergence(p: Dict[str, float], q: Dict[str, float]) -> float:
+    """Kullback–Leibler divergence ``KL(p || q)`` for discrete distributions."""
+
+    return sum(p[t] * math.log(p[t] / (q.get(t, EPS))) for t in p)
+
+
 # --------------------------- Primitives ---------------------------
 
 
 def pretrain(corpus: List[str], cfg: PretrainCfg) -> ModelHandle:
-    """
-    Pretraining stub → M0
-    Returns a base model handle with token stats; bind to real trainer as needed.
-    """
-    tokens = sum(len(t) for t in corpus)
-    time.sleep(0.01)
-    return ModelHandle(
-        "Codex-Base", "M0.Pretrained", {"tokens_seen": tokens, **cfg.__dict__}
-    )
+    """Train a unigram model on ``corpus`` and return a model handle."""
+
+    if not corpus:
+        raise ValueError("corpus must not be empty")
+    rng = random.Random(cfg.seed)
+    vocab: Dict[str, int] = {}
+    for text in corpus:
+        for tok in tokenize(text):
+            vocab[tok] = vocab.get(tok, 0) + 1
+    total = sum(vocab.values())
+    token_probs = {t: c / total for t, c in vocab.items()}
+    meta = {
+        "vocab": vocab,
+        "token_probs": token_probs,
+        "base_token_probs": token_probs.copy(),
+        "tokens_seen": total,
+        "seed": cfg.seed,
+        "lr": cfg.lr,
+        "epochs": cfg.epochs,
+        "rng_state": rng.getstate(),
+    }
+    return ModelHandle("Codex-Base", "M0.Pretrained", meta)
 
 
 def sft(model: ModelHandle, demos: List[Dict[str, Any]], cfg: SFTCfg) -> ModelHandle:
-    """
-    Supervised Fine-Tuning → M1
-    """
-    time.sleep(0.01)
-    return ModelHandle(model.name, "M1.SFT", {"samples": len(demos), **cfg.__dict__})
+    """Supervised fine-tuning using completion demonstrations."""
+
+    if not demos:
+        raise ValueError("demos must not be empty")
+    rng = random.Random(cfg.seed)
+    token_probs = model.meta["token_probs"].copy()
+    vocab = model.meta["vocab"].copy()
+    losses: List[float] = []
+    for _ in range(cfg.epochs):
+        rng.shuffle(demos)
+        for i in range(0, len(demos), cfg.batch_size):
+            batch = demos[i : i + cfg.batch_size]
+            tokens: List[str] = []
+            for ex in batch:
+                tokens.extend(tokenize(ex["completion"]))
+            if not tokens:
+                continue
+            loss = -sum(math.log(token_probs.get(t, EPS)) for t in tokens) / len(tokens)
+            losses.append(loss)
+            for t in tokens:
+                vocab[t] = vocab.get(t, 0) + 1
+            total = sum(vocab.values())
+            for t in vocab:
+                token_probs[t] = vocab[t] / total
+    model.meta.update(
+        {
+            "token_probs": token_probs,
+            "vocab": vocab,
+            "sft_loss": float(sum(losses) / len(losses)) if losses else 0.0,
+        }
+    )
+    return ModelHandle(model.name, "M1.SFT", model.meta)
 
 
 def train_reward_model(
     prefs: List[Tuple[str, str, str, int]], base: ModelHandle
 ) -> RewardModelHandle:
-    """
-    Reward-Model training from pairwise preferences:
-    Each tuple: (prompt, completion_A, completion_B, label ∈ {0,1} for A preferred)
-    """
-    time.sleep(0.01)
-    return RewardModelHandle("RM-Codex", base.name, {"pairs": len(prefs)})
+    """Train a simple logistic regression reward model on preferences."""
+
+    if not prefs:
+        raise ValueError("prefs must not be empty")
+    vocab = base.meta.get("vocab")
+    if not vocab:
+        raise ValueError("base model missing vocab")
+    token_index = {tok: i for i, tok in enumerate(vocab.keys())}
+    weights = [0.0] * len(token_index)
+    lr = 0.1
+    rng = random.Random(0)
+
+    def featurise(text: str) -> List[float]:
+        vec = [0.0] * len(token_index)
+        for tok in tokenize(text):
+            if tok in token_index:
+                vec[token_index[tok]] += 1.0
+        return vec
+
+    for _ in range(5):
+        rng.shuffle(prefs)
+        for _, a, b, label in prefs:
+            fa, fb = featurise(a), featurise(b)
+            diff = [x - y for x, y in zip(fa, fb)]
+            logit = sum(w * d for w, d in zip(weights, diff))
+            pred = 1 / (1 + math.exp(-logit))
+            grad = [(pred - label) * d for d in diff]
+            for i, g in enumerate(grad):
+                weights[i] -= lr * g
+
+    correct = 0
+    for _, a, b, label in prefs:
+        fa, fb = featurise(a), featurise(b)
+        diff = [x - y for x, y in zip(fa, fb)]
+        logit = sum(w * d for w, d in zip(weights, diff))
+        pred = 1 if logit > 0 else 0
+        correct += int(pred == label)
+    acc = correct / len(prefs)
+    meta = {
+        "weights": weights,
+        "token_index": token_index,
+        "accuracy": acc,
+        "prefs": list(prefs),
+    }
+    return RewardModelHandle("RM-Codex", base.name, meta)
 
 
 def rlhf_ppo(model: ModelHandle, rm: RewardModelHandle, cfg: RLHFCfg) -> ModelHandle:
-    """
-    RLHF stage via PPO → M2
-    """
-    time.sleep(0.01)
-    return ModelHandle(model.name, "M2.RLHF", {"rm": rm.name, **cfg.__dict__})
+    """Policy optimisation with a reward model and KL regularisation."""
+
+    prefs = rm.meta.get("prefs")
+    if not prefs:
+        raise ValueError("reward model missing training data")
+    token_probs = model.meta["token_probs"].copy()
+    base_probs = model.meta["token_probs"].copy()
+    rng = random.Random(cfg.seed)
+
+    def sample_completion(length: int = 4) -> List[str]:
+        tokens = list(token_probs.keys())
+        probs = list(token_probs.values())
+        return rng.choices(tokens, probs, k=length)
+
+    def reward_of(tokens: List[str]) -> float:
+        idx = rm.meta["token_index"]
+        weights = rm.meta["weights"]
+        score = 0.0
+        for t in tokens:
+            if t in idx:
+                score += weights[idx[t]]
+        return score
+
+    for _ in range(cfg.epochs):
+        rewards: List[float] = []
+        for prompt, _, _, _ in prefs:
+            completion = sample_completion()
+            r = reward_of(completion)
+            rewards.append(r)
+            baseline = sum(rewards) / len(rewards)
+            adv = r - baseline - cfg.kl_penalty * kl_divergence(token_probs, base_probs)
+            ratio = math.exp(cfg.lr * adv)
+            clipped = max(1 - cfg.ppo_clip, min(1 + cfg.ppo_clip, ratio))
+            for t in completion:
+                token_probs[t] *= clipped
+            total = sum(token_probs.values())
+            for k in token_probs:
+                token_probs[k] /= total
+
+    model.meta.update({"token_probs": token_probs})
+    return ModelHandle(model.name, "M2.RLHF", model.meta)
 
 
 # ---------------------------- Loss Terms --------------------------
 
 
 def loss_sft(model: ModelHandle, demos: List[Dict[str, Any]]) -> float:
-    """
-    Placeholder supervised loss L_SFT(M; D_code).
-    Lower is better. Replace with real evaluation.
-    """
-    # Toy: inverse with log on sample count
-    n = max(1, len(demos))
-    return 1.0 / math.log1p(n)
+    """Cross-entropy of demo completions under ``model``."""
+
+    token_probs = model.meta["token_probs"]
+    tokens: List[str] = []
+    for ex in demos:
+        tokens.extend(tokenize(ex["completion"]))
+    if not tokens:
+        return 0.0
+    return -sum(math.log(token_probs.get(t, EPS)) for t in tokens) / len(tokens)
 
 
 def loss_rlhf(model: ModelHandle, rm: RewardModelHandle) -> float:
-    """
-    Placeholder RLHF term L_RLHF(M; R).
-    Interpret lower as better (negative reward / regret proxy).
-    Replace with PPO rollout evaluation against reward model.
-    """
-    # Toy: decreases as 'epochs' increase in RLHFCfg, if present
-    steps = model.meta.get("epochs", 1)
-    return 1.0 / (1.0 + steps)
+    """Negative reward for greedy completions under ``model``."""
+
+    idx = rm.meta["token_index"]
+    weights = rm.meta["weights"]
+    token_probs = model.meta["token_probs"]
+    top_tokens = [
+        t for t, _ in sorted(token_probs.items(), key=lambda x: x[1], reverse=True)[:4]
+    ]
+    reward = sum(weights[idx[t]] if t in idx else 0.0 for t in top_tokens)
+    return -reward
 
 
 def regularizer(model: ModelHandle) -> float:
-    """
-    Ω(M): safety/regularization proxy (e.g., KL to a reference model, policy entropy control).
-    """
-    # Toy: small constant with mild jitter, deterministically seeded
-    rng = random.Random(model.meta.get("seed", 0))
-    return 0.05 + 0.01 * rng.random()
+    """Deterministic KL regularisation against the pretrained model."""
+
+    return kl_divergence(model.meta["token_probs"], model.meta["base_token_probs"])
 
 
 def objective_U(

--- a/src/codex_ml/__init__.py
+++ b/src/codex_ml/__init__.py
@@ -1,13 +1,13 @@
 """Minimal training pipeline stubs for Codex CLI."""
 
-from .pipeline import run_codex_pipeline
 from .config import (
-    TrainingWeights,
     PretrainingConfig,
-    SFTConfig,
     RLHFConfig,
+    SFTConfig,
+    TrainingWeights,
     ValidationThresholds,
 )
+from .pipeline import run_codex_pipeline
 
 __all__ = [
     "run_codex_pipeline",

--- a/src/codex_ml/pipeline.py
+++ b/src/codex_ml/pipeline.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Optional, Sequence, Tuple
 import os
+from typing import Any, Dict, Iterable, Optional, Sequence, Tuple
 
 from .config import (
-    TrainingWeights,
     PretrainingConfig,
-    SFTConfig,
     RLHFConfig,
+    SFTConfig,
+    TrainingWeights,
     ValidationThresholds,
 )
 

--- a/src/codex_ml/symbolic_pipeline.py
+++ b/src/codex_ml/symbolic_pipeline.py
@@ -172,9 +172,7 @@ def sft(model: ModelHandle, demos: List[Dict[str, Any]], cfg: SFTCfg) -> ModelHa
                 tokens.extend(tokenize(ex["completion"]))
             if not tokens:
                 continue
-            loss = -sum(math.log(token_probs.get(t, EPS)) for t in tokens) / len(
-                tokens
-            )
+            loss = -sum(math.log(token_probs.get(t, EPS)) for t in tokens) / len(tokens)
             losses.append(loss)
             for t in tokens:
                 vocab[t] = vocab.get(t, 0) + 1


### PR DESCRIPTION
## Summary
- add tokenization and KL utilities to the documentation pipeline
- implement functional pretrain/SFT/RLHF steps with real cross-entropy and reward losses
- format Codex modules to satisfy pre-commit

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab5877127483319ea5c4e673bba1ac