### PR TITLE
Document CLI tasks and config integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ After installation, the main CLI can be invoked as:
 codex-ml-cli --help
 ```
 
+### Maintenance tasks
+
+Utility tasks are exposed via `python -m codex.cli`:
+
+```bash
+python -m codex.cli tasks            # list allowed tasks
+python -m codex.cli run ingest       # ingest example data
+python -m codex.cli run ci           # run nox -s tests
+```
+
 ### Tokenization
 
 We use HF fast tokenizers with explicit `padding`/`truncation`/`max_length` to ensure batchable tensors.

--- a/docs/ops/training_args.md
+++ b/docs/ops/training_args.md
@@ -5,6 +5,15 @@
 - **gradient_accumulation_steps**: accumulate before optimizer step.
 - **early_stopping**: enable with patience/min_delta; wire to callbacks.EarlyStopping in your trainer loop.
 
+The repository ships with a base configuration at `configs/training/base.yaml`.
+Override any field with Hydra-style CLI arguments, e.g.:
+
+```bash
+python training/run.py training=base epochs=2 gradient_accumulation_steps=4
+```
+
+To resume from a saved run, pass `resume_from=/path/to/checkpoint`.
+
 ## Reproducibility
 
 - Use `set_seed(seed)` in training scripts to fix RNGs across `random`, `numpy`, and `torch`; a `seeds.json` file is written under the run directory.

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -6,5 +6,6 @@
 - Logits masking helper.
 - Sandboxed subprocess execution (best-effort).
 - Limitations and red-team considerations.
+- API layer masks strings resembling API keys (e.g. `sk-...`) unless `DISABLE_SECRET_FILTER=1`.
 
 > **Note to Codex:** Expand with concrete red-team datasets & tests.

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -156,7 +156,11 @@ def build_app():
     @app.post("/infer")
     async def infer(request: Request, _=Depends(api_key_auth)):
         payload = await request.json()
-        return {"result": payload, "ts": int(time.time())}
+        text = payload.get("prompt", "").strip()
+        out = f"Echo: {text}"
+        if os.getenv("DISABLE_SECRET_FILTER", "0") != "1":
+            out = re.sub(r"(?i)(sk-\w{10,})", "[SECRET]", out)
+        return {"completion": out, "ts": int(time.time())}
 
     @app.post("/train")
     async def train(request: Request, _=Depends(api_key_auth)):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import importlib
+from pathlib import Path
 
 from click.testing import CliRunner
 
@@ -29,6 +30,10 @@ def test_cli_run_invalid() -> None:
 
 def test_cli_run_valid() -> None:
     runner = CliRunner()
-    result = runner.invoke(cli_module.cli, ["run", "ingest"])
-    assert result.exit_code == 0
-    assert "Ingestion" in result.output
+    with runner.isolated_filesystem():
+        data_dir = Path("data")
+        data_dir.mkdir()
+        (data_dir / "example.jsonl").write_text("{}", encoding="utf-8")
+        result = runner.invoke(cli_module.cli, ["run", "ingest"])
+        assert result.exit_code == 0
+        assert "Ingested" in result.output

--- a/tests/test_engine_hf_trainer_grad_accum.py
+++ b/tests/test_engine_hf_trainer_grad_accum.py
@@ -1,8 +1,8 @@
-from pathlib import Path
-
 from training.engine_hf_trainer import load_training_arguments
 
 
 def test_gradient_accumulation(tmp_path):
-    args = load_training_arguments(None, tmp_path, None, gradient_accumulation_steps=3)
+    args = load_training_arguments(
+        None, tmp_path, None, hydra_cfg={"gradient_accumulation_steps": 3}
+    )
     assert args.gradient_accumulation_steps == 3

--- a/tests/test_training_arguments_flags.py
+++ b/tests/test_training_arguments_flags.py
@@ -4,6 +4,8 @@ from training.engine_hf_trainer import load_training_arguments
 
 
 def test_load_training_arguments_flags(tmp_path: Path):
-    args = load_training_arguments(None, tmp_path, precision="fp16", gradient_accumulation_steps=3)
+    args = load_training_arguments(
+        None, tmp_path, precision="fp16", hydra_cfg={"gradient_accumulation_steps": 3}
+    )
     assert args.fp16 is True
     assert args.gradient_accumulation_steps == 3


### PR DESCRIPTION
## Summary
- document codex CLI maintenance tasks in README
- describe base training config and resume flag
- add API secret filtering to hardened FastAPI app
- test Hydra config propagation and CLI ingestion

## Testing
- `pre-commit run --files README.md docs/ops/training_args.md docs/safety.md services/api/main.py tests/test_engine_hf_trainer_grad_accum.py tests/test_training_arguments_flags.py tests/test_cli.py`
- `pytest --no-cov tests/test_engine_hf_trainer_grad_accum.py tests/test_training_arguments_flags.py tests/training/test_base_config.py tests/test_cli.py tests/test_api_secret_filter.py tests/eval/test_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_68b48c0ca83083319269ac9bd2667392