### PR TITLE
Expose symbolic RLHF pipeline

### DIFF
--- a/src/codex_ml/__init__.py
+++ b/src/codex_ml/__init__.py
@@ -8,12 +8,30 @@ from .config import (
     ValidationThresholds,
 )
 from .pipeline import run_codex_pipeline
+from .symbolic_pipeline import (
+    ModelHandle,
+    PretrainCfg,
+    RewardModelCfg,
+    RewardModelHandle,
+    RLHFCfg,
+    SFTCfg,
+    Weights,
+    run_codex_symbolic_pipeline,
+)
 
 __all__ = [
     "run_codex_pipeline",
+    "run_codex_symbolic_pipeline",
     "TrainingWeights",
     "PretrainingConfig",
     "SFTConfig",
     "RLHFConfig",
     "ValidationThresholds",
+    "Weights",
+    "PretrainCfg",
+    "SFTCfg",
+    "RewardModelCfg",
+    "RLHFCfg",
+    "ModelHandle",
+    "RewardModelHandle",
 ]


### PR DESCRIPTION
## Summary
- re-export symbolic RLHF training pipeline from `codex_ml` package

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab79b0e38c8331adac127e2916d015