### PR TITLE
feat: add offline experiment tracking hooks

### DIFF
--- a/CHANGELOG_codex.md
+++ b/CHANGELOG_codex.md
@@ -7,4 +7,4 @@
 - Added unified `codex_ml.monitoring.codex_logging` with optional TensorBoard, W&B, and MLflow sinks.
 - Patched `engine_hf_trainer.py` and `functional_training.py` to sample CPU/GPU metrics and log per-step scalars.
 - Added offline test coverage for logging bootstrap and docs for monitoring and experiment tracking.
-- Deferred: full Trainer callbacks and extended NVML telemetry.
+- Deferred: online W&B/remote MLflow servers, full Trainer callbacks, and extended NVML telemetry.

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -28,4 +28,7 @@ wandb:
 mlflow:
   enable: false
   tracking_uri: ./mlruns
-  experiment: codex-experiments
+  experiment: codex
+
+tensorboard:
+  logdir: ./runs

--- a/docs/ops/experiment_tracking.md
+++ b/docs/ops/experiment_tracking.md
@@ -7,7 +7,7 @@ If MLflow is not installed, tracking gracefully degrades to local JSON artifact 
 ## CLI Flags
 - `--mlflow-enable` — turn on MLflow logging.
 - `--mlflow-tracking-uri` — defaults to `./mlruns` (local file store).
-- `--mlflow-experiment` — experiment name (default `codex-experiments`).
+- `--mlflow-experiment` — experiment name (default `codex`).
 
 ### Examples
 

--- a/docs/ops/monitoring.md
+++ b/docs/ops/monitoring.md
@@ -2,7 +2,7 @@
 
 This project provides optional integration for:
 - **TensorBoard** (scalars, histograms): logs under `runs/<run-name>/tensorboard/`
-- **Weights & Biases (W&B)**: enable with `--enable-wandb` and environment `WANDB_PROJECT=<your_project>`
+- **Weights & Biases (W&B)**: enable with `--enable-wandb` and run with `WANDB_MODE=offline` (or `disabled`) plus `WANDB_PROJECT=<your_project>`
 - **MLflow** (local file store): enable with `--mlflow-enable`, optionally set `--mlflow-tracking-uri` and `--mlflow-experiment`; logs to `runs/<run-name>/mlruns/`
 
 Both `scripts/deploy_codex_pipeline.py` and the Hydra CLI (`python -m codex_ml.cli.main`) honor these flags to stream metrics, GPU utilization, and persist run artifacts.
@@ -12,7 +12,7 @@ Both `scripts/deploy_codex_pipeline.py` and the Hydra CLI (`python -m codex_ml.c
 ```bash
 python tools/monitoring_integrate.py --run-name demo --enable-tensorboard --enable-mlflow
 # With Weights & Biases
-WANDB_PROJECT=myproj python tools/monitoring_integrate.py --run-name demo --enable-tensorboard --enable-wandb
+WANDB_MODE=offline WANDB_PROJECT=myproj python tools/monitoring_integrate.py --run-name demo --enable-tensorboard --enable-wandb
 # Pipeline example
 python scripts/deploy_codex_pipeline.py --corpus data.jsonl --demos demos.jsonl --prefs prefs.jsonl --output-dir out --enable-wandb --mlflow-enable
 # Hydra CLI example
@@ -37,7 +37,7 @@ Flags:
 
 Behavior:
 - TensorBoard: logs to `<output>/tb`
-- Weights & Biases: enabled when flag set
+- Weights & Biases: enabled when flag set (honours `WANDB_MODE` for offline/disabled)
 - MLflow: wraps `mlflow.*` via `codex_ml.tracking.mlflow_utils.*`; artifacts/runs tracked where configured
 
 ## Hardware metrics

--- a/functional_training.py
+++ b/functional_training.py
@@ -21,8 +21,10 @@ from codex_ml.monitoring.codex_logging import (
     CodexLoggers,
     _codex_log_all,
     _codex_logging_bootstrap,
-    _codex_patch_argparse,
     _codex_sample_system,
+)
+from codex_ml.monitoring.codex_logging import (
+    _codex_patch_argparse as _codex_monitor_patch_argparse,
 )
 from codex_ml.symbolic_pipeline import (
     PretrainCfg,
@@ -539,7 +541,8 @@ def build_parser() -> "argparse.ArgumentParser":
         default=0.0,
         help="test split fraction [0,1)",
     )
-    _codex_patch_argparse(p)
+    _codex_monitor_patch_argparse(p)
+    _functional_patch_argparse(p)
     return p
 
 
@@ -684,7 +687,7 @@ def _codex_apply_training_integration(args, train_loop_fn, config: dict):
     return wrapped_train_loop
 
 
-def _codex_patch_argparse(ap: argparse.ArgumentParser) -> None:
+def _functional_patch_argparse(ap: argparse.ArgumentParser) -> None:
     added = [a.dest for g in ap._action_groups for a in g._group_actions]  # type: ignore
     if "use_deeplearning" not in added:
         ap.add_argument(

--- a/src/codex_ml/monitoring/codex_logging.py
+++ b/src/codex_ml/monitoring/codex_logging.py
@@ -99,9 +99,12 @@ def _codex_logging_bootstrap(args: argparse.Namespace) -> CodexLoggers:
     wb = None
     if getattr(args, "enable_wandb", False) and wandb is not None:
         try:  # pragma: no cover - wandb may not be installed
+            mode = os.getenv("WANDB_MODE", "offline")
+            if mode not in {"offline", "disabled"}:
+                mode = "disabled"
             wb = wandb.init(
                 project=getattr(args, "wandb_project", "codex-offline"),
-                mode="offline",
+                mode=mode,
                 dir=getattr(args, "tb_logdir", "./runs"),
             )
         except Exception:

--- a/tests/test_monitoring_thread.py
+++ b/tests/test_monitoring_thread.py
@@ -22,9 +22,10 @@ def test_codex_logging_bootstrap(tmp_path, monkeypatch):
             str(tmp_path / "tb"),
         ]
     )
-    monkeypatch.setenv("WANDB_MODE", "offline")
-    loggers = mod._codex_logging_bootstrap(args)
-    mod._codex_log_all(0, {"loss": 0.0, **mod._codex_sample_system()}, loggers)
+    for mode in ("offline", "disabled"):
+        monkeypatch.setenv("WANDB_MODE", mode)
+        loggers = mod._codex_logging_bootstrap(args)
+        mod._codex_log_all(0, {"loss": 0.0, **mod._codex_sample_system()}, loggers)
 
 
 def test_system_metrics_thread_shutdown(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- respect `WANDB_MODE` env var when initialising W&B logging
- expose monitoring flags in functional training and document offline tracking defaults
- add smoke test for W&B offline/disabled modes and document config defaults

## Testing
- `pre-commit run --files src/codex_ml/monitoring/codex_logging.py functional_training.py configs/config.yaml docs/ops/monitoring.md docs/ops/experiment_tracking.md tests/test_monitoring_thread.py CHANGELOG_codex.md` *(fails: bandit missing pbr; isort complains about import order)*
- `pytest -q` *(fails: 5 tests in ingestion encoding suite)*
- `pytest -q tests/test_monitoring_thread.py`

------
https://chatgpt.com/codex/tasks/task_e_68adfc5a571c8331a14409ba3fd4eab6