### PR TITLE
chore: mark semgrep hook as manual

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,13 @@ repos:
         name: semgrep
         entry: semgrep
         args: [--config, p/ci]
-        timeout: 0
         language: system
-        # Allow extra time for initial rule downloads and environment setup
-        # Semgrep can take a while to install on first run which may exceed the
-        # default pre-commit timeout. Disabling the timeout prevents spurious
-        # failures where the hook stops before dependencies are ready.
+        stages: [manual]
+        # Semgrep requires a network-enabled environment for rule downloads.
+        # Marking this hook as `manual` avoids long installation delays during
+        # automated pre-commit runs. Execute explicitly via
+        # `pre-commit run --hook-stage manual semgrep` when semgrep is
+        # available.
 
 
 # BEGIN: CODEX_PRECOMMIT


### PR DESCRIPTION
## Summary
- avoid long semgrep environment setup by marking its pre-commit hook as manual

## Testing
- `pre-commit run --all-files` *(fails: imports not sorted, formatting issues)*
- `pytest` *(fails: 8 failed, 159 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68af27ca8d948331991786863ca25bab