### PR TITLE
fix: ensure mlflow utilities importable

### DIFF
--- a/deploy_codex_pipeline.py
+++ b/deploy_codex_pipeline.py
@@ -1,18 +1,21 @@
 # BEGIN: CODEX_DEPLOY_MONITORING
 # Codex injection: TensorBoard, W&B, MLflow wiring + system stats
-import argparse, os, json, time
+import argparse
 from pathlib import Path
+
 
 def _codex_stats():
     out = {}
     try:
         import psutil
+
         out["cpu_pct"] = psutil.cpu_percent(interval=0.1)
         out["mem_pct"] = psutil.virtual_memory().percent
     except Exception:
         pass
     try:
         import pynvml
+
         pynvml.nvmlInit()
         h = pynvml.nvmlDeviceGetHandleByIndex(0)
         mi = pynvml.nvmlDeviceGetMemoryInfo(h)
@@ -23,30 +26,35 @@ def _codex_stats():
         pass
     return out
 
+
 def _codex_tb(log_dir: Path):
     try:
         from torch.utils.tensorboard import SummaryWriter
+
         return SummaryWriter(log_dir=str(log_dir))
     except Exception:
         return None
+
 
 def _codex_wandb(enable: bool, cfg: dict):
     if not enable:
         return None
     try:
         import wandb
+
         wandb.init(project=cfg.get("wandb_project", "codex"), config=cfg)
         return wandb
     except Exception:
         return None
+
 
 def _codex_mlflow(enable: bool, uri: str | None, exp: str | None):
     if not enable:
         return None
     try:
         from codex_ml.tracking import mlflow_utils as MU
+
         cfg = MU.MlflowConfig(
-            enable=True,
             tracking_uri=uri or MU.MlflowConfig().tracking_uri,
             experiment=exp or MU.MlflowConfig().experiment,
         )
@@ -55,10 +63,13 @@ def _codex_mlflow(enable: bool, uri: str | None, exp: str | None):
     except Exception:
         return None
 
+
 def _codex_patch_argparse(ap: argparse.ArgumentParser) -> None:
     added = [a.dest for g in ap._action_groups for a in g._group_actions]  # type: ignore
     if "enable_wandb" not in added:
-        ap.add_argument("--enable-wandb", action="store_true", help="Enable Weights & Biases logging")
+        ap.add_argument(
+            "--enable-wandb", action="store_true", help="Enable Weights & Biases logging"
+        )
     if "mlflow_enable" not in added:
         ap.add_argument("--mlflow-enable", action="store_true", help="Enable MLflow logging")
     if "mlflow_tracking_uri" not in added:
@@ -66,13 +77,17 @@ def _codex_patch_argparse(ap: argparse.ArgumentParser) -> None:
     if "mlflow_experiment" not in added:
         ap.add_argument("--mlflow-experiment", default=None, help="MLflow experiment name")
 
+
 def _codex_logging_bootstrap(args, run_dir: Path, params: dict):
     tb = _codex_tb(run_dir / "tb")
     wb = _codex_wandb(bool(getattr(args, "enable_wandb", False)), params)
-    mlf = _codex_mlflow(bool(getattr(args, "mlflow_enable", False)),
-                        getattr(args, "mlflow_tracking_uri", None),
-                        getattr(args, "mlflow_experiment", None))
+    mlf = _codex_mlflow(
+        bool(getattr(args, "mlflow_enable", False)),
+        getattr(args, "mlflow_tracking_uri", None),
+        getattr(args, "mlflow_experiment", None),
+    )
     return {"tb": tb, "wandb": wb, "mlf": mlf, "stats": _codex_stats()}
+
 
 def _codex_log_all(handles, step: int, metrics: dict, artifacts: list[Path] | None = None):
     if handles.get("tb"):
@@ -94,4 +109,6 @@ def _codex_log_all(handles, step: int, metrics: dict, artifacts: list[Path] | No
                 MU.log_artifacts([art])
         except Exception:
             pass
+
+
 # END: CODEX_DEPLOY_MONITORING

--- a/src/codex_ml/tracking/__init__.py
+++ b/src/codex_ml/tracking/__init__.py
@@ -1,6 +1,7 @@
 """Convenience re-exports for MLflow tracking helpers."""
 
 from .mlflow_utils import (
+    MlflowConfig,
     ensure_local_artifacts,
     log_artifacts,
     log_metrics,
@@ -10,6 +11,7 @@ from .mlflow_utils import (
 )
 
 __all__ = [
+    "MlflowConfig",
     "start_run",
     "log_params",
     "log_metrics",


### PR DESCRIPTION
## Summary
- expose `MlflowConfig` from `codex_ml.tracking` and fix mlflow pipeline import
- align `deploy_codex_pipeline` with updated `MlflowConfig` signature

## Testing
- `pre-commit run --files deploy_codex_pipeline.py src/codex_ml/tracking/__init__.py`
- `pytest` *(fails: No module named 'hydra'; import file mismatch for test_mlflow_utils)*

------
https://chatgpt.com/codex/tasks/task_e_68b417fbb3ec8331a5a62b66fbdb20c5