### PR TITLE
chore: add sentinels for monitoring and packages

### DIFF
--- a/.codex/change_log.md
+++ b/.codex/change_log.md
@@ -15035,3 +15035,28 @@ def current_commit() -> str | None:
 
 ```
 
+## 2025-08-26T05:44:30Z — src/codex_ml/peft/__init__.py
+- **Action:** append
+- **Rationale:** insert guarded by PEFT_INIT
+
+## 2025-08-26T05:44:30Z — src/codex_ml/training/__init__.py
+- **Action:** append
+- **Rationale:** insert guarded by TRAIN_INIT
+
+## 2025-08-26T05:44:30Z — src/codex_ml/metrics/__init__.py
+- **Action:** append
+- **Rationale:** insert guarded by METRICS_INIT
+
+## 2025-08-26T05:44:30Z — src/codex_ml/monitoring/__init__.py
+- **Action:** append
+- **Rationale:** insert guarded by MONITOR_INIT
+
+## 2025-08-26T05:44:30Z — docs/ops/monitoring.md
+- **Action:** append
+- **Rationale:** insert guarded by <!-- SENTINEL -->
+```text
+
+## Prometheus (optional)
+
+```
+

--- a/.codex/errors.ndjson
+++ b/.codex/errors.ndjson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0bf5099bd249aa95907887b8ba9656446cdb20a2518cbc934c1f554023f747b
+oid sha256:0f422e95d865353718ac2a2d53417264a2ebf56aedb7c078eeacae74939f49e6
 size 650

--- a/.codex/results.md
+++ b/.codex/results.md
@@ -6427,3 +6427,1867 @@ Interrupted (^C): KeyboardInterrupt:
 Check the log at /root/.cache/pre-commit/pre-commit.log
 
 
+
+# Deps 2025-08-26T05:45:48Z
+
+## python -m pip install -r requirements-dev.txt
+```
+Requirement already satisfied: black in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements-dev.txt (line 2)) (25.1.0)
+Requirement already satisfied: isort in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements-dev.txt (line 3)) (6.0.1)
+Collecting flake8 (from -r requirements-dev.txt (line 4))
+  Downloading flake8-7.3.0-py2.py3-none-any.whl.metadata (3.8 kB)
+Requirement already satisfied: mypy in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements-dev.txt (line 5)) (1.17.1)
+Requirement already satisfied: pytest in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from -r requirements-dev.txt (line 6)) (8.4.1)
+Collecting pytest-cov (from -r requirements-dev.txt (line 7))
+  Downloading pytest_cov-6.2.1-py3-none-any.whl.metadata (30 kB)
+Collecting bandit (from -r requirements-dev.txt (line 8))
+  Downloading bandit-1.8.6-py3-none-any.whl.metadata (6.9 kB)
+Collecting semgrep (from -r requirements-dev.txt (line 9))
+  Downloading semgrep-1.133.0-cp39.cp310.cp311.py39.py310.py311-none-musllinux_1_0_x86_64.manylinux2014_x86_64.whl.metadata (1.8 kB)
+Collecting detect-secrets (from -r requirements-dev.txt (line 10))
+  Downloading detect_secrets-1.5.0-py3-none-any.whl.metadata (23 kB)
+Requirement already satisfied: click>=8.0.0 in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from black->-r requirements-dev.txt (line 2)) (8.2.1)
+Requirement already satisfied: mypy-extensions>=0.4.3 in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from black->-r requirements-dev.txt (line 2)) (1.1.0)
+Requirement already satisfied: packaging>=22.0 in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from black->-r requirements-dev.txt (line 2)) (25.0)
+Requirement already satisfied: pathspec>=0.9.0 in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from black->-r requirements-dev.txt (line 2)) (0.12.1)
+Requirement already satisfied: platformdirs>=2 in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from black->-r requirements-dev.txt (line 2)) (4.3.8)
+Collecting mccabe<0.8.0,>=0.7.0 (from flake8->-r requirements-dev.txt (line 4))
+  Downloading mccabe-0.7.0-py2.py3-none-any.whl.metadata (5.0 kB)
+Collecting pycodestyle<2.15.0,>=2.14.0 (from flake8->-r requirements-dev.txt (line 4))
+  Downloading pycodestyle-2.14.0-py2.py3-none-any.whl.metadata (4.5 kB)
+Collecting pyflakes<3.5.0,>=3.4.0 (from flake8->-r requirements-dev.txt (line 4))
+  Downloading pyflakes-3.4.0-py2.py3-none-any.whl.metadata (3.5 kB)
+Requirement already satisfied: typing_extensions>=4.6.0 in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from mypy->-r requirements-dev.txt (line 5)) (4.14.1)
+Requirement already satisfied: iniconfig>=1 in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from pytest->-r requirements-dev.txt (line 6)) (2.1.0)
+Requirement already satisfied: pluggy<2,>=1.5 in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from pytest->-r requirements-dev.txt (line 6)) (1.6.0)
+Requirement already satisfied: pygments>=2.7.2 in /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages (from pytest->-r requirements-dev.txt (line 6)) (2.19.2)
+Collecting coverage>=7.5 (from coverage[toml]>=7.5->pytest-cov->-r requirements-dev.txt (line 7))
+  Downloading coverage-7.10.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl.metadata (8.9 kB)
+Collecting PyYAML>=5.3.1 (from bandit->-r requirements-dev.txt (line 8))
+  Downloading PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.1 kB)
+Collecting stevedore>=1.20.0 (from bandit->-r requirements-dev.txt (line 8))
+  Downloading stevedore-5.5.0-py3-none-any.whl.metadata (2.2 kB)
+Collecting rich (from bandit->-r requirements-dev.txt (line 8))
+  Downloading rich-14.1.0-py3-none-any.whl.metadata (18 kB)
+Collecting attrs>=21.3 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading attrs-25.3.0-py3-none-any.whl.metadata (10 kB)
+Collecting boltons~=21.0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading boltons-21.0.0-py2.py3-none-any.whl.metadata (1.5 kB)
+Collecting click-option-group~=0.5 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading click_option_group-0.5.7-py3-none-any.whl.metadata (5.8 kB)
+Collecting click>=8.0.0 (from black->-r requirements-dev.txt (line 2))
+  Downloading click-8.1.8-py3-none-any.whl.metadata (2.3 kB)
+Collecting colorama~=0.4.0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading colorama-0.4.6-py2.py3-none-any.whl.metadata (17 kB)
+Collecting defusedxml~=0.7.1 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading defusedxml-0.7.1-py2.py3-none-any.whl.metadata (32 kB)
+Collecting exceptiongroup~=1.2.0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading exceptiongroup-1.2.2-py3-none-any.whl.metadata (6.6 kB)
+Collecting glom~=22.1 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading glom-22.1.0-py2.py3-none-any.whl.metadata (4.9 kB)
+Collecting jsonschema~=4.6 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading jsonschema-4.25.1-py3-none-any.whl.metadata (7.6 kB)
+Collecting opentelemetry-api~=1.25.0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_api-1.25.0-py3-none-any.whl.metadata (1.4 kB)
+Collecting opentelemetry-sdk~=1.25.0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_sdk-1.25.0-py3-none-any.whl.metadata (1.4 kB)
+Collecting opentelemetry-exporter-otlp-proto-http~=1.25.0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_exporter_otlp_proto_http-1.25.0-py3-none-any.whl.metadata (2.2 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.57b0-py3-none-any.whl.metadata (2.6 kB)
+Collecting peewee~=3.14 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading peewee-3.18.2.tar.gz (949 kB)
+     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 949.2/949.2 kB 8.3 MB/s  0:00:00
+  Installing build dependencies: started
+  Installing build dependencies: finished with status 'done'
+  Getting requirements to build wheel: started
+  Getting requirements to build wheel: finished with status 'done'
+  Preparing metadata (pyproject.toml): started
+  Preparing metadata (pyproject.toml): finished with status 'done'
+Collecting requests~=2.22 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading requests-2.32.5-py3-none-any.whl.metadata (4.9 kB)
+Collecting rich (from bandit->-r requirements-dev.txt (line 8))
+  Downloading rich-13.5.3-py3-none-any.whl.metadata (18 kB)
+Collecting ruamel.yaml>=0.18.5 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading ruamel.yaml-0.18.15-py3-none-any.whl.metadata (25 kB)
+Collecting tomli~=2.0.1 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading tomli-2.0.2-py3-none-any.whl.metadata (10.0 kB)
+Collecting urllib3~=2.0 (from semgrep->-r requirements-dev.txt (line 9))
+  Using cached urllib3-2.5.0-py3-none-any.whl.metadata (6.5 kB)
+Collecting wcmatch~=8.3 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading wcmatch-8.5.2-py3-none-any.whl.metadata (4.8 kB)
+Collecting face>=20.1.0 (from glom~=22.1->semgrep->-r requirements-dev.txt (line 9))
+  Downloading face-24.0.0-py3-none-any.whl.metadata (1.1 kB)
+Collecting jsonschema-specifications>=2023.03.6 (from jsonschema~=4.6->semgrep->-r requirements-dev.txt (line 9))
+  Downloading jsonschema_specifications-2025.4.1-py3-none-any.whl.metadata (2.9 kB)
+Collecting referencing>=0.28.4 (from jsonschema~=4.6->semgrep->-r requirements-dev.txt (line 9))
+  Downloading referencing-0.36.2-py3-none-any.whl.metadata (2.8 kB)
+Collecting rpds-py>=0.7.1 (from jsonschema~=4.6->semgrep->-r requirements-dev.txt (line 9))
+  Downloading rpds_py-0.27.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.2 kB)
+Collecting deprecated>=1.2.6 (from opentelemetry-api~=1.25.0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading Deprecated-1.2.18-py2.py3-none-any.whl.metadata (5.7 kB)
+Collecting importlib-metadata<=7.1,>=6.0 (from opentelemetry-api~=1.25.0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading importlib_metadata-7.1.0-py3-none-any.whl.metadata (4.7 kB)
+Collecting zipp>=0.5 (from importlib-metadata<=7.1,>=6.0->opentelemetry-api~=1.25.0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading zipp-3.23.0-py3-none-any.whl.metadata (3.6 kB)
+Collecting googleapis-common-protos~=1.52 (from opentelemetry-exporter-otlp-proto-http~=1.25.0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading googleapis_common_protos-1.70.0-py3-none-any.whl.metadata (9.3 kB)
+Collecting opentelemetry-exporter-otlp-proto-common==1.25.0 (from opentelemetry-exporter-otlp-proto-http~=1.25.0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_exporter_otlp_proto_common-1.25.0-py3-none-any.whl.metadata (1.7 kB)
+Collecting opentelemetry-proto==1.25.0 (from opentelemetry-exporter-otlp-proto-http~=1.25.0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_proto-1.25.0-py3-none-any.whl.metadata (2.2 kB)
+Collecting protobuf<5.0,>=3.19 (from opentelemetry-proto==1.25.0->opentelemetry-exporter-otlp-proto-http~=1.25.0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading protobuf-4.25.8-cp37-abi3-manylinux2014_x86_64.whl.metadata (541 bytes)
+Collecting opentelemetry-instrumentation==0.57b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.57b0-py3-none-any.whl.metadata (6.7 kB)
+Collecting opentelemetry-semantic-conventions==0.57b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.57b0-py3-none-any.whl.metadata (2.4 kB)
+Collecting opentelemetry-util-http==0.57b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.57b0-py3-none-any.whl.metadata (2.6 kB)
+Collecting wrapt<2.0.0,>=1.0.0 (from opentelemetry-instrumentation==0.57b0->opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl.metadata (6.4 kB)
+INFO: pip is looking at multiple versions of opentelemetry-semantic-conventions to determine which version is compatible with other requirements. This could take a while.
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.56b0-py3-none-any.whl.metadata (2.6 kB)
+Collecting opentelemetry-instrumentation==0.56b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.56b0-py3-none-any.whl.metadata (6.7 kB)
+Collecting opentelemetry-semantic-conventions==0.56b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.56b0-py3-none-any.whl.metadata (2.4 kB)
+Collecting opentelemetry-util-http==0.56b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.56b0-py3-none-any.whl.metadata (2.6 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.55b1-py3-none-any.whl.metadata (2.6 kB)
+Collecting opentelemetry-instrumentation==0.55b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.55b1-py3-none-any.whl.metadata (6.7 kB)
+Collecting opentelemetry-semantic-conventions==0.55b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.55b1-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-util-http==0.55b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.55b1-py3-none-any.whl.metadata (2.6 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.55b0-py3-none-any.whl.metadata (2.6 kB)
+Collecting opentelemetry-instrumentation==0.55b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.55b0-py3-none-any.whl.metadata (6.7 kB)
+Collecting opentelemetry-semantic-conventions==0.55b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.55b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-util-http==0.55b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.55b0-py3-none-any.whl.metadata (2.6 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.54b1-py3-none-any.whl.metadata (2.7 kB)
+Collecting opentelemetry-instrumentation==0.54b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.54b1-py3-none-any.whl.metadata (6.8 kB)
+Collecting opentelemetry-semantic-conventions==0.54b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.54b1-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-util-http==0.54b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.54b1-py3-none-any.whl.metadata (2.6 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.54b0-py3-none-any.whl.metadata (2.7 kB)
+Collecting opentelemetry-instrumentation==0.54b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.54b0-py3-none-any.whl.metadata (6.8 kB)
+Collecting opentelemetry-semantic-conventions==0.54b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.54b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-util-http==0.54b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.54b0-py3-none-any.whl.metadata (2.6 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.53b1-py3-none-any.whl.metadata (2.7 kB)
+Collecting opentelemetry-instrumentation==0.53b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.53b1-py3-none-any.whl.metadata (6.8 kB)
+Collecting opentelemetry-semantic-conventions==0.53b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.53b1-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-util-http==0.53b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.53b1-py3-none-any.whl.metadata (2.6 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.53b0-py3-none-any.whl.metadata (2.7 kB)
+Collecting opentelemetry-instrumentation==0.53b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.53b0-py3-none-any.whl.metadata (6.8 kB)
+Collecting opentelemetry-semantic-conventions==0.53b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.53b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-util-http==0.53b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.53b0-py3-none-any.whl.metadata (2.6 kB)
+INFO: pip is still looking at multiple versions of opentelemetry-semantic-conventions to determine which version is compatible with other requirements. This could take a while.
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.52b1-py3-none-any.whl.metadata (2.7 kB)
+Collecting opentelemetry-instrumentation==0.52b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.52b1-py3-none-any.whl.metadata (6.8 kB)
+Collecting opentelemetry-semantic-conventions==0.52b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.52b1-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-util-http==0.52b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.52b1-py3-none-any.whl.metadata (2.6 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.52b0-py3-none-any.whl.metadata (2.7 kB)
+Collecting opentelemetry-instrumentation==0.52b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.52b0-py3-none-any.whl.metadata (6.8 kB)
+Collecting opentelemetry-semantic-conventions==0.52b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.52b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-util-http==0.52b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.52b0-py3-none-any.whl.metadata (2.6 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.51b0-py3-none-any.whl.metadata (2.7 kB)
+Collecting opentelemetry-instrumentation==0.51b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.51b0-py3-none-any.whl.metadata (6.3 kB)
+Collecting opentelemetry-semantic-conventions==0.51b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.51b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-util-http==0.51b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.51b0-py3-none-any.whl.metadata (2.6 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.50b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-instrumentation==0.50b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.50b0-py3-none-any.whl.metadata (6.1 kB)
+Collecting opentelemetry-semantic-conventions==0.50b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.50b0-py3-none-any.whl.metadata (2.3 kB)
+Collecting opentelemetry-util-http==0.50b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.50b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.49b2-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-instrumentation==0.49b2 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.49b2-py3-none-any.whl.metadata (6.1 kB)
+Collecting opentelemetry-semantic-conventions==0.49b2 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.49b2-py3-none-any.whl.metadata (2.3 kB)
+Collecting opentelemetry-util-http==0.49b2 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.49b2-py3-none-any.whl.metadata (2.5 kB)
+INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.49b1-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-instrumentation==0.49b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.49b1-py3-none-any.whl.metadata (6.2 kB)
+Collecting opentelemetry-semantic-conventions==0.49b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.49b1-py3-none-any.whl.metadata (2.4 kB)
+Collecting opentelemetry-util-http==0.49b1 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.49b1-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.49b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-instrumentation==0.49b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.49b0-py3-none-any.whl.metadata (6.2 kB)
+Collecting opentelemetry-semantic-conventions==0.49b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.49b0-py3-none-any.whl.metadata (2.4 kB)
+Collecting opentelemetry-util-http==0.49b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.49b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.48b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-instrumentation==0.48b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.48b0-py3-none-any.whl.metadata (6.1 kB)
+Collecting opentelemetry-semantic-conventions==0.48b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.48b0-py3-none-any.whl.metadata (2.4 kB)
+Collecting opentelemetry-util-http==0.48b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.48b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting setuptools>=16.0 (from opentelemetry-instrumentation==0.48b0->opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Using cached setuptools-80.9.0-py3-none-any.whl.metadata (6.6 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.47b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-instrumentation==0.47b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.47b0-py3-none-any.whl.metadata (6.1 kB)
+Collecting opentelemetry-semantic-conventions==0.47b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.47b0-py3-none-any.whl.metadata (2.4 kB)
+Collecting opentelemetry-util-http==0.47b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.47b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-instrumentation-requests~=0.46b0 (from semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation_requests-0.46b0-py3-none-any.whl.metadata (2.5 kB)
+Collecting opentelemetry-instrumentation==0.46b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_instrumentation-0.46b0-py3-none-any.whl.metadata (6.1 kB)
+Collecting opentelemetry-semantic-conventions==0.46b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_semantic_conventions-0.46b0-py3-none-any.whl.metadata (2.3 kB)
+Collecting opentelemetry-util-http==0.46b0 (from opentelemetry-instrumentation-requests~=0.46b0->semgrep->-r requirements-dev.txt (line 9))
+  Downloading opentelemetry_util_http-0.46b0-py3-none-any.whl.metadata (2.4 kB)
+Collecting charset_normalizer<4,>=2 (from requests~=2.22->semgrep->-r requirements-dev.txt (line 9))
+  Downloading charset_normalizer-3.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (36 kB)
+Collecting idna<4,>=2.5 (from requests~=2.22->semgrep->-r requirements-dev.txt (line 9))
+  Using cached idna-3.10-py3-none-any.whl.metadata (10 kB)
+Collecting certifi>=2017.4.17 (from requests~=2.22->semgrep->-r requirements-dev.txt (line 9))
+  Using cached certifi-2025.8.3-py3-none-any.whl.metadata (2.4 kB)
+Collecting markdown-it-py>=2.2.0 (from rich->bandit->-r requirements-dev.txt (line 8))
+  Downloading markdown_it_py-4.0.0-py3-none-any.whl.metadata (7.3 kB)
+Collecting bracex>=2.1.1 (from wcmatch~=8.3->semgrep->-r requirements-dev.txt (line 9))
+  Downloading bracex-2.6-py3-none-any.whl.metadata (3.6 kB)
+Collecting mdurl~=0.1 (from markdown-it-py>=2.2.0->rich->bandit->-r requirements-dev.txt (line 8))
+  Downloading mdurl-0.1.2-py3-none-any.whl.metadata (1.6 kB)
+Collecting ruamel.yaml.clib>=0.2.7 (from ruamel.yaml>=0.18.5->semgrep->-r requirements-dev.txt (line 9))
+  Downloading ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.7 kB)
+Downloading flake8-7.3.0-py2.py3-none-any.whl (57 kB)
+Downloading mccabe-0.7.0-py2.py3-none-any.whl (7.3 kB)
+Downloading pycodestyle-2.14.0-py2.py3-none-any.whl (31 kB)
+Downloading pyflakes-3.4.0-py2.py3-none-any.whl (63 kB)
+Downloading pytest_cov-6.2.1-py3-none-any.whl (24 kB)
+Downloading bandit-1.8.6-py3-none-any.whl (133 kB)
+Downloading semgrep-1.133.0-cp39.cp310.cp311.py39.py310.py311-none-musllinux_1_0_x86_64.manylinux2014_x86_64.whl (49.4 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 49.4/49.4 MB 27.0 MB/s  0:00:01
+Downloading boltons-21.0.0-py2.py3-none-any.whl (193 kB)
+Downloading click-8.1.8-py3-none-any.whl (98 kB)
+Downloading click_option_group-0.5.7-py3-none-any.whl (11 kB)
+Downloading colorama-0.4.6-py2.py3-none-any.whl (25 kB)
+Downloading defusedxml-0.7.1-py2.py3-none-any.whl (25 kB)
+Downloading exceptiongroup-1.2.2-py3-none-any.whl (16 kB)
+Downloading glom-22.1.0-py2.py3-none-any.whl (100 kB)
+Downloading jsonschema-4.25.1-py3-none-any.whl (90 kB)
+Downloading opentelemetry_api-1.25.0-py3-none-any.whl (59 kB)
+Downloading importlib_metadata-7.1.0-py3-none-any.whl (24 kB)
+Downloading opentelemetry_exporter_otlp_proto_http-1.25.0-py3-none-any.whl (16 kB)
+Downloading opentelemetry_exporter_otlp_proto_common-1.25.0-py3-none-any.whl (17 kB)
+Downloading opentelemetry_proto-1.25.0-py3-none-any.whl (52 kB)
+Downloading googleapis_common_protos-1.70.0-py3-none-any.whl (294 kB)
+Downloading opentelemetry_instrumentation_requests-0.46b0-py3-none-any.whl (12 kB)
+Downloading opentelemetry_instrumentation-0.46b0-py3-none-any.whl (29 kB)
+Downloading opentelemetry_semantic_conventions-0.46b0-py3-none-any.whl (130 kB)
+Downloading opentelemetry_util_http-0.46b0-py3-none-any.whl (6.9 kB)
+Downloading opentelemetry_sdk-1.25.0-py3-none-any.whl (107 kB)
+Downloading protobuf-4.25.8-cp37-abi3-manylinux2014_x86_64.whl (294 kB)
+Downloading requests-2.32.5-py3-none-any.whl (64 kB)
+Downloading charset_normalizer-3.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (151 kB)
+Using cached idna-3.10-py3-none-any.whl (70 kB)
+Downloading rich-13.5.3-py3-none-any.whl (239 kB)
+Downloading tomli-2.0.2-py3-none-any.whl (13 kB)
+Using cached urllib3-2.5.0-py3-none-any.whl (129 kB)
+Downloading wcmatch-8.5.2-py3-none-any.whl (39 kB)
+Downloading wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl (88 kB)
+Downloading detect_secrets-1.5.0-py3-none-any.whl (120 kB)
+Downloading attrs-25.3.0-py3-none-any.whl (63 kB)
+Downloading bracex-2.6-py3-none-any.whl (11 kB)
+Using cached certifi-2025.8.3-py3-none-any.whl (161 kB)
+Downloading coverage-7.10.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl (251 kB)
+Downloading Deprecated-1.2.18-py2.py3-none-any.whl (10.0 kB)
+Downloading face-24.0.0-py3-none-any.whl (54 kB)
+Downloading jsonschema_specifications-2025.4.1-py3-none-any.whl (18 kB)
+Downloading markdown_it_py-4.0.0-py3-none-any.whl (87 kB)
+Downloading mdurl-0.1.2-py3-none-any.whl (10.0 kB)
+Downloading PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (767 kB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 767.5/767.5 kB 11.8 MB/s  0:00:00
+Downloading referencing-0.36.2-py3-none-any.whl (26 kB)
+Downloading rpds_py-0.27.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (386 kB)
+Downloading ruamel.yaml-0.18.15-py3-none-any.whl (119 kB)
+Downloading ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (754 kB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 754.1/754.1 kB 24.7 MB/s  0:00:00
+Using cached setuptools-80.9.0-py3-none-any.whl (1.2 MB)
+Downloading stevedore-5.5.0-py3-none-any.whl (49 kB)
+Downloading zipp-3.23.0-py3-none-any.whl (10 kB)
+Building wheels for collected packages: peewee
+  Building wheel for peewee (pyproject.toml): started
+  Building wheel for peewee (pyproject.toml): finished with status 'done'
+  Created wheel for peewee: filename=peewee-3.18.2-cp312-cp312-linux_x86_64.whl size=1046967 sha256=fec0391ed57fce588b7f63cc3624276786d7f356126dfc9fac8954c1ac7ed32d
+  Stored in directory: /root/.cache/pip/wheels/d1/df/a9/0202b051c65b11c992dd6db9f2babdd2c44ec7d35d511be5d3
+Successfully built peewee
+Installing collected packages: peewee, boltons, zipp, wrapt, urllib3, tomli, stevedore, setuptools, ruamel.yaml.clib, rpds-py, PyYAML, pyflakes, pycodestyle, protobuf, opentelemetry-util-http, mdurl, mccabe, idna, face, exceptiongroup, defusedxml, coverage, colorama, click, charset_normalizer, certifi, bracex, attrs, wcmatch, ruamel.yaml, requests, referencing, opentelemetry-proto, markdown-it-py, importlib-metadata, googleapis-common-protos, glom, flake8, deprecated, click-option-group, rich, pytest-cov, opentelemetry-exporter-otlp-proto-common, opentelemetry-api, jsonschema-specifications, detect-secrets, opentelemetry-semantic-conventions, opentelemetry-instrumentation, jsonschema, bandit, opentelemetry-sdk, opentelemetry-instrumentation-requests, opentelemetry-exporter-otlp-proto-http, semgrep
+  Attempting uninstall: click
+    Found existing installation: click 8.2.1
+    Uninstalling click-8.2.1:
+      Successfully uninstalled click-8.2.1
+
+Successfully installed PyYAML-6.0.2 attrs-25.3.0 bandit-1.8.6 boltons-21.0.0 bracex-2.6 certifi-2025.8.3 charset_normalizer-3.4.3 click-8.1.8 click-option-group-0.5.7 colorama-0.4.6 coverage-7.10.5 defusedxml-0.7.1 deprecated-1.2.18 detect-secrets-1.5.0 exceptiongroup-1.2.2 face-24.0.0 flake8-7.3.0 glom-22.1.0 googleapis-common-protos-1.70.0 idna-3.10 importlib-metadata-7.1.0 jsonschema-4.25.1 jsonschema-specifications-2025.4.1 markdown-it-py-4.0.0 mccabe-0.7.0 mdurl-0.1.2 opentelemetry-api-1.25.0 opentelemetry-exporter-otlp-proto-common-1.25.0 opentelemetry-exporter-otlp-proto-http-1.25.0 opentelemetry-instrumentation-0.46b0 opentelemetry-instrumentation-requests-0.46b0 opentelemetry-proto-1.25.0 opentelemetry-sdk-1.25.0 opentelemetry-semantic-conventions-0.46b0 opentelemetry-util-http-0.46b0 peewee-3.18.2 protobuf-4.25.8 pycodestyle-2.14.0 pyflakes-3.4.0 pytest-cov-6.2.1 referencing-0.36.2 requests-2.32.5 rich-13.5.3 rpds-py-0.27.0 ruamel.yaml-0.18.15 ruamel.yaml.clib-0.2.12 semgrep-1.133.0 setuptools-80.9.0 stevedore-5.5.0 tomli-2.0.2 urllib3-2.5.0 wcmatch-8.5.2 wrapt-1.17.3 zipp-3.23.0
+WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
+
+(exit=0)
+```
+
+## python -m pip install -r requirements.txt
+```
+
+# Validation 2025-08-26T05:50:44Z
+
+## GPU check
+```
+No NVIDIA GPU detected.
+
+(exit=0)
+```
+
+## black --check .
+```
+Skipping .ipynb files as Jupyter dependencies are not installed.
+You can fix this by running ``pip install "black[jupyter]"``
+would reformat /workspace/_codex_/.codex/run_db_utils_workflow.py
+would reformat /workspace/_codex_/.codex/run_workflow.py
+error: cannot format /workspace/_codex_/services/api/main.py: cannot use --safe with this file; failed to parse source file AST: unterminated f-string literal (detected at line 55) (<unknown>, line 55)
+This could be caused by running Black with an older Python version that does not support new syntax used in your source file.
+would reformat /workspace/_codex_/.codex/codex_repo_scout.py
+would reformat /workspace/_codex_/scripts/deploy_codex_pipeline.py
+would reformat /workspace/_codex_/src/codex_ml/cli/main.py
+would reformat /workspace/_codex_/src/codex_ml/data/cache.py
+would reformat /workspace/_codex_/src/codex_ml/data/sharding.py
+would reformat /workspace/_codex_/src/codex_ml/interfaces/reward_model.py
+would reformat /workspace/_codex_/src/codex_ml/data/cli.py
+would reformat /workspace/_codex_/src/codex_ml/interfaces/rl.py
+would reformat /workspace/_codex_/src/codex_ml/interfaces/tokenizer.py
+would reformat /workspace/_codex_/src/codex_ml/metrics/curves.py
+would reformat /workspace/_codex_/src/codex_ml/monitoring/prometheus.py
+would reformat /workspace/_codex_/src/codex_ml/peft/peft_adapter.py
+would reformat /workspace/_codex_/src/codex_ml/models/activations.py
+would reformat /workspace/_codex_/src/codex_ml/safety/risk_score.py
+would reformat /workspace/_codex_/src/codex_ml/safety/sandbox.py
+would reformat /workspace/_codex_/src/codex_ml/tokenization/sentencepiece_adapter.py
+would reformat /workspace/_codex_/src/codex_ml/tracking/cli.py
+would reformat /workspace/_codex_/src/codex_ml/safety/filters.py
+would reformat /workspace/_codex_/src/codex_ml/tracking/git_tag.py
+would reformat /workspace/_codex_/src/codex_ml/training/callbacks.py
+would reformat /workspace/_codex_/src/codex_ml/utils/checksums.py
+would reformat /workspace/_codex_/tests/test_activations.py
+would reformat /workspace/_codex_/src/codex_ml/data/loaders.py
+would reformat /workspace/_codex_/src/codex_ml/train_loop.py
+would reformat /workspace/_codex_/tests/test_data_cache_sharding.py
+would reformat /workspace/_codex_/tests/test_engine_hf_trainer.py
+would reformat /workspace/_codex_/tests/test_db_utils.py
+would reformat /workspace/_codex_/tests/test_metric_curves.py
+would reformat /workspace/_codex_/tests/test_loaders.py
+would reformat /workspace/_codex_/tests/test_interfaces_compat.py
+would reformat /workspace/_codex_/tests/test_metrics.py
+would reformat /workspace/_codex_/tests/test_sentencepiece_adapter.py
+would reformat /workspace/_codex_/src/codex_ml/utils/checkpointing.py
+would reformat /workspace/_codex_/tests/test_session_hooks.py
+would reformat /workspace/_codex_/tools/apply_data_loaders.py
+would reformat /workspace/_codex_/tools/apply_container_api.py
+would reformat /workspace/_codex_/tools/apply_hydra_scaffold.py
+would reformat /workspace/_codex_/tools/apply_interfaces.py
+would reformat /workspace/_codex_/tools/apply_ml_metrics.py
+would reformat /workspace/_codex_/tools/apply_safety.py
+would reformat /workspace/_codex_/tools/apply_mlflow_tracking.py
+would reformat /workspace/_codex_/tools/apply_pyproject_packaging.py
+would reformat /workspace/_codex_/tools/apply_stack_polish.py
+would reformat /workspace/_codex_/tools/codex_ingestion_workflow.py
+would reformat /workspace/_codex_/tools/codex_logging_workflow.py
+would reformat /workspace/_codex_/tools/codex_precommit_bootstrap.py
+would reformat /workspace/_codex_/tools/codex_sqlite_align.py
+would reformat /workspace/_codex_/tools/run_supplied_task.py
+would reformat /workspace/_codex_/training/engine_hf_trainer.py
+would reformat /workspace/_codex_/tools/monitoring_integrate.py
+would reformat /workspace/_codex_/tools/git_patch_parser_complete.py
+
+Oh no! 💥 💔 💥
+53 files would be reformatted, 131 files would be left unchanged, 1 file would fail to reformat.
+
+(exit=123)
+```
+
+## isort --check-only .
+```
+Skipped 1 files
+ERROR: /workspace/_codex_/functional_training.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/training/engine_hf_trainer.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/scripts/apply_session_logging_workflow.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/scripts/deep_research_task_process.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/scripts/deploy_codex_pipeline.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tools/apply_container_api.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tools/apply_interfaces.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tools/apply_safety.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tools/apply_stack_polish.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tools/codex_sqlite_align.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tools/codex_cli.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tools/apply_hydra_scaffold.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tools/apply_data_loaders.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tools/monitoring_integrate.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tools/apply_ml_metrics.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tools/apply_mlflow_tracking.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/train_loop.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/__init__.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/pipeline.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/monitoring/prometheus.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/data/cache.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/data/sharding.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/data/cli.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/training/callbacks.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/tokenization/__init__.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/tokenization/sentencepiece_adapter.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/cli/main.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/utils/checksums.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/models/activations.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/metrics/curves.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/peft/peft_adapter.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/interfaces/__init__.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/interfaces/rl.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/interfaces/tokenizer.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/interfaces/reward_model.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/safety/__init__.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/safety/risk_score.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/safety/filters.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/safety/sandbox.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/tracking/__init__.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex_ml/tracking/git_tag.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex/logging/viewer.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex/logging/session_query.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex/logging/query_logs.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex/logging/import_ndjson.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex/logging/session_logger.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex/logging/fetch_messages.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex/logging/export.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/src/codex/logging/db_utils.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_safety.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_metrics.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_activations.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_metric_curves.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_loaders.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_sentencepiece_adapter.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_data_cache_sharding.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_fetch_messages.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_symbolic_pipeline.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_db_utils.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_conversation_logger.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_interfaces_compat.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_tokenization.py Imports are incorrectly sorted and/or formatted.
+ERROR: /workspace/_codex_/tests/test_mlflow_utils.py Imports are incorrectly sorted and/or formatted.
+
+(exit=1)
+```
+
+## flake8 .
+```
+./.codex/codex_repo_scout.py:57:80: E501 line too long (82 > 79 characters)
+./.codex/codex_repo_scout.py:62:80: E501 line too long (86 > 79 characters)
+./.codex/codex_repo_scout.py:76:80: E501 line too long (86 > 79 characters)
+./.codex/codex_repo_scout.py:88:80: E501 line too long (89 > 79 characters)
+./.codex/codex_repo_scout.py:91:80: E501 line too long (112 > 79 characters)
+./.codex/codex_repo_scout.py:105:80: E501 line too long (80 > 79 characters)
+./.codex/codex_repo_scout.py:112:80: E501 line too long (89 > 79 characters)
+./.codex/codex_repo_scout.py:116:80: E501 line too long (81 > 79 characters)
+./.codex/codex_repo_scout.py:157:80: E501 line too long (85 > 79 characters)
+./.codex/codex_repo_scout.py:162:80: E501 line too long (83 > 79 characters)
+./.codex/codex_repo_scout.py:207:80: E501 line too long (86 > 79 characters)
+./.codex/codex_repo_scout.py:228:80: E501 line too long (80 > 79 characters)
+./.codex/codex_repo_scout.py:238:80: E501 line too long (88 > 79 characters)
+./.codex/codex_repo_scout.py:243:80: E501 line too long (85 > 79 characters)
+./.codex/codex_repo_scout.py:246:80: E501 line too long (82 > 79 characters)
+./.codex/codex_repo_scout.py:255:80: E501 line too long (107 > 79 characters)
+./.codex/codex_repo_scout.py:260:80: E501 line too long (81 > 79 characters)
+./.codex/codex_repo_scout.py:266:80: E501 line too long (83 > 79 characters)
+./.codex/codex_repo_scout.py:273:80: E501 line too long (81 > 79 characters)
+./.codex/codex_repo_scout.py:324:80: E501 line too long (85 > 79 characters)
+./.codex/codex_repo_scout.py:330:80: E501 line too long (85 > 79 characters)
+./.codex/codex_repo_scout.py:337:80: E501 line too long (84 > 79 characters)
+./.codex/codex_repo_scout.py:344:80: E501 line too long (80 > 79 characters)
+./.codex/codex_repo_scout.py:351:80: E501 line too long (81 > 79 characters)
+./.codex/codex_repo_scout.py:360:80: E501 line too long (83 > 79 characters)
+./.codex/codex_repo_scout.py:404:80: E501 line too long (83 > 79 characters)
+./.codex/codex_repo_scout.py:453:80: E501 line too long (81 > 79 characters)
+./.codex/codex_repo_scout.py:461:80: E501 line too long (92 > 79 characters)
+./.codex/codex_repo_scout.py:472:80: E501 line too long (90 > 79 characters)
+./.codex/codex_repo_scout.py:482:80: E501 line too long (86 > 79 characters)
+./.codex/codex_repo_scout.py:484:80: E501 line too long (82 > 79 characters)
+./.codex/codex_repo_scout.py:486:80: E501 line too long (91 > 79 characters)
+./.codex/codex_repo_scout.py:488:80: E501 line too long (80 > 79 characters)
+./.codex/codex_repo_scout.py:499:80: E501 line too long (84 > 79 characters)
+./.codex/run_db_utils_workflow.py:5:80: E501 line too long (89 > 79 characters)
+./.codex/run_db_utils_workflow.py:48:80: E501 line too long (80 > 79 characters)
+./.codex/run_db_utils_workflow.py:51:80: E501 line too long (103 > 79 characters)
+./.codex/run_db_utils_workflow.py:71:80: E501 line too long (131 > 79 characters)
+./.codex/run_db_utils_workflow.py:100:80: E501 line too long (82 > 79 characters)
+./.codex/run_db_utils_workflow.py:132:80: E501 line too long (111 > 79 characters)
+./.codex/run_db_utils_workflow.py:134:80: E501 line too long (91 > 79 characters)
+./.codex/run_db_utils_workflow.py:142:80: E501 line too long (92 > 79 characters)
+./.codex/run_db_utils_workflow.py:163:80: E501 line too long (125 > 79 characters)
+./.codex/run_db_utils_workflow.py:181:80: E501 line too long (83 > 79 characters)
+./.codex/run_db_utils_workflow.py:225:80: E501 line too long (84 > 79 characters)
+./.codex/run_db_utils_workflow.py:241:80: E501 line too long (97 > 79 characters)
+./.codex/run_db_utils_workflow.py:243:80: E501 line too long (114 > 79 characters)
+./.codex/run_db_utils_workflow.py:272:80: E501 line too long (81 > 79 characters)
+./.codex/run_db_utils_workflow.py:286:80: E501 line too long (83 > 79 characters)
+./.codex/run_db_utils_workflow.py:290:80: E501 line too long (80 > 79 characters)
+./.codex/run_db_utils_workflow.py:341:80: E501 line too long (125 > 79 characters)
+./.codex/run_db_utils_workflow.py:343:80: E501 line too long (121 > 79 characters)
+./.codex/run_db_utils_workflow.py:402:80: E501 line too long (188 > 79 characters)
+./.codex/run_db_utils_workflow.py:474:80: E501 line too long (80 > 79 characters)
+./.codex/run_db_utils_workflow.py:479:80: E501 line too long (83 > 79 characters)
+./.codex/run_repo_scout.py:84:80: E501 line too long (82 > 79 characters)
+./.codex/run_repo_scout.py:146:80: E501 line too long (82 > 79 characters)
+./.codex/run_repo_scout.py:162:80: E501 line too long (81 > 79 characters)
+./.codex/run_repo_scout.py:172:80: E501 line too long (82 > 79 characters)
+./.codex/run_repo_scout.py:215:80: E501 line too long (85 > 79 characters)
+./.codex/run_repo_scout.py:226:80: E501 line too long (86 > 79 characters)
+./.codex/run_repo_scout.py:229:80: E501 line too long (86 > 79 characters)
+./.codex/run_repo_scout.py:270:80: E501 line too long (86 > 79 characters)
+./.codex/run_repo_scout.py:294:80: E501 line too long (88 > 79 characters)
+./.codex/run_repo_scout.py:311:80: E501 line too long (85 > 79 characters)
+./.codex/run_repo_scout.py:336:80: E501 line too long (81 > 79 characters)
+./.codex/run_repo_scout.py:340:80: E501 line too long (88 > 79 characters)
+./.codex/run_repo_scout.py:351:80: E501 line too long (87 > 79 characters)
+./.codex/run_repo_scout.py:355:80: E501 line too long (83 > 79 characters)
+./.codex/run_repo_scout.py:385:80: E501 line too long (88 > 79 characters)
+./.codex/run_repo_scout.py:407:80: E501 line too long (81 > 79 characters)
+./.codex/run_repo_scout.py:425:80: E501 line too long (83 > 79 characters)
+./.codex/run_repo_scout.py:427:80: E501 line too long (85 > 79 characters)
+./.codex/run_repo_scout.py:433:80: E501 line too long (85 > 79 characters)
+./.codex/run_repo_scout.py:437:80: E501 line too long (81 > 79 characters)
+./.codex/run_repo_scout.py:443:80: E501 line too long (85 > 79 characters)
+./.codex/run_repo_scout.py:458:80: E501 line too long (80 > 79 characters)
+./.codex/run_repo_scout.py:489:80: E501 line too long (86 > 79 characters)
+./.codex/run_repo_scout.py:524:80: E501 line too long (81 > 79 characters)
+./.codex/run_repo_scout.py:533:80: E501 line too long (88 > 79 characters)
+./.codex/run_repo_scout.py:535:80: E501 line too long (83 > 79 characters)
+./.codex/run_repo_scout.py:547:80: E501 line too long (86 > 79 characters)
+./.codex/run_workflow.py:48:80: E501 line too long (85 > 79 characters)
+./.codex/run_workflow.py:53:80: E501 line too long (86 > 79 characters)
+./.codex/run_workflow.py:77:80: E501 line too long (88 > 79 characters)
+./.codex/run_workflow.py:83:80: E501 line too long (88 > 79 characters)
+./.codex/run_workflow.py:101:80: E501 line too long (84 > 79 characters)
+./.codex/run_workflow.py:106:80: E501 line too long (88 > 79 characters)
+./.codex/run_workflow.py:142:80: E501 line too long (87 > 79 characters)
+./.codex/run_workflow.py:180:80: E501 line too long (86 > 79 characters)
+./.codex/run_workflow.py:215:80: E501 line too long (96 > 79 characters)
+./.codex/run_workflow.py:229:80: E501 line too long (81 > 79 characters)
+./.codex/run_workflow.py:243:62: E203 whitespace before ':'
+./.codex/run_workflow.py:281:80: E501 line too long (88 > 79 characters)
+./.codex/run_workflow.py:289:80: E501 line too long (96 > 79 characters)
+./.codex/run_workflow.py:305:80: E501 line too long (87 > 79 characters)
+./.codex/run_workflow.py:331:80: E501 line too long (84 > 79 characters)
+./.codex/run_workflow.py:354:80: E501 line too long (86 > 79 characters)
+./.codex/run_workflow.py:380:80: E501 line too long (84 > 79 characters)
+./.codex/run_workflow.py:430:80: E501 line too long (85 > 79 characters)
+./.codex/run_workflow.py:471:80: E501 line too long (83 > 79 characters)
+./.codex/run_workflow.py:473:80: E501 line too long (83 > 79 characters)
+./.codex/run_workflow.py:502:80: E501 line too long (87 > 79 characters)
+./.codex/run_workflow.py:518:80: E501 line too long (80 > 79 characters)
+./.codex/smoke/import_check.py:66:80: E501 line too long (80 > 79 characters)
+./codex_setup.py:66:80: E501 line too long (85 > 79 characters)
+./codex_setup.py:132:80: E501 line too long (88 > 79 characters)
+./codex_setup.py:164:80: E501 line too long (81 > 79 characters)
+./codex_workflow.py:37:80: E501 line too long (81 > 79 characters)
+./codex_workflow.py:111:80: E501 line too long (89 > 79 characters)
+./codex_workflow.py:114:80: E501 line too long (111 > 79 characters)
+./codex_workflow.py:159:80: E501 line too long (84 > 79 characters)
+./codex_workflow.py:176:80: E501 line too long (86 > 79 characters)
+./codex_workflow.py:257:80: E501 line too long (82 > 79 characters)
+./codex_workflow.py:265:80: E501 line too long (87 > 79 characters)
+./codex_workflow.py:273:80: E501 line too long (82 > 79 characters)
+./codex_workflow.py:281:80: E501 line too long (84 > 79 characters)
+./codex_workflow.py:297:80: E501 line too long (85 > 79 characters)
+./codex_workflow.py:337:80: E501 line too long (91 > 79 characters)
+./codex_workflow.py:361:80: E501 line too long (85 > 79 characters)
+./codex_workflow.py:386:80: E501 line too long (81 > 79 characters)
+./codex_workflow.py:427:80: E501 line too long (80 > 79 characters)
+./codex_workflow.py:436:80: E501 line too long (84 > 79 characters)
+./codex_workflow.py:447:80: E501 line too long (81 > 79 characters)
+./codex_workflow.py:458:80: E501 line too long (83 > 79 characters)
+./codex_workflow.py:479:80: E501 line too long (118 > 79 characters)
+./documentation/codex_symbolic_pipeline.py:168:80: E501 line too long (85 > 79 characters)
+./documentation/codex_symbolic_pipeline.py:181:31: E203 whitespace before ':'
+./documentation/codex_symbolic_pipeline.py:187:80: E501 line too long (88 > 79 characters)
+./documentation/codex_symbolic_pipeline.py:258:80: E501 line too long (85 > 79 characters)
+./documentation/codex_symbolic_pipeline.py:291:80: E501 line too long (88 > 79 characters)
+./functional_training.py:1:80: E501 line too long (82 > 79 characters)
+./functional_training.py:111:80: E501 line too long (82 > 79 characters)
+./functional_training.py:132:80: E501 line too long (87 > 79 characters)
+./scripts/apply_session_logging_workflow.py:19:80: E501 line too long (80 > 79 characters)
+./scripts/apply_session_logging_workflow.py:61:80: E501 line too long (177 > 79 characters)
+./scripts/apply_session_logging_workflow.py:91:80: E501 line too long (111 > 79 characters)
+./scripts/apply_session_logging_workflow.py:103:80: E501 line too long (83 > 79 characters)
+./scripts/apply_session_logging_workflow.py:105:80: E501 line too long (80 > 79 characters)
+./scripts/apply_session_logging_workflow.py:147:80: E501 line too long (80 > 79 characters)
+./scripts/apply_session_logging_workflow.py:180:80: E501 line too long (85 > 79 characters)
+./scripts/apply_session_logging_workflow.py:181:80: E501 line too long (91 > 79 characters)
+./scripts/apply_session_logging_workflow.py:183:80: E501 line too long (89 > 79 characters)
+./scripts/apply_session_logging_workflow.py:184:80: E501 line too long (80 > 79 characters)
+./scripts/apply_session_logging_workflow.py:185:80: E501 line too long (83 > 79 characters)
+./scripts/apply_session_logging_workflow.py:202:80: E501 line too long (83 > 79 characters)
+./scripts/apply_session_logging_workflow.py:203:80: E501 line too long (83 > 79 characters)
+./scripts/apply_session_logging_workflow.py:204:80: E501 line too long (83 > 79 characters)
+./scripts/apply_session_logging_workflow.py:235:80: E501 line too long (98 > 79 characters)
+./scripts/apply_session_logging_workflow.py:240:80: E501 line too long (88 > 79 characters)
+./scripts/apply_session_logging_workflow.py:247:80: E501 line too long (88 > 79 characters)
+./scripts/apply_session_logging_workflow.py:255:80: E501 line too long (85 > 79 characters)
+./scripts/apply_session_logging_workflow.py:262:80: E501 line too long (101 > 79 characters)
+./scripts/apply_session_logging_workflow.py:269:80: E501 line too long (84 > 79 characters)
+./scripts/apply_session_logging_workflow.py:290:80: E501 line too long (83 > 79 characters)
+./scripts/apply_session_logging_workflow.py:295:80: E501 line too long (119 > 79 characters)
+./scripts/apply_session_logging_workflow.py:297:80: E501 line too long (85 > 79 characters)
+./scripts/apply_session_logging_workflow.py:307:80: E501 line too long (93 > 79 characters)
+./scripts/apply_session_logging_workflow.py:309:80: E501 line too long (98 > 79 characters)
+./scripts/apply_session_logging_workflow.py:324:80: E501 line too long (111 > 79 characters)
+./scripts/apply_session_logging_workflow.py:325:80: E501 line too long (93 > 79 characters)
+./scripts/apply_session_logging_workflow.py:326:80: E501 line too long (96 > 79 characters)
+./scripts/apply_session_logging_workflow.py:335:80: E501 line too long (97 > 79 characters)
+./scripts/apply_session_logging_workflow.py:344:80: E501 line too long (116 > 79 characters)
+./scripts/apply_session_logging_workflow.py:367:80: E501 line too long (92 > 79 characters)
+./scripts/apply_session_logging_workflow.py:429:80: E501 line too long (86 > 79 characters)
+./scripts/apply_session_logging_workflow.py:443:80: E501 line too long (85 > 79 characters)
+./scripts/apply_session_logging_workflow.py:445:80: E501 line too long (83 > 79 characters)
+./scripts/apply_session_logging_workflow.py:516:80: E501 line too long (88 > 79 characters)
+./scripts/apply_session_logging_workflow.py:519:80: E501 line too long (133 > 79 characters)
+./scripts/benchmark_logging.py:19:80: E501 line too long (89 > 79 characters)
+./scripts/benchmark_logging.py:31:80: E501 line too long (83 > 79 characters)
+./scripts/codex_end_to_end.py:5:80: E501 line too long (80 > 79 characters)
+./scripts/deep_research_task_process.py:5:80: E501 line too long (80 > 79 characters)
+./scripts/deep_research_task_process.py:12:80: E501 line too long (87 > 79 characters)
+./scripts/deep_research_task_process.py:14:80: E501 line too long (87 > 79 characters)
+./scripts/deep_research_task_process.py:15:80: E501 line too long (87 > 79 characters)
+./scripts/deep_research_task_process.py:16:80: E501 line too long (87 > 79 characters)
+./scripts/deep_research_task_process.py:17:80: E501 line too long (87 > 79 characters)
+./scripts/deep_research_task_process.py:20:80: E501 line too long (104 > 79 characters)
+./scripts/deep_research_task_process.py:21:80: E501 line too long (81 > 79 characters)
+./scripts/deep_research_task_process.py:23:80: E501 line too long (90 > 79 characters)
+./scripts/deep_research_task_process.py:26:80: E501 line too long (81 > 79 characters)
+./scripts/deep_research_task_process.py:29:80: E501 line too long (107 > 79 characters)
+./scripts/deep_research_task_process.py:31:80: E501 line too long (91 > 79 characters)
+./scripts/deep_research_task_process.py:32:80: E501 line too long (89 > 79 characters)
+./scripts/deep_research_task_process.py:35:80: E501 line too long (99 > 79 characters)
+./scripts/deep_research_task_process.py:37:80: E501 line too long (98 > 79 characters)
+./scripts/deep_research_task_process.py:38:80: E501 line too long (98 > 79 characters)
+./scripts/deep_research_task_process.py:39:80: E501 line too long (98 > 79 characters)
+./scripts/deep_research_task_process.py:40:80: E501 line too long (98 > 79 characters)
+./scripts/deep_research_task_process.py:41:80: E501 line too long (98 > 79 characters)
+./scripts/deep_research_task_process.py:42:80: E501 line too long (98 > 79 characters)
+./scripts/deep_research_task_process.py:43:80: E501 line too long (98 > 79 characters)
+./scripts/deep_research_task_process.py:62:80: E501 line too long (92 > 79 characters)
+./scripts/deep_research_task_process.py:81:80: E501 line too long (81 > 79 characters)
+./scripts/deep_research_task_process.py:141:80: E501 line too long (81 > 79 characters)
+./scripts/deep_research_task_process.py:166:80: E501 line too long (85 > 79 characters)
+./scripts/deep_research_task_process.py:192:80: E501 line too long (80 > 79 characters)
+./scripts/deep_research_task_process.py:237:80: E501 line too long (85 > 79 characters)
+./scripts/deep_research_task_process.py:238:80: E501 line too long (86 > 79 characters)
+./scripts/deep_research_task_process.py:241:80: E501 line too long (83 > 79 characters)
+./scripts/deep_research_task_process.py:247:80: E501 line too long (81 > 79 characters)
+./scripts/deep_research_task_process.py:249:80: E501 line too long (113 > 79 characters)
+./scripts/deep_research_task_process.py:273:80: E501 line too long (86 > 79 characters)
+./scripts/deep_research_task_process.py:345:80: E501 line too long (82 > 79 characters)
+./scripts/deep_research_task_process.py:368:80: E501 line too long (82 > 79 characters)
+./scripts/deep_research_task_process.py:389:80: E501 line too long (81 > 79 characters)
+./scripts/deep_research_task_process.py:406:80: E501 line too long (83 > 79 characters)
+./scripts/deep_research_task_process.py:423:80: E501 line too long (83 > 79 characters)
+./scripts/deep_research_task_process.py:426:80: E501 line too long (87 > 79 characters)
+./scripts/deep_research_task_process.py:432:80: E501 line too long (82 > 79 characters)
+./scripts/deep_research_task_process.py:440:80: E501 line too long (87 > 79 characters)
+./scripts/deep_research_task_process.py:443:80: E501 line too long (81 > 79 characters)
+./scripts/deep_research_task_process.py:455:80: E501 line too long (81 > 79 characters)
+./scripts/deep_research_task_process.py:522:80: E501 line too long (209 > 79 characters)
+./scripts/deep_research_task_process.py:524:80: E501 line too long (175 > 79 characters)
+./scripts/deep_research_task_process.py:526:80: E501 line too long (81 > 79 characters)
+./scripts/deep_research_task_process.py:545:80: E501 line too long (86 > 79 characters)
+./scripts/deep_research_task_process.py:570:80: E501 line too long (87 > 79 characters)
+./scripts/deep_research_task_process.py:572:80: E501 line too long (91 > 79 characters)
+./scripts/deep_research_task_process.py:575:80: E501 line too long (87 > 79 characters)
+./scripts/deep_research_task_process.py:590:80: E501 line too long (104 > 79 characters)
+./scripts/deep_research_task_process.py:610:80: E501 line too long (82 > 79 characters)
+./scripts/deep_research_task_process.py:650:80: E501 line too long (105 > 79 characters)
+./scripts/deep_research_task_process.py:667:80: E501 line too long (80 > 79 characters)
+./scripts/deep_research_task_process.py:689:80: E501 line too long (104 > 79 characters)
+./scripts/deep_research_task_process.py:694:80: E501 line too long (83 > 79 characters)
+./scripts/deep_research_task_process.py:770:80: E501 line too long (87 > 79 characters)
+./scripts/deep_research_task_process.py:774:80: E501 line too long (80 > 79 characters)
+./scripts/deep_research_task_process.py:786:80: E501 line too long (90 > 79 characters)
+./scripts/deep_research_task_process.py:821:80: E501 line too long (84 > 79 characters)
+./scripts/deep_research_task_process.py:848:80: E501 line too long (88 > 79 characters)
+./scripts/deep_research_task_process.py:855:80: E501 line too long (85 > 79 characters)
+./scripts/deep_research_task_process.py:869:80: E501 line too long (82 > 79 characters)
+./scripts/deep_research_task_process.py:924:80: E501 line too long (81 > 79 characters)
+./scripts/deep_research_task_process.py:954:80: E501 line too long (101 > 79 characters)
+./scripts/deep_research_task_process.py:965:80: E501 line too long (83 > 79 characters)
+./scripts/deep_research_task_process.py:1003:80: E501 line too long (84 > 79 characters)
+./scripts/deep_research_task_process.py:1114:80: E501 line too long (91 > 79 characters)
+./scripts/deep_research_task_process.py:1117:80: E501 line too long (134 > 79 characters)
+./scripts/deep_research_task_process.py:1120:80: E501 line too long (110 > 79 characters)
+./scripts/deep_research_task_process.py:1123:80: E501 line too long (86 > 79 characters)
+./scripts/deep_research_task_process.py:1126:80: E501 line too long (83 > 79 characters)
+./scripts/deep_research_task_process.py:1132:80: E501 line too long (83 > 79 characters)
+./scripts/deep_research_task_process.py:1135:80: E501 line too long (89 > 79 characters)
+./scripts/deep_research_task_process.py:1139:80: E501 line too long (82 > 79 characters)
+./scripts/deep_research_task_process.py:1145:80: E501 line too long (80 > 79 characters)
+./scripts/deep_research_task_process.py:1152:80: E501 line too long (84 > 79 characters)
+./scripts/deep_research_task_process.py:1155:80: E501 line too long (88 > 79 characters)
+./scripts/deep_research_task_process.py:1170:80: E501 line too long (87 > 79 characters)
+./scripts/deep_research_task_process.py:1185:80: E501 line too long (88 > 79 characters)
+./scripts/deploy_codex_pipeline.py:6:1: E265 block comment should start with '# '
+./scripts/deploy_codex_pipeline.py:10:80: E501 line too long (88 > 79 characters)
+./scripts/deploy_codex_pipeline.py:14:80: E501 line too long (97 > 79 characters)
+./scripts/deploy_codex_pipeline.py:58:80: E501 line too long (80 > 79 characters)
+./scripts/deploy_codex_pipeline.py:96:80: E501 line too long (87 > 79 characters)
+./scripts/deploy_codex_pipeline.py:132:80: E501 line too long (87 > 79 characters)
+./scripts/deploy_codex_pipeline.py:134:80: E501 line too long (88 > 79 characters)
+./scripts/deploy_codex_pipeline.py:197:80: E501 line too long (82 > 79 characters)
+./scripts/deploy_codex_pipeline.py:198:80: E501 line too long (86 > 79 characters)
+./scripts/deploy_codex_pipeline.py:212:80: E501 line too long (84 > 79 characters)
+./scripts/deploy_codex_pipeline.py:241:80: E501 line too long (84 > 79 characters)
+./scripts/deploy_codex_pipeline.py:278:80: E501 line too long (86 > 79 characters)
+./scripts/deploy_codex_pipeline.py:285:80: E501 line too long (82 > 79 characters)
+./scripts/deploy_codex_pipeline.py:287:80: E501 line too long (86 > 79 characters)
+./scripts/deploy_codex_pipeline.py:289:80: E501 line too long (81 > 79 characters)
+./scripts/deploy_codex_pipeline.py:295:80: E501 line too long (80 > 79 characters)
+./scripts/deploy_codex_pipeline.py:328:80: E501 line too long (88 > 79 characters)
+./scripts/deploy_codex_pipeline.py:330:80: E501 line too long (80 > 79 characters)
+./scripts/deploy_codex_pipeline.py:337:80: E501 line too long (81 > 79 characters)
+./scripts/env/print_env_info.py:11:80: E501 line too long (101 > 79 characters)
+./scripts/init_sample_db.py:64:80: E501 line too long (81 > 79 characters)
+./scripts/init_sample_db.py:93:80: E501 line too long (95 > 79 characters)
+./services/api/main.py:55:26: E999 SyntaxError: unterminated f-string literal (detected at line 55)
+./src/codex/chat.py:6:80: E501 line too long (80 > 79 characters)
+./src/codex/db/sqlite_patch.py:3:80: E501 line too long (80 > 79 characters)
+./src/codex/db/sqlite_patch.py:39:80: E501 line too long (81 > 79 characters)
+./src/codex/db/sqlite_patch.py:95:80: E501 line too long (84 > 79 characters)
+./src/codex/db/sqlite_patch.py:122:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/__init__.py:13:80: E501 line too long (82 > 79 characters)
+./src/codex/logging/conversation_logger.py:21:80: E501 line too long (81 > 79 characters)
+./src/codex/logging/conversation_logger.py:32:80: E501 line too long (88 > 79 characters)
+./src/codex/logging/conversation_logger.py:44:80: E501 line too long (86 > 79 characters)
+./src/codex/logging/db_utils.py:20:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/db_utils.py:42:80: E501 line too long (91 > 79 characters)
+./src/codex/logging/db_utils.py:100:80: E501 line too long (88 > 79 characters)
+./src/codex/logging/db_utils.py:125:80: E501 line too long (83 > 79 characters)
+./src/codex/logging/db_utils.py:133:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/export.py:31:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/export.py:40:80: E501 line too long (83 > 79 characters)
+./src/codex/logging/export.py:87:80: E501 line too long (85 > 79 characters)
+./src/codex/logging/export.py:105:80: E501 line too long (85 > 79 characters)
+./src/codex/logging/export.py:108:80: E501 line too long (82 > 79 characters)
+./src/codex/logging/fetch_messages.py:21:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/fetch_messages.py:85:80: E501 line too long (88 > 79 characters)
+./src/codex/logging/import_ndjson.py:7:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/import_ndjson.py:19:80: E501 line too long (82 > 79 characters)
+./src/codex/logging/import_ndjson.py:49:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/import_ndjson.py:57:80: E501 line too long (83 > 79 characters)
+./src/codex/logging/import_ndjson.py:61:80: E501 line too long (82 > 79 characters)
+./src/codex/logging/import_ndjson.py:177:80: E501 line too long (84 > 79 characters)
+./src/codex/logging/import_ndjson.py:250:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/query_logs.py:12:80: E501 line too long (81 > 79 characters)
+./src/codex/logging/query_logs.py:37:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/query_logs.py:55:80: E501 line too long (83 > 79 characters)
+./src/codex/logging/query_logs.py:211:80: E501 line too long (81 > 79 characters)
+./src/codex/logging/query_logs.py:222:80: E501 line too long (82 > 79 characters)
+./src/codex/logging/query_logs.py:225:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/query_logs.py:235:80: E501 line too long (82 > 79 characters)
+./src/codex/logging/query_logs.py:237:80: E501 line too long (84 > 79 characters)
+./src/codex/logging/query_logs.py:264:80: E501 line too long (88 > 79 characters)
+./src/codex/logging/session_hooks.py:10:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/session_hooks.py:59:80: E501 line too long (82 > 79 characters)
+./src/codex/logging/session_hooks.py:112:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/session_hooks.py:131:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/session_logger.py:36:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/session_logger.py:61:80: E501 line too long (81 > 79 characters)
+./src/codex/logging/session_logger.py:92:80: E501 line too long (83 > 79 characters)
+./src/codex/logging/session_logger.py:116:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/session_logger.py:121:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/session_logger.py:154:80: E501 line too long (82 > 79 characters)
+./src/codex/logging/session_logger.py:177:80: E501 line too long (84 > 79 characters)
+./src/codex/logging/session_logger.py:198:80: E501 line too long (86 > 79 characters)
+./src/codex/logging/session_logger.py:200:80: E501 line too long (88 > 79 characters)
+./src/codex/logging/session_logger.py:205:80: E501 line too long (84 > 79 characters)
+./src/codex/logging/session_logger.py:209:80: E501 line too long (85 > 79 characters)
+./src/codex/logging/session_logger.py:219:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/session_logger.py:259:80: E501 line too long (84 > 79 characters)
+./src/codex/logging/session_logger.py:282:80: E501 line too long (83 > 79 characters)
+./src/codex/logging/session_logger.py:312:80: E501 line too long (85 > 79 characters)
+./src/codex/logging/session_logger.py:324:80: E501 line too long (85 > 79 characters)
+./src/codex/logging/session_logger.py:335:80: E501 line too long (86 > 79 characters)
+./src/codex/logging/session_logger.py:352:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/session_logger.py:362:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/session_query.py:36:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/session_query.py:60:80: E501 line too long (81 > 79 characters)
+./src/codex/logging/session_query.py:84:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/session_query.py:85:80: E501 line too long (81 > 79 characters)
+./src/codex/logging/session_query.py:96:80: E501 line too long (81 > 79 characters)
+./src/codex/logging/session_query.py:151:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/session_query.py:179:80: E501 line too long (82 > 79 characters)
+./src/codex/logging/session_query.py:190:80: E501 line too long (82 > 79 characters)
+./src/codex/logging/session_query.py:195:80: E501 line too long (81 > 79 characters)
+./src/codex/logging/viewer.py:5:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/viewer.py:13:80: E501 line too long (86 > 79 characters)
+./src/codex/logging/viewer.py:14:80: E501 line too long (87 > 79 characters)
+./src/codex/logging/viewer.py:20:80: E501 line too long (85 > 79 characters)
+./src/codex/logging/viewer.py:23:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/viewer.py:36:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/viewer.py:74:80: E501 line too long (83 > 79 characters)
+./src/codex/logging/viewer.py:81:80: E501 line too long (88 > 79 characters)
+./src/codex/logging/viewer.py:89:80: E501 line too long (88 > 79 characters)
+./src/codex/logging/viewer.py:93:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/viewer.py:94:80: E501 line too long (80 > 79 characters)
+./src/codex/logging/viewer.py:158:80: E501 line too long (81 > 79 characters)
+./src/codex/logging/viewer.py:169:80: E501 line too long (83 > 79 characters)
+./src/codex/logging/viewer.py:210:80: E501 line too long (93 > 79 characters)
+./src/codex/logging/viewer.py:230:80: E501 line too long (84 > 79 characters)
+./src/codex/logging/viewer.py:244:80: E501 line too long (84 > 79 characters)
+./src/codex/monkeypatch/log_adapters.py:39:80: E501 line too long (86 > 79 characters)
+./src/codex/monkeypatch/log_adapters.py:59:80: E501 line too long (86 > 79 characters)
+./src/codex/utils/subprocess.py:20:80: E501 line too long (82 > 79 characters)
+./src/codex_ml/__init__.py:12:80: E501 line too long (93 > 79 characters)
+./src/codex_ml/__init__.py:15:5: F401 '.symbolic_pipeline.ModelHandle' imported but unused
+./src/codex_ml/__init__.py:15:5: F401 '.symbolic_pipeline.PretrainCfg' imported but unused
+./src/codex_ml/__init__.py:15:5: F401 '.symbolic_pipeline.RewardModelCfg' imported but unused
+./src/codex_ml/__init__.py:15:5: F401 '.symbolic_pipeline.RewardModelHandle' imported but unused
+./src/codex_ml/__init__.py:15:5: F401 '.symbolic_pipeline.RLHFCfg' imported but unused
+./src/codex_ml/__init__.py:15:5: F401 '.symbolic_pipeline.SFTCfg' imported but unused
+./src/codex_ml/__init__.py:15:5: F401 '.symbolic_pipeline.Weights' imported but unused
+./src/codex_ml/__init__.py:15:5: F401 '.symbolic_pipeline.run_codex_symbolic_pipeline' imported but unused
+./src/codex_ml/cli/main.py:16:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/cli/main.py:19:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/cli/main.py:24:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/cli/main.py:32:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/cli/main.py:32:80: E501 line too long (85 > 79 characters)
+./src/codex_ml/cli/main.py:39:1: E305 expected 2 blank lines after class or function definition, found 1
+./src/codex_ml/data/cache.py:5:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/data/cache.py:9:5: E301 expected 1 blank line, found 0
+./src/codex_ml/data/cache.py:18:5: E301 expected 1 blank line, found 0
+./src/codex_ml/data/cli.py:12:80: E501 line too long (85 > 79 characters)
+./src/codex_ml/data/cli.py:13:80: E501 line too long (81 > 79 characters)
+./src/codex_ml/data/cli.py:20:80: E501 line too long (95 > 79 characters)
+./src/codex_ml/data/loaders.py:13:5: F401 'pydantic as _pyd' imported but unused
+./src/codex_ml/data/loaders.py:68:80: E501 line too long (85 > 79 characters)
+./src/codex_ml/data/loaders.py:71:80: E501 line too long (84 > 79 characters)
+./src/codex_ml/data/loaders.py:75:80: E501 line too long (89 > 79 characters)
+./src/codex_ml/data/loaders.py:93:80: E501 line too long (139 > 79 characters)
+./src/codex_ml/data/loaders.py:96:80: E501 line too long (93 > 79 characters)
+./src/codex_ml/data/loaders.py:103:80: E501 line too long (139 > 79 characters)
+./src/codex_ml/data/loaders.py:120:80: E501 line too long (86 > 79 characters)
+./src/codex_ml/data/loaders.py:128:80: E501 line too long (88 > 79 characters)
+./src/codex_ml/data/loaders.py:134:80: E501 line too long (94 > 79 characters)
+./src/codex_ml/data/loaders.py:139:80: E501 line too long (82 > 79 characters)
+./src/codex_ml/data/loaders.py:146:80: E501 line too long (94 > 79 characters)
+./src/codex_ml/data/loaders.py:165:80: E501 line too long (108 > 79 characters)
+./src/codex_ml/data/sharding.py:4:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/data/sharding.py:4:60: E231 missing whitespace after ','
+./src/codex_ml/eval/metrics.py:40:80: E501 line too long (89 > 79 characters)
+./src/codex_ml/eval/metrics.py:80:80: E501 line too long (80 > 79 characters)
+./src/codex_ml/eval/metrics.py:132:80: E501 line too long (85 > 79 characters)
+./src/codex_ml/eval/metrics.py:148:80: E501 line too long (84 > 79 characters)
+./src/codex_ml/interfaces/reward_model.py:6:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/interfaces/reward_model.py:7:80: E501 line too long (82 > 79 characters)
+./src/codex_ml/interfaces/reward_model.py:10:80: E501 line too long (108 > 79 characters)
+./src/codex_ml/interfaces/reward_model.py:14:80: E501 line too long (137 > 79 characters)
+./src/codex_ml/interfaces/rl.py:6:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/interfaces/tokenizer.py:4:1: F401 'typing.Optional' imported but unused
+./src/codex_ml/interfaces/tokenizer.py:6:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/interfaces/tokenizer.py:9:80: E501 line too long (84 > 79 characters)
+./src/codex_ml/interfaces/tokenizer.py:14:80: E501 line too long (81 > 79 characters)
+./src/codex_ml/interfaces/tokenizer.py:18:80: E501 line too long (104 > 79 characters)
+./src/codex_ml/interfaces/tokenizer.py:20:80: E501 line too long (85 > 79 characters)
+./src/codex_ml/interfaces/tokenizer.py:23:80: E501 line too long (85 > 79 characters)
+./src/codex_ml/metrics/curves.py:7:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/metrics/curves.py:13:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/models/activations.py:11:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/models/activations.py:16:1: E302 expected 2 blank lines, found 0
+./src/codex_ml/models/activations.py:19:1: E302 expected 2 blank lines, found 0
+./src/codex_ml/models/activations.py:22:1: E302 expected 2 blank lines, found 0
+./src/codex_ml/models/activations.py:25:1: E302 expected 2 blank lines, found 0
+./src/codex_ml/models/activations.py:29:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/models/minilm.py:30:80: E501 line too long (85 > 79 characters)
+./src/codex_ml/models/minilm.py:38:80: E501 line too long (80 > 79 characters)
+./src/codex_ml/models/minilm.py:89:80: E501 line too long (84 > 79 characters)
+./src/codex_ml/monitoring/prometheus.py:4:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/monitoring/prometheus.py:10:59: E231 missing whitespace after ','
+./src/codex_ml/monitoring/prometheus.py:11:49: E231 missing whitespace after ','
+./src/codex_ml/peft/peft_adapter.py:4:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/peft/peft_adapter.py:5:80: E501 line too long (89 > 79 characters)
+./src/codex_ml/peft/peft_adapter.py:7:9: F401 'peft' imported but unused
+./src/codex_ml/safety/__init__.py:5:80: E501 line too long (87 > 79 characters)
+./src/codex_ml/safety/filters.py:9:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/safety/filters.py:50:80: E501 line too long (80 > 79 characters)
+./src/codex_ml/safety/filters.py:58:80: E501 line too long (103 > 79 characters)
+./src/codex_ml/safety/filters.py:59:80: E501 line too long (103 > 79 characters)
+./src/codex_ml/safety/filters.py:70:80: E501 line too long (80 > 79 characters)
+./src/codex_ml/safety/filters.py:78:13: F401 'numpy as np' imported but unused
+./src/codex_ml/safety/risk_score.py:4:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/safety/risk_score.py:5:22: E231 missing whitespace after ','
+./src/codex_ml/safety/risk_score.py:5:32: E231 missing whitespace after ','
+./src/codex_ml/safety/risk_score.py:5:38: E231 missing whitespace after ','
+./src/codex_ml/safety/risk_score.py:5:49: E231 missing whitespace after ','
+./src/codex_ml/safety/risk_score.py:5:56: E231 missing whitespace after ','
+./src/codex_ml/safety/sandbox.py:66:9: E301 expected 1 blank line, found 0
+./src/codex_ml/safety/sandbox.py:79:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/safety/sandbox.py:82:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/symbolic_pipeline.py:64:80: E501 line too long (83 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:65:80: E501 line too long (81 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:183:80: E501 line too long (85 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:242:28: E203 whitespace before ':'
+./src/codex_ml/symbolic_pipeline.py:248:80: E501 line too long (88 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:332:80: E501 line too long (85 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:371:80: E501 line too long (88 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:408:80: E501 line too long (88 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:415:80: E501 line too long (80 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:419:80: E501 line too long (80 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:425:80: E501 line too long (87 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:435:80: E501 line too long (86 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:441:80: E501 line too long (84 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:464:80: E501 line too long (89 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:483:80: E501 line too long (83 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:501:80: E501 line too long (82 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:503:80: E501 line too long (84 > 79 characters)
+./src/codex_ml/symbolic_pipeline.py:521:80: E501 line too long (82 > 79 characters)
+./src/codex_ml/tokenization/__init__.py:41:80: E501 line too long (83 > 79 characters)
+./src/codex_ml/tokenization/sentencepiece_adapter.py:10:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/tokenization/sentencepiece_adapter.py:14:5: E301 expected 1 blank line, found 0
+./src/codex_ml/tokenization/sentencepiece_adapter.py:14:80: E501 line too long (96 > 79 characters)
+./src/codex_ml/tokenization/sentencepiece_adapter.py:28:5: E301 expected 1 blank line, found 0
+./src/codex_ml/tokenization/sentencepiece_adapter.py:33:5: E301 expected 1 blank line, found 0
+./src/codex_ml/tokenization/sentencepiece_adapter.py:36:5: E301 expected 1 blank line, found 0
+./src/codex_ml/tracking/cli.py:33:80: E501 line too long (80 > 79 characters)
+./src/codex_ml/tracking/git_tag.py:5:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/tracking/git_tag.py:7:46: E231 missing whitespace after ','
+./src/codex_ml/tracking/git_tag.py:7:58: E231 missing whitespace after ','
+./src/codex_ml/tracking/git_tag.py:7:80: E501 line too long (85 > 79 characters)
+./src/codex_ml/tracking/mlflow_utils.py:53:80: E501 line too long (80 > 79 characters)
+./src/codex_ml/train_loop.py:11:16: E401 multiple imports on one line
+./src/codex_ml/train_loop.py:13:1: F401 'datetime.datetime' imported but unused
+./src/codex_ml/train_loop.py:16:1: F401 'codex_ml.eval.metrics.bleu' imported but unused
+./src/codex_ml/train_loop.py:16:1: F401 'codex_ml.eval.metrics.rouge_l' imported but unused
+./src/codex_ml/train_loop.py:21:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/train_loop.py:22:5: F811 redefinition of unused 'datetime' from line 13
+./src/codex_ml/train_loop.py:25:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/train_loop.py:25:80: E501 line too long (116 > 79 characters)
+./src/codex_ml/train_loop.py:46:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/train_loop.py:47:80: E501 line too long (80 > 79 characters)
+./src/codex_ml/train_loop.py:50:80: E501 line too long (100 > 79 characters)
+./src/codex_ml/train_loop.py:61:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/train_loop.py:65:80: E501 line too long (81 > 79 characters)
+./src/codex_ml/train_loop.py:73:80: E501 line too long (118 > 79 characters)
+./src/codex_ml/train_loop.py:74:80: E501 line too long (82 > 79 characters)
+./src/codex_ml/train_loop.py:76:1: E305 expected 2 blank lines after class or function definition, found 1
+./src/codex_ml/training/callbacks.py:3:1: E302 expected 2 blank lines, found 0
+./src/codex_ml/training/callbacks.py:8:5: E301 expected 1 blank line, found 0
+./src/codex_ml/utils/checkpointing.py:46:80: E501 line too long (81 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:71:80: E501 line too long (102 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:78:80: E501 line too long (83 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:101:80: E501 line too long (85 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:107:80: E501 line too long (88 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:111:80: E501 line too long (85 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:189:80: E501 line too long (106 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:199:80: E501 line too long (86 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:221:80: E501 line too long (94 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:228:80: E501 line too long (102 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:236:80: E501 line too long (92 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:238:80: E501 line too long (101 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:240:80: E501 line too long (99 > 79 characters)
+./src/codex_ml/utils/checkpointing.py:241:80: E501 line too long (82 > 79 characters)
+./src/codex_ml/utils/checksums.py:3:15: E401 multiple imports on one line
+./src/codex_ml/utils/checksums.py:6:1: E302 expected 2 blank lines, found 1
+./src/codex_ml/utils/checksums.py:15:1: E302 expected 2 blank lines, found 1
+./src/ingestion/__init__.py:4:80: E501 line too long (81 > 79 characters)
+./src/ingestion/__init__.py:61:80: E501 line too long (82 > 79 characters)
+./src/ingestion/__init__.py:71:80: E501 line too long (82 > 79 characters)
+./src/ingestion/encoding_detect.py:33:80: E501 line too long (84 > 79 characters)
+./tests/_codex_introspect.py:11:80: E501 line too long (80 > 79 characters)
+./tests/_codex_introspect.py:25:80: E501 line too long (84 > 79 characters)
+./tests/_codex_introspect.py:90:80: E501 line too long (82 > 79 characters)
+./tests/test_activations.py:4:1: E302 expected 2 blank lines, found 1
+./tests/test_activations.py:5:21: E231 missing whitespace after ','
+./tests/test_activations.py:5:28: E231 missing whitespace after ','
+./tests/test_activations.py:5:35: E231 missing whitespace after ','
+./tests/test_chat_session.py:32:80: E501 line too long (83 > 79 characters)
+./tests/test_chat_session.py:73:80: E501 line too long (87 > 79 characters)
+./tests/test_chat_session.py:81:80: E501 line too long (82 > 79 characters)
+./tests/test_checkpoint_roundtrip.py:9:80: E501 line too long (85 > 79 characters)
+./tests/test_codex_maintenance.py:12:80: E501 line too long (87 > 79 characters)
+./tests/test_data_cache_sharding.py:4:1: E302 expected 2 blank lines, found 1
+./tests/test_data_cache_sharding.py:8:10: E231 missing whitespace after ','
+./tests/test_data_cache_sharding.py:8:28: E231 missing whitespace after ','
+./tests/test_data_cache_sharding.py:8:30: E231 missing whitespace after ','
+./tests/test_data_cache_sharding.py:9:27: E231 missing whitespace after ','
+./tests/test_export.py:37:80: E501 line too long (85 > 79 characters)
+./tests/test_export.py:41:80: E501 line too long (81 > 79 characters)
+./tests/test_export.py:43:80: E501 line too long (85 > 79 characters)
+./tests/test_fetch_messages.py:40:80: E501 line too long (85 > 79 characters)
+./tests/test_fetch_messages.py:119:80: E501 line too long (80 > 79 characters)
+./tests/test_fetch_messages.py:143:80: E501 line too long (93 > 79 characters)
+./tests/test_fetch_messages.py:148:80: E501 line too long (95 > 79 characters)
+./tests/test_fetch_messages.py:153:80: E501 line too long (99 > 79 characters)
+./tests/test_import_ndjson.py:25:80: E501 line too long (88 > 79 characters)
+./tests/test_import_ndjson.py:44:80: E501 line too long (87 > 79 characters)
+./tests/test_import_ndjson.py:54:80: E501 line too long (82 > 79 characters)
+./tests/test_import_ndjson_cli.py:20:80: E501 line too long (82 > 79 characters)
+./tests/test_ingestion_encoding_coverage.py:16:80: E501 line too long (86 > 79 characters)
+./tests/test_ingestion_encoding_coverage.py:28:80: E501 line too long (87 > 79 characters)
+./tests/test_ingestion_encoding_coverage.py:55:80: E501 line too long (88 > 79 characters)
+./tests/test_ingestion_family_encoding.py:28:80: E501 line too long (82 > 79 characters)
+./tests/test_interfaces_compat.py:2:1: F401 'types' imported but unused
+./tests/test_interfaces_compat.py:2:10: E401 multiple imports on one line
+./tests/test_interfaces_compat.py:4:1: F401 'codex_ml.interfaces.RewardModel' imported but unused
+./tests/test_interfaces_compat.py:4:1: F401 'codex_ml.interfaces.RLAgent' imported but unused
+./tests/test_interfaces_compat.py:8:80: E501 line too long (90 > 79 characters)
+./tests/test_interfaces_compat.py:9:80: E501 line too long (92 > 79 characters)
+./tests/test_interfaces_compat.py:10:8: E221 multiple spaces before operator
+./tests/test_interfaces_compat.py:10:80: E501 line too long (80 > 79 characters)
+./tests/test_interfaces_compat.py:12:1: E302 expected 2 blank lines, found 1
+./tests/test_interfaces_compat.py:17:1: E302 expected 2 blank lines, found 1
+./tests/test_interfaces_compat.py:17:80: E501 line too long (85 > 79 characters)
+./tests/test_interfaces_compat.py:30:1: E302 expected 2 blank lines, found 1
+./tests/test_interfaces_compat.py:30:80: E501 line too long (87 > 79 characters)
+./tests/test_interfaces_compat.py:37:1: E302 expected 2 blank lines, found 1
+./tests/test_interfaces_compat.py:37:80: E501 line too long (82 > 79 characters)
+./tests/test_interfaces_compat.py:51:80: E501 line too long (113 > 79 characters)
+./tests/test_interfaces_compat.py:52:80: E501 line too long (110 > 79 characters)
+./tests/test_loaders.py:6:80: E501 line too long (83 > 79 characters)
+./tests/test_loaders.py:47:80: E501 line too long (80 > 79 characters)
+./tests/test_metric_curves.py:5:1: E302 expected 2 blank lines, found 1
+./tests/test_metrics.py:2:1: F401 'math' imported but unused
+./tests/test_metrics.py:6:1: E302 expected 2 blank lines, found 1
+./tests/test_metrics.py:7:14: E231 missing whitespace after ','
+./tests/test_metrics.py:7:16: E231 missing whitespace after ','
+./tests/test_metrics.py:7:18: E231 missing whitespace after ','
+./tests/test_metrics.py:7:20: E231 missing whitespace after ','
+./tests/test_metrics.py:8:14: E231 missing whitespace after ','
+./tests/test_metrics.py:8:16: E231 missing whitespace after ','
+./tests/test_metrics.py:8:18: E231 missing whitespace after ','
+./tests/test_metrics.py:8:20: E231 missing whitespace after ','
+./tests/test_metrics.py:11:1: E302 expected 2 blank lines, found 1
+./tests/test_metrics.py:12:14: E231 missing whitespace after ','
+./tests/test_metrics.py:12:16: E231 missing whitespace after ','
+./tests/test_metrics.py:13:14: E231 missing whitespace after ','
+./tests/test_metrics.py:13:19: E231 missing whitespace after ','
+./tests/test_metrics.py:14:80: E501 line too long (80 > 79 characters)
+./tests/test_metrics.py:16:1: E302 expected 2 blank lines, found 1
+./tests/test_metrics.py:20:1: E302 expected 2 blank lines, found 1
+./tests/test_metrics.py:29:1: E302 expected 2 blank lines, found 1
+./tests/test_minilm_forward.py:8:80: E501 line too long (87 > 79 characters)
+./tests/test_minilm_forward.py:19:80: E501 line too long (81 > 79 characters)
+./tests/test_ndjson_db_parity.py:21:80: E501 line too long (80 > 79 characters)
+./tests/test_ndjson_db_parity.py:22:80: E501 line too long (85 > 79 characters)
+./tests/test_query_logs_build_query.py:147:80: E501 line too long (87 > 79 characters)
+./tests/test_query_logs_build_query.py:222:80: E501 line too long (80 > 79 characters)
+./tests/test_query_logs_build_query.py:241:80: E501 line too long (88 > 79 characters)
+./tests/test_query_logs_build_query.py:440:80: E501 line too long (80 > 79 characters)
+./tests/test_query_logs_build_query.py:446:80: E501 line too long (82 > 79 characters)
+./tests/test_query_logs_build_query.py:469:80: E501 line too long (84 > 79 characters)
+./tests/test_query_logs_build_query.py:473:80: E501 line too long (84 > 79 characters)
+./tests/test_query_logs_build_query.py:494:80: E501 line too long (83 > 79 characters)
+./tests/test_query_logs_build_query.py:511:80: E501 line too long (84 > 79 characters)
+./tests/test_resume.py:15:14: E741 ambiguous variable name 'l'
+./tests/test_safety.py:3:1: F401 'pytest' imported but unused
+./tests/test_safety.py:11:80: E501 line too long (80 > 79 characters)
+./tests/test_safety.py:30:80: E501 line too long (85 > 79 characters)
+./tests/test_sentencepiece_adapter.py:3:80: E501 line too long (95 > 79 characters)
+./tests/test_session_hooks.py:39:80: E501 line too long (84 > 79 characters)
+./tests/test_session_hooks.py:45:80: E501 line too long (83 > 79 characters)
+./tests/test_session_hooks.py:69:80: E501 line too long (84 > 79 characters)
+./tests/test_session_hooks.py:96:80: E501 line too long (87 > 79 characters)
+./tests/test_session_hooks.py:98:80: E501 line too long (83 > 79 characters)
+./tests/test_session_hooks.py:119:80: E501 line too long (88 > 79 characters)
+./tests/test_session_hooks.py:125:80: E501 line too long (83 > 79 characters)
+./tests/test_session_logger_log_adapters.py:11:80: E501 line too long (87 > 79 characters)
+./tests/test_session_logger_log_adapters.py:12:80: E501 line too long (85 > 79 characters)
+./tests/test_session_logging.py:21:80: E501 line too long (86 > 79 characters)
+./tests/test_session_logging.py:91:80: E501 line too long (88 > 79 characters)
+./tests/test_session_logging.py:93:80: E501 line too long (82 > 79 characters)
+./tests/test_session_logging.py:120:80: E501 line too long (87 > 79 characters)
+./tests/test_session_logging.py:132:80: E501 line too long (81 > 79 characters)
+./tests/test_session_logging.py:247:80: E501 line too long (83 > 79 characters)
+./tests/test_session_logging.py:254:80: E501 line too long (81 > 79 characters)
+./tests/test_session_logging.py:258:80: E501 line too long (86 > 79 characters)
+./tests/test_session_logging.py:291:80: E501 line too long (86 > 79 characters)
+./tests/test_session_logging.py:307:80: E501 line too long (87 > 79 characters)
+./tests/test_session_query_cli.py:36:80: E501 line too long (82 > 79 characters)
+./tests/test_session_query_smoke.py:46:80: E501 line too long (82 > 79 characters)
+./tests/test_sqlite_pool.py:10:80: E501 line too long (80 > 79 characters)
+./tests/test_sqlite_pool.py:29:80: E501 line too long (81 > 79 characters)
+./tests/test_sqlite_pool.py:38:80: E501 line too long (88 > 79 characters)
+./tests/test_sqlite_pool_close.py:24:80: E501 line too long (87 > 79 characters)
+./tests/test_symbolic_pipeline.py:77:80: E501 line too long (81 > 79 characters)
+./tests/test_symbolic_pipeline.py:143:80: E501 line too long (87 > 79 characters)
+./tests/test_tokenization.py:24:80: E501 line too long (82 > 79 characters)
+./tools/apply_ci_precommit.py:4:80: E501 line too long (87 > 79 characters)
+./tools/apply_ci_precommit.py:7:80: E501 line too long (105 > 79 characters)
+./tools/apply_ci_precommit.py:12:80: E501 line too long (83 > 79 characters)
+./tools/apply_ci_precommit.py:16:80: E501 line too long (99 > 79 characters)
+./tools/apply_ci_precommit.py:44:80: E501 line too long (101 > 79 characters)
+./tools/apply_ci_precommit.py:58:80: E501 line too long (103 > 79 characters)
+./tools/apply_ci_precommit.py:63:80: E501 line too long (87 > 79 characters)
+./tools/apply_ci_precommit.py:176:80: E501 line too long (94 > 79 characters)
+./tools/apply_ci_precommit.py:191:80: E501 line too long (99 > 79 characters)
+./tools/apply_ci_precommit.py:225:80: E501 line too long (86 > 79 characters)
+./tools/apply_ci_precommit.py:241:80: E501 line too long (102 > 79 characters)
+./tools/apply_ci_precommit.py:285:80: E501 line too long (80 > 79 characters)
+./tools/apply_container_api.py:21:80: E501 line too long (80 > 79 characters)
+./tools/apply_container_api.py:49:80: E501 line too long (107 > 79 characters)
+./tools/apply_container_api.py:62:80: E501 line too long (107 > 79 characters)
+./tools/apply_container_api.py:66:80: E501 line too long (93 > 79 characters)
+./tools/apply_container_api.py:72:80: E501 line too long (87 > 79 characters)
+./tools/apply_container_api.py:91:80: E501 line too long (93 > 79 characters)
+./tools/apply_container_api.py:94:80: E501 line too long (103 > 79 characters)
+./tools/apply_container_api.py:101:80: E501 line too long (124 > 79 characters)
+./tools/apply_container_api.py:230:80: E501 line too long (97 > 79 characters)
+./tools/apply_container_api.py:299:80: E501 line too long (102 > 79 characters)
+./tools/apply_container_api.py:310:80: E501 line too long (105 > 79 characters)
+./tools/apply_container_api.py:311:80: E501 line too long (100 > 79 characters)
+./tools/apply_container_api.py:313:80: E501 line too long (112 > 79 characters)
+./tools/apply_container_api.py:315:80: E501 line too long (111 > 79 characters)
+./tools/apply_container_api.py:321:80: E501 line too long (87 > 79 characters)
+./tools/apply_container_api.py:322:80: E501 line too long (82 > 79 characters)
+./tools/apply_container_api.py:344:80: E501 line too long (100 > 79 characters)
+./tools/apply_container_api.py:348:80: E501 line too long (125 > 79 characters)
+./tools/apply_container_api.py:355:80: E501 line too long (132 > 79 characters)
+./tools/apply_container_api.py:363:80: E501 line too long (125 > 79 characters)
+./tools/apply_container_api.py:373:80: E501 line too long (90 > 79 characters)
+./tools/apply_container_api.py:378:80: E501 line too long (97 > 79 characters)
+./tools/apply_container_api.py:385:80: E501 line too long (114 > 79 characters)
+./tools/apply_container_api.py:386:80: E501 line too long (98 > 79 characters)
+./tools/apply_data_loaders.py:28:80: E501 line too long (107 > 79 characters)
+./tools/apply_data_loaders.py:41:80: E501 line too long (107 > 79 characters)
+./tools/apply_data_loaders.py:45:80: E501 line too long (93 > 79 characters)
+./tools/apply_data_loaders.py:55:80: E501 line too long (95 > 79 characters)
+./tools/apply_data_loaders.py:57:80: E501 line too long (81 > 79 characters)
+./tools/apply_data_loaders.py:60:80: E501 line too long (83 > 79 characters)
+./tools/apply_data_loaders.py:77:80: E501 line too long (85 > 79 characters)
+./tools/apply_data_loaders.py:87:80: E501 line too long (95 > 79 characters)
+./tools/apply_data_loaders.py:102:80: E501 line too long (94 > 79 characters)
+./tools/apply_data_loaders.py:103:80: E501 line too long (100 > 79 characters)
+./tools/apply_docs.py:3:80: E501 line too long (87 > 79 characters)
+./tools/apply_docs.py:7:80: E501 line too long (113 > 79 characters)
+./tools/apply_docs.py:17:80: E501 line too long (105 > 79 characters)
+./tools/apply_docs.py:46:80: E501 line too long (101 > 79 characters)
+./tools/apply_docs.py:60:80: E501 line too long (107 > 79 characters)
+./tools/apply_docs.py:65:80: E501 line too long (87 > 79 characters)
+./tools/apply_docs.py:72:80: E501 line too long (87 > 79 characters)
+./tools/apply_docs.py:113:80: E501 line too long (128 > 79 characters)
+./tools/apply_docs.py:115:80: E501 line too long (118 > 79 characters)
+./tools/apply_docs.py:157:80: E501 line too long (87 > 79 characters)
+./tools/apply_docs.py:278:80: E501 line too long (111 > 79 characters)
+./tools/apply_docs.py:283:80: E501 line too long (86 > 79 characters)
+./tools/apply_docs.py:307:80: E501 line too long (97 > 79 characters)
+./tools/apply_docs.py:324:80: E501 line too long (82 > 79 characters)
+./tools/apply_docs.py:325:80: E501 line too long (88 > 79 characters)
+./tools/apply_docs.py:333:80: E501 line too long (82 > 79 characters)
+./tools/apply_docs.py:364:80: E501 line too long (83 > 79 characters)
+./tools/apply_docs.py:426:80: E501 line too long (80 > 79 characters)
+./tools/apply_hydra_scaffold.py:12:80: E501 line too long (91 > 79 characters)
+./tools/apply_hydra_scaffold.py:30:1: E302 expected 2 blank lines, found 1
+./tools/apply_hydra_scaffold.py:33:1: E302 expected 2 blank lines, found 1
+./tools/apply_hydra_scaffold.py:35:80: E501 line too long (82 > 79 characters)
+./tools/apply_hydra_scaffold.py:39:1: E302 expected 2 blank lines, found 1
+./tools/apply_hydra_scaffold.py:39:80: E501 line too long (82 > 79 characters)
+./tools/apply_hydra_scaffold.py:54:1: E302 expected 2 blank lines, found 1
+./tools/apply_hydra_scaffold.py:64:80: E501 line too long (111 > 79 characters)
+./tools/apply_hydra_scaffold.py:70:1: E302 expected 2 blank lines, found 1
+./tools/apply_hydra_scaffold.py:70:80: E501 line too long (94 > 79 characters)
+./tools/apply_hydra_scaffold.py:82:1: E305 expected 2 blank lines after class or function definition, found 1
+./tools/apply_hydra_scaffold.py:149:80: E501 line too long (85 > 79 characters)
+./tools/apply_hydra_scaffold.py:163:80: E501 line too long (87 > 79 characters)
+./tools/apply_hydra_scaffold.py:184:1: E302 expected 2 blank lines, found 1
+./tools/apply_hydra_scaffold.py:186:80: E501 line too long (103 > 79 characters)
+./tools/apply_hydra_scaffold.py:187:80: E501 line too long (111 > 79 characters)
+./tools/apply_hydra_scaffold.py:188:80: E501 line too long (113 > 79 characters)
+./tools/apply_hydra_scaffold.py:193:80: E501 line too long (87 > 79 characters)
+./tools/apply_hydra_scaffold.py:195:80: E501 line too long (110 > 79 characters)
+./tools/apply_hydra_scaffold.py:200:80: E501 line too long (81 > 79 characters)
+./tools/apply_hydra_scaffold.py:201:80: E501 line too long (88 > 79 characters)
+./tools/apply_hydra_scaffold.py:206:1: E302 expected 2 blank lines, found 1
+./tools/apply_hydra_scaffold.py:210:80: E501 line too long (104 > 79 characters)
+./tools/apply_hydra_scaffold.py:215:80: E501 line too long (82 > 79 characters)
+./tools/apply_hydra_scaffold.py:218:80: E501 line too long (87 > 79 characters)
+./tools/apply_hydra_scaffold.py:222:1: E302 expected 2 blank lines, found 1
+./tools/apply_hydra_scaffold.py:237:1: E305 expected 2 blank lines after class or function definition, found 1
+./tools/apply_interfaces.py:4:80: E501 line too long (80 > 79 characters)
+./tools/apply_interfaces.py:19:80: E501 line too long (155 > 79 characters)
+./tools/apply_interfaces.py:22:1: F401 'os' imported but unused
+./tools/apply_interfaces.py:22:1: F401 're' imported but unused
+./tools/apply_interfaces.py:22:10: E401 multiple imports on one line
+./tools/apply_interfaces.py:33:1: E302 expected 2 blank lines, found 1
+./tools/apply_interfaces.py:36:1: E302 expected 2 blank lines, found 1
+./tools/apply_interfaces.py:40:80: E501 line too long (107 > 79 characters)
+./tools/apply_interfaces.py:45:1: E302 expected 2 blank lines, found 1
+./tools/apply_interfaces.py:51:80: E501 line too long (103 > 79 characters)
+./tools/apply_interfaces.py:54:80: E501 line too long (93 > 79 characters)
+./tools/apply_interfaces.py:57:1: E302 expected 2 blank lines, found 1
+./tools/apply_interfaces.py:59:80: E501 line too long (87 > 79 characters)
+./tools/apply_interfaces.py:65:1: E305 expected 2 blank lines after class or function definition, found 1
+./tools/apply_interfaces.py:74:80: E501 line too long (84 > 79 characters)
+./tools/apply_interfaces.py:79:80: E501 line too long (81 > 79 characters)
+./tools/apply_interfaces.py:83:80: E501 line too long (104 > 79 characters)
+./tools/apply_interfaces.py:85:80: E501 line too long (85 > 79 characters)
+./tools/apply_interfaces.py:88:80: E501 line too long (85 > 79 characters)
+./tools/apply_interfaces.py:116:80: E501 line too long (88 > 79 characters)
+./tools/apply_interfaces.py:119:80: E501 line too long (108 > 79 characters)
+./tools/apply_interfaces.py:123:80: E501 line too long (137 > 79 characters)
+./tools/apply_interfaces.py:149:80: E501 line too long (83 > 79 characters)
+./tools/apply_interfaces.py:183:80: E501 line too long (90 > 79 characters)
+./tools/apply_interfaces.py:184:80: E501 line too long (92 > 79 characters)
+./tools/apply_interfaces.py:185:80: E501 line too long (80 > 79 characters)
+./tools/apply_interfaces.py:192:80: E501 line too long (85 > 79 characters)
+./tools/apply_interfaces.py:205:80: E501 line too long (87 > 79 characters)
+./tools/apply_interfaces.py:212:80: E501 line too long (82 > 79 characters)
+./tools/apply_interfaces.py:226:80: E501 line too long (113 > 79 characters)
+./tools/apply_interfaces.py:227:80: E501 line too long (110 > 79 characters)
+./tools/apply_interfaces.py:235:80: E501 line too long (87 > 79 characters)
+./tools/apply_interfaces.py:246:80: E501 line too long (101 > 79 characters)
+./tools/apply_interfaces.py:249:80: E501 line too long (86 > 79 characters)
+./tools/apply_interfaces.py:254:80: E501 line too long (82 > 79 characters)
+./tools/apply_interfaces.py:256:80: E501 line too long (80 > 79 characters)
+./tools/apply_interfaces.py:262:80: E501 line too long (117 > 79 characters)
+./tools/apply_interfaces.py:268:80: E501 line too long (116 > 79 characters)
+./tools/apply_interfaces.py:283:1: E302 expected 2 blank lines, found 1
+./tools/apply_interfaces.py:285:80: E501 line too long (93 > 79 characters)
+./tools/apply_interfaces.py:286:80: E501 line too long (94 > 79 characters)
+./tools/apply_interfaces.py:288:80: E501 line too long (86 > 79 characters)
+./tools/apply_interfaces.py:297:80: E501 line too long (84 > 79 characters)
+./tools/apply_interfaces.py:299:80: E501 line too long (83 > 79 characters)
+./tools/apply_interfaces.py:302:80: E501 line too long (102 > 79 characters)
+./tools/apply_interfaces.py:306:1: E302 expected 2 blank lines, found 1
+./tools/apply_interfaces.py:319:1: E302 expected 2 blank lines, found 1
+./tools/apply_interfaces.py:325:80: E501 line too long (102 > 79 characters)
+./tools/apply_interfaces.py:333:80: E501 line too long (90 > 79 characters)
+./tools/apply_interfaces.py:339:1: E302 expected 2 blank lines, found 1
+./tools/apply_interfaces.py:342:80: E501 line too long (120 > 79 characters)
+./tools/apply_interfaces.py:343:80: E501 line too long (98 > 79 characters)
+./tools/apply_interfaces.py:352:1: E305 expected 2 blank lines after class or function definition, found 1
+./tools/apply_ml_metrics.py:6:80: E501 line too long (84 > 79 characters)
+./tools/apply_ml_metrics.py:8:80: E501 line too long (83 > 79 characters)
+./tools/apply_ml_metrics.py:9:80: E501 line too long (96 > 79 characters)
+./tools/apply_ml_metrics.py:20:1: F401 'os' imported but unused
+./tools/apply_ml_metrics.py:20:1: F401 'tempfile' imported but unused
+./tools/apply_ml_metrics.py:20:10: E401 multiple imports on one line
+./tools/apply_ml_metrics.py:34:1: E302 expected 2 blank lines, found 1
+./tools/apply_ml_metrics.py:37:1: E302 expected 2 blank lines, found 1
+./tools/apply_ml_metrics.py:38:80: E501 line too long (96 > 79 characters)
+./tools/apply_ml_metrics.py:41:1: E302 expected 2 blank lines, found 1
+./tools/apply_ml_metrics.py:41:80: E501 line too long (85 > 79 characters)
+./tools/apply_ml_metrics.py:51:1: E302 expected 2 blank lines, found 1
+./tools/apply_ml_metrics.py:57:80: E501 line too long (103 > 79 characters)
+./tools/apply_ml_metrics.py:59:80: E501 line too long (95 > 79 characters)
+./tools/apply_ml_metrics.py:62:1: E302 expected 2 blank lines, found 1
+./tools/apply_ml_metrics.py:77:1: E305 expected 2 blank lines after class or function definition, found 1
+./tools/apply_ml_metrics.py:108:80: E501 line too long (125 > 79 characters)
+./tools/apply_ml_metrics.py:110:80: E501 line too long (89 > 79 characters)
+./tools/apply_ml_metrics.py:118:80: E501 line too long (103 > 79 characters)
+./tools/apply_ml_metrics.py:146:80: E501 line too long (106 > 79 characters)
+./tools/apply_ml_metrics.py:160:80: E501 line too long (98 > 79 characters)
+./tools/apply_ml_metrics.py:179:80: E501 line too long (112 > 79 characters)
+./tools/apply_ml_metrics.py:188:80: E501 line too long (92 > 79 characters)
+./tools/apply_ml_metrics.py:201:80: E501 line too long (103 > 79 characters)
+./tools/apply_ml_metrics.py:204:80: E501 line too long (115 > 79 characters)
+./tools/apply_ml_metrics.py:205:80: E501 line too long (115 > 79 characters)
+./tools/apply_ml_metrics.py:206:80: E501 line too long (113 > 79 characters)
+./tools/apply_ml_metrics.py:238:80: E501 line too long (116 > 79 characters)
+./tools/apply_ml_metrics.py:260:80: E501 line too long (80 > 79 characters)
+./tools/apply_ml_metrics.py:263:80: E501 line too long (100 > 79 characters)
+./tools/apply_ml_metrics.py:286:80: E501 line too long (120 > 79 characters)
+./tools/apply_ml_metrics.py:287:80: E501 line too long (86 > 79 characters)
+./tools/apply_ml_metrics.py:309:80: E501 line too long (80 > 79 characters)
+./tools/apply_ml_metrics.py:333:1: E302 expected 2 blank lines, found 1
+./tools/apply_ml_metrics.py:342:1: E302 expected 2 blank lines, found 1
+./tools/apply_ml_metrics.py:351:80: E501 line too long (93 > 79 characters)
+./tools/apply_ml_metrics.py:355:1: E302 expected 2 blank lines, found 1
+./tools/apply_ml_metrics.py:361:80: E501 line too long (100 > 79 characters)
+./tools/apply_ml_metrics.py:374:1: E302 expected 2 blank lines, found 1
+./tools/apply_ml_metrics.py:376:80: E501 line too long (126 > 79 characters)
+./tools/apply_ml_metrics.py:377:80: E501 line too long (105 > 79 characters)
+./tools/apply_ml_metrics.py:378:80: E501 line too long (89 > 79 characters)
+./tools/apply_ml_metrics.py:383:1: E302 expected 2 blank lines, found 1
+./tools/apply_ml_metrics.py:386:80: E501 line too long (89 > 79 characters)
+./tools/apply_ml_metrics.py:387:80: E501 line too long (93 > 79 characters)
+./tools/apply_ml_metrics.py:388:80: E501 line too long (90 > 79 characters)
+./tools/apply_ml_metrics.py:396:80: E501 line too long (164 > 79 characters)
+./tools/apply_ml_metrics.py:398:1: E305 expected 2 blank lines after class or function definition, found 1
+./tools/apply_mlflow_tracking.py:14:80: E501 line too long (95 > 79 characters)
+./tools/apply_mlflow_tracking.py:17:80: E501 line too long (155 > 79 characters)
+./tools/apply_mlflow_tracking.py:49:80: E501 line too long (107 > 79 characters)
+./tools/apply_mlflow_tracking.py:62:80: E501 line too long (107 > 79 characters)
+./tools/apply_mlflow_tracking.py:66:80: E501 line too long (93 > 79 characters)
+./tools/apply_mlflow_tracking.py:72:80: E501 line too long (87 > 79 characters)
+./tools/apply_mlflow_tracking.py:128:80: E501 line too long (102 > 79 characters)
+./tools/apply_mlflow_tracking.py:138:80: E501 line too long (98 > 79 characters)
+./tools/apply_mlflow_tracking.py:140:80: E501 line too long (90 > 79 characters)
+./tools/apply_mlflow_tracking.py:141:80: E501 line too long (86 > 79 characters)
+./tools/apply_mlflow_tracking.py:202:80: E501 line too long (80 > 79 characters)
+./tools/apply_mlflow_tracking.py:212:80: E501 line too long (84 > 79 characters)
+./tools/apply_mlflow_tracking.py:213:80: E501 line too long (88 > 79 characters)
+./tools/apply_mlflow_tracking.py:222:80: E501 line too long (117 > 79 characters)
+./tools/apply_mlflow_tracking.py:238:80: E501 line too long (101 > 79 characters)
+./tools/apply_mlflow_tracking.py:240:80: E501 line too long (112 > 79 characters)
+./tools/apply_mlflow_tracking.py:246:80: E501 line too long (98 > 79 characters)
+./tools/apply_mlflow_tracking.py:247:80: E501 line too long (92 > 79 characters)
+./tools/apply_mlflow_tracking.py:248:80: E501 line too long (85 > 79 characters)
+./tools/apply_mlflow_tracking.py:249:80: E501 line too long (86 > 79 characters)
+./tools/apply_mlflow_tracking.py:270:80: E501 line too long (82 > 79 characters)
+./tools/apply_mlflow_tracking.py:284:80: E501 line too long (94 > 79 characters)
+./tools/apply_mlflow_tracking.py:316:80: E501 line too long (100 > 79 characters)
+./tools/apply_mlflow_tracking.py:317:80: E501 line too long (115 > 79 characters)
+./tools/apply_mlflow_tracking.py:326:80: E501 line too long (90 > 79 characters)
+./tools/apply_mlflow_tracking.py:329:80: E501 line too long (114 > 79 characters)
+./tools/apply_pyproject_packaging.py:9:80: E501 line too long (86 > 79 characters)
+./tools/apply_pyproject_packaging.py:60:80: E501 line too long (112 > 79 characters)
+./tools/apply_pyproject_packaging.py:162:80: E501 line too long (84 > 79 characters)
+./tools/apply_pyproject_packaging.py:165:80: E501 line too long (84 > 79 characters)
+./tools/apply_pyproject_packaging.py:192:80: E501 line too long (87 > 79 characters)
+./tools/apply_pyproject_packaging.py:199:80: E501 line too long (88 > 79 characters)
+./tools/apply_pyproject_packaging.py:200:80: E501 line too long (84 > 79 characters)
+./tools/apply_pyproject_packaging.py:211:80: E501 line too long (88 > 79 characters)
+./tools/apply_pyproject_packaging.py:216:80: E501 line too long (82 > 79 characters)
+./tools/apply_pyproject_packaging.py:228:80: E501 line too long (84 > 79 characters)
+./tools/apply_pyproject_packaging.py:238:80: E501 line too long (83 > 79 characters)
+./tools/apply_pyproject_packaging.py:241:80: E501 line too long (88 > 79 characters)
+./tools/apply_pyproject_packaging.py:266:80: E501 line too long (95 > 79 characters)
+./tools/apply_pyproject_packaging.py:284:80: E501 line too long (85 > 79 characters)
+./tools/apply_pyproject_packaging.py:288:80: E501 line too long (87 > 79 characters)
+./tools/apply_pyproject_packaging.py:317:80: E501 line too long (83 > 79 characters)
+./tools/apply_pyproject_packaging.py:323:80: E501 line too long (97 > 79 characters)
+./tools/apply_safety.py:6:1: F401 'json' imported but unused
+./tools/apply_safety.py:6:1: F401 'textwrap' imported but unused
+./tools/apply_safety.py:6:18: E401 multiple imports on one line
+./tools/apply_safety.py:17:1: E302 expected 2 blank lines, found 1
+./tools/apply_safety.py:20:1: E302 expected 2 blank lines, found 1
+./tools/apply_safety.py:21:80: E501 line too long (80 > 79 characters)
+./tools/apply_safety.py:23:1: E302 expected 2 blank lines, found 1
+./tools/apply_safety.py:24:80: E501 line too long (119 > 79 characters)
+./tools/apply_safety.py:26:1: E302 expected 2 blank lines, found 1
+./tools/apply_safety.py:33:1: E305 expected 2 blank lines after class or function definition, found 1
+./tools/apply_safety.py:68:1: E302 expected 2 blank lines, found 1
+./tools/apply_safety.py:81:1: E305 expected 2 blank lines after class or function definition, found 1
+./tools/apply_stack_polish.py:7:10: E401 multiple imports on one line
+./tools/apply_stack_polish.py:20:1: E302 expected 2 blank lines, found 1
+./tools/apply_stack_polish.py:23:1: E302 expected 2 blank lines, found 1
+./tools/apply_stack_polish.py:27:80: E501 line too long (107 > 79 characters)
+./tools/apply_stack_polish.py:32:1: E302 expected 2 blank lines, found 1
+./tools/apply_stack_polish.py:38:80: E501 line too long (103 > 79 characters)
+./tools/apply_stack_polish.py:41:80: E501 line too long (93 > 79 characters)
+./tools/apply_stack_polish.py:44:1: E302 expected 2 blank lines, found 1
+./tools/apply_stack_polish.py:57:1: E305 expected 2 blank lines after class or function definition, found 1
+./tools/apply_stack_polish.py:97:80: E501 line too long (80 > 79 characters)
+./tools/apply_stack_polish.py:116:80: E501 line too long (96 > 79 characters)
+./tools/apply_stack_polish.py:149:80: E501 line too long (95 > 79 characters)
+./tools/apply_stack_polish.py:205:80: E501 line too long (89 > 79 characters)
+./tools/apply_stack_polish.py:235:80: E501 line too long (107 > 79 characters)
+./tools/apply_stack_polish.py:253:80: E501 line too long (95 > 79 characters)
+./tools/apply_stack_polish.py:410:80: E501 line too long (91 > 79 characters)
+./tools/apply_stack_polish.py:463:80: E501 line too long (130 > 79 characters)
+./tools/apply_stack_polish.py:464:80: E501 line too long (116 > 79 characters)
+./tools/apply_stack_polish.py:466:80: E501 line too long (93 > 79 characters)
+./tools/apply_stack_polish.py:489:80: E501 line too long (85 > 79 characters)
+./tools/apply_stack_polish.py:495:1: E302 expected 2 blank lines, found 1
+./tools/apply_stack_polish.py:502:80: E501 line too long (84 > 79 characters)
+./tools/apply_stack_polish.py:503:80: E501 line too long (83 > 79 characters)
+./tools/apply_stack_polish.py:511:80: E501 line too long (93 > 79 characters)
+./tools/apply_stack_polish.py:514:80: E501 line too long (81 > 79 characters)
+./tools/apply_stack_polish.py:517:80: E501 line too long (102 > 79 characters)
+./tools/apply_stack_polish.py:521:80: E501 line too long (85 > 79 characters)
+./tools/apply_stack_polish.py:523:80: E501 line too long (88 > 79 characters)
+./tools/apply_stack_polish.py:524:80: E501 line too long (84 > 79 characters)
+./tools/apply_stack_polish.py:534:1: E302 expected 2 blank lines, found 1
+./tools/apply_stack_polish.py:536:18: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:536:23: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:536:29: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:536:39: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:536:44: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:537:18: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:537:23: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:537:29: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:537:39: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:537:44: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:544:80: E501 line too long (86 > 79 characters)
+./tools/apply_stack_polish.py:553:1: E302 expected 2 blank lines, found 1
+./tools/apply_stack_polish.py:555:30: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:556:37: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:556:47: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:557:42: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:557:57: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:558:31: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:559:52: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:559:79: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:559:80: E501 line too long (85 > 79 characters)
+./tools/apply_stack_polish.py:560:44: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:560:49: E231 missing whitespace after ','
+./tools/apply_stack_polish.py:567:80: E501 line too long (86 > 79 characters)
+./tools/apply_stack_polish.py:576:1: E302 expected 2 blank lines, found 1
+./tools/apply_stack_polish.py:592:1: E305 expected 2 blank lines after class or function definition, found 1
+./tools/apply_stack_polish.py:593:11: W292 no newline at end of file
+./tools/codex_agents_workflow.py:73:80: E501 line too long (85 > 79 characters)
+./tools/codex_agents_workflow.py:83:80: E501 line too long (86 > 79 characters)
+./tools/codex_agents_workflow.py:114:80: E501 line too long (88 > 79 characters)
+./tools/codex_agents_workflow.py:128:80: E501 line too long (99 > 79 characters)
+./tools/codex_agents_workflow.py:168:80: E501 line too long (103 > 79 characters)
+./tools/codex_agents_workflow.py:173:80: E501 line too long (86 > 79 characters)
+./tools/codex_agents_workflow.py:175:80: E501 line too long (89 > 79 characters)
+./tools/codex_agents_workflow.py:190:80: E501 line too long (80 > 79 characters)
+./tools/codex_agents_workflow.py:195:80: E501 line too long (87 > 79 characters)
+./tools/codex_agents_workflow.py:196:80: E501 line too long (95 > 79 characters)
+./tools/codex_agents_workflow.py:206:80: E501 line too long (83 > 79 characters)
+./tools/codex_agents_workflow.py:235:80: E501 line too long (108 > 79 characters)
+./tools/codex_agents_workflow.py:244:80: E501 line too long (98 > 79 characters)
+./tools/codex_agents_workflow.py:254:80: E501 line too long (86 > 79 characters)
+./tools/codex_agents_workflow.py:261:80: E501 line too long (131 > 79 characters)
+./tools/codex_agents_workflow.py:275:80: E501 line too long (98 > 79 characters)
+./tools/codex_agents_workflow.py:279:80: E501 line too long (86 > 79 characters)
+./tools/codex_agents_workflow.py:291:80: E501 line too long (81 > 79 characters)
+./tools/codex_agents_workflow.py:303:80: E501 line too long (89 > 79 characters)
+./tools/codex_agents_workflow.py:348:80: E501 line too long (96 > 79 characters)
+./tools/codex_cli.py:23:80: E501 line too long (83 > 79 characters)
+./tools/codex_cli.py:31:80: E501 line too long (81 > 79 characters)
+./tools/codex_cli.py:98:80: E501 line too long (85 > 79 characters)
+./tools/codex_exec.py:14:80: E501 line too long (85 > 79 characters)
+./tools/codex_exec.py:107:80: E501 line too long (83 > 79 characters)
+./tools/codex_exec.py:165:80: E501 line too long (80 > 79 characters)
+./tools/codex_exec.py:200:80: E501 line too long (84 > 79 characters)
+./tools/codex_exec.py:225:80: E501 line too long (81 > 79 characters)
+./tools/codex_exec.py:253:80: E501 line too long (87 > 79 characters)
+./tools/codex_import_normalizer.py:6:80: E501 line too long (86 > 79 characters)
+./tools/codex_import_normalizer.py:8:80: E501 line too long (84 > 79 characters)
+./tools/codex_import_normalizer.py:42:80: E501 line too long (80 > 79 characters)
+./tools/codex_import_normalizer.py:73:80: E501 line too long (81 > 79 characters)
+./tools/codex_import_normalizer.py:143:80: E501 line too long (81 > 79 characters)
+./tools/codex_import_normalizer.py:144:80: E501 line too long (83 > 79 characters)
+./tools/codex_import_normalizer.py:158:80: E501 line too long (80 > 79 characters)
+./tools/codex_import_normalizer.py:254:80: E501 line too long (83 > 79 characters)
+./tools/codex_import_normalizer.py:286:80: E501 line too long (82 > 79 characters)
+./tools/codex_import_normalizer.py:297:80: E501 line too long (82 > 79 characters)
+./tools/codex_import_normalizer.py:313:80: E501 line too long (83 > 79 characters)
+./tools/codex_import_normalizer.py:315:80: E501 line too long (81 > 79 characters)
+./tools/codex_import_normalizer.py:347:80: E501 line too long (81 > 79 characters)
+./tools/codex_import_normalizer.py:359:80: E501 line too long (82 > 79 characters)
+./tools/codex_import_normalizer.py:362:80: E501 line too long (84 > 79 characters)
+./tools/codex_ingestion_workflow.py:3:80: E501 line too long (120 > 79 characters)
+./tools/codex_ingestion_workflow.py:44:80: E501 line too long (88 > 79 characters)
+./tools/codex_ingestion_workflow.py:65:80: E501 line too long (85 > 79 characters)
+./tools/codex_ingestion_workflow.py:77:80: E501 line too long (111 > 79 characters)
+./tools/codex_ingestion_workflow.py:86:80: E501 line too long (88 > 79 characters)
+./tools/codex_ingestion_workflow.py:117:80: E501 line too long (82 > 79 characters)
+./tools/codex_ingestion_workflow.py:130:80: E501 line too long (84 > 79 characters)
+./tools/codex_ingestion_workflow.py:143:80: E501 line too long (134 > 79 characters)
+./tools/codex_ingestion_workflow.py:146:80: E501 line too long (81 > 79 characters)
+./tools/codex_ingestion_workflow.py:170:80: E501 line too long (85 > 79 characters)
+./tools/codex_ingestion_workflow.py:181:80: E501 line too long (101 > 79 characters)
+./tools/codex_ingestion_workflow.py:193:80: E501 line too long (82 > 79 characters)
+./tools/codex_ingestion_workflow.py:198:80: E501 line too long (87 > 79 characters)
+./tools/codex_ingestion_workflow.py:228:80: E501 line too long (109 > 79 characters)
+./tools/codex_ingestion_workflow.py:266:80: E501 line too long (130 > 79 characters)
+./tools/codex_ingestion_workflow.py:280:80: E501 line too long (108 > 79 characters)
+./tools/codex_ingestion_workflow.py:291:80: E501 line too long (82 > 79 characters)
+./tools/codex_ingestion_workflow.py:295:80: E501 line too long (81 > 79 characters)
+./tools/codex_ingestion_workflow.py:315:80: E501 line too long (88 > 79 characters)
+./tools/codex_ingestion_workflow.py:352:80: E501 line too long (87 > 79 characters)
+./tools/codex_ingestion_workflow.py:361:80: E501 line too long (85 > 79 characters)
+./tools/codex_ingestion_workflow.py:400:80: E501 line too long (102 > 79 characters)
+./tools/codex_ingestion_workflow.py:430:80: E501 line too long (86 > 79 characters)
+./tools/codex_ingestion_workflow.py:433:80: E501 line too long (82 > 79 characters)
+./tools/codex_ingestion_workflow.py:448:80: E501 line too long (81 > 79 characters)
+./tools/codex_ingestion_workflow.py:464:80: E501 line too long (84 > 79 characters)
+./tools/codex_logging_workflow.py:51:80: E501 line too long (87 > 79 characters)
+./tools/codex_logging_workflow.py:52:80: E501 line too long (95 > 79 characters)
+./tools/codex_logging_workflow.py:53:80: E501 line too long (101 > 79 characters)
+./tools/codex_logging_workflow.py:54:80: E501 line too long (104 > 79 characters)
+./tools/codex_logging_workflow.py:67:80: E501 line too long (82 > 79 characters)
+./tools/codex_logging_workflow.py:89:80: E501 line too long (87 > 79 characters)
+./tools/codex_logging_workflow.py:98:80: E501 line too long (84 > 79 characters)
+./tools/codex_logging_workflow.py:101:80: E501 line too long (111 > 79 characters)
+./tools/codex_logging_workflow.py:136:80: E501 line too long (85 > 79 characters)
+./tools/codex_logging_workflow.py:139:80: E501 line too long (82 > 79 characters)
+./tools/codex_logging_workflow.py:154:80: E501 line too long (83 > 79 characters)
+./tools/codex_logging_workflow.py:182:80: E501 line too long (80 > 79 characters)
+./tools/codex_logging_workflow.py:188:80: E501 line too long (86 > 79 characters)
+./tools/codex_logging_workflow.py:194:80: E501 line too long (82 > 79 characters)
+./tools/codex_logging_workflow.py:198:80: E501 line too long (86 > 79 characters)
+./tools/codex_logging_workflow.py:209:80: E501 line too long (87 > 79 characters)
+./tools/codex_logging_workflow.py:218:80: E501 line too long (80 > 79 characters)
+./tools/codex_logging_workflow.py:221:80: E501 line too long (86 > 79 characters)
+./tools/codex_logging_workflow.py:232:80: E501 line too long (87 > 79 characters)
+./tools/codex_logging_workflow.py:249:80: E501 line too long (105 > 79 characters)
+./tools/codex_logging_workflow.py:255:80: E501 line too long (95 > 79 characters)
+./tools/codex_logging_workflow.py:296:80: E501 line too long (87 > 79 characters)
+./tools/codex_logging_workflow.py:313:80: E501 line too long (88 > 79 characters)
+./tools/codex_logging_workflow.py:316:80: E501 line too long (84 > 79 characters)
+./tools/codex_logging_workflow.py:324:80: E501 line too long (86 > 79 characters)
+./tools/codex_logging_workflow.py:341:80: E501 line too long (86 > 79 characters)
+./tools/codex_logging_workflow.py:369:80: E501 line too long (85 > 79 characters)
+./tools/codex_logging_workflow.py:390:80: E501 line too long (84 > 79 characters)
+./tools/codex_logging_workflow.py:396:80: E501 line too long (86 > 79 characters)
+./tools/codex_logging_workflow.py:441:80: E501 line too long (108 > 79 characters)
+./tools/codex_logging_workflow.py:443:80: E501 line too long (98 > 79 characters)
+./tools/codex_logging_workflow.py:450:80: E501 line too long (122 > 79 characters)
+./tools/codex_logging_workflow.py:451:80: E501 line too long (100 > 79 characters)
+./tools/codex_logging_workflow.py:453:80: E501 line too long (92 > 79 characters)
+./tools/codex_logging_workflow.py:461:80: E501 line too long (87 > 79 characters)
+./tools/codex_logging_workflow.py:465:80: E501 line too long (81 > 79 characters)
+./tools/codex_logging_workflow.py:481:80: E501 line too long (88 > 79 characters)
+./tools/codex_logging_workflow.py:485:80: E501 line too long (102 > 79 characters)
+./tools/codex_logging_workflow.py:505:80: E501 line too long (84 > 79 characters)
+./tools/codex_maintenance.py:27:80: E501 line too long (84 > 79 characters)
+./tools/codex_maintenance.py:64:80: E501 line too long (82 > 79 characters)
+./tools/codex_patch_session_logging.py:57:80: E501 line too long (87 > 79 characters)
+./tools/codex_patch_session_logging.py:105:80: E501 line too long (80 > 79 characters)
+./tools/codex_patch_session_logging.py:108:80: E501 line too long (111 > 79 characters)
+./tools/codex_patch_session_logging.py:144:80: E501 line too long (95 > 79 characters)
+./tools/codex_patch_session_logging.py:153:80: E501 line too long (85 > 79 characters)
+./tools/codex_patch_session_logging.py:170:80: E501 line too long (80 > 79 characters)
+./tools/codex_patch_session_logging.py:181:80: E501 line too long (90 > 79 characters)
+./tools/codex_patch_session_logging.py:183:80: E501 line too long (81 > 79 characters)
+./tools/codex_patch_session_logging.py:220:69: E203 whitespace before ':'
+./tools/codex_patch_session_logging.py:221:80: E501 line too long (86 > 79 characters)
+./tools/codex_patch_session_logging.py:237:80: E501 line too long (84 > 79 characters)
+./tools/codex_patch_session_logging.py:258:80: E501 line too long (82 > 79 characters)
+./tools/codex_patch_session_logging.py:271:80: E501 line too long (81 > 79 characters)
+./tools/codex_patch_session_logging.py:273:80: E501 line too long (81 > 79 characters)
+./tools/codex_patch_session_logging.py:281:80: E501 line too long (86 > 79 characters)
+./tools/codex_patch_session_logging.py:283:80: E501 line too long (83 > 79 characters)
+./tools/codex_patch_session_logging.py:302:80: E501 line too long (91 > 79 characters)
+./tools/codex_patch_session_logging.py:308:80: E501 line too long (83 > 79 characters)
+./tools/codex_patch_session_logging.py:312:80: E501 line too long (108 > 79 characters)
+./tools/codex_patch_session_logging.py:318:80: E501 line too long (101 > 79 characters)
+./tools/codex_patch_session_logging.py:321:80: E501 line too long (84 > 79 characters)
+./tools/codex_precommit_bootstrap.py:5:80: E501 line too long (84 > 79 characters)
+./tools/codex_precommit_bootstrap.py:54:80: E501 line too long (88 > 79 characters)
+./tools/codex_precommit_bootstrap.py:59:80: E501 line too long (81 > 79 characters)
+./tools/codex_precommit_bootstrap.py:62:80: E501 line too long (88 > 79 characters)
+./tools/codex_precommit_bootstrap.py:101:80: E501 line too long (81 > 79 characters)
+./tools/codex_precommit_bootstrap.py:104:80: E501 line too long (86 > 79 characters)
+./tools/codex_precommit_bootstrap.py:122:80: E501 line too long (83 > 79 characters)
+./tools/codex_precommit_bootstrap.py:172:80: E501 line too long (88 > 79 characters)
+./tools/codex_precommit_bootstrap.py:198:80: E501 line too long (84 > 79 characters)
+./tools/codex_precommit_bootstrap.py:205:80: E501 line too long (80 > 79 characters)
+./tools/codex_precommit_bootstrap.py:215:80: E501 line too long (82 > 79 characters)
+./tools/codex_precommit_bootstrap.py:321:80: E501 line too long (83 > 79 characters)
+./tools/codex_precommit_bootstrap.py:343:80: E501 line too long (88 > 79 characters)
+./tools/codex_precommit_bootstrap.py:348:80: E501 line too long (82 > 79 characters)
+./tools/codex_precommit_bootstrap.py:350:80: E501 line too long (80 > 79 characters)
+./tools/codex_precommit_bootstrap.py:362:80: E501 line too long (86 > 79 characters)
+./tools/codex_precommit_bootstrap.py:374:80: E501 line too long (86 > 79 characters)
+./tools/codex_precommit_bootstrap.py:386:80: E501 line too long (87 > 79 characters)
+./tools/codex_precommit_bootstrap.py:387:80: E501 line too long (83 > 79 characters)
+./tools/codex_precommit_bootstrap.py:417:80: E501 line too long (86 > 79 characters)
+./tools/codex_session_logging_workflow.py:58:80: E501 line too long (84 > 79 characters)
+./tools/codex_session_logging_workflow.py:61:80: E501 line too long (83 > 79 characters)
+./tools/codex_session_logging_workflow.py:87:80: E501 line too long (86 > 79 characters)
+./tools/codex_session_logging_workflow.py:102:80: E501 line too long (84 > 79 characters)
+./tools/codex_session_logging_workflow.py:104:80: E501 line too long (87 > 79 characters)
+./tools/codex_session_logging_workflow.py:141:80: E501 line too long (82 > 79 characters)
+./tools/codex_session_logging_workflow.py:158:80: E501 line too long (85 > 79 characters)
+./tools/codex_session_logging_workflow.py:187:80: E501 line too long (83 > 79 characters)
+./tools/codex_session_logging_workflow.py:214:80: E501 line too long (88 > 79 characters)
+./tools/codex_session_logging_workflow.py:216:80: E501 line too long (82 > 79 characters)
+./tools/codex_session_logging_workflow.py:227:80: E501 line too long (81 > 79 characters)
+./tools/codex_session_logging_workflow.py:300:80: E501 line too long (80 > 79 characters)
+./tools/codex_session_logging_workflow.py:307:80: E501 line too long (81 > 79 characters)
+./tools/codex_session_logging_workflow.py:340:80: E501 line too long (84 > 79 characters)
+./tools/codex_session_logging_workflow.py:349:80: E501 line too long (86 > 79 characters)
+./tools/codex_session_logging_workflow.py:360:80: E501 line too long (83 > 79 characters)
+./tools/codex_session_logging_workflow.py:367:80: E501 line too long (80 > 79 characters)
+./tools/codex_session_logging_workflow.py:374:80: E501 line too long (84 > 79 characters)
+./tools/codex_session_logging_workflow.py:395:80: E501 line too long (82 > 79 characters)
+./tools/codex_session_logging_workflow.py:398:80: E501 line too long (83 > 79 characters)
+./tools/codex_sqlite_align.py:26:80: E501 line too long (80 > 79 characters)
+./tools/codex_sqlite_align.py:129:80: E501 line too long (83 > 79 characters)
+./tools/codex_sqlite_align.py:133:80: E501 line too long (263 > 79 characters)
+./tools/codex_sqlite_align.py:177:80: E501 line too long (80 > 79 characters)
+./tools/codex_sqlite_align.py:180:80: E501 line too long (84 > 79 characters)
+./tools/codex_sqlite_align.py:189:80: E501 line too long (83 > 79 characters)
+./tools/codex_sqlite_align.py:207:80: E501 line too long (85 > 79 characters)
+./tools/codex_sqlite_align.py:211:80: E501 line too long (88 > 79 characters)
+./tools/codex_sqlite_align.py:221:33: E203 whitespace before ':'
+./tools/codex_sqlite_align.py:224:63: E203 whitespace before ':'
+./tools/codex_sqlite_align.py:243:80: E501 line too long (84 > 79 characters)
+./tools/codex_sqlite_align.py:248:80: E501 line too long (84 > 79 characters)
+./tools/codex_sqlite_align.py:253:80: E501 line too long (85 > 79 characters)
+./tools/codex_sqlite_align.py:261:80: E501 line too long (80 > 79 characters)
+./tools/codex_sqlite_align.py:264:80: E501 line too long (81 > 79 characters)
+./tools/codex_sqlite_align.py:285:80: E501 line too long (83 > 79 characters)
+./tools/codex_sqlite_align.py:334:80: E501 line too long (80 > 79 characters)
+./tools/codex_sqlite_align.py:343:80: E501 line too long (81 > 79 characters)
+./tools/codex_sqlite_align.py:353:80: E501 line too long (81 > 79 characters)
+./tools/codex_sqlite_align.py:412:80: E501 line too long (82 > 79 characters)
+./tools/codex_sqlite_align.py:415:80: E501 line too long (84 > 79 characters)
+./tools/codex_sqlite_align.py:425:80: E501 line too long (83 > 79 characters)
+./tools/codex_sqlite_align.py:439:80: E501 line too long (84 > 79 characters)
+./tools/codex_sqlite_align.py:446:80: E501 line too long (84 > 79 characters)
+./tools/codex_sqlite_align.py:480:80: E501 line too long (80 > 79 characters)
+./tools/codex_sqlite_align.py:488:80: E501 line too long (97 > 79 characters)
+./tools/codex_sqlite_align.py:493:80: E501 line too long (80 > 79 characters)
+./tools/codex_sqlite_align.py:496:80: E501 line too long (80 > 79 characters)
+./tools/codex_sqlite_align.py:510:80: E501 line too long (83 > 79 characters)
+./tools/codex_sqlite_align.py:517:80: E501 line too long (121 > 79 characters)
+./tools/codex_src_consolidation.py:82:80: E501 line too long (83 > 79 characters)
+./tools/codex_src_consolidation.py:111:80: E501 line too long (82 > 79 characters)
+./tools/codex_src_consolidation.py:122:80: E501 line too long (84 > 79 characters)
+./tools/codex_src_consolidation.py:126:80: E501 line too long (87 > 79 characters)
+./tools/codex_src_consolidation.py:148:80: E501 line too long (81 > 79 characters)
+./tools/codex_src_consolidation.py:150:80: E501 line too long (84 > 79 characters)
+./tools/codex_src_consolidation.py:169:80: E501 line too long (84 > 79 characters)
+./tools/codex_src_consolidation.py:179:80: E501 line too long (82 > 79 characters)
+./tools/codex_src_consolidation.py:222:80: E501 line too long (87 > 79 characters)
+./tools/codex_src_consolidation.py:289:80: E501 line too long (83 > 79 characters)
+./tools/codex_src_consolidation.py:298:80: E501 line too long (88 > 79 characters)
+./tools/codex_src_consolidation.py:302:80: E501 line too long (87 > 79 characters)
+./tools/codex_src_consolidation.py:312:80: E501 line too long (80 > 79 characters)
+./tools/codex_src_consolidation.py:321:80: E501 line too long (81 > 79 characters)
+./tools/codex_src_consolidation.py:339:80: E501 line too long (85 > 79 characters)
+./tools/codex_src_consolidation.py:433:80: E501 line too long (81 > 79 characters)
+./tools/codex_supplied_task_runner.py:44:80: E501 line too long (80 > 79 characters)
+./tools/codex_supplied_task_runner.py:52:80: E501 line too long (86 > 79 characters)
+./tools/codex_supplied_task_runner.py:53:80: E501 line too long (87 > 79 characters)
+./tools/codex_supplied_task_runner.py:59:80: E501 line too long (85 > 79 characters)
+./tools/codex_supplied_task_runner.py:62:80: E501 line too long (80 > 79 characters)
+./tools/codex_supplied_task_runner.py:99:80: E501 line too long (90 > 79 characters)
+./tools/codex_supplied_task_runner.py:102:80: E501 line too long (110 > 79 characters)
+./tools/codex_supplied_task_runner.py:109:80: E501 line too long (82 > 79 characters)
+./tools/codex_supplied_task_runner.py:110:80: E501 line too long (85 > 79 characters)
+./tools/codex_supplied_task_runner.py:138:18: W605 invalid escape sequence '\.'
+./tools/codex_supplied_task_runner.py:138:25: W605 invalid escape sequence '\s'
+./tools/codex_supplied_task_runner.py:138:80: E501 line too long (124 > 79 characters)
+./tools/codex_supplied_task_runner.py:169:80: E501 line too long (83 > 79 characters)
+./tools/codex_supplied_task_runner.py:171:80: E501 line too long (113 > 79 characters)
+./tools/codex_supplied_task_runner.py:181:80: E501 line too long (83 > 79 characters)
+./tools/codex_supplied_task_runner.py:203:80: E501 line too long (84 > 79 characters)
+./tools/codex_supplied_task_runner.py:206:80: E501 line too long (83 > 79 characters)
+./tools/codex_supplied_task_runner.py:230:80: E501 line too long (84 > 79 characters)
+./tools/codex_supplied_task_runner.py:236:80: E501 line too long (82 > 79 characters)
+./tools/codex_supplied_task_runner.py:245:80: E501 line too long (81 > 79 characters)
+./tools/codex_supplied_task_runner.py:248:80: E501 line too long (88 > 79 characters)
+./tools/codex_supplied_task_runner.py:255:80: E501 line too long (85 > 79 characters)
+./tools/codex_supplied_task_runner.py:270:80: E501 line too long (80 > 79 characters)
+./tools/codex_supplied_task_runner.py:276:80: E501 line too long (83 > 79 characters)
+./tools/codex_supplied_task_runner.py:286:80: E501 line too long (88 > 79 characters)
+./tools/codex_supplied_task_runner.py:320:80: E501 line too long (128 > 79 characters)
+./tools/codex_supplied_task_runner.py:355:80: E501 line too long (81 > 79 characters)
+./tools/codex_supplied_task_runner.py:356:80: E501 line too long (88 > 79 characters)
+./tools/codex_supplied_task_runner.py:367:80: E501 line too long (88 > 79 characters)
+./tools/codex_supplied_task_runner.py:377:80: E501 line too long (80 > 79 characters)
+./tools/codex_supplied_task_runner.py:381:80: E501 line too long (84 > 79 characters)
+./tools/codex_workflow_session_query.py:16:80: E501 line too long (81 > 79 characters)
+./tools/export_to_parquet.py:34:80: E501 line too long (81 > 79 characters)
+./tools/export_to_parquet.py:40:80: E501 line too long (84 > 79 characters)
+./tools/export_to_parquet.py:52:80: E501 line too long (81 > 79 characters)
+./tools/git_patch_parser_complete.py:82:80: E501 line too long (83 > 79 characters)
+./tools/git_patch_parser_complete.py:87:80: E501 line too long (80 > 79 characters)
+./tools/git_patch_parser_complete.py:129:80: E501 line too long (84 > 79 characters)
+./tools/git_patch_parser_complete.py:187:80: E501 line too long (84 > 79 characters)
+./tools/git_patch_parser_complete.py:501:80: E501 line too long (80 > 79 characters)
+./tools/git_patch_parser_complete.py:503:80: E501 line too long (86 > 79 characters)
+./tools/git_patch_parser_complete.py:509:80: E501 line too long (87 > 79 characters)
+./tools/git_patch_parser_complete.py:537:80: E501 line too long (83 > 79 characters)
+./tools/git_patch_parser_complete.py:539:80: E501 line too long (81 > 79 characters)
+./tools/git_patch_parser_complete.py:547:80: E501 line too long (80 > 79 characters)
+./tools/git_patch_parser_complete.py:596:80: E501 line too long (82 > 79 characters)
+./tools/git_patch_parser_complete.py:614:80: E501 line too long (85 > 79 characters)
+./tools/git_patch_parser_complete.py:651:80: E501 line too long (83 > 79 characters)
+./tools/git_patch_parser_complete.py:676:80: E501 line too long (84 > 79 characters)
+./tools/git_patch_parser_complete.py:685:66: E203 whitespace before ':'
+./tools/git_patch_parser_complete.py:694:80: E501 line too long (86 > 79 characters)
+./tools/git_patch_parser_complete.py:716:80: E501 line too long (86 > 79 characters)
+./tools/git_patch_parser_complete.py:717:80: E501 line too long (84 > 79 characters)
+./tools/monitoring_integrate.py:54:80: E501 line too long (111 > 79 characters)
+./tools/monitoring_integrate.py:57:80: E501 line too long (95 > 79 characters)
+./tools/monitoring_integrate.py:60:80: E501 line too long (87 > 79 characters)
+./tools/monitoring_integrate.py:88:80: E501 line too long (80 > 79 characters)
+./tools/monitoring_integrate.py:105:80: E501 line too long (84 > 79 characters)
+./tools/monitoring_integrate.py:153:80: E501 line too long (100 > 79 characters)
+./tools/monitoring_integrate.py:182:80: E501 line too long (85 > 79 characters)
+./tools/monitoring_integrate.py:213:80: E501 line too long (97 > 79 characters)
+./tools/monitoring_integrate.py:221:80: E501 line too long (88 > 79 characters)
+./tools/monitoring_integrate.py:224:80: E501 line too long (97 > 79 characters)
+./tools/monitoring_integrate.py:232:80: E501 line too long (99 > 79 characters)
+./tools/monitoring_integrate.py:235:80: E501 line too long (95 > 79 characters)
+./tools/monitoring_integrate.py:238:80: E501 line too long (93 > 79 characters)
+./tools/monitoring_integrate.py:251:80: E501 line too long (98 > 79 characters)
+./tools/monitoring_integrate.py:253:80: E501 line too long (81 > 79 characters)
+./tools/monitoring_integrate.py:259:80: E501 line too long (84 > 79 characters)
+./tools/monitoring_integrate.py:263:80: E501 line too long (84 > 79 characters)
+./tools/monitoring_integrate.py:265:80: E501 line too long (101 > 79 characters)
+./tools/monitoring_integrate.py:268:80: E501 line too long (99 > 79 characters)
+./tools/monitoring_integrate.py:270:80: E501 line too long (90 > 79 characters)
+./tools/monitoring_integrate.py:273:80: E501 line too long (87 > 79 characters)
+./tools/monitoring_integrate.py:277:80: E501 line too long (80 > 79 characters)
+./tools/monitoring_integrate.py:281:80: E501 line too long (82 > 79 characters)
+./tools/monitoring_integrate.py:284:80: E501 line too long (90 > 79 characters)
+./tools/monitoring_integrate.py:286:80: E501 line too long (90 > 79 characters)
+./tools/monitoring_integrate.py:288:80: E501 line too long (89 > 79 characters)
+./tools/monitoring_integrate.py:311:80: E501 line too long (80 > 79 characters)
+./tools/monitoring_integrate.py:322:80: E501 line too long (94 > 79 characters)
+./tools/monitoring_integrate.py:323:80: E501 line too long (117 > 79 characters)
+./tools/monitoring_integrate.py:324:80: E501 line too long (80 > 79 characters)
+./tools/monitoring_integrate.py:327:80: E501 line too long (101 > 79 characters)
+./tools/monitoring_integrate.py:329:80: E501 line too long (121 > 79 characters)
+./tools/monitoring_integrate.py:333:80: E501 line too long (80 > 79 characters)
+./tools/monitoring_integrate.py:334:80: E501 line too long (96 > 79 characters)
+./tools/monitoring_integrate.py:352:80: E501 line too long (109 > 79 characters)
+./tools/monitoring_integrate.py:359:80: E501 line too long (105 > 79 characters)
+./tools/monitoring_integrate.py:361:80: E501 line too long (92 > 79 characters)
+./tools/monitoring_integrate.py:362:80: E501 line too long (100 > 79 characters)
+./tools/monitoring_integrate.py:363:80: E501 line too long (111 > 79 characters)
+./tools/monitoring_integrate.py:364:80: E501 line too long (102 > 79 characters)
+./tools/monitoring_integrate.py:365:80: E501 line too long (110 > 79 characters)
+./tools/monitoring_integrate.py:367:80: E501 line too long (99 > 79 characters)
+./tools/monitoring_integrate.py:378:80: E501 line too long (82 > 79 characters)
+./tools/monitoring_integrate.py:391:80: E501 line too long (106 > 79 characters)
+./tools/monitoring_integrate.py:399:80: E501 line too long (84 > 79 characters)
+./tools/monitoring_integrate.py:401:80: E501 line too long (113 > 79 characters)
+./tools/purge_session_logs.py:29:80: E501 line too long (84 > 79 characters)
+./tools/purge_session_logs.py:53:80: E501 line too long (93 > 79 characters)
+./tools/purge_session_logs.py:58:80: E501 line too long (84 > 79 characters)
+./tools/run_supplied_task.py:7:80: E501 line too long (87 > 79 characters)
+./tools/run_supplied_task.py:10:80: E501 line too long (81 > 79 characters)
+./tools/run_supplied_task.py:68:80: E501 line too long (99 > 79 characters)
+./tools/run_supplied_task.py:72:80: E501 line too long (81 > 79 characters)
+./tools/run_supplied_task.py:80:80: E501 line too long (85 > 79 characters)
+./tools/run_supplied_task.py:86:80: E501 line too long (81 > 79 characters)
+./tools/run_supplied_task.py:131:80: E501 line too long (80 > 79 characters)
+./tools/run_supplied_task.py:168:80: E501 line too long (94 > 79 characters)
+./tools/run_supplied_task.py:176:80: E501 line too long (84 > 79 characters)
+./tools/run_supplied_task.py:201:80: E501 line too long (96 > 79 characters)
+./tools/run_supplied_task.py:223:80: E501 line too long (86 > 79 characters)
+./tools/run_supplied_task.py:229:80: E501 line too long (124 > 79 characters)
+./tools/run_supplied_task.py:231:80: E501 line too long (96 > 79 characters)
+./tools/run_supplied_task.py:244:80: E501 line too long (110 > 79 characters)
+./tools/run_supplied_task.py:251:80: E501 line too long (113 > 79 characters)
+./tools/run_supplied_task.py:269:80: E501 line too long (87 > 79 characters)
+./tools/run_supplied_task.py:281:80: E501 line too long (100 > 79 characters)
+./tools/run_supplied_task.py:292:55: E203 whitespace before ':'
+./tools/run_supplied_task.py:302:80: E501 line too long (108 > 79 characters)
+./tools/run_supplied_task.py:318:80: E501 line too long (87 > 79 characters)
+./tools/run_supplied_task.py:325:80: E501 line too long (82 > 79 characters)
+./tools/run_supplied_task.py:332:80: E501 line too long (88 > 79 characters)
+./tools/run_supplied_task.py:339:80: E501 line too long (80 > 79 characters)
+./tools/run_supplied_task.py:350:80: E501 line too long (103 > 79 characters)
+./tools/run_supplied_task.py:364:80: E501 line too long (86 > 79 characters)
+./tools/run_supplied_task.py:373:80: E501 line too long (82 > 79 characters)
+./tools/run_supplied_task.py:380:80: E501 line too long (88 > 79 characters)
+./tools/run_supplied_task.py:395:80: E501 line too long (84 > 79 characters)
+./tools/test_auto_analyze_errors.py:64:80: E501 line too long (80 > 79 characters)
+./tools/unify_logging_canonical.py:3:80: E501 line too long (116 > 79 characters)
+./tools/unify_logging_canonical.py:46:80: E501 line too long (97 > 79 characters)
+./tools/unify_logging_canonical.py:52:80: E501 line too long (81 > 79 characters)
+./tools/unify_logging_canonical.py:54:80: E501 line too long (85 > 79 characters)
+./tools/unify_logging_canonical.py:79:80: E501 line too long (88 > 79 characters)
+./tools/unify_logging_canonical.py:91:80: E501 line too long (83 > 79 characters)
+./tools/unify_logging_canonical.py:117:80: E501 line too long (80 > 79 characters)
+./tools/unify_logging_canonical.py:120:80: E501 line too long (111 > 79 characters)
+./tools/unify_logging_canonical.py:148:80: E501 line too long (84 > 79 characters)
+./tools/unify_logging_canonical.py:188:80: E501 line too long (85 > 79 characters)
+./tools/unify_logging_canonical.py:211:80: E501 line too long (86 > 79 characters)
+./tools/unify_logging_canonical.py:231:80: E501 line too long (84 > 79 characters)
+./tools/unify_logging_canonical.py:255:80: E501 line too long (86 > 79 characters)
+./tools/unify_logging_canonical.py:267:80: E501 line too long (80 > 79 characters)
+./tools/unify_logging_canonical.py:279:80: E501 line too long (84 > 79 characters)
+./tools/unify_logging_canonical.py:283:80: E501 line too long (107 > 79 characters)
+./tools/unify_logging_canonical.py:318:80: E501 line too long (124 > 79 characters)
+./tools/unify_logging_canonical.py:319:80: E501 line too long (128 > 79 characters)
+./tools/unify_logging_canonical.py:323:80: E501 line too long (117 > 79 characters)
+./tools/verify_data_paths.py:4:80: E501 line too long (80 > 79 characters)
+./tools/workflow_merge.py:3:80: E501 line too long (86 > 79 characters)
+./tools/workflow_merge.py:47:80: E501 line too long (80 > 79 characters)
+./tools/workflow_merge.py:54:80: E501 line too long (113 > 79 characters)
+./tools/workflow_merge.py:70:80: E501 line too long (101 > 79 characters)
+./tools/workflow_merge.py:105:80: E501 line too long (81 > 79 characters)
+./tools/workflow_merge.py:143:80: E501 line too long (83 > 79 characters)
+./tools/workflow_merge.py:159:80: E501 line too long (82 > 79 characters)
+./tools/workflow_merge.py:178:80: E501 line too long (84 > 79 characters)
+./tools/workflow_merge.py:180:80: E501 line too long (85 > 79 characters)
+./tools/workflow_merge.py:270:80: E501 line too long (85 > 79 characters)
+./tools/workflow_merge.py:300:80: E501 line too long (80 > 79 characters)
+./tools/workflow_merge.py:332:80: E501 line too long (84 > 79 characters)
+./tools/workflow_merge.py:343:80: E501 line too long (87 > 79 characters)
+./tools/workflow_merge.py:364:80: E501 line too long (84 > 79 characters)
+./training/engine_hf_trainer.py:41:80: E501 line too long (101 > 79 characters)
+./training/engine_hf_trainer.py:42:80: E501 line too long (87 > 79 characters)
+./training/engine_hf_trainer.py:58:80: E501 line too long (80 > 79 characters)
+./training/engine_hf_trainer.py:114:80: E501 line too long (101 > 79 characters)
+./training/engine_hf_trainer.py:116:80: E501 line too long (104 > 79 characters)
+<unknown>:138: SyntaxWarning: invalid escape sequence '\.'
+
+(exit=1)
+```
+
+## mypy --ignore-missing-imports .
+```
+services/api/main.py:55: error: Unterminated f-string literal (detected at line 55)  [syntax]
+Found 1 error in 1 file (errors prevented further checking)
+
+(exit=2)
+```
+
+## pytest -q --maxfail=1
+```
+
+============================================================ ERRORS ============================================================
+__________________________________________ ERROR collecting tests/test_activations.py __________________________________________
+ImportError while importing test module '/workspace/_codex_/tests/test_activations.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+tests/test_activations.py:2: in <module>
+    from codex_ml.models.activations import get_activation
+src/codex_ml/models/__init__.py:3: in <module>
+    from .minilm import MiniLM, MiniLMConfig
+src/codex_ml/models/minilm.py:12: in <module>
+    import torch
+E   ModuleNotFoundError: No module named 'torch'
+=================================================== short test summary info ====================================================
+ERROR tests/test_activations.py
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+1 error in 0.14s
+
+(exit=1)
+```

--- a/docs/ops/monitoring.md
+++ b/docs/ops/monitoring.md
@@ -20,3 +20,5 @@ WANDB_PROJECT=myproj python tools/monitoring_integrate.py --run-name demo --enab
 All executions run locally via CLI. Do NOT activate any GitHub Actions online files.
 
 ## Prometheus (optional)
+
+<!-- SENTINEL -->

--- a/src/codex_ml/metrics/__init__.py
+++ b/src/codex_ml/metrics/__init__.py
@@ -1,0 +1,1 @@
+# METRICS_INIT

--- a/src/codex_ml/monitoring/__init__.py
+++ b/src/codex_ml/monitoring/__init__.py
@@ -1,0 +1,1 @@
+# MONITOR_INIT

--- a/src/codex_ml/peft/__init__.py
+++ b/src/codex_ml/peft/__init__.py
@@ -1,0 +1,1 @@
+# PEFT_INIT

--- a/src/codex_ml/training/__init__.py
+++ b/src/codex_ml/training/__init__.py
@@ -1,0 +1,1 @@
+# TRAIN_INIT


### PR DESCRIPTION
## Summary
- add explicit sentinels to codex_ml package initializers
- note Prometheus option in monitoring docs with patch marker

## Testing
- `black --check .` *(fails: exit 123)*
- `isort --check-only .` *(fails: exit 1)*
- `flake8 .` *(fails: exit 1)*
- `mypy --ignore-missing-imports .` *(fails: exit 2)*
- `pytest -q --maxfail=1` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pre-commit run --all-files` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ad49630ea88331a9fa963f7922d8d2