### PR TITLE
chore: clean test imports and typing redundancy

### DIFF
--- a/tests/test_mlflow_utils_root.py
+++ b/tests/test_mlflow_utils_root.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-import json
 
 from codex_ml.tracking import ensure_local_artifacts, seed_snapshot, start_run
 

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -36,7 +36,6 @@ from transformers import (
     TrainingArguments,
     __version__ as _hf_version,
 )
-from typing import Optional
 
 from codex_ml.monitoring.codex_logging import (
     CodexLoggers,


### PR DESCRIPTION
## Summary
- tidy `tests/test_mlflow_utils_root.py` imports and remove duplicate import
- drop redundant Optional import in trainer

## Testing
- `pre-commit run --files tests/test_mlflow_utils_root.py training/engine_hf_trainer.py` *(fails: Check for leftover merge conflict markers)*
- `pytest tests/ingestion/test_io_text.py tests/interfaces/test_tokenizer_hf.py tests/test_codex_run_tasks.py tests/test_mlflow_utils_root.py tests/test_model_loader.py` *(fails: coverage 15.50% < 70%)*

------
https://chatgpt.com/codex/tasks/task_e_68b20151cdec83319f19dc75c78d61de