### PR TITLE
Add deterministic deploy pipeline script

### DIFF
--- a/scripts/deploy_codex_pipeline.py
+++ b/scripts/deploy_codex_pipeline.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Minimal deterministic codex deployment pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def _sha256(path: Path) -> str:
+    """Return SHA256 hex digest of file contents."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _count_jsonl(path: Path) -> int:
+    """Count non-empty JSON lines in ``path``.
+
+    Each line is parsed to ensure valid JSON and to avoid relying on ``hash``
+    or other non-deterministic behaviour.
+    """
+    count = 0
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            if line.strip():
+                json.loads(line)
+                count += 1
+    return count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Deploy codex pipeline")
+    parser.add_argument("--corpus", type=Path, required=True)
+    parser.add_argument("--demos", type=Path, required=True)
+    parser.add_argument("--prefs", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    out_dir = args.output_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = {
+        "corpus_sha256": _sha256(args.corpus),
+        "num_demos": _count_jsonl(args.demos),
+        "num_prefs": _count_jsonl(args.prefs),
+    }
+
+    (out_dir / "summary.json").write_text(
+        json.dumps(summary, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deploy_codex_pipeline.py
+++ b/tests/test_deploy_codex_pipeline.py
@@ -1,0 +1,36 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_reproducible_run(tmp_path: Path) -> None:
+    """Ensure pipeline produces identical summaries given the same inputs."""
+    # Prepare toy data
+    corpus = tmp_path / "corpus.txt"
+    demos = tmp_path / "demos.jsonl"
+    prefs = tmp_path / "prefs.jsonl"
+    corpus.write_text("print('hi')\n")
+    demos.write_text('{"prompt":"p","completion":"c"}\n')
+    prefs.write_text('["p","a","b",1]\n')
+
+    def run_once(out_dir: Path) -> dict[str, object]:
+        subprocess.run(
+            [
+                "python",
+                "scripts/deploy_codex_pipeline.py",
+                "--corpus",
+                str(corpus),
+                "--demos",
+                str(demos),
+                "--prefs",
+                str(prefs),
+                "--output-dir",
+                str(out_dir),
+            ],
+            check=True,
+        )
+        return json.loads((out_dir / "summary.json").read_text())
+
+    s1 = run_once(tmp_path / "run1")
+    s2 = run_once(tmp_path / "run2")
+    assert s1 == s2


### PR DESCRIPTION
## Summary
- implement `deploy_codex_pipeline.py` to produce reproducible summary from corpus, demos, and prefs
- add regression test ensuring pipeline output is deterministic

## Testing
- `pre-commit run --all-files` *(interrupted: KeyboardInterrupt, environment setup)*
- `pytest tests/test_deploy_codex_pipeline.py::test_reproducible_run -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab911a0fe4833195e5b4133b018c71