### PR TITLE
chore: disable remote CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,148 +1,66 @@
 name: CI Workflow
-
 on:
   workflow_dispatch:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-jobs:
-  lint:
-    name: Lint (ruff --diff)
-    runs-on: [self-hosted, linux, codex]
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - name: Cache pip
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-py-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
-      - name: Install Ruff
-        run: python -m pip install -U pip && pip install ruff
-      - name: Run Ruff
-        run: ruff --diff
-
-  type-check:
-    name: Type-Check (mypy)
-    runs-on: [self-hosted, linux, codex]
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - name: Cache pip
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-py-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
-      - name: Install MyPy
-        run: python -m pip install -U pip && pip install mypy
-      - name: Run MyPy
-        run: mypy .
-
-  test:
-    name: Tests (pytest)
-    runs-on: [self-hosted, linux, codex]
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - name: Cache pip
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-py-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
-      - name: Install Pytest
-        run: python -m pip install -U pip && pip install pytest
-      - name: Run pytest
-        run: pytest -q --maxfail=1
-
-  coverage:
-    name: Coverage (pytest + coverage)
-    runs-on: [self-hosted, linux, codex]
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - name: Cache pip
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-py-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
-      - name: Install Pytest & Coverage
-        run: python -m pip install -U pip && pip install pytest coverage
-      - name: Run pytest with coverage
-        run: pytest --cov=. --maxfail=1 --disable-warnings
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-report
-          path: coverage.xml
-
-  sast:
-    name: SAST (Bandit, Semgrep, Detect-Secrets)
-    runs-on: [self-hosted, linux, codex]
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - name: Cache pip
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-py-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
-      - name: Install SAST tools
-        run: python -m pip install -U pip && pip install bandit semgrep detect-secrets
-      - name: Run Bandit
-        run: bandit -r .
-      - name: Run Semgrep
-        run: semgrep --config p/ci
-      - name: Run Detect Secrets
-        run: detect-secrets scan
-
-# BEGIN: CODEX_CI_MANUAL
-on:
-  workflow_dispatch:
 jobs:
   lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version:
+        - '3.9'
+        - '3.10'
+        - '3.11'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - run: pip install black isort flake8
-      - run: black --version && isort --version && flake8 --version
-      - run: black --check .
-      - run: isort --check-only --profile black .
-      - run: flake8 .
-
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+    - run: pip install black isort flake8
+    - run: black --version && isort --version && flake8 --version
+    - run: black --check .
+    - run: isort --check-only --profile black .
+    - run: flake8 .
+    if: ${{ false }}
   type:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version:
+        - '3.9'
+        - '3.10'
+        - '3.11'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - run: pip install mypy
-      - run: mypy --ignore-missing-imports .
-
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+    - run: pip install mypy
+    - run: mypy --ignore-missing-imports .
+    if: ${{ false }}
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version:
+        - '3.9'
+        - '3.10'
+        - '3.11'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - run: pip install -e .[dev] pytest pytest-cov
-      - run: pytest -q --maxfail=1 --cov=src --cov-report=xml --cov-fail-under=80
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: coverage-xml-${{ matrix.python-version }}
-          path: coverage.xml
-# END: CODEX_CI_MANUAL
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+    - run: pip install -e .[dev] pytest pytest-cov
+    - run: pytest -q --maxfail=1 --cov=src --cov-report=xml --cov-fail-under=80
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: coverage-xml-${{ matrix.python-version }}
+        path: coverage.xml
+    if: ${{ false }}

--- a/.github/workflows/codex-ci.yml
+++ b/.github/workflows/codex-ci.yml
@@ -1,36 +1,47 @@
 name: codex-ci
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   ci:
-    runs-on: [self-hosted, linux, codex]
+    runs-on:
+    - self-hosted
+    - linux
+    - codex
     permissions:
       contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-        with:
-          python-version: '3.12'
-      - name: Cache pip
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-py-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
-      - name: Install dependencies
-        run: |
-          python -m pip install -U pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-          if [ -f pyproject.toml ]; then python -m pip install poetry; fi
-          if [ -f poetry.lock ]; then poetry install --no-interaction --no-ansi; fi
-      - name: Run pre-commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
-        with:
-          extra_args: --all-files
-      - name: Run tests
-        run: pytest -q
+    - name: Checkout
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      with:
+        python-version: '3.12'
+    - name: Cache pip
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-py-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml',
+          '**/poetry.lock') }}
+    - name: Install dependencies
+      run: 'python -m pip install -U pip
+
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt;
+        fi
+
+        if [ -f pyproject.toml ]; then python -m pip install poetry; fi
+
+        if [ -f poetry.lock ]; then poetry install --no-interaction --no-ansi; fi
+
+        '
+    - name: Run pre-commit
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
+      with:
+        extra_args: --all-files
+    - name: Run tests
+      run: pytest -q
+    if: ${{ false }}

--- a/.github/workflows/codex-self-hosted-ci.yml
+++ b/.github/workflows/codex-self-hosted-ci.yml
@@ -1,32 +1,32 @@
 name: CI
-
 on:
   workflow_dispatch:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   lint-and-test:
-    runs-on: [self-hosted, linux, codex]
+    runs-on:
+    - self-hosted
+    - linux
+    - codex
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      with:
+        python-version: '3.12'
+    - name: Cache pip
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-py-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml',
+          '**/poetry.lock') }}
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
+      with:
+        extra_args: --all-files --show-diff-on-failure
+    - run: 'pip install -e .[dev]
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-        with:
-          python-version: '3.12'
+        pytest
 
-      - name: Cache pip
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-py-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
-
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
-        with:
-          extra_args: --all-files --show-diff-on-failure
-
-      - run: |
-          pip install -e .[dev]
-          pytest
+        '
+    if: ${{ false }}

--- a/.github/workflows/codex-self-manage.yml
+++ b/.github/workflows/codex-self-manage.yml
@@ -1,59 +1,64 @@
 name: codex-self-manage
-
 on:
-  workflow_dispatch: {}
-
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   ci:
-    runs-on: [self-hosted, linux, codex]
+    runs-on:
+    - self-hosted
+    - linux
+    - codex
     permissions:
       contents: read
       security-events: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+    - name: Checkout
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      with:
+        python-version: '3.12'
+    - name: Cache pip
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-py-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml',
+          '**/poetry.lock') }}
+    - name: Install project + tools
+      run: 'python -m pip install -U pip
 
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-        with:
-          python-version: '3.12'
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-      - name: Cache pip
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-py-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
+        pip install -e .
 
-      - name: Install project + tools
-        run: |
-          python -m pip install -U pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install -e .
-          pip install pre-commit pytest coverage pip-audit || true
-          if [ -f pyproject.toml ]; then python -m pip install poetry; fi
-          if [ -f poetry.lock ]; then poetry install --no-interaction --no-ansi; fi
+        pip install pre-commit pytest coverage pip-audit || true
 
-      - name: Run pre-commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
-        with:
-          extra_args: --all-files
+        if [ -f pyproject.toml ]; then python -m pip install poetry; fi
 
-      - name: Tests (with coverage)
-        run: |
-          coverage run -m pytest -q
-          coverage xml
+        if [ -f poetry.lock ]; then poetry install --no-interaction --no-ansi; fi
 
-      - name: Dependency audit (pip-audit)
-        run: |
-          pip-audit -r requirements.txt || true
-          pip-audit || true
+        '
+    - name: Run pre-commit
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
+      with:
+        extra_args: --all-files
+    - name: Tests (with coverage)
+      run: 'coverage run -m pytest -q
 
-      - name: Codex CLI audit (log)
-        run: python tools/codex_cli.py audit
-        env:
-          CODEX_CLI_SKIP_PRECOMMIT: "1"
-          CODEX_CLI_SKIP_TESTS: "1"
+        coverage xml
+
+        '
+    - name: Dependency audit (pip-audit)
+      run: 'pip-audit -r requirements.txt || true
+
+        pip-audit || true
+
+        '
+    - name: Codex CLI audit (log)
+      run: python tools/codex_cli.py audit
+      env:
+        CODEX_CLI_SKIP_PRECOMMIT: '1'
+        CODEX_CLI_SKIP_TESTS: '1'
+    if: ${{ false }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,25 +1,24 @@
 name: Release
-
 on:
   workflow_dispatch:
-
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - uses: docker/setup-buildx-action@v3
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: ghcr.io/${{ github.repository }}:latest
+    if: ${{ false }}

--- a/CHANGELOG_codex.md
+++ b/CHANGELOG_codex.md
@@ -14,3 +14,10 @@
 - Introduced deterministic data splitting utility.
 - Generated `requirements.lock` and local test gate script.
 - Sanitized external links in README for offline use.
+## CI policy docs — 2025-08-26T20:17:49Z
+- Created /workspace/_codex_/docs/ci.md (web search allowed; remote CI disallowed)
+
+## Disable remote CI — 2025-08-26T20:17:49Z
+- Patched 5 workflow file(s) to `workflow_dispatch` and guarded jobs.
+- Total jobs guarded: 7
+

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,17 @@
+# CI Policy (Codex Environment)
+
+- **Web search:** allowed for research/documentation.
+- **Remote CI / GitHub Actions on hosted runners:** **disallowed** by default to avoid cost.
+- All workflows in `.github/workflows/` are configured for manual runs only via `workflow_dispatch`, and **every job** is guarded with:
+  ```yaml
+  if: ${{ false }}
+  ```
+
+This prevents automatic execution on GitHub-hosted runners.
+
+## How to re-enable *manually* (rare)
+
+If you intentionally need to run a workflow, you may replace a job guard with a condition using manual inputs, still via `workflow_dispatch`. See GitHub docs for manual workflows and conditions. (2025-08-26T20:17:49Z)
+
+For extra assurance, repository administrators can disable Actions entirely in **Settings → Actions → Disable Actions**.
+

--- a/tools/disable_remote_ci.py
+++ b/tools/disable_remote_ci.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Disable remote CI costs by:
+- Converting every workflow trigger to `workflow_dispatch`.
+- Guarding every job with `if: ${{ false }}`.
+- Adding docs/ci.md explaining policy: web search allowed; remote CI disallowed.
+Notes:
+- Local lint/tests/coverage should run in the Codex Ubuntu environment only.
+- This does NOT block analysts from using web search.
+"""
+from __future__ import annotations
+import sys, re, json, datetime as dt
+from pathlib import Path
+
+try:
+    import yaml  # PyYAML
+except Exception:
+    print("[WARN] PyYAML not found; attempting minimal regex fallback", file=sys.stderr)
+    yaml = None
+
+ROOT = Path.cwd()
+WF_DIR = ROOT / ".github" / "workflows"
+DOCS = ROOT / "docs"
+CODEX = ROOT / ".codex"
+ERRORS_MD = CODEX / "errors.md"
+ERRORS_ND = CODEX / "errors.ndjson"
+CHANGELOG = ROOT / "CHANGELOG_codex.md"
+
+
+def utcnow():
+    return dt.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def record_error(step, desc, err, ctx=""):
+    CODEX.mkdir(parents=True, exist_ok=True)
+    msg = f"""Question for ChatGPT-5 {utcnow()}:
+While performing [{step}:{desc}], encountered the following error:
+{type(err).__name__}: {err}
+Context: {ctx}
+What are the possible causes, and how can this be resolved while preserving intended functionality?
+"""
+    ERRORS_MD.write_text((ERRORS_MD.read_text() if ERRORS_MD.exists() else "") + "\n\n" + msg, encoding="utf-8")
+    with ERRORS_ND.open("a", encoding="utf-8") as f:
+        json.dump({"ts": utcnow(), "step": step, "desc": desc, "error": f"{type(err).__name__}: {err}", "ctx": ctx}, f)
+        f.write("\n")
+
+
+def append_changelog(title, bullets):
+    body = "".join([f"- {b}\n" for b in bullets])
+    with open(CHANGELOG, "a", encoding="utf-8") as f:
+        f.write(f"## {title} — {utcnow()}\n{body}\n")
+
+
+def hard_guard_jobs(doc: dict) -> int:
+    """Add `if: ${{ false }}` to every job."""
+    jobs = doc.get("jobs", {}) or {}
+    count = 0
+    for name, job in jobs.items():
+        if isinstance(job, dict):
+            if_cond = job.get("if")
+            if str(if_cond).strip() != "${{ false }}":
+                job["if"] = "${{ false }}"
+                count += 1
+    doc["jobs"] = jobs
+    return count
+
+
+def set_manual_trigger(doc: dict) -> bool:
+    """Replace any `on:` with only workflow_dispatch."""
+    changed = False
+    on_val = doc.get("on")
+    target = {"workflow_dispatch": None}
+    if on_val != target:
+        doc["on"] = target
+        changed = True
+    return changed
+
+
+def patch_yaml(path: Path) -> tuple[bool, int]:
+    """Patch a workflow file; return (any_change, jobs_guarded)."""
+    text = path.read_text(encoding="utf-8")
+    if yaml:
+        data = yaml.safe_load(text) or {}
+        if not isinstance(data, dict):
+            data = {}
+        c1 = set_manual_trigger(data)
+        c2 = hard_guard_jobs(data)
+        if c1 or c2:
+            path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+        return (c1 or c2, c2)
+    # Fallback (coarse regex) if PyYAML missing
+    any_change = False
+    # Replace entire on: block with `on:\n  workflow_dispatch:`
+    new = re.sub(r"(?ms)^on:\s*(?:.+?)(?=^\S|\Z)", "on:\n  workflow_dispatch:\n", text)
+    if new != text:
+        any_change = True
+        text = new
+    # For each job under jobs:, inject if line when missing (best-effort)
+    def guard_jobs(txt: str) -> tuple[str, int]:
+        jobs_guarded = 0
+        pattern = re.compile(r"(?m)^(\s{2}[A-Za-z0-9_.-]+:\s*\n(\s{4}.+\n)*)")
+        pos = 0
+        out = ""
+        for m in pattern.finditer(txt):
+            block = m.group(0)
+            if "\n    if:" not in block:
+                block = block.splitlines()
+                indent = "    "
+                block.insert(1, f"{indent}if: ${{ false }}")
+                jobs_guarded += 1
+                block = "\n".join(block) + "\n"
+            out += txt[pos:m.start()] + block
+            pos = m.end()
+        out += txt[pos:]
+        return out, jobs_guarded
+    text, guarded = guard_jobs(text)
+    if any_change or guarded:
+        path.write_text(text, encoding="utf-8")
+    return (any_change or bool(guarded), guarded)
+
+
+def write_ci_doc():
+    DOCS.mkdir(parents=True, exist_ok=True)
+    p = DOCS / "ci.md"
+    content = f"""# CI Policy (Codex Environment)
+
+- **Web search:** allowed for research/documentation.
+- **Remote CI / GitHub Actions on hosted runners:** **disallowed** by default to avoid cost.
+- All workflows in `.github/workflows/` are configured for manual runs only via `workflow_dispatch`, and **every job** is guarded with:
+  ```yaml
+  if: ${{{{ false }}}}
+  ```
+
+This prevents automatic execution on GitHub-hosted runners.
+
+## How to re-enable *manually* (rare)
+
+If you intentionally need to run a workflow, you may replace a job guard with a condition using manual inputs, still via `workflow_dispatch`. See GitHub docs for manual workflows and conditions. ({utcnow()})
+"""
+    p.write_text(content, encoding="utf-8")
+    append_changelog("CI policy docs", [f"Created {p} (web search allowed; remote CI disallowed)"])
+
+
+def main():
+    if not WF_DIR.exists():
+        print("[INFO] No workflows directory; nothing to patch.")
+        write_ci_doc()
+        return
+    changed_files = 0
+    total_jobs_guarded = 0
+    for wf in sorted(WF_DIR.glob("*.y*ml")):
+        try:
+            changed, guarded = patch_yaml(wf)
+            if changed:
+                changed_files += 1
+                total_jobs_guarded += guarded
+        except Exception as e:
+            record_error("STEP_06", "Patch workflow triggers/guards", e, ctx=str(wf))
+    write_ci_doc()
+    append_changelog("Disable remote CI", [
+        f"Patched {changed_files} workflow file(s) to `workflow_dispatch` and guarded jobs.",
+        f"Total jobs guarded: {total_jobs_guarded}",
+    ])
+    print(f"[Summary] Patched files: {changed_files} | Jobs guarded: {total_jobs_guarded}")
+    print(f"[Docs]    Wrote: {DOCS / 'ci.md'}")
+    if ERRORS_MD.exists():
+        print(f"[Errors]  See: {ERRORS_MD} and {ERRORS_ND}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- disable all workflows by switching to `workflow_dispatch` and guarding jobs
- document local-only CI policy and add automation script

## Testing
- `pre-commit run --all-files` *(fails: KeyboardInterrupt)*
- `pytest` *(fails: 8 failed, 151 passed, 7 skipped, 1 xfailed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1639e1b88331bf02b9c101047118