### PR TITLE
feat: add ephemeral runner toolkit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,6 +111,13 @@ repos:
         entry: |
           bash -lc 'mdformat --check $(git ls-files "*.md" | grep -v "^\.codex/")'
 
+      - id: label-policy-lint
+        name: Label policy lint (.github/workflows)
+        language: system
+        pass_filenames: false
+        entry: |
+          bash -lc 'python3 tools/label_policy_lint.py'
+
       # ===== Secrets (baseline required) =====
       - id: detect-secrets
         name: Detect secrets (baseline required)

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ codex-ml-cli --help
 ```
 
 ### Tokenization
+
 We use HF fast tokenizers with explicit `padding`/`truncation`/`max_length` to ensure batchable tensors.
 Example:
+
 ```python
 from interfaces.tokenizer import HFTokenizer
 tk = HFTokenizer("distilbert-base-uncased", padding="max_length", truncation=True, max_length=128)
@@ -567,6 +569,7 @@ This repository enforces **offline-only** validation in the Codex environment.
 - Use `./ci_local.sh` for local gates (lint, tests, coverage).
 
 ## Quickstart
+
 ```bash
 pip install -e .[dev]
 pre-commit install
@@ -576,3 +579,8 @@ codex-train
 # enable local MLflow
 export MLFLOW_TRACKING_URI="file:./mlruns"
 ```
+
+## Single-Job (Ephemeral) Self-Hosted Runners
+
+See `docs/ephemeral-runners.md` for the toolkit, label policy, pre-flight, and CLI.
+Tools operate externally and do not modify GitHub Actions workflows.

--- a/docs/ephemeral-runners.md
+++ b/docs/ephemeral-runners.md
@@ -1,0 +1,61 @@
+# Ephemeral (Single-Job) Self-Hosted Runners — Codex Toolkit
+
+This repository includes a toolkit so ChatGPT Codex can launch a self-hosted runner that processes **one** job and then automatically de-registers.
+
+## Secrets
+
+Provide a GitHub PAT via one of these secrets (highest priority first):
+
+1. Environment secret `CODEX_ENVIRONMENT_RUNNER` in environment `Aries_Serpent_codex_`
+1. Repository secret `_CODEX_BOT_RUNNER`
+1. Organization secret `_CODEX_ACTION_RUNNER`
+
+Expose the chosen value to the shell as `GH_PAT`:
+
+```bash
+export GH_PAT="${CODEX_ENVIRONMENT_RUNNER:-${_CODEX_BOT_RUNNER:-${_CODEX_ACTION_RUNNER:-}}}"
+```
+
+## Label policy
+
+`tools/label_policy.json` defines allowed labels and required base labels. Lint workflows locally:
+
+```bash
+pre-commit run label-policy-lint -a
+```
+
+## Pre-flight minimal labels
+
+Compute a minimal label set for queued jobs on branch `0B_base_`:
+
+```bash
+GH_PAT=... python3 tools/preflight_minimal_labels.py --branch 0B_base_
+```
+
+If no queued jobs are found, the script falls back to `linux,x64,codex`.
+
+## One-shot runner CLI
+
+Launch an ephemeral runner, either with auto labels or explicit labels:
+
+```bash
+# Auto labels from queued jobs
+GH_PAT=... tools/ephem_runner.sh --auto-labels --branch 0B_base_
+
+# Explicit labels
+GH_PAT=... tools/ephem_runner.sh --labels linux,x64,codex
+```
+
+### Flags
+
+- `--owner`, `--repo`, `--branch` – override defaults `Aries-Serpent`, `_codex_`, `0B_base_`
+- `--labels` – comma-separated labels
+- `--auto-labels` – derive labels from queued jobs
+- `--runner-version` – pin runner version (default `2.328.0`)
+- `--work-dir` – working directory (default `_work`)
+- `--name-prefix` – runner name prefix (default `codex-ephem`)
+- `--no-disable-update` – allow self-update
+
+## Notes
+
+No GitHub Actions workflow files are modified. Runners register with `--ephemeral`, process one job, and disappear.

--- a/tests/test_label_policy_lint.py
+++ b/tests/test_label_policy_lint.py
@@ -1,0 +1,80 @@
+import json
+import pathlib
+import subprocess
+import sys
+
+SAMPLE_OK = """
+name: ok
+on: [push]
+jobs:
+  build:
+    runs-on: [self-hosted, linux, x64, codex]
+    steps: []
+"""
+
+SAMPLE_BAD = """
+name: bad
+on: [push]
+jobs:
+  test:
+    runs-on: [self-hosted, linux, x64, nosuchlabel]
+    steps: []
+"""
+
+
+def _write(path: pathlib.Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def test_lint_ok(tmp_path: pathlib.Path) -> None:
+    wf = tmp_path / ".github/workflows"
+    wf.mkdir(parents=True)
+    _write(wf / "ok.yml", SAMPLE_OK)
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools/label_policy.json").write_text(
+        json.dumps(
+            {
+                "allowed_labels": ["self-hosted", "linux", "x64", "codex"],
+                "required_base": ["self-hosted", "linux", "x64"],
+                "defaults_for_string_runs_on": ["linux", "x64", "codex"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "tools/label_policy_lint.py").write_text(
+        pathlib.Path("tools/label_policy_lint.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, str(tmp_path / "tools/label_policy_lint.py")],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0
+
+
+def test_lint_bad(tmp_path: pathlib.Path) -> None:
+    wf = tmp_path / ".github/workflows"
+    wf.mkdir(parents=True)
+    _write(wf / "bad.yml", SAMPLE_BAD)
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools/label_policy.json").write_text(
+        json.dumps(
+            {
+                "allowed_labels": ["self-hosted", "linux", "x64", "codex"],
+                "required_base": ["self-hosted", "linux", "x64"],
+                "defaults_for_string_runs_on": ["linux", "x64", "codex"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "tools/label_policy_lint.py").write_text(
+        pathlib.Path("tools/label_policy_lint.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, str(tmp_path / "tools/label_policy_lint.py")],
+        cwd=tmp_path,
+        capture_output=True,
+    )
+    assert result.returncode != 0
+    assert b"disallowed labels" in result.stderr

--- a/tools/ephem_runner.sh
+++ b/tools/ephem_runner.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Ephemeral (single-job) GitHub Actions runner bring-up for Aries-Serpent/_codex_.
+# No workflow edits. Requires GH_PAT and minimal label set.
+#
+# Usage (auto labels from queued jobs):
+#   GH_PAT=... tools/ephem_runner.sh --auto-labels --branch 0B_base_
+#
+# Or provide labels explicitly:
+#   GH_PAT=... tools/ephem_runner.sh --labels linux,x64,codex
+#
+# Required: GH_PAT in env (repo/org admin for registration token).
+
+OWNER="${OWNER:-Aries-Serpent}"
+REPO="${REPO:-_codex_}"
+BRANCH="${BRANCH:-0B_base_}"
+RUNNER_VERSION="${RUNNER_VERSION:-2.328.0}"
+RUNNER_PKG="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+RUNNER_SHA256="${RUNNER_SHA256:-01066fad3a2893e63e6ca880ae3a1fad5bf9329d60e77ee15f2b97c148c3cd4e}"
+RUNNER_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_PKG}"
+WORK_DIR="${WORK_DIR:-_work}"
+DISABLE_UPDATE="${DISABLE_UPDATE:-1}"
+NAME_PREFIX="${NAME_PREFIX:-codex-ephem}"
+LABELS="${LABELS:-}"
+AUTO_LABELS=0
+
+# Print error and exit
+_die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+# Ensure dependency exists
+_need() {
+  command -v "$1" >/dev/null 2>&1 || _die "Missing dependency: $1"
+}
+
+# Parse flags
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --owner)
+      OWNER="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --branch)
+      BRANCH="$2"
+      shift 2
+      ;;
+    --labels)
+      LABELS="$2"
+      shift 2
+      ;;
+    --auto-labels)
+      AUTO_LABELS=1
+      shift
+      ;;
+    --runner-version)
+      RUNNER_VERSION="$2"
+      RUNNER_PKG="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+      RUNNER_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_PKG}"
+      shift 2
+      ;;
+    --work-dir)
+      WORK_DIR="$2"
+      shift 2
+      ;;
+    --name-prefix)
+      NAME_PREFIX="$2"
+      shift 2
+      ;;
+    --no-disable-update)
+      DISABLE_UPDATE=0
+      shift
+      ;;
+    -h|--help)
+      sed -n '1,120p' "$0"
+      exit 0
+      ;;
+    *)
+      _die "Unknown arg: $1"
+      ;;
+  esac
+done
+
+[[ -n "${GH_PAT:-}" ]] || _die "GH_PAT not set. Export from secrets before running."
+
+_need curl
+_need tar
+_need shasum
+
+if [[ ${AUTO_LABELS} -eq 1 ]]; then
+  _need python3
+  LABELS="$(python3 tools/preflight_minimal_labels.py \
+    --owner "$OWNER" --repo "$REPO" --branch "$BRANCH" \
+    --gh-pat "$GH_PAT")" || _die "preflight label computation failed"
+  [[ -n "$LABELS" ]] || _die "preflight returned empty labels"
+fi
+
+REPO_URL="https://github.com/${OWNER}/${REPO}"
+mkdir -p actions-runner
+cd actions-runner
+
+REG_TOKEN_JSON="$(curl -fsSL -X POST \
+  -H "Authorization: Bearer ${GH_PAT}" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/${OWNER}/${REPO}/actions/runners/registration-token")"
+
+if command -v jq >/dev/null 2>&1; then
+  REG_TOKEN="$(printf '%s' "$REG_TOKEN_JSON" | jq -r '.token')"
+else
+  REG_TOKEN="$(python3 - <<'PY'
+import json,sys
+print(json.load(sys.stdin)['token'])
+PY
+)"
+fi
+
+[[ -n "$REG_TOKEN" && "$REG_TOKEN" != "null" ]] || _die "Failed to fetch registration token"
+
+curl -fsSL -o "$RUNNER_PKG" "$RUNNER_URL"
+echo "${RUNNER_SHA256}  ${RUNNER_PKG}" | shasum -a 256 -c
+
+tar xzf "$RUNNER_PKG"
+
+./config.sh --check --url "$REPO_URL" || true
+
+NAME="${NAME_PREFIX}-$(hostname)-$RANDOM"
+CONFIG_ARGS=(--url "$REPO_URL" --token "$REG_TOKEN" --name "$NAME" --work "$WORK_DIR" --unattended --ephemeral)
+[[ -n "$LABELS" ]] && CONFIG_ARGS+=(--labels "$LABELS")
+[[ $DISABLE_UPDATE -eq 1 ]] && CONFIG_ARGS+=(--disableupdate)
+
+./config.sh "${CONFIG_ARGS[@]}"
+
+exec ./run.sh

--- a/tools/label_policy.json
+++ b/tools/label_policy.json
@@ -1,0 +1,13 @@
+{
+  "allowed_labels": [
+    "self-hosted",
+    "linux",
+    "x64",
+    "codex",
+    "gpu",
+    "cuda12",
+    "cpu"
+  ],
+  "required_base": ["self-hosted", "linux", "x64"],
+  "defaults_for_string_runs_on": ["linux", "x64", "codex"]
+}

--- a/tools/label_policy_lint.py
+++ b/tools/label_policy_lint.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Validate that workflow files use allowed self-hosted runner labels."""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+from typing import List
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - dependency check
+    print("Install pyyaml to run label policy lint.", file=sys.stderr)
+    sys.exit(2)
+
+POLICY_PATH = pathlib.Path("tools/label_policy.json")
+WF_DIR = pathlib.Path(".github/workflows")
+
+
+def as_list(value: object) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    return []
+
+
+def load_policy() -> tuple[set[str], set[str], set[str]]:
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    allowed = set(policy["allowed_labels"])
+    required = set(policy.get("required_base", []))
+    defaults = set(policy.get("defaults_for_string_runs_on", []))
+    return allowed, required, defaults
+
+
+def lint_file(
+    path: pathlib.Path, allowed: set[str], required: set[str], defaults: set[str]
+) -> List[str]:
+    errors: List[str] = []
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    jobs = (data or {}).get("jobs", {})
+    for job_name, job in (jobs or {}).items():
+        runs_on = job.get("runs-on")
+        if runs_on is None:
+            continue
+        labels = as_list(runs_on)
+        if "self-hosted" in labels:
+            if labels == ["self-hosted"]:
+                labels = ["self-hosted", *defaults]
+            extra_labels = [label for label in labels if label not in allowed]
+            missing_base = [label for label in required if label not in labels]
+            if extra_labels:
+                errors.append(f"{path}:{job_name}: disallowed labels: {extra_labels}")
+            if missing_base:
+                errors.append(f"{path}:{job_name}: missing required base labels: {missing_base}")
+    return errors
+
+
+def main() -> int:
+    if not WF_DIR.exists():
+        print("No .github/workflows directory; nothing to lint.")
+        return 0
+    allowed, required, defaults = load_policy()
+    problems: List[str] = []
+    for file in sorted(WF_DIR.glob("*.y*ml")):
+        problems.extend(lint_file(file, allowed, required, defaults))
+    if problems:
+        print("Label policy violations:\n- " + "\n- ".join(problems), file=sys.stderr)
+        return 1
+    print("Label policy: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/preflight_minimal_labels.py
+++ b/tools/preflight_minimal_labels.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Derive minimal labels for queued self-hosted jobs on a branch."""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - dependency check
+    print("Install pyyaml to run preflight.", file=sys.stderr)
+    sys.exit(2)
+
+API = "https://api.github.com"
+POLICY_PATH = "tools/label_policy.json"
+
+
+def _request(url: str, token: str, method: str = "GET") -> Dict[str, Any]:
+    req = urllib.request.Request(
+        url,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "codex-preflight",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def list_queued_runs(owner: str, repo: str, branch: str, token: str) -> List[Dict[str, Any]]:
+    qs = urllib.parse.urlencode({"status": "queued", "branch": branch, "per_page": 100})
+    url = f"{API}/repos/{owner}/{repo}/actions/runs?{qs}"
+    data = _request(url, token)
+    return data.get("workflow_runs", [])
+
+
+def get_workflow(owner: str, repo: str, workflow_id: int, token: str) -> Dict[str, Any]:
+    url = f"{API}/repos/{owner}/{repo}/actions/workflows/{workflow_id}"
+    return _request(url, token)
+
+
+def get_file_at_sha(owner: str, repo: str, path: str, ref: str, token: str) -> str:
+    qs = urllib.parse.urlencode({"ref": ref})
+    url = f"{API}/repos/{owner}/{repo}/contents/{urllib.parse.quote(path)}?{qs}"
+    obj = _request(url, token)
+    if obj.get("encoding") == "base64":
+        return base64.b64decode(obj["content"]).decode("utf-8")
+    return obj.get("content", "")
+
+
+def minimal_labels_from_yaml(
+    yaml_text: str,
+    allowed: set[str],
+    required_base: set[str],
+    defaults_for_string: List[str],
+) -> Optional[List[str]]:
+    doc = yaml.safe_load(yaml_text) or {}
+    jobs = doc.get("jobs", {})
+    for job in (jobs or {}).values():
+        runs_on = job.get("runs-on")
+        if runs_on is None:
+            continue
+        labels = [runs_on] if isinstance(runs_on, str) else list(runs_on)
+        if "self-hosted" in labels:
+            if labels == ["self-hosted"]:
+                labels = ["self-hosted", *defaults_for_string]
+            label_set = set(labels)
+            if not required_base.issubset(label_set):
+                label_set |= required_base
+            if not label_set.issubset(allowed):
+                label_set = (label_set & allowed) | required_base
+                label_set.add("self-hosted")
+            return [label for label in label_set if label != "self-hosted"]
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--owner", default=os.environ.get("OWNER", "Aries-Serpent"))
+    parser.add_argument("--repo", default=os.environ.get("REPO", "_codex_"))
+    parser.add_argument("--branch", default=os.environ.get("BRANCH", "0B_base_"))
+    parser.add_argument("--gh-pat", default=os.environ.get("GH_PAT"))
+    args = parser.parse_args()
+
+    if not args.gh_pat:
+        print("GH_PAT required", file=sys.stderr)
+        return 2
+
+    policy = json.loads(open(POLICY_PATH, "r", encoding="utf-8").read())
+    allowed = set(policy["allowed_labels"])
+    required_base = set(policy.get("required_base", []))
+    defaults = policy.get("defaults_for_string_runs_on", [])
+
+    runs = list_queued_runs(args.owner, args.repo, args.branch, args.gh_pat)
+    if not runs:
+        fallback = [label for label in (*required_base, "codex") if label != "self-hosted"]
+        print(",".join(sorted(fallback)))
+        return 0
+    run = sorted(runs, key=lambda r: r.get("created_at", ""))[0]
+    wf_id = run.get("workflow_id")
+    sha = run.get("head_sha")
+    if not wf_id or not sha:
+        fallback = [label for label in (*required_base, "codex") if label != "self-hosted"]
+        print(",".join(sorted(fallback)))
+        return 0
+    workflow = get_workflow(args.owner, args.repo, wf_id, args.gh_pat)
+    path = workflow.get("path")
+    if not path:
+        fallback = [label for label in (*required_base, "codex") if label != "self-hosted"]
+        print(",".join(sorted(fallback)))
+        return 0
+    yml = get_file_at_sha(args.owner, args.repo, path, sha, args.gh_pat)
+    labels = minimal_labels_from_yaml(yml, allowed, required_base, defaults)
+    if labels:
+        print(",".join(sorted(set(labels))))
+        return 0
+    fallback = [label for label in (*required_base, "codex") if label != "self-hosted"]
+    print(",".join(sorted(set(fallback))))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `tools/ephem_runner.sh` to provision single-job self-hosted runners for Aries-Serpent/_codex_
- introduce label policy with linter and preflight label inspector
- document ephemeral runner workflow and wire pre-commit hook

## Testing
- `pre-commit run --all-files` *(fails: mdformat: various repository markdown files not formatted)*
- `pytest` *(fails: tests/test_engine_hf_trainer.py::test_hf_trainer_smoke - TrainingArguments.__init__() got an unexpected keyword argument 'label_smoothing_factor')*


------
https://chatgpt.com/codex/tasks/task_e_68b057fb6d5c8331876024555839c363