### PR TITLE
Add registry and logging utilities

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,12 @@ pythonpath =
     .
     src
 testpaths = tests
+addopts = -q --cov=src/codex_ml --cov-report=term --cov-fail-under=70
+markers =
+    interfaces: tests for interface contracts
+    ml: machine-learning tests
+    data: data handling tests
+    infra: infrastructure tests
+    perf: performance tests
+    regression: regression tests
+    security: security and safety tests

--- a/src/codex_ml/data/loaders.py
+++ b/src/codex_ml/data/loaders.py
@@ -187,6 +187,24 @@ def stream_paths(
             break
 
 
+def split_indices(
+    n: int, *, val_split: float = 0.1, test_split: float = 0.0, seed: int = 0
+) -> tuple[list[int], list[int], list[int]]:
+    """Return deterministic train/val/test indices for *n* samples."""
+    assert 0.0 <= test_split < 1.0 and 0.0 <= val_split < 1.0
+    import random as _rnd
+
+    idx = list(range(n))
+    _rnd.seed(seed)
+    _rnd.shuffle(idx)
+    n_test = int(n * test_split)
+    n_val = int(n * val_split)
+    test_idx = idx[:n_test]
+    val_idx = idx[n_test : n_test + n_val]
+    train_idx = idx[n_test + n_val :]
+    return train_idx, val_idx, test_idx
+
+
 def collect_stats(
     stream: Iterable[PromptCompletion], sample_limit: Optional[int] = None
 ) -> Dict[str, Any]:

--- a/src/codex_ml/interfaces/__init__.py
+++ b/src/codex_ml/interfaces/__init__.py
@@ -1,7 +1,14 @@
 # BEGIN: CODEX_IFACE_INIT
+from .registry import get, register
 from .reward_model import RewardModel
 from .rl import RLAgent
 from .tokenizer import TokenizerAdapter
 
-__all__ = ["TokenizerAdapter", "RewardModel", "RLAgent"]
+__all__ = [
+    "TokenizerAdapter",
+    "RewardModel",
+    "RLAgent",
+    "register",
+    "get",
+]
 # END: CODEX_IFACE_INIT

--- a/src/codex_ml/interfaces/registry.py
+++ b/src/codex_ml/interfaces/registry.py
@@ -1,0 +1,28 @@
+"""Simple registry for pluggable components.
+
+This registry allows registering tokenizers, reward models and RL agents under
+string keys. Interfaces are loaded on demand via entry-points or config.
+"""
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, Callable, Dict
+
+_REGISTRY: Dict[str, Callable[..., Any]] = {}
+
+
+def register(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    def deco(fn: Callable[..., Any]) -> Callable[..., Any]:
+        _REGISTRY[name] = fn
+        return fn
+
+    return deco
+
+
+def get(name: str, *, fallback: str | None = None) -> Any:
+    if name in _REGISTRY:
+        return _REGISTRY[name]
+    if fallback:
+        module, attr = fallback.split(":")
+        return getattr(import_module(module), attr)
+    raise KeyError(f"No registered component named {name}")

--- a/src/codex_ml/train_loop.py
+++ b/src/codex_ml/train_loop.py
@@ -42,17 +42,22 @@ def record_metrics(
         "config_hash": cfg_hash,
         "notes": notes,
     }
-    out = ART_DIR / "metrics.json"
+    # write list for back-compat
+    out_list = ART_DIR / "metrics.json"
     prev: List[Dict[str, Any]] = []
-    if out.exists():
+    if out_list.exists():
         try:
-            prev = json.loads(out.read_text(encoding="utf-8"))
+            prev = json.loads(out_list.read_text(encoding="utf-8"))
             if not isinstance(prev, list):
                 prev = []
         except Exception:
             prev = []
     prev.append(payload)
-    out.write_text(json.dumps(prev, indent=2), encoding="utf-8")
+    out_list.write_text(json.dumps(prev, indent=2), encoding="utf-8")
+    # append NDJSON for streaming analytics
+    out_ndjson = ART_DIR / "metrics.ndjson"
+    with out_ndjson.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload) + "\n")
 
 
 def demo_epoch(epoch: int) -> Dict[str, float]:

--- a/tests/test_ndjson_logging.py
+++ b/tests/test_ndjson_logging.py
@@ -1,0 +1,12 @@
+from codex_ml import train_loop
+
+
+def test_record_metrics_ndjson(tmp_path, monkeypatch):
+    monkeypatch.setattr(train_loop, "ART_DIR", tmp_path)
+    train_loop.record_metrics("p", 0, {"a": 1}, "cfg")
+    train_loop.record_metrics("p", 1, {"a": 2}, "cfg")
+    lines = (tmp_path / "metrics.ndjson").read_text().strip().splitlines()
+    assert len(lines) == 2
+    data = [__import__("json").loads(line) for line in lines]
+    assert data[0]["epoch"] == 0
+    assert data[1]["epoch"] == 1

--- a/tests/test_peft_integration.py
+++ b/tests/test_peft_integration.py
@@ -1,0 +1,12 @@
+import pytest
+
+from codex_ml.models import MiniLM, MiniLMConfig
+from codex_ml.peft.peft_adapter import apply_lora
+
+peft = pytest.importorskip("peft")
+
+
+def test_peft_apply_lora():
+    model = MiniLM(MiniLMConfig(vocab_size=10))
+    adapted = apply_lora(model, {"r": 2})
+    assert hasattr(adapted, "peft_config")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,9 @@
+from codex_ml.interfaces import get, register
+
+
+def test_registry_register_get():
+    @register("dummy")
+    class Dummy:
+        pass
+
+    assert get("dummy") is Dummy

--- a/tests/test_split_indices.py
+++ b/tests/test_split_indices.py
@@ -1,0 +1,12 @@
+from codex_ml.data.loaders import split_indices
+
+
+def test_split_indices_deterministic():
+    t1 = split_indices(100, val_split=0.2, test_split=0.1, seed=42)
+    t2 = split_indices(100, val_split=0.2, test_split=0.1, seed=42)
+    assert t1 == t2
+    train, val, test = t1
+    assert len(train) + len(val) + len(test) == 100
+    assert set(train).isdisjoint(val)
+    assert set(train).isdisjoint(test)
+    assert set(val).isdisjoint(test)


### PR DESCRIPTION
## Summary
- write metrics in both JSON list and NDJSON formats
- expose LoRA hyper-parameters and registry for pluggable components
- add deterministic data split helper and related tests

## Testing
- `pre-commit run --all-files` *(fails: missing bandit and semgrep)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afc4d873fc8331a042d413829ee549