### PR TITLE
docs: model codex run as dynamical system

### DIFF
--- a/docs/dynamical-system.md
+++ b/docs/dynamical-system.md
@@ -1,65 +1,261 @@
 <!-- BEGIN: CODEX_DOCS_DYNAMICAL_SYSTEM -->
-# Codex as a Dynamical System
+# Codex Dynamics: a quantum-operational model for single-shot repo runs
 
-The Codex single-shot run can be interpreted through the lens of a quantum-style dynamical system. Repository states evolve through discrete phases, patches act as quanta, and quality gates serve as projectors.
+## Table of contents
 
-## 1. System Overview
+1. State space and observables
+2. Phase operators (P₁…P₆)
+3. Quality gates as projectors
+4. Patch algebra (creation/annihilation on files)
+5. Canonicalization triad (merge/rename/delete)
+6. Open-system dynamics (Hamiltonian + jump errors)
+7. Action/optimal-control formulation
+8. Measurement & run outcomes
+9. Stability, invariants, and fixed points
+10. Toy derivation on a duplicate-file family
+11. Prompt adapter (how to use this in Codex specs)
+12. Symbol legend
 
-Let $|\Psi_t\rangle$ denote the repository process state at time $t$. The run progresses through phases $\{\mathsf{Prep},\mathsf{Map},\mathsf{Build},\mathsf{Prune},\mathsf{Error},\mathsf{Finalize}\}$ with tunable weights $\vec\kappa$.
+---
 
-## 2. State Space & Operators
+# 1) State space and observables
 
-- Basis $\{|r\rangle\}$ spans repo configurations.
-- Patch creation/rollback operators: $a^\dagger$ creates a patch, $a$ reverts it, with $[a,a^\dagger]=\mathbf{1}$.
-- Quality debt operator $D\ge0$ accumulates lint, type, test, coverage, and doc violations.
-- $G$ is the GitHub Actions activation operator; feasible states satisfy $G|\Psi_t\rangle=0$.
-- Phase generators $\mathcal{H}_\phi$ drive each phase $\phi$.
+Let the run live in a composite Hilbert space
 
-## 3. Dynamics
+```
+𝓗 = 𝓗_files ⊗ 𝓗_tests ⊗ 𝓗_docs ⊗ 𝓗_tools .
+```
 
-A phase-weighted Hamiltonian combines phase generators:
+The repo’s instantaneous state is a vector |R_t⟩ or density matrix ρ_t on 𝓗.
+File-family occupancies are number operators `{N_f}`; coverage, lint, type, etc. are Hermitian observables.
 
-$$H = \alpha\mathcal{H}_{\text{prep}} + \beta\mathcal{H}_{\text{map}} + \gamma\mathcal{H}_{\text{build}} + \delta\mathcal{H}_{\text{prune}} + \varepsilon\mathcal{H}_{\text{error}} + \zeta\mathcal{H}_{\text{final}}.$$
+---
 
-An illustrative build generator:
+# 2) Phase operators (P₁…P₆)
 
-$$\mathcal{H}_{\text{build}} = \eta_1 a^\dagger + \eta_2 a D + \eta_3 D^2.$$
+Associate each execution phase with a (possibly time-dependent) operator:
 
-Evolution follows a Schrödinger-like equation $i\hbar\partial_t|\Psi_t\rangle = H|\Psi_t\rangle$.
+```
+P₁: Preparation
+P₂: Search & Mapping
+P₃: Best-Effort Construction
+P₄: Controlled Pruning
+P₅: Error Capture
+P₆: Finalization
+```
 
-## 4. Constraints & Projectors
+In the ideal, phase evolution is unitary `U_k = e^{-i H_k Δt}`; in practice we allow completely positive trace-preserving (CPTP) maps `𝓤_k` to model side-effects.
 
-Quality gates are projectors $\Pi_\text{lint},\Pi_\text{type},\Pi_\text{test},\Pi_{\text{cov}(\ge c)},\Pi_\text{docs},\Pi_\text{noGH}$. The hard constraint $\Pi_\text{noGH}|\Psi\rangle=|\Psi\rangle$ keeps GitHub Actions off. Soft penalties use $1-\langle\Psi|\Pi_j|\Psi\rangle$.
+---
 
-## 5. Measurements & Error Capture
+# 3) Quality gates as projectors
 
-Failure probability is $P_{\text{err}}(t) = \langle\Psi_t|\Pi_{\text{err}}|\Psi_t\rangle$. On error, a logging superoperator appends diagnostic entries while preserving state evolution.
+Define projectors (pass = 1, fail = 0):
 
-## 6. Objective: Free-Energy Minimization
+```
+Π_lint, Π_type, Π_test, Π_cov(θ)
+```
 
-We minimize run energy
+with a coverage observable `Ĉ ∈ [0,100]` and threshold θ:
 
-$$\mathbb{E}[E] = \langle\Psi|H|\Psi\rangle + \sum_j\lambda_j\mathcal{C}_j(\Psi)$$
+```
+Π_cov(θ) = Θ(Ĉ − θ)       (Θ is the Heaviside step function).
+```
 
-subject to $G|\Psi\rangle=0$. Temperature $T$ tunes exploration via $\beta=1/(k_B T)$.
+The composite gate is
 
-## 7. Stationary Conditions
+```
+G(θ) = Π_lint Π_type Π_test Π_cov(θ).
+```
 
-Variational calculus yields
+A successful run postselects onto the +1 eigenspace of G(θ).
 
-$$(i\hbar\partial_t - H)|\Psi_t\rangle = \left(\lambda_G G + \sum_j \lambda_j \nabla_\Psi \mathcal{C}_j\right)|\Psi_t\rangle,$$
+---
 
-interpreted algorithmically: propose a patch with $a^\dagger$ that decreases quality debt; accept if it lowers $\mathbb{E}[E]$, otherwise revert with $a$.
+# 4) Patch algebra (creation/annihilation on files)
 
-## 8. Discrete Algorithmic Analog
+Model a unified patch to file f as a bosonic excitation with payload Δ:
 
-With discrete steps $k$, $|\Psi_{k+1}\rangle = M_{\text{gates}} U_\Delta(\vec\kappa) |\Psi_k\rangle$, where $U_\Delta \approx I - i\Delta H$. Acceptance follows a Metropolis rule
+```
+[a_f, a_g†] = δ_fg ,   [a_f, a_g] = 0 .
+```
 
-$$p_{\text{accept}} = \min\left(1, e^{-\beta(\mathbb{E}[E]_{k+1}-\mathbb{E}[E]_k)}\right).$$
+Applying a patch is the action of `a_f†(Δ)`; reverting is `a_f(Δ)`.
+Define a patch-cost operator (time-local)
 
-## 9. Summary Equation
+```
+ℂ = ∑_f ∫ dΔ  c_f(Δ) a_f†(Δ) a_f(Δ),
+```
 
-$$\boxed{\min_{|\Psi\rangle:G|\Psi\rangle=0}\left\{\langle\Psi|H|\Psi\rangle + \sum_j\lambda_j\left(1-\langle\Psi|\Pi_j|\Psi\rangle\right)\right\};\ |\Psi_{k+1}\rangle \leftarrow M_{\text{gates}} U_\Delta(\vec\kappa) |\Psi_k\rangle.}$$
+and a risk functional ℛ (see §7) that weights invasive edits.
 
-This formulation explains how Codex converges to high-quality, constraint-satisfying patches while ensuring GitHub Actions remain inactive.
+Public-API (re)exports are encoded as commuting constraints `E_s = 1` for each expected symbol s in `__all__/index.ts/lib.rs`.
+
+---
+
+# 5) Canonicalization triad (merge/rename/delete)
+
+For each duplicate family 𝔽 (e.g., `tokenizer.py0, .py1, .py00 → tokenizer.py`) define idempotent operators:
+
+```
+𝕄_𝔽  (merge) ,   ℜ_𝔽  (rename) ,   𝔇_𝔽  (delete)
+```
+
+with laws
+
+```
+𝕄_𝔽² = 𝕄_𝔽 ,   ℜ_𝔽² = ℜ_𝔽 ,   𝔇_𝔽² = 𝔇_𝔽 ,
+[𝕄_𝔽, ℜ_𝔽] = 0,   ℜ_𝔽 𝔇_𝔽 = 𝔇_𝔽 ℜ_𝔽 ,
+N_suffix,𝔽 • (ℜ_𝔽 𝕄_𝔽) = 0   (no suffixed files remain).
+```
+
+A successful canonicalization is the projector
+
+```
+C_𝔽 = 𝔇_𝔽 ℜ_𝔽 𝕄_𝔽 .
+```
+
+---
+
+# 6) Open-system dynamics (Hamiltonian + jump errors)
+
+Let the controlled Hamiltonian be
+
+```
+H(t) = ∑_{k=1}^6 u_k(t) H_k  +  λ ℂ  +  μ ℛ ,
+```
+
+where `u_k(t) ∈ {0,1}` toggles phases, λ, μ ≥ 0 tune cost/risk penalties.
+
+Operationally the run is an open system evolving by a Lindblad master equation:
+
+```
+ṙho = −i [H(t), ρ] + ∑_e γ_e ( J_e ρ J_e† − ½ {J_e† J_e, ρ} ),
+```
+
+where each error mode e (lint fail, type fail, flaky test, IO error, etc.) has jump operator J_e.
+Phase-5 logging corresponds to applying a documentation creation operator `D†` that appends a structured entry to `Codex_Questions.md` whenever any J_e fires.
+
+---
+
+# 7) Action/optimal-control formulation
+
+Treat the run as an optimal-control problem minimizing the action
+
+```
+S[path] = ∫_0^T [ L_base(ρ,u) + λ ⟨ℂ⟩_ρ + μ ⟨ℛ⟩_ρ
+                 + α (1 − ⟨Π_test⟩_ρ) + β (θ − ⟨Ĉ⟩_ρ)_+ ] dt
+```
+
+subject to boundary constraints:
+
+```
+Π_noGH |R_t⟩ = |R_t⟩     (superselection: no GitHub Actions),
+G(θ) |R_T⟩ = |R_T⟩       (all gates pass at final time),
+C_𝔽 |R_T⟩ = |R_T⟩       (all canonicalizations applied),
+E_s |R_T⟩ = |R_T⟩       (public exports present).
+```
+
+Here `(x)_+ = max(x,0)`, and `Π_noGH` forbids any `.github/workflows/*` activation.
+
+The partition function over all admissible patch paths is
+
+```
+Z(β) = ∑_{paths} exp(−β S[path]),
+```
+
+useful for reasoning about alternative diffs/branch strategies.
+
+---
+
+# 8) Measurement & run outcomes
+
+At T, perform the projective measurement `{G(θ), 1−G(θ)}`.
+Success probability:
+
+```
+p_succ = Tr[ G(θ) ρ_T ] .
+```
+
+Conditioning on success collapses onto the “green build” manifold; otherwise the state is fed back through P₅ (error capture) with updated controls.
+
+---
+
+# 9) Stability, invariants, and fixed points
+
+**Invariants.**
+
+* No-Actions invariant: `[H(t), Π_noGH] = 0` ⇒ forbidden files cannot be created/activated.
+* Canonicalization decreases a Lyapunov potential `Φ = ∑_𝔽 N_suffix,𝔽`, and
+
+```
+Φ_{t+} ≤ Φ_{t},   Φ_T = 0  (at a fixed point).
+```
+
+**Fixed points.**
+A fixed point `ρ*` satisfies
+
+```
+[H(·), ρ*] = 0 ,   J_e ρ* = 0 ∀e ,   G(θ) ρ* = ρ* .
+```
+
+Interpretation: no pending edits, no error channels active, all gates passing.
+
+---
+
+# 10) Toy derivation on a duplicate-file family
+
+Consider one family 𝔽 = {`x.py0`, `x.py1`} with target `x.py`.
+Occupancies `(n0, n1, n)` are eigenvalues of `{N_0, N_1, N}`.
+
+Start with `|ψ₀⟩ = |1,1,0⟩`. Apply merge→rename→delete:
+
+```
+|ψ₁⟩ = 𝕄_𝔽 |1,1,0⟩ = |0,0,1⟩         (content union landed in canonical)
+|ψ₂⟩ = ℜ_𝔽 |0,0,1⟩ = |0,0,1⟩         (idempotent if already canonical)
+|ψ₃⟩ = 𝔇_𝔽 |0,0,1⟩ = |0,0,1⟩         (no residual suffixed files)
+```
+
+Quality gate projector `G(θ)` then acts only on tests/coverage; `Π_cov(θ)=1` if `Ĉ ≥ θ`.
+
+---
+
+# 11) Prompt adapter (drop-in snippet for your Codex specs)
+
+```
+—[Quantum-Operational Constraints]—
+1) Treat phases as control fields u_k(t) ∈ {0,1} multiplying H_k.
+2) Minimize S[path] in §7; respect superselection Π_noGH and terminal constraints G(θ)=1, C_𝔽=1.
+3) Implement canonicalization via the commuting, idempotent triad (𝕄, ℜ, 𝔇) per family.
+4) Encode patches with creation ops a_f†; prefer low ℂ, low ℛ; keep exports E_s satisfied.
+5) On any failure channel J_e, emit a Phase-5 log entry (exact template), then continue with adjusted controls.
+6) Stop only when at a fixed point ρ* with Φ=0 and G(θ)=1.
+```
+
+---
+
+# 12) Symbol legend (quick reference)
+
+* `|R_t⟩, ρ_t` — repo state (vector/density).
+* `P₁…P₆` — phase operators (prep, map, build, prune, errors, finalize).
+* `G(θ)` — composite quality gate with coverage threshold θ.
+* `Π_noGH` — “no GitHub Actions” projector (hard constraint).
+* `a_f†(Δ), a_f(Δ)` — patch create/revert on file f with delta Δ.
+* `ℂ` — patch-cost operator; `ℛ` — risk functional.
+* `𝕄, ℜ, 𝔇` — merge/rename/delete canonicalization ops (idempotent, commuting).
+* `J_e` — error jump operator; `γ_e` — its rate.
+* `H(t)` — controlled Hamiltonian; `u_k(t)` — phase control fields.
+* `S[path]` — action to minimize; `Z(β)` — run partition function.
+* `Φ` — duplicate-suffix potential; `ρ*` — fixed point (green build).
+
+---
+
+### One-line mnemonic
+
+```
+“Drive ρ_t with U_phases while damping by J_errors,
+create minimal a†-patches, annihilate duplicates with (𝕄,ℜ,𝔇),
+postselect on G(θ)=1 under Π_noGH — and you’re done.”
+```
+
 <!-- END: CODEX_DOCS_DYNAMICAL_SYSTEM -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Concepts: concepts.md
-  - Dynamical System: dynamical-system.md
+  - Codex Dynamics: dynamical-system.md
   - API Reference: api.md
   - Tutorials:
       - Quickstart (CPU): tutorials/quickstart.md


### PR DESCRIPTION
This pull request introduces a comprehensive new documentation page, "Codex Dynamics," that presents an algebraic structures-quantum-operational model for single-shot repository runs. The new document formalizes the phases, constraints, and algebraic structures underlying Codex's approach to repo modifications and quality gates, and it is now linked in the documentation navigation.

Documentation additions and navigation:

* Added a new `dynamical-system.md` file detailing the Codex Dynamics model, including state space, phase operators, quality gates, patch algebra, canonicalization, open-system dynamics, optimal control, measurement, stability, and a prompt adapter for Codex specs.
* Updated `mkdocs.yml` to include "Codex Dynamics" in the documentation navigation, making the new material easily accessible.

---

## Summary
- document Codex run as a dynamical system of phases, operators, and quality projectors
- add new doc to MkDocs navigation

## Testing
- `pre-commit run --all-files` *(fails: trailing whitespace hook modified many files)*
- `pre-commit run --files mkdocs.yml docs/dynamical-system.md`
- `pytest` *(fails: ImportError and test collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d6302e5c83319246aa7ec362f379