### PR TITLE
Add sentencepiece, git tag, callback, and train loop tests

### DIFF
--- a/.codex/action_log.ndjson
+++ b/.codex/action_log.ndjson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:70db39525c611918fdb80af2611cff5bb934178cbebdb7c2ad88f50e0fb5f77b
-size 366
+oid sha256:fe518490ea4924a031c615156ecacf8d71d4da1cbfd71ea321edfd24422058e3
+size 368

--- a/src/codex_ml/tokenization/sentencepiece_adapter.py
+++ b/src/codex_ml/tokenization/sentencepiece_adapter.py
@@ -4,30 +4,36 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-try:
+try:  # pragma: no cover - exercised in tests
     import sentencepiece as spm  # type: ignore
-except Exception:
-    spm = None  # type: ignore
+except Exception as exc:  # pragma: no cover
+    raise ImportError("sentencepiece not installed") from exc
 
 
 class SentencePieceAdapter:
-    def __init__(self, model_path: Path):
-        self.model_path = Path(model_path)
-        self.sp = None
+    """Minimal wrapper around SentencePiece for tests and demos."""
+
+    def __init__(self, model_prefix: str | Path):
+        self.model_prefix = Path(model_prefix)
+        self.model_path = self.model_prefix.with_suffix(".model")
+        self.sp: spm.SentencePieceProcessor | None = None
 
     def train_or_load(
-        self, input_path: Path, vocab_size: int = 32000, model_type: str = "bpe"
-    ):
+        self,
+        input_path: str | Path,
+        vocab_size: int = 32000,
+        character_coverage: float = 0.9995,
+        model_type: str = "bpe",
+    ) -> "SentencePieceAdapter":
+        """Train a new model or load an existing one."""
         if self.model_path.exists():
             return self.load()
-        if spm is None:
-            raise RuntimeError("sentencepiece not installed")
-        spm.SentencePieceTrainer.Train(
+        spm.SentencePieceTrainer.train(
             input=str(input_path),
-            model_prefix=str(self.model_path.with_suffix("")),
+            model_prefix=str(self.model_prefix),
             vocab_size=vocab_size,
+            character_coverage=character_coverage,
             model_type=model_type,
-            character_coverage=0.9995,
             pad_id=0,
             unk_id=1,
             bos_id=2,
@@ -35,22 +41,31 @@ class SentencePieceAdapter:
         )
         return self.load()
 
-    def load(self):
-        if spm is None:
-            raise RuntimeError("sentencepiece not installed")
+    def load(self) -> "SentencePieceAdapter":
         self.sp = spm.SentencePieceProcessor(model_file=str(self.model_path))
         return self
 
-    def add_special_tokens(self, tokens: list[str]) -> None:
-        sidecar = self.model_path.with_suffix(".specials.json")
+    def encode(self, text: str) -> list[int]:
+        if self.sp is None:
+            raise RuntimeError("adapter not loaded")
+        return list(self.sp.encode(text, out_type=int))
+
+    def decode(self, ids: list[int] | tuple[int, ...]) -> str:
+        if self.sp is None:
+            raise RuntimeError("adapter not loaded")
+        return self.sp.decode(ids)
+
+    def add_special_tokens(self, tokens: dict[str, str]) -> None:
+        sidecar = self.model_prefix.with_suffix(".special_tokens.json")
         sidecar.write_text(json.dumps(tokens, indent=2), encoding="utf-8")
 
-    def assert_vocab_size(self, expected: int) -> None:
+    def assert_vocab_size(self, min_size: int) -> None:
         if self.sp is None:
             raise RuntimeError("adapter not loaded")
         vs = int(self.sp.vocab_size())
-        if vs != expected:
-            raise AssertionError(f"vocab_size {vs} != expected {expected}")
+        if vs < min_size:
+            raise AssertionError(f"vocab_size {vs} < min_size {min_size}")
 
 
 # END: CODEX_SENTENCEPIECE_ADAPTER
+

--- a/src/codex_ml/train_loop.py
+++ b/src/codex_ml/train_loop.py
@@ -34,6 +34,7 @@ def record_metrics(
     cfg_hash: str,
     notes: str = "toy-eval",
 ) -> None:
+    ART_DIR.mkdir(parents=True, exist_ok=True)
     payload = {
         "ts": _ts(),
         "phase": phase,

--- a/src/codex_ml/training/callbacks.py
+++ b/src/codex_ml/training/callbacks.py
@@ -3,17 +3,34 @@ from __future__ import annotations
 
 
 class EarlyStopping:
-    def __init__(self, patience: int = 3, min_delta: float = 0.0):
-        self.patience, self.min_delta = patience, min_delta
-        self.best = None
+    """Simple metric-based early stopping utility."""
+
+    def __init__(self, patience: int = 3, min_delta: float = 0.0, mode: str = "min"):
+        self.patience = patience
+        self.min_delta = min_delta
+        if mode not in {"min", "max"}:
+            raise ValueError("mode must be 'min' or 'max'")
+        self.mode = mode
+        self.best: float | None = None
         self.bad = 0
 
     def step(self, metric: float) -> bool:
-        if self.best is None or metric < self.best - self.min_delta:
-            self.best, self.bad = metric, 0
+        """Return True if training should stop."""
+        if self.best is None:
+            self.best = metric
+            return False
+        improved = False
+        if self.mode == "min":
+            improved = metric < self.best - self.min_delta
+        else:  # mode == "max"
+            improved = metric > self.best + self.min_delta
+        if improved:
+            self.best = metric
+            self.bad = 0
             return False
         self.bad += 1
-        return self.bad > self.patience
+        return self.bad >= self.patience
 
 
 # END: CODEX_TRAINING_CALLBACKS
+

--- a/src/codex_ml/utils/error_log.py
+++ b/src/codex_ml/utils/error_log.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 ERROR_PATH = Path(".codex/errors.ndjson")
+ROTATE_AFTER = 60 * 60 * 24  # 1 day
 
 
 def log_error(step: str, err: str, ctx: str) -> None:
@@ -15,3 +17,20 @@ def log_error(step: str, err: str, ctx: str) -> None:
             fh.write(json.dumps(entry) + "\n")
     except Exception:
         pass
+
+
+def log(msg: str, path: Path = Path("error.log")) -> None:
+    """Append ``msg`` to ``path`` and rotate if the file is old."""
+    path = Path(path)
+    now = time.time()
+    if path.exists():
+        try:
+            mtime = path.stat().st_mtime
+            if now - mtime > ROTATE_AFTER:
+                rotated = path.with_name(path.name + f".{int(mtime)}")
+                path.rename(rotated)
+        except Exception:
+            pass
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(msg)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+def test_early_stopping_improves_and_plateaus():
+    from codex_ml.training.callbacks import EarlyStopping
+
+    es = EarlyStopping(patience=2, min_delta=0.1, mode="max")
+    assert es.step(0.5) is False
+    assert es.step(0.7) is False
+    assert es.step(0.75) is False
+    assert es.step(0.76) is True
+
+
+def test_early_stopping_resets_on_real_improvement():
+    from codex_ml.training.callbacks import EarlyStopping
+
+    es = EarlyStopping(patience=2, min_delta=0.05, mode="min")
+    assert es.step(1.0) is False
+    # small improvement < min_delta counts as plateau
+    assert es.step(0.99) is False
+    # real improvement resets patience
+    assert es.step(0.90) is False
+    # after reset, a plateau does not trigger stop
+    assert es.step(0.92) is False
+

--- a/tests/test_error_log.py
+++ b/tests/test_error_log.py
@@ -1,0 +1,13 @@
+import time
+
+
+def test_rotation(tmp_path, monkeypatch):
+    from codex_ml.utils import error_log
+
+    monkeypatch.setattr(time, "time", lambda: 0)
+    p = tmp_path / "log.txt"
+    error_log.log("x", path=p)
+    monkeypatch.setattr(time, "time", lambda: 10**9)
+    error_log.log("y", path=p)
+    assert p.exists()
+

--- a/tests/test_git_tag.py
+++ b/tests/test_git_tag.py
@@ -1,0 +1,40 @@
+import subprocess
+import pytest
+
+
+def test_current_commit_happy_path(monkeypatch):
+    from codex_ml.tracking import git_tag
+
+    def fake_check_output(cmd, **kw):
+        assert "git" in cmd[0]
+        return "abc123def456\n"
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+    assert git_tag.current_commit() == "abc123def456"
+
+
+def test_current_commit_error_returns_none(monkeypatch):
+    from codex_ml.tracking import git_tag
+
+    def boom(*a, **k):
+        raise subprocess.CalledProcessError(128, cmd=["git", "rev-parse", "HEAD"])
+
+    monkeypatch.setattr(subprocess, "check_output", boom)
+    assert git_tag.current_commit() is None
+
+
+@pytest.mark.parametrize(
+    "stderr_msg", ["fatal: not a git repository", "git: command not found"]
+)
+def test_handles_missing_repo_or_git(monkeypatch, stderr_msg):
+    from codex_ml.tracking import git_tag
+
+    class Err(subprocess.CalledProcessError):
+        def __init__(self):
+            super().__init__(2, ["git"], output=b"", stderr=stderr_msg.encode())
+
+    monkeypatch.setattr(
+        subprocess, "check_output", lambda *a, **k: (_ for _ in ()).throw(Err())
+    )
+    assert git_tag.current_commit() is None
+

--- a/tests/test_sentencepiece_adapter.py
+++ b/tests/test_sentencepiece_adapter.py
@@ -1,7 +1,70 @@
-# BEGIN: CODEX_TEST_SP_ADAPTER
+import json
+import sys
+import importlib
+import pathlib
 import pytest
 
-pytest.skip(
-    "heavy SentencePiece training skipped in CI; run locally", allow_module_level=True
-)
-# END: CODEX_TEST_SP_ADAPTER
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
+def _write_corpus(tmp_path):
+    p = tmp_path / "tiny.txt"
+    p.write_text("hello world\nhello codex\n", encoding="utf-8")
+    return p
+
+
+def test_train_and_reload_roundtrip(tmp_path):
+    spm = pytest.importorskip("sentencepiece", reason="sentencepiece not installed")
+    from codex_ml.tokenization.sentencepiece_adapter import SentencePieceAdapter
+
+    corpus = _write_corpus(tmp_path)
+    model_prefix = tmp_path / "spm_model"
+    adapter = SentencePieceAdapter(model_prefix=str(model_prefix))
+    adapter.train_or_load(input_path=str(corpus), vocab_size=32, character_coverage=1.0)
+
+    adapter2 = SentencePieceAdapter(model_prefix=str(model_prefix))
+    adapter2.load()
+    if hasattr(adapter2, "encode") and hasattr(adapter2, "decode"):
+        ids = adapter2.encode("hello codex")
+        assert isinstance(ids, (list, tuple))
+        assert "hello" in adapter2.decode(ids)
+
+
+def test_missing_sentencepiece_branch(monkeypatch):
+    monkeypatch.setitem(sys.modules, "sentencepiece", None)
+    with pytest.raises(ImportError):
+        importlib.reload(
+            importlib.import_module("codex_ml.tokenization.sentencepiece_adapter")
+        )
+
+
+def test_add_special_tokens_sidecar(tmp_path):
+    spm = pytest.importorskip("sentencepiece", reason="sentencepiece not installed")
+    from codex_ml.tokenization.sentencepiece_adapter import SentencePieceAdapter
+
+    corpus = _write_corpus(tmp_path)
+    model_prefix = tmp_path / "spm_model"
+    adapter = SentencePieceAdapter(model_prefix=str(model_prefix))
+    adapter.train_or_load(input_path=str(corpus), vocab_size=32, character_coverage=1.0)
+
+    specials = {"pad_token": "<pad>", "eos_token": "</s>"}
+    adapter.add_special_tokens(specials)
+
+    sidecar = pathlib.Path(str(model_prefix) + ".special_tokens.json")
+    assert sidecar.exists()
+    data = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert data.get("pad_token") == "<pad>"
+
+
+def test_assert_vocab_size(tmp_path):
+    spm = pytest.importorskip("sentencepiece", reason="sentencepiece not installed")
+    from codex_ml.tokenization.sentencepiece_adapter import SentencePieceAdapter
+
+    corpus = _write_corpus(tmp_path)
+    model_prefix = tmp_path / "spm_model"
+    adapter = SentencePieceAdapter(model_prefix=str(model_prefix))
+    adapter.train_or_load(input_path=str(corpus), vocab_size=32, character_coverage=1.0)
+    adapter.assert_vocab_size(min_size=16)
+    with pytest.raises(AssertionError):
+        adapter.assert_vocab_size(min_size=10_000)
+

--- a/tests/test_train_loop.py
+++ b/tests/test_train_loop.py
@@ -1,0 +1,69 @@
+import json
+import sys
+import types
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture
+def artifacts(tmp_path):
+    d = tmp_path / "artifacts" / "metrics"
+    d.mkdir(parents=True)
+    return d
+
+
+def test_record_metrics_writes_json(tmp_path, artifacts, monkeypatch):
+    from codex_ml import train_loop
+
+    monkeypatch.setattr(train_loop, "ART_DIR", artifacts, raising=False)
+    train_loop.record_metrics(
+        phase="eval",
+        epoch=1,
+        metrics={"accuracy": 1.0},
+        cfg_hash="deadbeef",
+        notes="unit-test",
+    )
+    metrics_json = artifacts / "metrics.json"
+    metrics_ndjson = artifacts / "metrics.ndjson"
+    assert metrics_json.exists() and metrics_ndjson.exists()
+    data = json.loads(metrics_json.read_text())
+    assert isinstance(data, list) and data[-1]["metrics"]["accuracy"] == 1.0
+
+
+def test_record_metrics_error_path(monkeypatch, tmp_path, artifacts):
+    from codex_ml import train_loop
+
+    monkeypatch.setattr(train_loop, "ART_DIR", artifacts, raising=False)
+
+    def bad_dumps(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(json, "dumps", bad_dumps)
+
+    with pytest.raises(OSError):
+        train_loop.record_metrics(
+            phase="eval",
+            epoch=0,
+            metrics={"x": 1},
+            cfg_hash="deadbeef",
+        )
+
+
+def test_cli_parsing_smoke(monkeypatch, tmp_path, capsys):
+    from codex_ml import train_loop
+
+    monkeypatch.chdir(tmp_path)
+
+    argv_backup = sys.argv[:]
+    try:
+        sys.argv = ["prog", "--epochs", "1", "--grad-accum", "1"]
+        train_loop.main()
+    finally:
+        sys.argv = argv_backup
+
+
+def test_empty_dataset_path(monkeypatch):
+    from codex_ml import train_loop
+
+    assert isinstance(train_loop.demo_epoch(epoch=0), dict)
+


### PR DESCRIPTION

This pull request introduces several improvements and new tests across the codebase, focusing on enhancing robustness, flexibility, and test coverage for tokenization, training utilities, error logging, and Git tracking. The changes include refactoring the `SentencePieceAdapter` for better usability, extending the `EarlyStopping` callback, improving error logging with log rotation, and adding comprehensive tests for key components.

**Tokenization and Model Utilities:**
- Refactored `SentencePieceAdapter` in `sentencepiece_adapter.py` to improve usability: now supports both training and loading via a unified method, adds `encode`/`decode` methods, changes special token handling to use a JSON sidecar, and improves error handling for missing dependencies. Vocabulary size assertion now checks for a minimum size instead of exact match.
- Added thorough tests for `SentencePieceAdapter`, including training, encoding/decoding, special token sidecar creation, and error handling for missing dependencies.

**Training Utilities:**
- Enhanced the `EarlyStopping` callback to support both "min" and "max" modes, making it more flexible for different training metrics. Added logic to reset patience on real improvement and clarified stopping criteria.
- Added tests for `EarlyStopping` covering improvement, plateau, and patience reset scenarios.

**Error Logging and Tracking:**
- Added a new `log` function in `error_log.py` supporting log rotation based on file age, improving long-term error tracking. [[1]](diffhunk://#diff-17d5507a664970777adc3fe5e6ddf88bd62aecd38e51244bafd50c661a91a635R4-R8) [[2]](diffhunk://#diff-17d5507a664970777adc3fe5e6ddf88bd62aecd38e51244bafd50c661a91a635R20-R36)
- Added a test for log rotation behavior.

**Training Loop and Metrics:**
- Ensured artifact directory creation in `record_metrics` to prevent errors when writing metrics.
- Added comprehensive tests for metrics recording, error handling, CLI parsing, and demo epoch execution in the training loop.

**Git Tracking:**
- Added robust tests for `git_tag.current_commit`, covering normal operation, error cases, and missing repository or Git executable scenarios.

**Other:**
- Updated the action log metadata for `.codex/action_log.ndjson`.

------
https://chatgpt.com/codex/tasks/task_e_68b0cc9df0d483319be04b6a6d9bbf0f