### PR TITLE
Add training config, CLI tasks, and secret filtering

### DIFF
--- a/configs/training/base.yaml
+++ b/configs/training/base.yaml
@@ -1,3 +1,19 @@
+# Default training configuration for Codex.
+model_name: "sshleifer/tiny-gpt2"
+tokenizer_name: null  # Use model_name
+precision: "fp16"
+gradient_accumulation_steps: 1
+epochs: 3
+val_split: 0.1
+test_split: 0.0
+logging:
+  tensorboard: true
+  mlflow_enable: false
+  wandb_enable: false
+checkpoint:
+  dir: "./checkpoints"
+  save_steps: 100
+# TrainingArguments defaults
 output_dir: ./outputs
 overwrite_output_dir: true
 per_device_train_batch_size: 2
@@ -6,5 +22,4 @@ logging_steps: 1
 save_steps: 1
 lora_r: null
 lora_alpha: 16
-precision: fp32
 checkpoint_dir: null

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from fastapi import FastAPI, Request, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel, Field
 
 ARTIFACTS = Path(os.getenv("ARTIFACTS_DIR", "/artifacts"))
@@ -52,8 +53,7 @@ async def _startup() -> None:
                 for e in range(job["epochs"]):
                     await asyncio.sleep(0.2)
                     (run_dir / f"epoch-{e + 1}.txt").write_text(
-                        f"epoch {e + 1} done
-", encoding="utf-8"
+                        f"epoch {e + 1} done", encoding="utf-8"
                     )
                 (run_dir / "metadata.json").write_text(
                     json.dumps({"epochs": job["epochs"]}), encoding="utf-8"
@@ -75,6 +75,9 @@ async def _startup() -> None:
 async def infer(req: InferRequest) -> InferResponse:
     text = req.prompt.strip()
     out = f"Echo: {text}"
+    # basic secret filtering: mask sequences resembling API keys or tokens
+    if os.getenv("DISABLE_SECRET_FILTER", "0") != "1":
+        out = re.sub(r"(?i)(sk-\w{10,})", "[SECRET]", out)
     return InferResponse(completion=out, tokens=len(out.split()))
 
 
@@ -107,24 +110,29 @@ async def api_key_middleware(request: Request, call_next):
         raise
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=500, detail=str(exc))
+
+
 # BEGIN: CODEX_FASTAPI_HARDEN
 # FastAPI app with background queue, API-key middleware, and basic handlers
-from __future__ import annotations
-import os, asyncio, time
-from typing import Optional
+
+import asyncio  # noqa: E402
+import os  # noqa: E402
+
 try:
-    from fastapi import FastAPI, Request, HTTPException, Depends
-    from fastapi.responses import JSONResponse
+    from fastapi import Depends, FastAPI, HTTPException, Request  # noqa: E402
+    from fastapi.responses import JSONResponse  # noqa: E402
 except Exception:
     FastAPI = None  # type: ignore
 
 API_KEY_ENV = "CODEX_API_KEY"
+
 
 def api_key_auth(request: Request) -> None:  # type: ignore
     key = os.environ.get(API_KEY_ENV)
     header = request.headers.get("x-api-key")
     if key and header != key:
         raise HTTPException(status_code=401, detail="Unauthorized")
+
 
 def build_app():
     if FastAPI is None:
@@ -164,7 +172,7 @@ def build_app():
 
     async def worker():
         while True:
-            job = await queue.get()
+            _ = await queue.get()
             await asyncio.sleep(0.1)
             queue.task_done()
 
@@ -173,6 +181,7 @@ def build_app():
         asyncio.create_task(worker())
 
     return app
+
 
 app = build_app()
 # END: CODEX_FASTAPI_HARDEN

--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -4,14 +4,40 @@ Unified CLI for codex, using click for subcommands and input validation.
 
 from __future__ import annotations
 
+import subprocess
 import sys
+from pathlib import Path
 
 import click
 
+
+def _run_ingest() -> None:
+    """Ingest example data into the Codex environment."""
+    src = Path("data/example.jsonl")
+    dst = Path("data/ingested.jsonl")
+    if not src.exists():
+        print(f"No source data found at {src}")
+        return
+    dst.write_text(src.read_text(), encoding="utf-8")
+    print(f"Ingested {src} -> {dst}")
+
+
+def _run_ci() -> None:
+    """Run local CI checks (lint + tests)."""
+    try:
+        subprocess.run(["nox", "-s", "tests"], check=True)
+    except Exception as exc:  # noqa: BLE001
+        print(f"CI failed: {exc}")
+
+
+def _fix_pool() -> None:
+    print("Pool fix not yet implemented; see issue #123.")
+
+
 ALLOWED_TASKS = {
-    "ingest": lambda: print("Ingestion scaffold created (placeholder)."),
-    "ci": lambda: print("CI workflow unified."),
-    "pool-fix": lambda: print("SQLite connection pool fix applied."),
+    "ingest": _run_ingest,
+    "ci": _run_ci,
+    "pool-fix": _fix_pool,
 }
 
 

--- a/tests/eval/test_metrics.py
+++ b/tests/eval/test_metrics.py
@@ -1,0 +1,18 @@
+import math
+
+from codex_ml.eval.metrics import perplexity, token_accuracy
+
+
+def test_perplexity_from_logits():
+    logits = [[1.0, 0.0], [0.0, 1.0]]
+    targets = [0, 1]
+    ppl = perplexity(logits, targets, from_logits=True)
+    expected = math.exp(-(math.log(math.e / (math.e + 1)) + math.log(math.e / (math.e + 1))) / 2)
+    assert abs(ppl - expected) < 1e-3
+
+
+def test_token_accuracy():
+    preds = [1, 2, 3, 4]
+    targets = [1, 0, 3, 5]
+    acc = token_accuracy(preds, targets)
+    assert acc == 0.5

--- a/tests/test_api_secret_filter.py
+++ b/tests/test_api_secret_filter.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from services.api.main import app
+
+
+def test_secret_filtering_masks_keys():
+    client = TestClient(app)
+    payload = {"prompt": "send sk-abcdef1234567890 now"}
+    resp = client.post("/infer", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "[SECRET]" in data["completion"]

--- a/tests/training/test_base_config.py
+++ b/tests/training/test_base_config.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from training.engine_hf_trainer import load_training_arguments
+
+
+def test_base_config_load(tmp_path):
+    cfg = load_training_arguments(
+        Path("configs/training/base.yaml"),
+        tmp_path,
+        None,
+    )
+    assert cfg.output_dir == str(tmp_path)
+    assert cfg.gradient_accumulation_steps == 1

--- a/tools/run_codex_improvements.py
+++ b/tools/run_codex_improvements.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Utility script to automate Codex improvement phases."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ERROR_FILE = Path(".codex/error_capture_blocks.md")
+
+
+def log_error(step: str, exc: Exception) -> None:
+    ERROR_FILE.parent.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    with ERROR_FILE.open("a", encoding="utf-8") as fh:
+        fh.write(f"Question for ChatGPT {ts}:\nWhile performing [{step}], encountered: {exc}\n")
+
+
+def run(cmd: list[str], step: str) -> int:
+    try:
+        return subprocess.call(cmd)
+    except Exception as exc:  # noqa: BLE001
+        log_error(step, exc)
+        return 1
+
+
+def phase_prep() -> int:
+    req = Path("requirements/base.txt")
+    if req.exists():
+        return run([sys.executable, "-m", "pip", "install", "-r", str(req)], "prep")
+    return 0
+
+
+def phase_tests() -> int:
+    return run(["nox", "-s", "tests"], "tests")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--phases",
+        nargs="*",
+        default=["prep", "tests"],
+        help="Phases to run",
+    )
+    args = parser.parse_args()
+    status = 0
+    if "prep" in args.phases:
+        status |= phase_prep()
+    if "tests" in args.phases:
+        status |= phase_tests()
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- provide default training YAML and trainer support for Hydra overrides and checkpoint resume
- replace placeholder CLI tasks with ingestion and local CI commands
- filter potential secrets from API responses and add regression tests

## Testing
- `pre-commit run --files configs/training/base.yaml services/api/main.py src/codex/cli.py training/engine_hf_trainer.py tests/eval/test_metrics.py tests/test_api_secret_filter.py tests/training/test_base_config.py tools/run_codex_improvements.py`
- `pytest` *(fails: import file mismatch for test_mlflow_utils)*

------
https://chatgpt.com/codex/tasks/task_e_68b488e79ec48331864e6dd07b10b222