### PR TITLE
fix: restore no-op MLflow context manager

### DIFF
--- a/CHANGELOG_Codex.md
+++ b/CHANGELOG_Codex.md
@@ -1,5 +1,16 @@
 # Codex Changelog
 
+## 2025-08-29 – Restore no-op MLflow context manager
+
+### WHY
+- Maintain previous behaviour where disabled MLflow tracking yields a no-op context manager.
+
+### RISK
+- Low: ensures `with start_run(cfg)` continues to work when tracking is off or unavailable.
+
+### ROLLBACK
+- Revert this commit to return ``None`` instead.
+
 ## 2025-08-29 – Local orchestration scripts
 
 ### WHY

--- a/src/codex_ml/tracking/mlflow_utils.py
+++ b/src/codex_ml/tracking/mlflow_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ContextManager, Dict, Mapping, Optional, Union
@@ -27,8 +28,8 @@ class MlflowConfig:
 
 def start_run(
     cfg_or_experiment: Union[MlflowConfig, str], tracking_uri: str | None = None
-) -> Optional[ContextManager[Any]]:
-    """Start an MLflow run if MLflow is installed; otherwise return ``None``.
+) -> ContextManager[Any]:
+    """Start an MLflow run if available; otherwise return a no-op context manager.
 
     Accepts either a :class:`MlflowConfig` or an experiment name for backward
     compatibility with older helper utilities.
@@ -36,7 +37,7 @@ def start_run(
 
     if isinstance(cfg_or_experiment, MlflowConfig):
         if not cfg_or_experiment.enable:
-            return None
+            return nullcontext()
         experiment = cfg_or_experiment.experiment
         tracking_uri = cfg_or_experiment.tracking_uri
     else:
@@ -45,7 +46,7 @@ def start_run(
     try:
         import mlflow
     except Exception:  # pragma: no cover - optional dep
-        return None
+        return nullcontext()
 
     if tracking_uri:
         mlflow.set_tracking_uri(tracking_uri)

--- a/tools/codex_exec.py
+++ b/tools/codex_exec.py
@@ -34,7 +34,7 @@ import sys
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 # ---------- Constants ----------
 QUESTION_FILE = "Codex_Questions.md"
@@ -83,7 +83,7 @@ def append_text(p: Path, data: str) -> None:
 
 
 def run(
-    cmd: List[str], cwd: Optional[Path] = None, timeout: Optional[int] = None
+    cmd: Sequence[str], cwd: Optional[Path] = None, timeout: Optional[int] = None
 ) -> Tuple[int, str, str]:
     proc = subprocess.run(
         cmd, cwd=str(cwd) if cwd else None, capture_output=True, text=True, timeout=timeout


### PR DESCRIPTION
## Summary
- preserve nullcontext when MLflow tracking is disabled or missing
- document MLflow no-op behavior in CHANGELOG
- accept Sequence in `codex_exec.run` helper

## Testing
- `pre-commit run --files CHANGELOG_Codex.md src/codex_ml/tracking/mlflow_utils.py tools/codex_exec.py`
- `pytest` *(fails: test_cli_lint_smoke, test_cli_test_smoke, test_cli_audit_smoke, test_codex_maintenance_summary, test_run_task_writes_files, test_logging_viewer_cli_text_output, test_logging_viewer_cli_json_output, test_start_run_noop, test_tail_option, test_readme_session_logger_example, test_requirements_lock_exists, test_internal_search_finds_known_string, test_assert_vocab_size, test_record_metrics_writes_json, test_import_error)*

------
https://chatgpt.com/codex/tasks/task_e_68b2418c20488331828a994982c44dbb