### PR TITLE
fix: allow autoscaler to spawn concurrent runners

### DIFF
--- a/tools/ephem_autoscaler.sh
+++ b/tools/ephem_autoscaler.sh
@@ -58,8 +58,13 @@ PY
 
 spawn_one(){
   local labels="$1"
-  echo "[autoscaler] Spawning ephemeral runner with labels: $labels"
-  GH_PAT="$GH_PAT" bash tools/ephem_runner.sh --labels "$labels" --branch "$BRANCH" &
+  local id="$(date +%s)-$RANDOM"
+  local runner_dir="actions-runner-${id}"
+  local work_dir="_work-${id}"
+  local name_prefix="codex-ephem-${id}"
+  echo "[autoscaler] Spawning ephemeral runner with labels: $labels (dir: $runner_dir)"
+  GH_PAT="$GH_PAT" bash tools/ephem_runner.sh --labels "$labels" --branch "$BRANCH" \
+    --runner-dir "$runner_dir" --work-dir "$work_dir" --name-prefix "$name_prefix" &
   active_pids+=("$!")
 }
 

--- a/tools/ephem_runner.sh
+++ b/tools/ephem_runner.sh
@@ -18,6 +18,7 @@ RUNNER_VERSION="${RUNNER_VERSION:-2.328.0}"
 RUNNER_PKG="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
 RUNNER_SHA256="${RUNNER_SHA256:-01066fad3a2893e63e6ca880ae3a1fad5bf9329d60e77ee15f2b97c148c3cd4e}"
 RUNNER_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_PKG}"
+RUNNER_DIR="${RUNNER_DIR:-actions-runner}"
 WORK_DIR="${WORK_DIR:-_work}"
 DISABLE_UPDATE="${DISABLE_UPDATE:-1}"
 NAME_PREFIX="${NAME_PREFIX:-codex-ephem}"
@@ -64,6 +65,10 @@ while [[ $# -gt 0 ]]; do
       RUNNER_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_PKG}"
       shift 2
       ;;
+    --runner-dir)
+      RUNNER_DIR="$2"
+      shift 2
+      ;;
     --work-dir)
       WORK_DIR="$2"
       shift 2
@@ -101,8 +106,8 @@ if [[ ${AUTO_LABELS} -eq 1 ]]; then
 fi
 
 REPO_URL="https://github.com/${OWNER}/${REPO}"
-mkdir -p actions-runner
-cd actions-runner
+mkdir -p "$RUNNER_DIR"
+cd "$RUNNER_DIR"
 
 REG_TOKEN_JSON="$(curl -fsSL -X POST \
   -H "Authorization: Bearer ${GH_PAT}" \


### PR DESCRIPTION
This pull request introduces a toolkit for managing single-job (ephemeral) self-hosted GitHub Actions runners, along with a label policy enforcement mechanism and supporting documentation. The main changes include new scripts for provisioning and autoscaling ephemeral runners, label policy linting, updates to pre-commit hooks, and expanded documentation for these features.

**Ephemeral runner toolkit and automation:**

* Added `tools/ephem_runner.sh` and `tools/ephem_autoscaler.sh` scripts to provision and autoscale ephemeral (single-job) self-hosted runners, including support for label derivation, autoscaling based on queue length, and secure runner registration. [[1]](diffhunk://#diff-c7b0abbcd7f6d0d715e9bb45ba6dce763dfd0648a9bbf877922f32df776f704eR1-R147) [[2]](diffhunk://#diff-a6592f100e95d36db84091e6c877a99f37202cbeee2e7b3ff4f76877a38018c9R1-R98)
* Introduced `docs/ephemeral-runners.md` with detailed instructions and usage examples for the ephemeral runner toolkit, label policy, and pre-flight tools.

**Label policy enforcement:**

* Added `tools/label_policy.json` to define allowed and required runner labels, and `tools/label_policy_lint.py` to lint workflow files for label compliance; integrated the linter as a pre-commit hook. [[1]](diffhunk://#diff-e3806e7994d1e40d0aa42a3d69ac3cb60a8766a328afe04a4c5cdcb5f71f4568R1-R17) [[2]](diffhunk://#diff-a324e972d80480e06977c438a84b18591773b4f623882043691c5f1dfeeb8fbdR1-R77) [[3]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R6-R44) [[4]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L102-R150)
* Added tests for label policy linting and runner doctor utilities. [[1]](diffhunk://#diff-b3fe2c529ae1148e259bc651607d7533c0d6ff4736a0c75faffb23c77cab4906R1-R80) [[2]](diffhunk://#diff-52d1ea3afc4011ceb3577c01d4af5436a1fcb8befb256d28e595acd47b247a8dR1-R18)

**Documentation and configuration updates:**

* Updated `README.md` to document the ephemeral runner toolkit, clarify HuggingFace `transformers` requirements, and improve environment variable and quickstart sections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R40) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L155-R160) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R575) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R585-R589)
* Updated development requirements (`requirements-dev.txt`) to specify minimum versions for `pytest` and `pytest-cov`.