### PR TITLE
feat: record training metrics to ndjson

### DIFF
--- a/src/codex_ml/peft/peft_adapter.py
+++ b/src/codex_ml/peft/peft_adapter.py
@@ -25,23 +25,6 @@ DEFAULT_CFG: dict = {
 
 
 def apply_lora(model, cfg: dict | None = None, **overrides):
-    """Apply LoRA adapters via ``peft`` when available.
-
-    Args:
-        model: The base model to wrap.
-        cfg: Optional configuration dictionary.
-        **overrides: Keyword arguments that override configuration values.
-
-    Returns:
-        The adapted model or the original model if ``peft`` is unavailable.
-        In all cases, the merged configuration is attached to the returned
-        model under ``peft_config`` for inspection.
-    """
-
-    merged = {**DEFAULT_CFG, **(cfg or {}), **overrides}
-    setattr(model, "peft_config", merged)
-
-def apply_lora(model, cfg: dict | None = None, **overrides):
     """Attach LoRA adapters via :mod:`peft` when available.
 
     Parameters

--- a/src/codex_ml/train_loop.py
+++ b/src/codex_ml/train_loop.py
@@ -71,22 +71,34 @@ def record_metrics(
 
 
 def demo_epoch(epoch: int, grad_accum: int = 1) -> Dict[str, float]:
-    # Create a toy prediction/target scenario where accuracy and ppl can improve
+    """Simulate a training epoch with gradient accumulation.
+
+    This toy loop splits the synthetic dataset into ``grad_accum`` micro-batches
+    and pretends to step an optimiser once per accumulation cycle. Metrics are
+    computed over the full epoch. The number of optimiser steps is returned for
+    introspection in tests.
+    """
+
     random.seed(42 + epoch)
     targets = [random.randint(0, 4) for _ in range(100)]
-    preds = [
-        t if random.random() < (0.4 + 0.15 * epoch) else random.randint(0, 4)
-        for t in targets
-    ]
+    preds: list[int] = []
+    micro = max(1, len(targets) // max(1, grad_accum))
+    steps = 0
+    for i in range(0, len(targets), micro):
+        batch_t = targets[i : i + micro]
+        batch_p = [
+            t if random.random() < (0.4 + 0.15 * epoch) else random.randint(0, 4) for t in batch_t
+        ]
+        preds.extend(batch_p)
+        steps += 1
     acc = token_accuracy(preds, targets)
-    # Build logits such that correct class probability improves per epoch
     logits = []
     for t in targets:
         base = [0.0] * 5
         base[t] = 1.0 + 0.3 * epoch
         logits.append(base)
     ppl = perplexity(logits, targets, from_logits=True)
-    return {"acc": acc, "ppl": ppl, "grad_accum": grad_accum}
+    return {"acc": acc, "ppl": ppl, "grad_accum": grad_accum, "steps": steps}
 
 
 def main():

--- a/src/ingestion/__init__.py
+++ b/src/ingestion/__init__.py
@@ -1,7 +1,57 @@
 """Ingestion utilities package."""
 
-from .encoding_detect import detect_encoding
-from .io_text import read_text
-from .utils import deterministic_shuffle
+from __future__ import annotations
 
-__all__ = ["read_text", "deterministic_shuffle", "detect_encoding"]
+from pathlib import Path
+from typing import Iterator, Union
+
+from .encoding_detect import detect_encoding
+from .io_text import read_text as _read_text
+from .utils import deterministic_shuffle, read_text_file
+
+__all__ = [
+    "read_text",
+    "deterministic_shuffle",
+    "detect_encoding",
+    "ingest",
+    "Ingestor",
+]
+
+
+def read_text(path: Path | str, encoding: str = "utf-8") -> str:
+    text, _ = _read_text(Path(path), encoding=encoding)
+    return text
+
+
+def ingest(
+    path: Union[str, Path], *, encoding: str = "utf-8", chunk_size: int | None = None
+) -> Union[str, Iterator[str]]:
+    """Read text data from ``path`` with optional chunked iteration."""
+
+    p = Path(path)
+    if not p.is_file():
+        raise FileNotFoundError(p)
+    if chunk_size is None:
+        return read_text_file(p, encoding=encoding)
+
+    def _gen() -> Iterator[str]:
+        with p.open("r", encoding=encoding) as fh:
+            while True:
+                chunk = fh.read(chunk_size)
+                if not chunk:
+                    break
+                yield chunk
+
+    return _gen()
+
+
+class Ingestor:
+    """Shim class exposing :func:`ingest` as a static method."""
+
+    @staticmethod
+    def ingest(
+        path: Union[str, Path],
+        encoding: str = "utf-8",
+        chunk_size: int | None = None,
+    ) -> Union[str, Iterator[str]]:
+        return ingest(path, encoding=encoding, chunk_size=chunk_size)

--- a/src/ingestion/utils.py
+++ b/src/ingestion/utils.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import random
+from pathlib import Path
 from typing import List, Sequence, TypeVar
+
+from .encoding_detect import detect_encoding
+from .io_text import read_text as _read_text
 
 T = TypeVar("T")
 
-__all__ = ["deterministic_shuffle"]
+__all__ = [
+    "deterministic_shuffle",
+    "read_text",
+    "read_text_file",
+    "_detect_encoding",
+]
 
 
 def deterministic_shuffle(seq: Sequence[T], seed: int) -> List[T]:
@@ -17,3 +26,26 @@ def deterministic_shuffle(seq: Sequence[T], seed: int) -> List[T]:
     rng = random.Random(seed)
     rng.shuffle(items)
     return items
+
+
+def read_text(path: Path | str, encoding: str = "utf-8") -> str:
+    """Read text from ``path`` using optional encoding detection.
+
+    This is a thin wrapper around :func:`ingestion.io_text.read_text` that
+    returns just the decoded string for convenience.
+    """
+
+    text, _ = _read_text(Path(path), encoding=encoding)
+    return text
+
+
+def read_text_file(path: Path | str, encoding: str = "utf-8") -> str:
+    """Alias for :func:`read_text` for backwards compatibility."""
+
+    return read_text(path, encoding=encoding)
+
+
+def _detect_encoding(path: Path) -> str:
+    """Internal helper used by legacy ingestors for encoding detection."""
+
+    return detect_encoding(Path(path))

--- a/tests/test_engine_hf_trainer.py
+++ b/tests/test_engine_hf_trainer.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import torch
@@ -15,14 +16,23 @@ def test_hf_trainer_smoke(tmp_path):
         config_path=config,
         fp16=torch.cuda.is_available(),
     )
-    # metrics should include training loss and global_step
     assert "train_loss" in metrics
     assert metrics.get("global_step", 0) > 0
-    # HF may save in safetensors format by default
     saved = tmp_path / "pytorch_model.bin"
     if not saved.exists():
         saved = tmp_path / "model.safetensors"
     assert saved.exists()
+
+
+def test_hf_trainer_writes_metrics(tmp_path):
+    texts = ["hi", "there"]
+    metrics = run_hf_trainer(texts, tmp_path, model_name="sshleifer/tiny-gpt2")
+    metrics_json = tmp_path / "metrics.json"
+    metrics_ndjson = tmp_path / "metrics.ndjson"
+    assert metrics_json.exists()
+    assert metrics_ndjson.exists()
+    record = json.loads(metrics_ndjson.read_text().splitlines()[-1])
+    assert record.get("global_step") == metrics.get("global_step")
 
 
 def test_compute_metrics_smoke():

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -19,6 +19,7 @@ import json
 import math
 import os
 import random
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, Optional
@@ -351,6 +352,16 @@ def run_hf_trainer(
             writer.close()
         except Exception:
             pass
+
+    # Persist metrics to JSON and NDJSON for downstream analytics
+    metrics_json = output_dir / "metrics.json"
+    with metrics_json.open("w", encoding="utf-8") as fh:
+        json.dump(metrics, fh)
+    metrics_ndjson = output_dir / "metrics.ndjson"
+    record = dict(metrics)
+    record["ts"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    with metrics_ndjson.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
 
     return metrics
 


### PR DESCRIPTION
## Summary
- drop duplicate stub in `apply_lora`
- persist HuggingFace trainer metrics to JSON and NDJSON files
- add ingestion helper functions and ingest shim
- simulate gradient accumulation in demo training loop

## Testing
- `pre-commit run --files src/ingestion/utils.py src/ingestion/__init__.py src/codex_ml/train_loop.py`
- `pytest --import-mode=importlib --cov=src/codex_ml --cov-fail-under=80 -q` *(fails: coverage DataError and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f3c75a2483319632b2c48bd420fb