### PR TITLE
Add static code analysis step

### DIFF
--- a/CHANGELOG_codex.md
+++ b/CHANGELOG_codex.md
@@ -1,3 +1,8 @@
+## 2025-11-25 – Static code analysis step
+- Added `static_code_analysis` stage to `analysis/audit_pipeline.py` and integrated it with `ci_local.sh`.
+- Logs syntax-check metrics for Python sources.
+- Introduced a unit test verifying metric emission.
+
 ## 2025-11-24 – Offline upgrade script
 - Added `codex_ast_upgrade.py` to automate tiered parsing setup and offline auditing.
 

--- a/ci_local.sh
+++ b/ci_local.sh
@@ -5,6 +5,9 @@ echo "[codex] running local gates (offline-only)"
 if command -v pre-commit >/dev/null 2>&1; then
   pre-commit run --all-files || true
 fi
+if command -v python >/dev/null 2>&1 && [ -f analysis/audit_pipeline.py ]; then
+  python analysis/audit_pipeline.py --repo . --steps static_code_analysis >/dev/null || true
+fi
 if command -v pytest >/dev/null 2>&1; then
   pytest -q || true
   pytest --cov --cov-fail-under=70 || true

--- a/tests/test_static_code_analysis_step.py
+++ b/tests/test_static_code_analysis_step.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+from analysis.audit_pipeline import step_static_code_analysis
+
+
+def test_static_code_analysis_logs(tmp_path: Path) -> None:
+    metrics = tmp_path / "m.jsonl"
+    repo_root = Path(__file__).resolve().parents[1]
+    step_static_code_analysis(repo_root, metrics)
+    data = metrics.read_text().strip().splitlines()
+    assert data
+    record = json.loads(data[-1])
+    assert record["name"] == "static.analysis.errors"
+    assert isinstance(record["value"], int)
+    assert record["value"] >= 0


### PR DESCRIPTION
## Summary
- add `static_code_analysis` to audit pipeline using `py_compile`
- run static analysis in `ci_local.sh`
- test metric logging and document in changelog

## Testing
- `pre-commit run --files analysis/audit_pipeline.py ci_local.sh tests/test_static_code_analysis_step.py CHANGELOG_codex.md`
- `pre-commit run --all-files` *(fails: imports incorrectly sorted in unrelated files)*
- `pytest` *(fails: multiple existing test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68af2b89f5e883318abe009ca499b39e