### PR TITLE
feat: add apply flag to runner doctor

### DIFF
--- a/tools/runner_doctor.py
+++ b/tools/runner_doctor.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
 """
 Self-hosted runner doctor: list, find offline, cleanup repo registrations & local dirs.
-All operations default to --dry-run. Requires GH_PAT with repo Actions permissions.
+All operations default to --dry-run; pass --apply to perform cleanup.
+Requires GH_PAT with repo Actions permissions.
 """
 from __future__ import annotations
-import argparse, json, os, sys, shutil, time, urllib.request
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import time
+import urllib.request
 
 API = "https://api.github.com"
 OWNER = os.environ.get("OWNER", "Aries-Serpent")
@@ -48,7 +56,18 @@ def main() -> int:
     ap.add_argument("--cleanup-dirs", action="store_true")
     ap.add_argument("--dirs-glob", default="actions-runner")
     ap.add_argument("--min-age-mins", type=int, default=60)
-    ap.add_argument("--dry-run", action="store_true", default=True)
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Only print planned actions without executing (default)",
+    )
+    ap.add_argument(
+        "--apply",
+        dest="dry_run",
+        action="store_false",
+        help="Execute actions instead of only printing",
+    )
     args = ap.parse_args()
     if not args.gh_pat:
         print("GH_PAT required", file=sys.stderr)


### PR DESCRIPTION
This pull request improves the usability and clarity of the `tools/runner_doctor.py` script, particularly around how dry-run and actual cleanup actions are triggered. The most important changes are:

**Command-line argument improvements:**

* Added a new `--apply` argument to explicitly perform cleanup actions; by default, the script now only prints planned actions unless `--apply` is specified.
* Enhanced the help text for the `--dry-run` and `--apply` arguments to clarify their behavior for users.

**Documentation and import cleanup:**

* Updated the script's top-level documentation to mention the new `--apply` flag and clarified usage instructions.
* Reformatted and organized import statements for improved readability.