### PR TITLE
feat: add ephemeral runner toolkit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,45 @@ minimum_pre_commit_version: "3.7.0"
 default_install_hook_types: [pre-commit, pre-push]
 
 repos:
+  - repo: https://github.com/hukkin/mdformat
+    rev: 0.7.22
+    hooks:
+      - id: mdformat
+        name: mdformat (auto-fix)
+        additional_dependencies:
+          - mdformat-gfm
+        files: |
+          (?x)^
+          (
+            README\.md|
+            docs/.*\.md
+          )$
+        exclude: |
+          (?x)^
+          (
+            codex_digest/.*|
+            CHANGELOG.*\.md|
+            _codex_status_update-.*\.md
+          )$
+      - id: mdformat
+        name: mdformat (check)
+        args: [--check]
+        additional_dependencies:
+          - mdformat-gfm
+        files: |
+          (?x)^
+          (
+            README\.md|
+            docs/.*\.md
+          )$
+        exclude: |
+          (?x)^
+          (
+            codex_digest/.*|
+            CHANGELOG.*\.md|
+            _codex_status_update-.*\.md
+          )$
+        stages: [manual]
   - repo: local
     hooks:
       # ===== Safety rails =====
@@ -99,17 +138,16 @@ repos:
       - id: yamllint
         name: YAML lint
         language: system
-        types_or: [yaml]
         pass_filenames: false
         entry: |
-          bash -lc 'yamllint -s .'
+          bash -lc 'yamllint -d "{extends: default, rules: {document-start: disable, line-length: disable}}" $(git ls-files "*.yml" "*.yaml" | grep -v "^archive/")'
 
-      - id: mdformat
-        name: mdformat (Markdown format check)
+      - id: label-policy-lint
+        name: Label policy lint (.github/workflows)
         language: system
         pass_filenames: false
         entry: |
-          bash -lc 'mdformat --check $(git ls-files "*.md" | grep -v "^\.codex/")'
+          bash -lc 'python3 tools/label_policy_lint.py'
 
       # ===== Secrets (baseline required) =====
       - id: detect-secrets

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint test build type setup venv env-info
+.PHONY: format lint test build type setup venv env-info codex-gates
 
 format:
 	pre-commit run --all-files
@@ -25,3 +25,7 @@ env-info:
 	python scripts/env/print_env_info.py
 
 include codex.mk
+
+## Run local gates with the exact same entrypoint humans and bots use
+codex-gates:
+	@bash ./ci_local.sh

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ pip install .
 python -c "import codex; import codex.logging"
 ```
 
+This project requires `transformers>=4.3.3` for HuggingFace Trainer support;
+later versions such as `4.38` or `4.55` are also compatible.
+
 After installation, the main CLI can be invoked as:
 
 ```bash
@@ -31,8 +34,10 @@ codex-ml-cli --help
 ```
 
 ### Tokenization
+
 We use HF fast tokenizers with explicit `padding`/`truncation`/`max_length` to ensure batchable tensors.
 Example:
+
 ```python
 from interfaces.tokenizer import HFTokenizer
 tk = HFTokenizer("distilbert-base-uncased", padding="max_length", truncation=True, max_length=128)
@@ -139,22 +144,22 @@ docker run --rm -it \
 
 The following environment variables can be set to configure runtime installation. Note that a limited subset of versions are supported (indicated in the table below):
 
-| Environment variable | Description | Supported versions | Additional packages |
+| Environment variable       | Description                | Supported versions                               | Additional packages                                                  |
 | -------------------------- | -------------------------- | ------------------------------------------------ | -------------------------------------------------------------------- |
-| `CODEX_ENV_PYTHON_VERSION` | Python version to install | `3.10`, `3.11.12`, `3.12`, `3.13` | `pyenv`, `poetry`, `uv`, `ruff`, `black`, `mypy`, `pyright`, `isort` |
-| `CODEX_ENV_NODE_VERSION` | Node.js version to install | `18`, `20`, `22` | `corepack`, `yarn`, `pnpm`, `npm` |
-| `CODEX_ENV_RUST_VERSION` | Rust version to install | `1.83.0`, `1.84.1`, `1.85.1`, `1.86.0`, `1.87.0` | |
-| `CODEX_ENV_GO_VERSION` | Go version to install | `1.22.12`, `1.23.8`, `1.24.3` | |
-| `CODEX_ENV_SWIFT_VERSION` | Swift version to install | `5.10`, `6.1` | |
+| `CODEX_ENV_PYTHON_VERSION` | Python version to install  | `3.10`, `3.11.12`, `3.12`, `3.13`                | `pyenv`, `poetry`, `uv`, `ruff`, `black`, `mypy`, `pyright`, `isort` |
+| `CODEX_ENV_NODE_VERSION`   | Node.js version to install | `18`, `20`, `22`                                 | `corepack`, `yarn`, `pnpm`, `npm`                                    |
+| `CODEX_ENV_RUST_VERSION`   | Rust version to install    | `1.83.0`, `1.84.1`, `1.85.1`, `1.86.0`, `1.87.0` |                                                                      |
+| `CODEX_ENV_GO_VERSION`     | Go version to install      | `1.22.12`, `1.23.8`, `1.24.3`                    |                                                                      |
+| `CODEX_ENV_SWIFT_VERSION`  | Swift version to install   | `5.10`, `6.1`                                    |                                                                      |
 
 ### Custom user setup
 
 If a shell script exists at `.codex/user_setup.sh`, it runs once after the environment is initialized. Override the location with `CODEX_USER_SETUP_PATH`. The sentinel `.codex/.user_setup.done` prevents reruns unless `CODEX_USER_SETUP_FORCE=1` is set. Output is written to `.codex/setup_logs/<timestamp>.log`.
 
-| Environment variable | Description |
-| -------------------- | ----------- |
-| `CODEX_USER_SETUP_PATH` | Path to the user setup script. Defaults to `.codex/user_setup.sh`. |
-| `CODEX_USER_SETUP_FORCE` | Run the user setup even if `.codex/.user_setup.done` exists. |
+| Environment variable     | Description                                                        |
+| ------------------------ | ------------------------------------------------------------------ |
+| `CODEX_USER_SETUP_PATH`  | Path to the user setup script. Defaults to `.codex/user_setup.sh`. |
+| `CODEX_USER_SETUP_FORCE` | Run the user setup even if `.codex/.user_setup.done` exists.       |
 
 ## Training & Monitoring
 
@@ -567,6 +572,7 @@ This repository enforces **offline-only** validation in the Codex environment.
 - Use `./ci_local.sh` for local gates (lint, tests, coverage).
 
 ## Quickstart
+
 ```bash
 pip install -e .[dev]
 pre-commit install
@@ -576,3 +582,8 @@ codex-train
 # enable local MLflow
 export MLFLOW_TRACKING_URI="file:./mlruns"
 ```
+
+## Single-Job (Ephemeral) Self-Hosted Runners
+
+See `docs/ephemeral-runners.md` for the toolkit, label policy, pre-flight, and CLI.
+Tools operate externally and do not modify GitHub Actions workflows.

--- a/ci_local.sh
+++ b/ci_local.sh
@@ -1,15 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
-echo "[codex] running local gates (offline-only)"
-if command -v pre-commit >/dev/null 2>&1; then
-  pre-commit run --all-files || true
-fi
-if command -v python >/dev/null 2>&1 && [ -f analysis/audit_pipeline.py ]; then
-  python analysis/audit_pipeline.py --repo . --steps static_code_analysis >/dev/null || true
-fi
-if command -v pytest >/dev/null 2>&1; then
-  pytest -q || true
-  pytest --cov --cov-fail-under=70 || true
-fi
-echo "[codex] done"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$HERE/tools/bootstrap_dev_env.sh"
+source "$HERE/.venv/bin/activate"
+.venv/bin/pre-commit run --all-files
+.venv/bin/pytest

--- a/docs/ephemeral-runners.md
+++ b/docs/ephemeral-runners.md
@@ -1,0 +1,103 @@
+# Ephemeral (Single-Job) Self-Hosted Runners — Codex Toolkit
+
+This repository includes a toolkit so ChatGPT Codex can launch a self-hosted runner that processes **one** job and then automatically de-registers.
+
+## Secrets
+
+Provide a GitHub PAT via one of these secrets (highest priority first):
+
+1. Environment secret `CODEX_ENVIRONMENT_RUNNER` in environment `Aries_Serpent_codex_`
+1. Repository secret `_CODEX_BOT_RUNNER`
+1. Organization secret `_CODEX_ACTION_RUNNER`
+
+Expose the chosen value to the shell as `GH_PAT`:
+
+```bash
+export GH_PAT="${CODEX_ENVIRONMENT_RUNNER:-${_CODEX_BOT_RUNNER:-${_CODEX_ACTION_RUNNER:-}}}"
+```
+
+## Label policy
+
+`tools/label_policy.json` defines allowed labels and required base labels. Lint workflows locally:
+
+```bash
+pre-commit run label-policy-lint -a
+```
+
+## Pre-flight minimal labels
+
+Compute a minimal label set for queued jobs on branch `0B_base_`:
+
+```bash
+GH_PAT=... python3 tools/preflight_minimal_labels.py --branch 0B_base_
+```
+
+If no queued jobs are found, the script falls back to `linux,x64,codex`.
+
+### Additional environment secrets
+
+- `CODEX_RUNNER_SHA256` – expected SHA256 for the runner archive; used for integrity verification.
+- `CODEX_RUNNER_TOKEN` – optional **registration token** to pass directly to `config.sh`.
+  If unset, the runner will mint a short-lived token via the **documented REST endpoint** (expires ~1h).
+  See: *Create a registration token for a repository* (REST).
+
+## One-shot runner CLI
+
+Launch an ephemeral runner, either with auto labels or explicit labels:
+
+```bash
+# Auto labels from queued jobs
+GH_PAT=... tools/ephem_runner.sh --auto-labels --branch 0B_base_
+
+# Explicit labels
+GH_PAT=... tools/ephem_runner.sh --labels linux,x64,codex
+```
+
+### Flags
+
+- `--owner`, `--repo`, `--branch` – override defaults `Aries-Serpent`, `_codex_`, `0B_base_`
+- `--labels` – comma-separated labels
+- `--auto-labels` – derive labels from queued jobs
+- `--runner-version` – pin runner version (default `2.328.0`)
+- `--work-dir` – working directory (default `_work`)
+- `--name-prefix` – runner name prefix (default `codex-ephem`)
+- `--no-disable-update` – allow self-update
+
+## Notes
+
+No GitHub Actions workflow files are modified. Runners register with `--ephemeral`, process one job, and disappear.
+
+**Docs & semantics**
+
+- Ephemeral/JIT runners perform **at most one job** and then auto-uninstall / deregister; `config.sh --ephemeral` is the intended switch.
+- Runner selection is controlled by `runs-on` **labels** and runner group routing; our preflight computes a minimal label set.
+- Registration token creation, runner listing/deletion, and queued run inspection use **only** GitHub’s official REST endpoints.
+
+### References
+
+- [GitHub Docs – Using self-hosted runners in a workflow](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/use-in-a-workflow)
+- [GitHub Docs – REST API: Self-hosted runners](https://docs.github.com/en/rest/actions/self-hosted-runners)
+- [pre-commit – Installation & usage](https://pre-commit.com/#installation)
+
+## Autoscaling single-job runners
+
+Provision up to `N` ephemeral workers while queued jobs exist:
+
+```bash
+GH_PAT=... tools/ephem_autoscaler.sh --branch 0B_base_ --max 2 --poll 10
+# derive max from queue length, capped at 4
+GH_PAT=... tools/ephem_autoscaler.sh --branch 0B_base_ --scale-from-queue --cap 4
+```
+
+- Jobs select runners by `runs-on` **labels**; preflight resolves the minimal set.
+- Ephemeral runners de-register automatically after exactly one job.
+
+## Self-heal & admin
+
+List and prune offline registrations; remove stale local directories (dry-run by default):
+
+```bash
+GH_PAT=... python3 tools/runner_doctor.py --cleanup-offline --cleanup-dirs --min-age-mins 60
+```
+
+Security hardening for self-hosted runners (ephemeral/JIT, isolation, cleanup) follows GitHub guidance.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,9 +3,13 @@ black
 isort
 flake8
 mypy
-pytest
-pytest-cov
+pytest>=8.0
+pytest-cov>=6.0
 bandit
 semgrep
 detect-secrets
+pre-commit
+yamllint
+shellcheck-py
+pip-audit
 # END: CODEX_DEV_REQUIREMENTS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 duckdb>=0.10
 # BEGIN: CODEX_RUN_REQUIREMENTS
-transformers
+transformers>=4.3.3
 datasets
 sentencepiece
 accelerate
 peft
+pydantic>=2.11.7
 # END: CODEX_RUN_REQUIREMENTS

--- a/tests/test_label_policy_lint.py
+++ b/tests/test_label_policy_lint.py
@@ -1,0 +1,80 @@
+import json
+import pathlib
+import subprocess
+import sys
+
+SAMPLE_OK = """
+name: ok
+on: [push]
+jobs:
+  build:
+    runs-on: [self-hosted, linux, x64, codex]
+    steps: []
+"""
+
+SAMPLE_BAD = """
+name: bad
+on: [push]
+jobs:
+  test:
+    runs-on: [self-hosted, linux, x64, nosuchlabel]
+    steps: []
+"""
+
+
+def _write(path: pathlib.Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def test_lint_ok(tmp_path: pathlib.Path) -> None:
+    wf = tmp_path / ".github/workflows"
+    wf.mkdir(parents=True)
+    _write(wf / "ok.yml", SAMPLE_OK)
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools/label_policy.json").write_text(
+        json.dumps(
+            {
+                "allowed_labels": ["self-hosted", "linux", "x64", "codex"],
+                "required_base": ["self-hosted", "linux", "x64"],
+                "defaults_for_string_runs_on": ["linux", "x64", "codex"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "tools/label_policy_lint.py").write_text(
+        pathlib.Path("tools/label_policy_lint.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, str(tmp_path / "tools/label_policy_lint.py")],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0
+
+
+def test_lint_bad(tmp_path: pathlib.Path) -> None:
+    wf = tmp_path / ".github/workflows"
+    wf.mkdir(parents=True)
+    _write(wf / "bad.yml", SAMPLE_BAD)
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools/label_policy.json").write_text(
+        json.dumps(
+            {
+                "allowed_labels": ["self-hosted", "linux", "x64", "codex"],
+                "required_base": ["self-hosted", "linux", "x64"],
+                "defaults_for_string_runs_on": ["linux", "x64", "codex"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "tools/label_policy_lint.py").write_text(
+        pathlib.Path("tools/label_policy_lint.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, str(tmp_path / "tools/label_policy_lint.py")],
+        cwd=tmp_path,
+        capture_output=True,
+    )
+    assert result.returncode != 0
+    assert b"disallowed labels" in result.stderr

--- a/tests/test_runner_doctor.py
+++ b/tests/test_runner_doctor.py
@@ -1,0 +1,18 @@
+import json, types
+from pathlib import Path
+
+SAMPLE = {"runners": [
+    {"id": 1, "name": "r1", "status": "online"},
+    {"id": 2, "name": "r2", "status": "offline"},
+]}
+
+def test_parse_offline(tmp_path, monkeypatch):
+    import tools.runner_doctor as rd  # type: ignore
+
+    def fake_req(path, token, method="GET"):
+        assert path.startswith("/repos/")
+        return SAMPLE
+
+    monkeypatch.setattr(rd, "_req", fake_req)
+    out = rd.list_runners("token")
+    assert any(r["status"] == "offline" for r in out)

--- a/tools/bootstrap_dev_env.sh
+++ b/tools/bootstrap_dev_env.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Deterministic bootstrap for local gates (pre-commit + pytest).
+# Creates .venv if missing, upgrades pip, installs repo + dev deps,
+# and ensures CLIs invoked by hooks are present.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$HERE"
+VENV="${VENV:-.venv}"
+PY="${PYTHON:-python3}"
+
+if [[ ! -d "$VENV" ]]; then "$PY" -m venv "$VENV"; fi
+source "$VENV/bin/activate"
+python -m pip install --upgrade pip setuptools wheel
+# Project + dev requirements
+pip install -r requirements.txt -r requirements-dev.txt
+# Gate CLIs used by hooks / logs: pre-commit, yamllint, shellcheck, semgrep, pip-audit
+pip install pre-commit yamllint shellcheck-py semgrep pip-audit
+# Pre-install hook envs so first run is deterministic
+pre-commit install --install-hooks --overwrite
+echo "[bootstrap] Ready. Run: pre-commit run --all-files && pytest"
+

--- a/tools/codex_workflow_executor.py
+++ b/tools/codex_workflow_executor.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Codex Workflow Executor (no remote CI activation)
+
+Features:
+- README parsing and reference normalization (replaces legacy secret names with CODEX_* equivalents).
+- Ensures tiny Make target that shells to ci_local.sh.
+- Ensures ci_local.sh uses venv and runs pre-commit + pytest deterministically.
+- Best-effort local gates, runner bring-up, autoscaler, and doctor (only if GH_PAT or CODEX_RUNNER_TOKEN present).
+- Gap documentation to .codex/codex_change_log.md
+- Error capture formatted as ChatGPT-5 research questions to .codex/research_questions.md
+- Final summary printout.
+
+Note: DOES NOT modify or enable GitHub Actions workflows.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CODEX_DIR = ROOT / ".codex"
+CHANGELOG = CODEX_DIR / "codex_change_log.md"
+QUESTIONS = CODEX_DIR / "research_questions.md"
+README = ROOT / "README.md"
+MAKEFILE = ROOT / "Makefile"
+CI_LOCAL = ROOT / "ci_local.sh"
+
+
+def ts() -> str:
+    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def ensure_codex_dir() -> None:
+    CODEX_DIR.mkdir(exist_ok=True)
+
+
+def log_change(msg: str) -> None:
+    ensure_codex_dir()
+    with CHANGELOG.open("a", encoding="utf-8") as f:
+        f.write(f"- [{ts()}] {msg}\n")
+
+
+def ask_gpt5(step: str, err: str, ctx: str) -> None:
+    ensure_codex_dir()
+    with QUESTIONS.open("a", encoding="utf-8") as f:
+        f.write(
+            "Question for ChatGPT-5:\n"
+            f"While performing {step}, encountered the following error:\n"
+            f"{err}\n"
+            f"Context: {ctx}\n"
+            "What are the possible causes, and how can this be resolved while preserving intended functionality?\n\n"
+        )
+
+
+def run(cmd: list[str], step_label: str, check: bool = True, env: dict[str, str] | None = None):
+    try:
+        res = subprocess.run(
+            cmd,
+            cwd=ROOT,
+            env=env or os.environ,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        print(res.stdout)
+        if check and res.returncode != 0:
+            raise RuntimeError(f"exit {res.returncode}\n{res.stdout}")
+        return res.returncode, res.stdout
+    except Exception as e:  # pragma: no cover - error path
+        ask_gpt5(step_label, str(e), f"cmd={' '.join(cmd)}")
+        log_change(f"❌ {step_label} failed: {e}")
+        if check:
+            raise
+        return 1, str(e)
+
+
+def normalize_readme() -> None:
+    if not README.exists():
+        return
+    text = README.read_text(encoding="utf-8")
+    repls = {
+        r"\brunner[-_]?sha256\b": "CODEX_RUNNER_SHA256",
+        r"\brunner[-_]?token\b": "CODEX_RUNNER_TOKEN",
+    }
+    orig = text
+    for pat, to in repls.items():
+        text = re.sub(pat, to, text, flags=re.IGNORECASE)
+    if text != orig:
+        README.write_text(text, encoding="utf-8")
+        log_change("README normalized env secret references to CODEX_*")
+
+
+def ensure_make_target_shells() -> None:
+    snippet = ".PHONY: codex-gates\ncodex-gates:\n\t@bash ci_local.sh\n"
+    if MAKEFILE.exists():
+        mf = MAKEFILE.read_text(encoding="utf-8")
+        if "codex-gates" not in mf or "@bash ci_local.sh" not in mf:
+            MAKEFILE.write_text(mf.rstrip() + "\n\n" + snippet, encoding="utf-8")
+            log_change("Added tiny Make target that shells to ci_local.sh")
+    else:
+        MAKEFILE.write_text(snippet, encoding="utf-8")
+        log_change("Created Makefile with tiny codex-gates target")
+
+
+def ensure_ci_local_present() -> None:
+    expected = (
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "HERE=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")\" && pwd)\"\n"
+        "bash \"$HERE/tools/bootstrap_dev_env.sh\"\n"
+        "source \"$HERE/.venv/bin/activate\"\n"
+        ".venv/bin/pre-commit run --all-files\n"
+        ".venv/bin/pytest\n"
+    )
+    if not CI_LOCAL.exists():
+        CI_LOCAL.write_text(expected, encoding="utf-8")
+        os.chmod(CI_LOCAL, 0o755)
+        log_change("Created ci_local.sh (venv-pinned)")
+        return
+    cur = CI_LOCAL.read_text(encoding="utf-8")
+    if ".venv/bin/pre-commit" not in cur or ".venv/bin/pytest" not in cur:
+        CI_LOCAL.write_text(expected, encoding="utf-8")
+        os.chmod(CI_LOCAL, 0o755)
+        log_change("Hardened ci_local.sh to use venv binaries")
+
+
+def maybe_run_gates():
+    return run(["bash", "ci_local.sh"], "Phase 3.1: Run local gates", check=False)
+
+
+def maybe_runner_and_autoscaler() -> None:
+    env = os.environ.copy()
+    if not env.get("GH_PAT") and not env.get("CODEX_RUNNER_TOKEN"):
+        log_change("Skipped runner/autoscaler (no GH_PAT or CODEX_RUNNER_TOKEN)")
+        return
+    run(
+        ["bash", "tools/ephem_runner.sh", "--labels", "linux,x64,codex"],
+        "Phase 3.2: Bring up ephemeral runner",
+        check=False,
+        env=env,
+    )
+    run(
+        ["bash", "tools/ephem_autoscaler.sh", "--branch", "0B_base_", "--scale-from-queue", "--cap", "4"],
+        "Phase 3.3: Autoscale from queue",
+        check=False,
+        env=env,
+    )
+
+
+def doctor_pass() -> None:
+    env = os.environ.copy()
+    if not env.get("GH_PAT"):
+        log_change("Skipped doctor (no GH_PAT)")
+        return
+    run(
+        [
+            "python3",
+            "tools/runner_doctor.py",
+            "--cleanup-offline",
+            "--cleanup-dirs",
+            "--min-age-mins",
+            "60",
+        ],
+        "Phase 3.4: Runner doctor",
+        check=False,
+        env=env,
+    )
+
+
+def main() -> int:
+    ensure_codex_dir()
+    log_change("Begin codex_workflow_executor")
+    try:
+        normalize_readme()
+    except Exception as e:  # pragma: no cover
+        ask_gpt5("Phase 1: README normalization", str(e), "updating env secret references")
+    try:
+        ensure_make_target_shells()
+        ensure_ci_local_present()
+    except Exception as e:  # pragma: no cover
+        ask_gpt5("Phase 1: Ensure make/entrypoint", str(e), "creating Make target and ci_local.sh")
+
+    gates_rc, gates_out = 1, ""
+    try:
+        gates_rc, gates_out = maybe_run_gates()
+        log_change(f"Local gates completed with exit={gates_rc}")
+    except Exception as e:  # pragma: no cover
+        ask_gpt5("Phase 3.1: Run local gates", str(e), "pre-commit/pytest via venv")
+
+    try:
+        maybe_runner_and_autoscaler()
+        log_change("Runner bring-up and autoscaler attempted (best-effort)")
+    except Exception as e:  # pragma: no cover
+        ask_gpt5("Phase 3.2/3.3: Runner & autoscaler", str(e), "ephemeral config and queue scaling")
+
+    try:
+        doctor_pass()
+        log_change("Doctor sweep attempted (cleanup offline runners & stale dirs)")
+    except Exception as e:  # pragma: no cover
+        ask_gpt5("Phase 3.4: Runner doctor", str(e), "cleanup cycle")
+
+    try:
+        ensure_codex_dir()
+        summary = {
+            "gates_exit_code": gates_rc,
+            "change_log": str(CHANGELOG),
+            "research_questions": str(QUESTIONS),
+        }
+        (CODEX_DIR / "last_summary.json").write_text(
+            json.dumps(summary, indent=2), encoding="utf-8"
+        )
+        print(json.dumps(summary, indent=2))
+        log_change("End codex_workflow_executor")
+    except Exception as e:  # pragma: no cover
+        ask_gpt5("Phase 6: Finalization", str(e), "writing last_summary.json / logs")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:  # pragma: no cover
+        ask_gpt5("Global", "KeyboardInterrupt", "User interrupted script")
+        log_change("Interrupted by user (KeyboardInterrupt)")
+        sys.exit(130)
+    except Exception as e:  # pragma: no cover
+        ask_gpt5("Global", str(e), "Unhandled exception at toplevel")
+        sys.exit(1)

--- a/tools/ephem_autoscaler.sh
+++ b/tools/ephem_autoscaler.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Auto-provision ephemeral (single-job) runners until the queue drains.
+# Uses GitHub REST (registration token) and repo workflows to derive labels.
+# Requires: GH_PAT, curl, jq|python3, tar, shasum.
+#
+# Usage:
+#   GH_PAT=... tools/ephem_autoscaler.sh --branch 0B_base_ --max 2 --poll 10
+#   GH_PAT=... tools/ephem_autoscaler.sh --branch 0B_base_ --scale-from-queue --cap 4
+
+OWNER="${OWNER:-Aries-Serpent}"
+REPO="${REPO:-_codex_}"
+BRANCH="${BRANCH:-0B_base_}"
+MAX="${MAX:-2}"
+CAP="${CAP:-5}"
+POLL="${POLL:-10}"
+LABELS_OVERRIDE="${LABELS_OVERRIDE:-}" 
+SCALE_FROM_QUEUE=0
+RUNNER_TOKEN_OVERRIDE="${CODEX_RUNNER_TOKEN:-}" # Optional: pass token through to runner
+
+_die(){ echo "ERROR: $*" >&2; exit 1; }
+_need(){ command -v "$1" >/dev/null 2>&1 || _die "Missing dependency: $1"; }
+_need curl; _need tar
+command -v sha256sum >/dev/null 2>&1 || command -v shasum >/dev/null 2>&1 || _die "Missing sha256sum/shasum"
+# Either we have GH_PAT (to mint short-lived tokens) or we were given a CODEX_RUNNER_TOKEN.
+[[ -n "${GH_PAT:-}" || -n "$RUNNER_TOKEN_OVERRIDE" ]] || _die "Set GH_PAT or CODEX_RUNNER_TOKEN"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --owner) OWNER="$2"; shift 2;;
+    --repo) REPO="$2"; shift 2;;
+    --branch) BRANCH="$2"; shift 2;;
+    --max) MAX="$2"; shift 2;;
+    --cap) CAP="$2"; shift 2;;
+    --poll) POLL="$2"; shift 2;;
+    --labels-override) LABELS_OVERRIDE="$2"; shift 2;;
+    --scale-from-queue) SCALE_FROM_QUEUE=1; shift;;
+    -h|--help)
+      sed -n '1,120p' "$0"; exit 0;;
+    *) _die "Unknown arg: $1";;
+  esac
+done
+
+active_pids=()
+cleanup(){ for p in "${active_pids[@]:-}"; do kill "$p" 2>/dev/null || true; done; }
+trap cleanup EXIT INT TERM
+
+count_queued(){
+  local url="https://api.github.com/repos/${OWNER}/${REPO}/actions/runs?status=queued&branch=${BRANCH}&per_page=100"
+  local json
+  json=$(curl -fsSL -H "Authorization: Bearer ${GH_PAT}" -H "Accept: application/vnd.github+json" "$url")
+  if command -v jq >/dev/null 2>&1; then
+    echo "$json" | jq '.workflow_runs | length'
+  else
+    python3 - <<'PY'
+import json,sys
+print(len(json.load(sys.stdin).get('workflow_runs', [])))
+PY
+  fi
+}
+
+spawn_one(){
+  local labels="$1"
+  echo "[autoscaler] Spawning ephemeral runner with labels: $labels"
+  GH_PAT="$GH_PAT" CODEX_RUNNER_TOKEN="$RUNNER_TOKEN_OVERRIDE" \
+    bash tools/ephem_runner.sh --labels "$labels" --branch "$BRANCH" &
+  active_pids+=("$!")
+}
+
+while :; do
+  if [[ -z "$LABELS_OVERRIDE" ]]; then
+    _need python3
+    labels=$(python3 tools/preflight_minimal_labels.py --owner "$OWNER" --repo "$REPO" --branch "$BRANCH" --gh-pat "$GH_PAT") || _die "preflight failed"
+  else
+    labels="$LABELS_OVERRIDE"
+  fi
+
+  [[ -n "$labels" ]] || { echo "[autoscaler] No labels returned; sleeping $POLL"; sleep "$POLL"; continue; }
+
+  if (( SCALE_FROM_QUEUE )); then
+    queued=$(count_queued)
+    (( queued > CAP )) && queued=$CAP
+    MAX=$queued
+  fi
+
+  live=()
+  for p in "${active_pids[@]:-}"; do
+    if kill -0 "$p" 2>/dev/null; then live+=("$p"); fi
+  done
+  active_pids=("${live[@]}")
+
+  need=$(( MAX - ${#active_pids[@]} ))
+  if (( need > 0 )); then
+    for _ in $(seq 1 "$need"); do spawn_one "$labels"; done
+  fi
+  sleep "$POLL"
+done

--- a/tools/ephem_runner.sh
+++ b/tools/ephem_runner.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Ephemeral (single-job) GitHub Actions runner bring-up for Aries-Serpent/_codex_.
+# No workflow edits. Requires GH_PAT and minimal label set.
+#
+# Usage (auto labels from queued jobs):
+#   GH_PAT=... tools/ephem_runner.sh --auto-labels --branch 0B_base_
+#
+# Or provide labels explicitly:
+#   GH_PAT=... tools/ephem_runner.sh --labels linux,x64,codex
+#
+# Required: GH_PAT in env (repo/org admin for registration token).
+
+OWNER="${OWNER:-Aries-Serpent}"
+REPO="${REPO:-_codex_}"
+BRANCH="${BRANCH:-0B_base_}"
+RUNNER_VERSION="${RUNNER_VERSION:-2.328.0}"
+RUNNER_PKG="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+RUNNER_SHA256_DEFAULT="01066fad3a2893e63e6ca880ae3a1fad5bf9329d60e77ee15f2b97c148c3cd4e"
+# Allow env secret to override expected checksum
+RUNNER_SHA256="${CODEX_RUNNER_SHA256:-${RUNNER_SHA256:-$RUNNER_SHA256_DEFAULT}}"
+RUNNER_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_PKG}"
+WORK_DIR="${WORK_DIR:-_work}"
+DISABLE_UPDATE="${DISABLE_UPDATE:-1}"
+NAME_PREFIX="${NAME_PREFIX:-codex-ephem}"
+LABELS="${LABELS:-}"
+AUTO_LABELS=0
+RUNNER_TOKEN_OVERRIDE="${CODEX_RUNNER_TOKEN:-}"
+
+# Print error and exit
+_die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+# Ensure dependency exists
+_need() {
+  command -v "$1" >/dev/null 2>&1 || _die "Missing dependency: $1"
+}
+
+# Parse flags
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --owner)
+      OWNER="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --branch)
+      BRANCH="$2"
+      shift 2
+      ;;
+    --labels)
+      LABELS="$2"
+      shift 2
+      ;;
+    --auto-labels)
+      AUTO_LABELS=1
+      shift
+      ;;
+    --runner-version)
+      RUNNER_VERSION="$2"
+      RUNNER_PKG="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+      RUNNER_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_PKG}"
+      shift 2
+      ;;
+    --work-dir)
+      WORK_DIR="$2"
+      shift 2
+      ;;
+    --name-prefix)
+      NAME_PREFIX="$2"
+      shift 2
+      ;;
+    --no-disable-update)
+      DISABLE_UPDATE=0
+      shift
+      ;;
+    -h|--help)
+      sed -n '1,120p' "$0"
+      exit 0
+      ;;
+    *)
+      _die "Unknown arg: $1"
+      ;;
+  esac
+done
+
+[[ -n "${GH_PAT:-}" ]] || { [[ -n "$RUNNER_TOKEN_OVERRIDE" ]] || _die "GH_PAT not set (or CODEX_RUNNER_TOKEN missing)."; }
+
+_need curl
+_need tar
+command -v sha256sum >/dev/null 2>&1 || command -v shasum >/dev/null 2>&1 || _die "Missing sha256sum/shasum"
+
+if [[ ${AUTO_LABELS} -eq 1 ]]; then
+  _need python3
+  LABELS="$(python3 tools/preflight_minimal_labels.py \
+    --owner "$OWNER" --repo "$REPO" --branch "$BRANCH" \
+    --gh-pat "$GH_PAT")" || _die "preflight label computation failed"
+  [[ -n "$LABELS" ]] || _die "preflight returned empty labels"
+fi
+
+REPO_URL="https://github.com/${OWNER}/${REPO}"
+mkdir -p actions-runner
+cd actions-runner
+
+# Prefer explicit override token if provided; otherwise create a short-lived
+# registration token via the documented REST endpoint (expires ~1h).
+# Ref: REST – Create a registration token for a repository.
+# https://docs.github.com/en/rest/actions/self-hosted-runners
+if [[ -n "$RUNNER_TOKEN_OVERRIDE" ]]; then
+  REG_TOKEN="$RUNNER_TOKEN_OVERRIDE"
+else
+  REG_TOKEN_JSON="$(curl -fsSL -X POST \
+    -H "Authorization: Bearer ${GH_PAT}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${OWNER}/${REPO}/actions/runners/registration-token")"
+  if command -v jq >/dev/null 2>&1; then
+    REG_TOKEN="$(printf '%s' "$REG_TOKEN_JSON" | jq -r '.token')"
+  else
+    REG_TOKEN="$(python3 - <<'PY'
+import json,sys
+print(json.load(sys.stdin)['token'])
+PY
+)"
+  fi
+fi
+
+[[ -n "$REG_TOKEN" && "$REG_TOKEN" != "null" ]] || _die "Failed to fetch registration token"
+
+curl -fsSL -o "$RUNNER_PKG" "$RUNNER_URL"
+# Verify archive integrity (prefer sha256sum; fallback to shasum -a 256)
+if command -v sha256sum >/dev/null 2>&1; then
+  echo "${RUNNER_SHA256}  ${RUNNER_PKG}" | sha256sum -c
+else
+  echo "${RUNNER_SHA256}  ${RUNNER_PKG}" | shasum -a 256 -c
+fi
+
+tar xzf "$RUNNER_PKG"
+
+./config.sh --check --url "$REPO_URL" || true
+
+NAME="${NAME_PREFIX}-$(hostname)-$RANDOM"
+# --ephemeral ensures a runner performs exactly one job then auto-deregisters.
+# GitHub documents ephemeral one-job behavior and the --ephemeral flag
+# (self-hosted runner security / JIT/ephemeral guidance).
+CONFIG_ARGS=(--url "$REPO_URL" --token "$REG_TOKEN" --name "$NAME" --work "$WORK_DIR" --unattended --ephemeral)
+[[ -n "$LABELS" ]] && CONFIG_ARGS+=(--labels "$LABELS")
+[[ $DISABLE_UPDATE -eq 1 ]] && CONFIG_ARGS+=(--disableupdate)
+
+./config.sh "${CONFIG_ARGS[@]}"
+
+# Run once; after the job completes, the runner deregisters server-side.
+# Local artifacts remain in $WORK_DIR and may be cleaned by a janitor.
+exec ./run.sh

--- a/tools/label_policy.json
+++ b/tools/label_policy.json
@@ -1,0 +1,16 @@
+{
+  "allowed_labels": [
+    "self-hosted",
+    "linux",
+    "x64",
+    "codex",
+    "gpu",
+    "cuda12",
+    "cpu",
+    "ram64",
+    "diskLarge",
+    "python311"
+  ],
+  "required_base": ["self-hosted", "linux", "x64"],
+  "defaults_for_string_runs_on": ["linux", "x64", "codex"]
+}

--- a/tools/label_policy_lint.py
+++ b/tools/label_policy_lint.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Validate that workflow files use allowed self-hosted runner labels."""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+from typing import List
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - dependency check
+    print("Install pyyaml to run label policy lint.", file=sys.stderr)
+    sys.exit(2)
+
+POLICY_PATH = pathlib.Path("tools/label_policy.json")
+WF_DIR = pathlib.Path(".github/workflows")
+
+
+def as_list(value: object) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    return []
+
+
+def load_policy() -> tuple[set[str], set[str], set[str]]:
+    policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+    allowed = set(policy["allowed_labels"])
+    required = set(policy.get("required_base", []))
+    defaults = set(policy.get("defaults_for_string_runs_on", []))
+    return allowed, required, defaults
+
+
+def lint_file(
+    path: pathlib.Path, allowed: set[str], required: set[str], defaults: set[str]
+) -> List[str]:
+    errors: List[str] = []
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    jobs = (data or {}).get("jobs", {})
+    for job_name, job in (jobs or {}).items():
+        runs_on = job.get("runs-on")
+        if runs_on is None:
+            continue
+        labels = as_list(runs_on)
+        if "self-hosted" in labels:
+            if labels == ["self-hosted"]:
+                labels = ["self-hosted", *defaults]
+            extra_labels = [label for label in labels if label not in allowed]
+            missing_base = [label for label in required if label not in labels]
+            if extra_labels:
+                errors.append(f"{path}:{job_name}: disallowed labels: {extra_labels}")
+            if missing_base:
+                errors.append(f"{path}:{job_name}: missing required base labels: {missing_base}")
+    return errors
+
+
+def main() -> int:
+    if not WF_DIR.exists():
+        print("No .github/workflows directory; nothing to lint.")
+        return 0
+    allowed, required, defaults = load_policy()
+    problems: List[str] = []
+    for file in sorted(WF_DIR.glob("*.y*ml")):
+        problems.extend(lint_file(file, allowed, required, defaults))
+    if problems:
+        print("Label policy violations:\n- " + "\n- ".join(problems), file=sys.stderr)
+        return 1
+    print("Label policy: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/preflight_minimal_labels.py
+++ b/tools/preflight_minimal_labels.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Derive minimal labels for queued self-hosted jobs on a branch."""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - dependency check
+    print("Install pyyaml to run preflight.", file=sys.stderr)
+    sys.exit(2)
+
+API = "https://api.github.com"
+POLICY_PATH = "tools/label_policy.json"
+
+
+def _request(url: str, token: str, method: str = "GET") -> Dict[str, Any]:
+    req = urllib.request.Request(
+        url,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "codex-preflight",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def list_queued_runs(owner: str, repo: str, branch: str, token: str) -> List[Dict[str, Any]]:
+    qs = urllib.parse.urlencode({"status": "queued", "branch": branch, "per_page": 100})
+    url = f"{API}/repos/{owner}/{repo}/actions/runs?{qs}"
+    data = _request(url, token)
+    return data.get("workflow_runs", [])
+
+
+def get_workflow(owner: str, repo: str, workflow_id: int, token: str) -> Dict[str, Any]:
+    url = f"{API}/repos/{owner}/{repo}/actions/workflows/{workflow_id}"
+    return _request(url, token)
+
+
+def get_file_at_sha(owner: str, repo: str, path: str, ref: str, token: str) -> str:
+    qs = urllib.parse.urlencode({"ref": ref})
+    url = f"{API}/repos/{owner}/{repo}/contents/{urllib.parse.quote(path)}?{qs}"
+    obj = _request(url, token)
+    if obj.get("encoding") == "base64":
+        return base64.b64decode(obj["content"]).decode("utf-8")
+    return obj.get("content", "")
+
+
+def minimal_labels_from_yaml(
+    yaml_text: str,
+    allowed: set[str],
+    required_base: set[str],
+    defaults_for_string: List[str],
+) -> Optional[List[str]]:
+    doc = yaml.safe_load(yaml_text) or {}
+    jobs = doc.get("jobs", {})
+    for job in (jobs or {}).values():
+        runs_on = job.get("runs-on")
+        if runs_on is None:
+            continue
+        labels = [runs_on] if isinstance(runs_on, str) else list(runs_on)
+        if "self-hosted" in labels:
+            if labels == ["self-hosted"]:
+                labels = ["self-hosted", *defaults_for_string]
+            label_set = set(labels)
+            if not required_base.issubset(label_set):
+                label_set |= required_base
+            if not label_set.issubset(allowed):
+                label_set = (label_set & allowed) | required_base
+                label_set.add("self-hosted")
+            return [label for label in label_set if label != "self-hosted"]
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--owner", default=os.environ.get("OWNER", "Aries-Serpent"))
+    parser.add_argument("--repo", default=os.environ.get("REPO", "_codex_"))
+    parser.add_argument("--branch", default=os.environ.get("BRANCH", "0B_base_"))
+    parser.add_argument("--gh-pat", default=os.environ.get("GH_PAT"))
+    args = parser.parse_args()
+
+    if not args.gh_pat:
+        print("GH_PAT required", file=sys.stderr)
+        return 2
+
+    policy = json.loads(open(POLICY_PATH, "r", encoding="utf-8").read())
+    allowed = set(policy["allowed_labels"])
+    required_base = set(policy.get("required_base", []))
+    defaults = policy.get("defaults_for_string_runs_on", [])
+
+    runs = list_queued_runs(args.owner, args.repo, args.branch, args.gh_pat)
+    if not runs:
+        fallback = [label for label in (*required_base, "codex") if label != "self-hosted"]
+        print(",".join(sorted(fallback)))
+        return 0
+    run = sorted(runs, key=lambda r: r.get("created_at", ""))[0]
+    wf_id = run.get("workflow_id")
+    sha = run.get("head_sha")
+    if not wf_id or not sha:
+        fallback = [label for label in (*required_base, "codex") if label != "self-hosted"]
+        print(",".join(sorted(fallback)))
+        return 0
+    workflow = get_workflow(args.owner, args.repo, wf_id, args.gh_pat)
+    path = workflow.get("path")
+    if not path:
+        fallback = [label for label in (*required_base, "codex") if label != "self-hosted"]
+        print(",".join(sorted(fallback)))
+        return 0
+    yml = get_file_at_sha(args.owner, args.repo, path, sha, args.gh_pat)
+    labels = minimal_labels_from_yaml(yml, allowed, required_base, defaults)
+    if labels:
+        print(",".join(sorted(set(labels))))
+        return 0
+    fallback = [label for label in (*required_base, "codex") if label != "self-hosted"]
+    print(",".join(sorted(set(fallback))))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/runner_doctor.py
+++ b/tools/runner_doctor.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+Self-hosted runner doctor: list, find offline, cleanup repo registrations & local dirs.
+All operations default to --dry-run. Requires GH_PAT with repo Actions permissions.
+"""
+from __future__ import annotations
+import argparse, json, os, sys, shutil, time, urllib.request
+
+API = "https://api.github.com"
+OWNER = os.environ.get("OWNER", "Aries-Serpent")
+REPO = os.environ.get("REPO", "_codex_")
+
+
+def _req(path: str, token: str, method: str = "GET"):
+    url = f"{API}{path}"
+    req = urllib.request.Request(
+        url,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "codex-runner-doctor",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def list_runners(token: str):
+    return _req(f"/repos/{OWNER}/{REPO}/actions/runners", token).get("runners", [])
+
+
+def delete_runner(token: str, runner_id: int):
+    path = f"/repos/{OWNER}/{REPO}/actions/runners/{runner_id}"
+    req = urllib.request.Request(
+        f"{API}{path}",
+        method="DELETE",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # nosec B310
+        return resp.status
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gh-pat", default=os.environ.get("GH_PAT"))
+    ap.add_argument("--cleanup-offline", action="store_true")
+    ap.add_argument("--cleanup-dirs", action="store_true")
+    ap.add_argument("--dirs-glob", default="actions-runner")
+    ap.add_argument("--min-age-mins", type=int, default=60)
+    ap.add_argument("--dry-run", action="store_true", default=True)
+    args = ap.parse_args()
+    if not args.gh_pat:
+        print("GH_PAT required", file=sys.stderr)
+        return 2
+
+    runners = list_runners(args.gh_pat)
+    now = time.time()
+    print(json.dumps({"count": len(runners), "sample": runners[:3]}, indent=2))
+
+    if args.cleanup_offline:
+        for r in runners:
+            if r.get("status") == "offline":
+                rid = r["id"]
+                name = r.get("name")
+                print(f"[doctor] offline: id={rid} name={name}")
+                if not args.dry_run:
+                    delete_runner(args.gh_pat, rid)
+                    print(f"[doctor] deleted: id={rid}")
+
+    if args.cleanup_dirs:
+        base = args.dirs_glob
+        if os.path.isdir(base):
+            for entry in os.scandir(base):
+                if entry.is_dir():
+                    age_min = int((now - entry.stat().st_mtime) / 60)
+                    if age_min >= args.min_age_mins:
+                        print(f"[doctor] stale dir: {entry.path} age_min={age_min}")
+                        if not args.dry_run:
+                            shutil.rmtree(entry.path, ignore_errors=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add bootstrap script to deterministically install dev and gate tooling
- harden runner scripts with checksum and token overrides plus early dependency checks
- document additional runner secrets and reference GitHub and pre-commit guidance
- add codex-gates make target and run gates from venv executables
- introduce codex_workflow_executor to enforce entrypoints and optional runner orchestration

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b057fb6d5c8331876024555839c363