### PR TITLE
Restore monitoring maybe_start_run shim

### DIFF
--- a/src/codex_ml/monitoring/mlflow_utils.py
+++ b/src/codex_ml/monitoring/mlflow_utils.py
@@ -1,9 +1,49 @@
 """Deprecated shim for backward compatibility.
 
 The tracking utilities now live under :mod:`codex_ml.tracking.mlflow_utils`.
-This module simply re-exports all public symbols so existing imports from
-``codex_ml.monitoring`` continue to function.
+This module re-exports those symbols and restores the legacy
+``maybe_start_run`` helper used by older monitoring code.
 """
 
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from ..tracking import mlflow_utils as _tracking_mlflow_utils
 from ..tracking.mlflow_utils import *  # noqa: F401,F403
 
+# Expose the underlying ``mlflow`` module so older call sites and tests that
+# patch ``mlflow_utils.mlflow`` continue to work.
+mlflow = _tracking_mlflow_utils._mlf
+
+__all__ = _tracking_mlflow_utils.__all__ + ["maybe_start_run", "mlflow"]
+
+
+def maybe_start_run(experiment: Optional[str] = None):
+    """Conditionally start an MLflow run based on environment variables.
+
+    Returns the context manager from :func:`mlflow.start_run` when tracking is
+    enabled and the tracking URI is configured, otherwise returns ``None``.
+    A ``RuntimeError`` is raised if MLflow is requested but not installed.
+    """
+
+    if os.getenv("CODEX_ENABLE_MLFLOW") != "1":
+        return None
+
+    tracking_uri = os.getenv("MLFLOW_TRACKING_URI")
+    if not tracking_uri:
+        return None
+
+    if mlflow is None:  # pragma: no cover - depends on optional dependency
+        raise RuntimeError("mlflow is not installed")
+
+    try:
+        mlflow.set_tracking_uri(tracking_uri)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise RuntimeError("Failed to set MLflow tracking URI") from exc
+
+    try:
+        return mlflow.start_run(run_name=experiment)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise RuntimeError("Failed to start MLflow run") from exc


### PR DESCRIPTION
## Summary
- restore `maybe_start_run` in monitoring shim with environment-based logic
- expose underlying `mlflow` module for legacy patches

## Testing
- `pre-commit run --files src/codex_ml/monitoring/mlflow_utils.py`
- `nox -s tests` *(fails: The starlette.testclient module requires the httpx package to be installed; plus other missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68b54f68d56883318ce64176b2ca6d77