### PR TITLE
Fix semgrep hook initialization by using local command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     hooks:
       - id: bandit
         args: ['--exit-zero', '-x', 'tests', '-s', 'B404,B603,B607,B110,B112,B608']
+        additional_dependencies: [pbr]
 
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
@@ -27,11 +28,13 @@ repos:
         args: ['--baseline', '.secrets.baseline']
         exclude: '.codex/inventory.json'
 
-  - repo: https://github.com/returntocorp/semgrep
-    rev: v1.92.0
+  - repo: local
     hooks:
       - id: semgrep
+        name: semgrep
+        entry: semgrep
         args: [--config, p/ci]
+        language: system
 
 # BEGIN: CODEX_PRECOMMIT
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Summary
- avoid slow semgrep environment setup by running local `semgrep` binary instead of remote hook
- ensure bandit hook installs `pbr` dependency

## Testing
- `pre-commit run --all-files` *(incomplete: environment installation still in progress)*
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68af1c2f7f7083319d01f38c88aee3b3