### PR TITLE
feat: enhance checkpoint rng and seeding

### DIFF
--- a/docs/ops/training_args.md
+++ b/docs/ops/training_args.md
@@ -5,6 +5,6 @@
 - **early_stopping**: enable with patience/min_delta; wire to callbacks.EarlyStopping in your trainer loop.
 
 ## Reproducibility
-- Use `set_seed(seed)` in training scripts to fix RNGs across `random`, `numpy`, and `torch`.
-- Checkpoints save `rng.json` capturing library states and restore them on load.
-- `seeds.json` records seeds used for each run.
+- Use `set_seed(seed)` in training scripts to fix RNGs across `random`, `numpy`, and `torch`; a `seeds.json` file is written under the run directory.
+- Each checkpoint records `rng.json` with RNG states for Python, NumPy, and Torch (CPU & CUDA) and restores them on load.
+- `CheckpointManager.resume_from` validates model and optimizer parameter shapes and raises informative errors on mismatch.

--- a/src/codex_ml/utils/checkpointing.py
+++ b/src/codex_ml/utils/checkpointing.py
@@ -32,14 +32,14 @@ try:  # pragma: no cover - optional torch dependency
 
     TORCH_AVAILABLE = True
 except Exception:  # pragma: no cover - torch missing
-TORCH_AVAILABLE = False
+    TORCH_AVAILABLE = False
 
 try:  # pragma: no cover - optional numpy dependency
     import numpy as np
 
     NUMPY_AVAILABLE = True
 except Exception:  # pragma: no cover - numpy missing
-NUMPY_AVAILABLE = False
+    NUMPY_AVAILABLE = False
 
 
 def _write_json(path: Path, data: Dict[str, Any]) -> None:
@@ -51,25 +51,45 @@ def _read_json(path: Path) -> Dict[str, Any]:
 
 
 def _rng_dump() -> Dict[str, Any]:
-    state: Dict[str, Any] = {"python": random.getstate()}
+    py_state = random.getstate()
+    state: Dict[str, Any] = {"python": [py_state[0], list(py_state[1]), py_state[2]]}
     if NUMPY_AVAILABLE:
-        state["numpy"] = np.random.get_state()
+        np_state = np.random.get_state()
+        state["numpy"] = [
+            np_state[0],
+            np_state[1].tolist(),
+            np_state[2],
+            np_state[3],
+            np_state[4],
+        ]
     if TORCH_AVAILABLE:
         state["torch"] = {"cpu": torch.random.get_rng_state().tolist()}
         if torch.cuda.is_available():  # pragma: no cover - cuda optional
-            state["torch"]["cuda"] = torch.cuda.get_rng_state_all()
+            state["torch"]["cuda"] = [s.tolist() for s in torch.cuda.get_rng_state_all()]
     return state
 
 
 def _rng_load(state: Dict[str, Any]) -> None:
     if "python" in state:
-        random.setstate(tuple(state["python"]))
+        py_state = state["python"]
+        random.setstate((py_state[0], tuple(py_state[1]), py_state[2]))
     if NUMPY_AVAILABLE and "numpy" in state:
-        np.random.set_state(tuple(state["numpy"]))
+        np_state = state["numpy"]
+        np.random.set_state(
+            (
+                np_state[0],
+                np.array(np_state[1], dtype=np.uint32),
+                np_state[2],
+                np_state[3],
+                np_state[4],
+            )
+        )
     if TORCH_AVAILABLE and "torch" in state:
-        torch.random.set_rng_state(torch.tensor(state["torch"]["cpu"]))
+        torch.random.set_rng_state(torch.tensor(state["torch"]["cpu"], dtype=torch.uint8))
         if "cuda" in state["torch"] and torch.cuda.is_available():  # pragma: no cover - cuda optional
-            torch.cuda.set_rng_state_all(state["torch"]["cuda"])
+            torch.cuda.set_rng_state_all(
+                [torch.tensor(s, dtype=torch.uint8) for s in state["torch"]["cuda"]]
+            )
 
 
 def set_seed(seed: int, out_dir: Optional[Path | str] = None) -> Dict[str, int]:
@@ -199,6 +219,7 @@ class CheckpointManager:
                 self._verify_state_dict(model.state_dict(), state["model"])
                 model.load_state_dict(state["model"])
             if optimizer is not None and state.get("optimizer") is not None:
+                self._verify_optimizer_state(optimizer, state["optimizer"])
                 try:
                     optimizer.load_state_dict(state["optimizer"])
                 except Exception as exc:  # noqa: BLE001
@@ -215,9 +236,13 @@ class CheckpointManager:
         else:
             raise RuntimeError(f"no compatible state file found under: {path}")
 
-        with contextlib.suppress(Exception):
-            rng_state = _read_json(path / "rng.json")
-            _rng_load(rng_state)
+        rng_path = path / "rng.json"
+        if rng_path.exists():
+            try:
+                rng_state = _read_json(rng_path)
+                _rng_load(rng_state)
+            except Exception as exc:  # noqa: BLE001
+                raise RuntimeError(f"failed to restore RNG state: {exc}") from exc
 
         meta = _read_json(path / "meta.json") if (path / "meta.json").exists() else {}
         return {"meta": meta, "state": bool(state)}
@@ -262,6 +287,44 @@ class CheckpointManager:
             if mismatched:
                 msgs.append(f"mismatched: {mismatched[:5]}{' ...' if len(mismatched) > 5 else ''}")
             raise ValueError("state_dict verification failed: " + "; ".join(msgs))
+
+    def _verify_optimizer_state(self, optimizer: Any, loaded_sd: Dict[str, Any]) -> None:
+        """Check optimizer param counts and tensor shapes before loading."""
+        if not TORCH_AVAILABLE:
+            return
+
+        params = [p for group in optimizer.param_groups for p in group.get("params", [])]
+        loaded_groups = loaded_sd.get("param_groups", [])
+        loaded_state = loaded_sd.get("state", {})
+        loaded_param_ids = [pid for g in loaded_groups for pid in g.get("params", [])]
+
+        if len(params) != len(loaded_param_ids):
+            raise ValueError(
+                f"optimizer param count mismatch: expected {len(params)}, got {len(loaded_param_ids)}"
+            )
+
+        mismatched = []
+        for param, pid in zip(params, loaded_param_ids):
+            state_entry = loaded_state.get(pid)
+            if state_entry is None:
+                continue
+            for key, val in state_entry.items():
+                if torch.is_tensor(val) and tuple(val.shape) != tuple(param.shape):
+                    mismatched.append((pid, key, tuple(param.shape), tuple(val.shape)))
+
+        unexpected = [pid for pid in loaded_state.keys() if pid not in set(loaded_param_ids)]
+        if unexpected or mismatched:
+            msgs = []
+            if unexpected:
+                msgs.append(
+                    f"unexpected params: {unexpected[:10]}{' ...' if len(unexpected) > 10 else ''}"
+                )
+            if mismatched:
+                sample = [
+                    (pid, key, exp, got) for pid, key, exp, got in mismatched[:5]
+                ]
+                msgs.append(f"mismatched: {sample}{' ...' if len(mismatched) > 5 else ''}")
+            raise ValueError("optimizer state verification failed: " + "; ".join(msgs))
 
 
 __all__ = ["CheckpointManager"]

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -27,6 +27,8 @@ from transformers import (
     TrainingArguments,
 )
 
+from codex_ml.utils.checkpointing import set_seed
+
 
 @dataclass
 class HFTrainerConfig:
@@ -70,6 +72,7 @@ def run_hf_trainer(
     tokenizer_name: Optional[str] = None,
     config_path: Optional[Path] = None,
     fp16: bool = False,
+    seed: int = 0,
 ) -> Dict[str, float]:
     """Train a causal LM using HuggingFace ``Trainer``.
 
@@ -90,12 +93,16 @@ def run_hf_trainer(
         Path to YAML file defining ``TrainingArguments``.
     fp16:
         If ``True`` and CUDA is available, enable half precision training.
+    seed:
+        RNG seed applied across libraries and recorded to ``seeds.json``.
 
     Returns
     -------
     Dict[str, float]
         Training metrics returned by ``Trainer.train``.
     """
+
+    set_seed(seed, output_dir)
 
     tokenizer_name = tokenizer_name or model_name
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)


### PR DESCRIPTION
## Summary
- capture Python, NumPy, and Torch RNG state (CPU/CUDA) in checkpoints and restore on resume with shape checks for models and optimizers
- add `set_seed` helper usage across training scripts and persist seeds
- document reproducibility guarantees in training argument docs

## Testing
- `pre-commit run --all-files` *(fails: check-yaml duplicate key, black formatting, isort issues)*
- `pytest` *(fails: ingestion encoding assertions, missing accelerate earlier; subset passing after installs)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5863abec83319a9fc6841b35ca5d