### PR TITLE
feat: add basic risk classifier

### DIFF
--- a/src/codex_ml/safety/risk_score.py
+++ b/src/codex_ml/safety/risk_score.py
@@ -1,19 +1,60 @@
 # BEGIN: CODEX_RISK_SCORE
-"""Placeholder keyword-based risk scoring.
+"""Simple safety classifier with optional transformer backend.
 
-This stub assigns a score of ``1.0`` when any risky keyword is found in the
-input text (case-insensitive) and ``0.0`` otherwise.
-
-TODO: replace with a real model-based classifier.
-"""
+The function attempts to load a tiny sentiment model via ``transformers`` to
+produce a probabilistic risk score. When the dependency or model is
+unavailable, it falls back to a logistic model based on keyword matches.
+Scores are always in the ``[0.0, 1.0]`` range."""
 from __future__ import annotations
 
-FLAGGED = {"password", "api_key", "ssn", "rm -rf /", "kill", "drop database"}
+from math import exp
+from typing import Dict
+
+try:  # optional dependency for a real classifier
+    from transformers import pipeline  # type: ignore
+except Exception:  # pragma: no cover - transformers not installed
+    pipeline = None  # type: ignore
+
+MODEL_NAME = "philschmid/tiny-bert-sst2-distilled"
+_classifier = None
+
+# keyword weights used by the fallback logistic model
+WEIGHTS: Dict[str, float] = {
+    "password": 1.0,
+    "api_key": 1.0,
+    "ssn": 1.0,
+    "rm -rf /": 2.0,
+    "kill": 2.0,
+    "drop database": 2.0,
+}
+
+
+def _load_classifier():
+    global _classifier
+    if pipeline is None:
+        return None
+    if _classifier is None:
+        _classifier = pipeline("text-classification", model=MODEL_NAME)
+    return _classifier
+
+
+def _keyword_logistic(text: str) -> float:
+    tl = text.lower()
+    score = sum(weight for k, weight in WEIGHTS.items() if k in tl)
+    return 1.0 / (1.0 + exp(-score)) if score > 0 else 0.0
 
 
 def risk_score(text: str) -> float:
-    tl = text.lower()
-    return 1.0 if any(k in tl for k in FLAGGED) else 0.0
+    """Return a risk score between 0 and 1 for ``text``."""
+    clf = _load_classifier()
+    if clf is not None:
+        result = clf(text, truncation=True)[0]
+        score = float(result["score"])
+        label = result["label"].lower()
+        if label in {"negative", "toxic", "unsafe", "label_1"}:
+            return score
+        return 1.0 - score
+    return _keyword_logistic(text)
 
 
 # END: CODEX_RISK_SCORE

--- a/tests/safety/test_risk_score.py
+++ b/tests/safety/test_risk_score.py
@@ -2,8 +2,8 @@ from codex_ml.safety.risk_score import risk_score
 
 
 def test_safe_text():
-    assert risk_score("hello world") == 0.0
+    assert 0.0 <= risk_score("hello world") < 0.5
 
 
 def test_flagged_text():
-    assert risk_score("leak password please") == 1.0
+    assert risk_score("leak password please") > 0.5


### PR DESCRIPTION
## Summary
- incorporate optional transformer-based classifier with keyword fallback to score text risk
- adjust risk score tests for probabilistic outputs

## Testing
- `pre-commit run --files src/codex_ml/safety/risk_score.py tests/safety/test_risk_score.py`
- `pytest -q` *(fails: ImportError: cannot import name 'read_text' from 'ingestion.utils')*


------
https://chatgpt.com/codex/tasks/task_e_68b349a4864c8331a954bfd2e311fb8e