### PR TITLE
chore: enforce coverage in nox tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -18,8 +18,19 @@ def quality(session):
 
 @nox.session(python=["3.9", "3.10", "3.11", "3.12"])
 def tests(session):
-    session.install("pytest", "charset-normalizer>=3.0.0", "chardet>=5.0.0")
-    session.run("pytest", "-q")
+    session.install(
+        "pytest",
+        "pytest-cov",
+        "charset-normalizer>=3.0.0",
+        "chardet>=5.0.0",
+    )
+    session.run(
+        "pytest",
+        "--cov=src/codex_ml",
+        "--cov-fail-under=80",
+        "-q",
+        *session.posargs,
+    )
 
 
 @nox.session


### PR DESCRIPTION
## Summary
- enforce minimum coverage in nox tests session
- install pytest-cov and apply 80% coverage gate

## Testing
- `pre-commit run --files noxfile.py`
- `pytest -q` *(fails: ImportError: cannot import name 'read_text' from 'ingestion.utils')*

------
https://chatgpt.com/codex/tasks/task_e_68b34760b3b4833184766703ba37e307