### PR TITLE
feat: expand lora helper and log inventory

### DIFF
--- a/deploy_codex_pipeline.py
+++ b/deploy_codex_pipeline.py
@@ -54,7 +54,7 @@ def _codex_mlflow(enable: bool, uri: str | None, exp: str | None):
     try:
         import codex_ml.tracking as MU
 
-        cfg = MU.MlflowConfig(tracking_uri=uri, experiment=exp)
+        cfg = MU.MlflowConfig(enable=True, tracking_uri=uri, experiment=exp)
         run_cm = MU.start_run(cfg)
         run_cm.__enter__()
         return MU, run_cm


### PR DESCRIPTION
## Summary
- ensure MlflowConfig enables tracking when `--mlflow-enable` is set so runs and artifact logging are active
- avoid replaying identical batches during gradient accumulation by looping only over provided micro-batches

## Testing
- `pre-commit run --files deploy_codex_pipeline.py functional_training.py tests/interfaces/test_tokenizer_hf.py` *(fails: ruff/isort modify functional_training.py)*
- `pytest` *(fails: 12 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b529b770a08331a78b805e4a82c447