### PR TITLE
chore: gate tests with coverage and document env

### DIFF
--- a/.codex/deferred_items.md
+++ b/.codex/deferred_items.md
@@ -3,3 +3,5 @@
 - Expand LoRA adapter to support additional PEFT strategies.
 - Document advanced CLI usage and configuration.
 - Increase test coverage for codex utilities.
+- Explore dynamic configuration of LoRA ranks per layer.
+- Add end-to-end tests for codex-ml training pipelines.

--- a/.codex/inventory.txt
+++ b/.codex/inventory.txt
@@ -1,3 +1,4 @@
+# Environment inventory generated Sun Aug 31 03:16:44 UTC 2025
 Python 3.12.10
 accelerate==1.10.1
 aiohappyeyeballs==2.6.1
@@ -87,7 +88,6 @@ pandas==2.3.2
 pandocfilters==1.5.1
 pathspec==0.12.1
 peft==0.17.1
-pip==25.2
 platformdirs==4.3.8
 pluggy==1.6.0
 pre_commit==4.3.0
@@ -132,8 +132,8 @@ traitlets==5.14.3
 transformers==4.56.0
 triton==3.4.0
 typer==0.17.3
-typing_extensions==4.14.1
 typing-inspection==0.4.1
+typing_extensions==4.14.1
 tzdata==2025.2
 ujson==5.11.0
 urllib3==2.5.0

--- a/_codex_status_update-2025-08-31.md
+++ b/_codex_status_update-2025-08-31.md
@@ -1,0 +1,13 @@
+# Status Update - 2025-08-31
+
+## Completed
+- Extended `apply_lora` to merge defaults with provided configuration and keyword overrides.
+- Added coverage enforcement to `noxfile.py` and refreshed basic CLI and adapter tests.
+- Logged Python environment to `.codex/inventory.txt` for reproducibility.
+
+## Deferred
+See [`.codex/deferred_items.md`](.codex/deferred_items.md) for postponed tasks.
+
+## Open Questions
+- Should the LoRA helper expose per-layer rank scaling?
+- Are additional CLI commands needed for codex-ml workflows?

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,9 +11,14 @@ def lint(session):
 @nox.session
 def quality(session):
     """Run formatting hooks and tests locally."""
-    session.install("pre-commit", "pytest")
+    session.install("pre-commit", "pytest", "pytest-cov")
     session.run("pre-commit", "run", "--all-files")
-    session.run("pytest", "-q")
+    session.run(
+        "pytest",
+        "--cov=src/codex_ml",
+        "--cov-fail-under=80",
+        "-q",
+    )
 
 
 @nox.session(python=["3.9", "3.10", "3.11", "3.12"])

--- a/tests/test_hydra_cli.py
+++ b/tests/test_hydra_cli.py
@@ -9,3 +9,9 @@ pytest.importorskip("hydra")
 def test_hydra_cli_smoke():
     cmd = [sys.executable, "-m", "src.codex_ml.cli.main", "dry_run=true", "pipeline.steps=[]"]
     subprocess.run(cmd, check=True)
+
+
+def test_hydra_cli_help():
+    cmd = [sys.executable, "-m", "src.codex_ml.cli.main", "--help"]
+    proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    assert "Usage" in proc.stdout


### PR DESCRIPTION
## Summary
- enforce 80% coverage gate in `noxfile.py`
- add basic help test for `codex_ml` CLI entry point
- record current Python environment and note follow-up tasks

## Testing
- `pre-commit run --files noxfile.py tests/test_hydra_cli.py .codex/deferred_items.md .codex/inventory.txt _codex_status_update-2025-08-31.md`
- `pytest -q` *(fails: ImportError: cannot import name 'read_text' from 'ingestion.utils')*
- `pytest tests/test_peft_adapter.py tests/test_hydra_cli.py tests/test_cli.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68b3be0159d48331ab23697d86716812