### PR TITLE
fix: ensure LoRA config persists

### DIFF
--- a/tests/test_peft_adapter.py
+++ b/tests/test_peft_adapter.py
@@ -8,7 +8,9 @@ class DummyModel:
 
 def test_apply_lora_without_peft(monkeypatch):
     model = DummyModel()
-    out = apply_lora(model, r=4)
+    out = apply_lora(model, {"lora_alpha": 32, "task_type": "SEQ_CLS"}, r=4)
     assert out is model
     assert hasattr(out, "peft_config")
     assert out.peft_config["r"] == 4
+    assert out.peft_config["lora_alpha"] == 32
+    assert out.peft_config["task_type"] == "SEQ_CLS"


### PR DESCRIPTION
## Summary
- attach final LoRA configuration to adapted models and merge override values
- expand LoRA adapter test to verify merged configuration

## Testing
- `pre-commit run --files src/codex_ml/peft/peft_adapter.py tests/test_peft_adapter.py`
- `pytest` *(fails: ImportError cannot import name 'read_text' from 'ingestion.utils')*

------
https://chatgpt.com/codex/tasks/task_e_68b39fb2b5b88331a4891e042d99a5b6