### PR TITLE
feat: log validation metrics

### DIFF
--- a/CHANGELOG_codex.md
+++ b/CHANGELOG_codex.md
@@ -1,0 +1,4 @@
+## 2025-05-19 – Validation metrics & splits
+- Added: `--val-split`/`--test-split` flags and per-epoch validation logging to `metrics.json`.
+- Deferred: stratified splits, GPU-heavy metrics, and online trackers.
+- Risks: small datasets may skip evaluation when insufficient tokens.

--- a/docs/ops/training_args.md
+++ b/docs/ops/training_args.md
@@ -8,3 +8,19 @@
 - Use `set_seed(seed)` in training scripts to fix RNGs across `random`, `numpy`, and `torch`; a `seeds.json` file is written under the run directory.
 - Each checkpoint records `rng.json` with RNG states for Python, NumPy, and Torch (CPU & CUDA) and restores them on load.
 - `CheckpointManager.resume_from` validates model and optimizer parameter shapes and raises informative errors on mismatch.
+
+## Validation & Test Splits
+
+New CLI flags allow basic dataset splitting during MiniLM training:
+
+- `--val-split <float>`: validation fraction in `[0,1)`, default `0.10`.
+- `--test-split <float>`: test fraction in `[0,1)`, default `0.0`.
+
+### metrics.json (NDJSON)
+Each validation pass appends a line to `metrics.json`:
+
+```json
+{"ts":"<ISO8601>","epoch":0,"split":"val","token_accuracy":0.0,"perplexity":1.0,"config_hash":"<sha256>"}
+```
+
+Set `METRICS_JSON_PATH` to change the output path.

--- a/tests/test_metrics_logging.py
+++ b/tests/test_metrics_logging.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+from functional_training import emit_validation_metric_record
+
+
+def test_emit_validation_metric_record(tmp_path: Path) -> None:
+    metrics = tmp_path / "metrics.json"
+    payload = {
+        "epoch": 0,
+        "split": "val",
+        "token_accuracy": 0.0,
+        "perplexity": 1.0,
+        "config": {"val_split": 0.1, "test_split": 0.0, "epoch": 0},
+    }
+    emit_validation_metric_record(str(metrics), payload)
+    assert metrics.exists(), "metrics.json should be created"
+    lines = metrics.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) >= 1
+    for line in lines:
+        rec = json.loads(line)
+        assert rec.get("split") == "val"
+        assert "token_accuracy" in rec and "perplexity" in rec


### PR DESCRIPTION
## Summary
- add validation/test splits and NDJSON metric logging for MiniLM training
- expose `--val-split` and `--test-split` CLI flags and helper `emit_validation_metric_record`
- document new metrics file and update changelog

## Testing
- `pre-commit run --files functional_training.py tests/test_metrics_logging.py docs/ops/training_args.md CHANGELOG_codex.md` *(fails: ModuleNotFoundError: No module named 'pbr')*
- `pytest tests/test_metrics_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ade23b47f48331a8cb0742394f2246