### PR TITLE
feat(mlflow): disable system metrics

### DIFF
--- a/src/codex_ml/tracking/mlflow_utils.py
+++ b/src/codex_ml/tracking/mlflow_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional
@@ -39,6 +40,7 @@ def start_run(cfg: MlflowConfig):
         return _noop()
     if not _HAS_MLFLOW:
         raise RuntimeError("MLflow requested but not installed")
+    os.environ.setdefault("MLFLOW_ENABLE_SYSTEM_METRICS", "false")
     _mlf.set_tracking_uri(cfg.tracking_uri)
     _mlf.set_experiment(cfg.experiment)
     return _mlf.start_run()

--- a/tests/tracking/test_mlflow_utils.py
+++ b/tests/tracking/test_mlflow_utils.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import contextlib
 import importlib
+import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -30,3 +33,19 @@ def test_seed_snapshot(tmp_path, monkeypatch):
     out = mod.seed_snapshot({"a": 1}, tmp_path, enabled=True)
     assert out.exists()
     assert called["path"] == out
+
+
+def test_start_run_sets_env(monkeypatch, tmp_path):
+    mod = importlib.import_module("codex_ml.tracking.mlflow_utils")
+    fake = SimpleNamespace(
+        set_tracking_uri=lambda uri: None,
+        set_experiment=lambda exp: None,
+        start_run=lambda: contextlib.nullcontext("run"),
+    )
+    monkeypatch.setattr(mod, "_HAS_MLFLOW", True)
+    monkeypatch.setattr(mod, "_mlf", fake)
+    monkeypatch.delenv("MLFLOW_ENABLE_SYSTEM_METRICS", raising=False)
+    cfg = mod.MlflowConfig(enable=True, tracking_uri=str(tmp_path), experiment="e")
+    with mod.start_run(cfg) as run:
+        assert run == "run"
+    assert os.environ["MLFLOW_ENABLE_SYSTEM_METRICS"] == "false"


### PR DESCRIPTION
## Summary
- set `MLFLOW_ENABLE_SYSTEM_METRICS` to `false` to avoid collecting system metrics by default
- test MLflow run initialization sets the environment variable

## Testing
- `pre-commit run --all-files`
- `pytest` *(fails: 24 failed, 213 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b11d4caa4483318847c290e3378d99