### PR TITLE
feat: integrate optional lora adapter

### DIFF
--- a/src/codex_ml/peft/peft_adapter.py
+++ b/src/codex_ml/peft/peft_adapter.py
@@ -1,21 +1,39 @@
 from __future__ import annotations
 
-try:
-    from peft import LoraConfig, get_peft_model  # optional dependency
-except Exception:  # pragma: no cover
-    LoraConfig = None
-    get_peft_model = None
+"""LoRA integration for Codex models.
+
+When the optional ``peft`` package is available, this helper wraps a model with
+low-rank adapters. Configuration can be supplied as a dictionary containing
+``r``, ``lora_alpha``, ``lora_dropout`` and ``bias``. If ``peft`` is not
+installed, the function returns the model unchanged.
+"""
+
+try:  # optional dependency
+    from peft import LoraConfig, get_peft_model
+except Exception:  # pragma: no cover - peft not installed
+    LoraConfig = None  # type: ignore
+    get_peft_model = None  # type: ignore
 
 
 def apply_lora(model, cfg: dict | None = None):
-    """Attach LoRA adapters via `peft` when available; otherwise return model unchanged."""
+    """Apply LoRA adapters via ``peft`` when available.
+
+    Args:
+        model: The base model to wrap.
+        cfg: Optional configuration dictionary.
+
+    Returns:
+        The adapted model or the original model if ``peft`` is unavailable.
+    """
+
     if get_peft_model is None:
         return model
+
     cfg = cfg or {"r": 8, "lora_alpha": 16, "lora_dropout": 0.05, "bias": "none"}
     try:
         config = LoraConfig(task_type="CAUSAL_LM", **cfg)
         return get_peft_model(model, config)
     except Exception:
-        # As a graceful fallback ensure the returned object exposes `peft_config`
+        # Fall back to returning the original model but expose the attempted config
         setattr(model, "peft_config", cfg)
         return model

--- a/tests/test_peft_adapter.py
+++ b/tests/test_peft_adapter.py
@@ -1,5 +1,5 @@
-import torch.nn as nn
 import pytest
+import torch.nn as nn
 
 from src.codex_ml.peft.peft_adapter import apply_lora
 
@@ -11,7 +11,7 @@ def test_apply_lora_noop_without_peft():
 
 
 def test_apply_lora_with_peft():
-    peft = pytest.importorskip("peft")
+    pytest.importorskip("peft")
     model = nn.Linear(4, 4)
     patched = apply_lora(model)
     assert patched is not None


### PR DESCRIPTION
## Summary
- expand LoRA helper with docs and fallback
- fix peft adapter tests

## Testing
- `pre-commit run --files src/codex_ml/peft/peft_adapter.py tests/test_peft_adapter.py`
- `pytest tests/test_peft_adapter.py --cov-fail-under=0 -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b34760b3b4833184766703ba37e307