### PR TITLE
fix: guard CUDA seeding on CPU-only machines

### DIFF
--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -82,7 +82,8 @@ def _seed_everything(seed: int = 42):
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
     torch.backends.cudnn.benchmark = False
     torch.use_deterministic_algorithms(True)
 


### PR DESCRIPTION
## Summary

-

## Testing

- [ ] `pre-commit run --all-files`
- [ ] `pytest -q`

## Risks

-

## Rollback

-
