### PR TITLE
feat: add reward model and RL agent interfaces

### DIFF
--- a/docs/architecture/interfaces.md
+++ b/docs/architecture/interfaces.md
@@ -5,8 +5,8 @@ This project defines abstract interfaces to allow **swappable implementations** 
 
 ## Interfaces
 - `TokenizerAdapter` — encode/decode, vocab_size/pad_id/eos_id, optional batch_encode.
-- `RewardModel` — score(prompt, completion, metadata?), optional batch_score.
-- `RLAgent` — select_action, update(trajectory)->metrics, save/load.
+- `RewardModel` — evaluate(prompt, completion, metadata?), learn(data)->metrics, optional batch_evaluate.
+- `RLAgent` — act, update(trajectory)->metrics, save/load.
 
 ## Swapping Implementations
 1. Provide implementation import paths (e.g., `pkg.module:Class`) via environment:

--- a/documentation/codex_pipeline_scaffold.md
+++ b/documentation/codex_pipeline_scaffold.md
@@ -70,7 +70,7 @@ policy = load_weights(M1_path)
 for step in range(rl_steps):
     prompts = sample_prompts()
     responses = policy.generate(prompts)
-    rewards = reward_model.score(prompts, responses)
+    rewards = reward_model.batch_evaluate(prompts, responses)
     policy = ppo_update(policy, prompts, responses, rewards)
 
 save_weights(policy, M2_path)

--- a/src/codex_ml/interfaces/reward_model.py
+++ b/src/codex_ml/interfaces/reward_model.py
@@ -6,10 +6,10 @@ from typing import Any, Mapping, Optional
 
 
 class RewardModel(ABC):
-    """Abstract reward model producing a scalar score for (prompt, completion)."""
+    """Abstract reward model producing a scalar evaluation for (prompt, completion)."""
 
     @abstractmethod
-    def score(
+    def evaluate(
         self,
         prompt: str,
         completion: str,
@@ -19,18 +19,23 @@ class RewardModel(ABC):
         """Return a scalar reward (higher is better)."""
         raise NotImplementedError
 
-    def batch_score(
+    def batch_evaluate(
         self,
         pairs: list[tuple[str, str]],
         *,
         metadatas: Optional[list[Optional[Mapping[str, Any]]]] = None,
     ) -> list[float]:
-        """Optional batch scoring; default maps to score()."""
+        """Optional batch evaluation; default maps to evaluate()."""
         res: list[float] = []
         for i, (p, c) in enumerate(pairs):
             md = metadatas[i] if metadatas and i < len(metadatas) else None
-            res.append(self.score(p, c, metadata=md))
+            res.append(self.evaluate(p, c, metadata=md))
         return res
+
+    @abstractmethod
+    def learn(self, data: Any) -> dict[str, float]:
+        """Update model parameters from data and return training metrics."""
+        raise NotImplementedError
 
 
 # END: CODEX_IFACE_REWARD

--- a/src/codex_ml/interfaces/rl.py
+++ b/src/codex_ml/interfaces/rl.py
@@ -9,7 +9,7 @@ class RLAgent(ABC):
     """Abstract RL agent for text generation or other environments."""
 
     @abstractmethod
-    def select_action(self, state: Any) -> Any:
+    def act(self, state: Any) -> Any:
         """Choose an action for the given state."""
         raise NotImplementedError
 

--- a/tests/test_interfaces_compat.py
+++ b/tests/test_interfaces_compat.py
@@ -1,11 +1,11 @@
 # BEGIN: CODEX_IFACE_TESTS
 import importlib
 import os
-from typing import Any
+from typing import Any, Mapping, Optional
 
 import pytest
 
-from codex_ml.interfaces import TokenizerAdapter
+from codex_ml.interfaces import RewardModel, RLAgent, TokenizerAdapter
 
 # Configuration:
 # Provide module paths via environment or a config file consumed elsewhere.
@@ -40,15 +40,17 @@ def test_tokenizer_adapter_contract():
 def test_reward_model_contract():
     cls = _load(RWD_PATH)
     inst = cls()  # TODO: supply kwargs if needed
-    score = inst.score("prompt", "completion")
+    score = inst.evaluate("prompt", "completion")
     assert isinstance(score, float)
+    metrics = inst.learn([("prompt", "completion", 1.0)])
+    assert isinstance(metrics, dict)
 
 
 @pytest.mark.skipif(RL_PATH is None, reason="RLAgent implementation not provided")
 def test_rl_agent_contract(tmp_path):
     cls = _load(RL_PATH)
     inst = cls()  # TODO: supply kwargs if needed
-    a = inst.select_action({"obs": 1})
+    a = inst.act({"obs": 1})
     assert a is not None
     metrics = inst.update({"states": [], "actions": [], "rewards": []})
     assert isinstance(metrics, dict)
@@ -56,6 +58,48 @@ def test_rl_agent_contract(tmp_path):
     inst.save(str(p))
     assert p.exists()
     inst.load(str(p))
+
+
+class _DummyRewardModel(RewardModel):
+    def evaluate(
+        self, prompt: str, completion: str, *, metadata: Optional[Any] = None
+    ) -> float:
+        return 0.0
+
+    def learn(self, data: Any) -> dict[str, float]:
+        return {"loss": 0.0}
+
+
+def test_reward_model_abc():
+    rm = _DummyRewardModel()
+    assert isinstance(rm.evaluate("p", "c"), float)
+    assert isinstance(rm.learn([]), dict)
+
+
+class _DummyRLAgent(RLAgent):
+    def act(self, state: Any) -> Any:
+        return 1
+
+    def update(self, trajectory: Mapping[str, Any]) -> dict[str, float]:
+        return {"loss": 0.0}
+
+    def save(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("x")
+
+    def load(self, path: str) -> None:
+        with open(path, "r", encoding="utf-8") as fh:
+            fh.read()
+
+
+def test_rl_agent_abc(tmp_path):
+    agent = _DummyRLAgent()
+    assert agent.act({}) == 1
+    assert isinstance(agent.update({}), dict)
+    p = tmp_path / "agent.bin"
+    agent.save(str(p))
+    assert p.exists()
+    agent.load(str(p))
 
 
 # --- Codex prompts (for future completion) ---

--- a/tools/apply_interfaces.py
+++ b/tools/apply_interfaces.py
@@ -124,23 +124,28 @@ S_REWARD = "# BEGIN: CODEX_IFACE_REWARD"
 REWARD = f"""{S_REWARD}
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import Optional, Mapping, Any
+from typing import Any, Mapping, Optional
 
 class RewardModel(ABC):
-    \"\"\"Abstract reward model producing a scalar score for (prompt, completion).\"\"\"
+    \"\"\"Abstract reward model producing a scalar evaluation for (prompt, completion).\"\"\"
 
     @abstractmethod
-    def score(self, prompt: str, completion: str, *, metadata: Optional[Mapping[str, Any]] = None) -> float:
+    def evaluate(self, prompt: str, completion: str, *, metadata: Optional[Mapping[str, Any]] = None) -> float:
         \"\"\"Return a scalar reward (higher is better).\"\"\"
         raise NotImplementedError
 
-    def batch_score(self, pairs: list[tuple[str, str]], *, metadatas: Optional[list[Optional[Mapping[str, Any]]]] = None) -> list[float]:
-        \"\"\"Optional batch scoring; default maps to score().\"\"\"
+    def batch_evaluate(self, pairs: list[tuple[str, str]], *, metadatas: Optional[list[Optional[Mapping[str, Any]]]] = None) -> list[float]:
+        \"\"\"Optional batch evaluation; default maps to evaluate().\"\"\"
         res: list[float] = []
         for i, (p, c) in enumerate(pairs):
             md = metadatas[i] if metadatas and i < len(metadatas) else None
-            res.append(self.score(p, c, metadata=md))
+            res.append(self.evaluate(p, c, metadata=md))
         return res
+
+    @abstractmethod
+    def learn(self, data: Any) -> dict[str, float]:
+        \"\"\"Update model parameters from data and return training metrics.\"\"\"
+        raise NotImplementedError
 # END: CODEX_IFACE_REWARD
 """
 
@@ -154,7 +159,7 @@ class RLAgent(ABC):
     \"\"\"Abstract RL agent for text generation or other environments.\"\"\"
 
     @abstractmethod
-    def select_action(self, state: Any) -> Any:
+    def act(self, state: Any) -> Any:
         \"\"\"Choose an action for the given state.\"\"\"
         raise NotImplementedError
 
@@ -189,7 +194,7 @@ __all__ = ["TokenizerAdapter", "RewardModel", "RLAgent"]
 S_TESTS = "# BEGIN: CODEX_IFACE_TESTS"
 TESTS = f"""{S_TESTS}
 import os, importlib, types, pytest
-from typing import Any
+from typing import Any, Mapping, Optional
 from codex_ml.interfaces import TokenizerAdapter, RewardModel, RLAgent
 
 # Configuration:
@@ -220,14 +225,16 @@ def test_tokenizer_adapter_contract():
 def test_reward_model_contract():
     cls = _load(RWD_PATH)
     inst = cls()  # TODO: supply kwargs if needed
-    score = inst.score("prompt", "completion")
+    score = inst.evaluate("prompt", "completion")
     assert isinstance(score, float)
+    metrics = inst.learn([("prompt", "completion", 1.0)])
+    assert isinstance(metrics, dict)
 
 @pytest.mark.skipif(RL_PATH is None, reason="RLAgent implementation not provided")
 def test_rl_agent_contract(tmp_path):
     cls = _load(RL_PATH)
     inst = cls()  # TODO: supply kwargs if needed
-    a = inst.select_action({{"obs": 1}})
+    a = inst.act({{"obs": 1}})
     assert a is not None
     metrics = inst.update({{"states": [], "actions": [], "rewards": []}})
     assert isinstance(metrics, dict)
@@ -235,6 +242,46 @@ def test_rl_agent_contract(tmp_path):
     inst.save(str(p))
     assert p.exists()
     inst.load(str(p))
+
+
+class _DummyRewardModel(RewardModel):
+    def evaluate(self, prompt: str, completion: str, *, metadata: Optional[Any] = None) -> float:
+        return 0.0
+
+    def learn(self, data: Any) -> dict[str, float]:
+        return {"loss": 0.0}
+
+
+def test_reward_model_abc():
+    rm = _DummyRewardModel()
+    assert isinstance(rm.evaluate("p", "c"), float)
+    assert isinstance(rm.learn([]), dict)
+
+
+class _DummyRLAgent(RLAgent):
+    def act(self, state: Any) -> Any:
+        return 1
+
+    def update(self, trajectory: Mapping[str, Any]) -> dict[str, float]:
+        return {"loss": 0.0}
+
+    def save(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("x")
+
+    def load(self, path: str) -> None:
+        with open(path, "r", encoding="utf-8") as fh:
+            fh.read()
+
+
+def test_rl_agent_abc(tmp_path):
+    agent = _DummyRLAgent()
+    assert agent.act({}) == 1
+    assert isinstance(agent.update({}), dict)
+    p = tmp_path / "agent.bin"
+    agent.save(str(p))
+    assert p.exists()
+    agent.load(str(p))
 
 # --- Codex prompts (for future completion) ---
 # TODO[Codex]: If your implementations require constructor arguments, update tests to pass minimal viable config.
@@ -261,8 +308,8 @@ This project defines abstract interfaces to allow **swappable implementations** 
 
 ## Interfaces
 - `TokenizerAdapter` — encode/decode, vocab_size/pad_id/eos_id, optional batch_encode.
-- `RewardModel` — score(prompt, completion, metadata?), optional batch_score.
-- `RLAgent` — select_action, update(trajectory)->metrics, save/load.
+- `RewardModel` — evaluate(prompt, completion, metadata?), learn(data)->metrics, optional batch_evaluate.
+- `RLAgent` — act, update(trajectory)->metrics, save/load.
 
 ## Swapping Implementations
 1. Provide implementation import paths (e.g., `pkg.module:Class`) via environment:


### PR DESCRIPTION
## Summary
- add abstract RewardModel and RLAgent interfaces
- cover interfaces with compliance tests and update tooling
- document new interface methods

## Testing
- `pre-commit run --all-files` (failed: formatting issues in unrelated files)
- `pytest` (failed: encoding detection tests)


------
https://chatgpt.com/codex/tasks/task_e_68adbec795808331a4da79d04c6880f4