### PR TITLE
0 c base 

### DIFF
--- a/src/codex_ml/tracking/mlflow_utils.py
+++ b/src/codex_ml/tracking/mlflow_utils.py
@@ -283,12 +283,12 @@ def log_artifacts(
         _log_single(p)
 
 
-def seed_snapshot(
-    seeds: Mapping[str, Any], out_dir: Path, *, enabled: Optional[bool] = None
-) -> Path:
-    """Write seeds.json under out_dir and optionally log it to MLflow.
+def seed_snapshot(seeds: Mapping[str, Any], out_dir: Path, *, enabled: bool = False) -> Path:
+    """Write seeds.json under ``out_dir`` and optionally log it to MLflow.
 
-    Returns the path to the written seeds.json. Raises RuntimeError on IO failure.
+    By default this only writes the file locally; pass ``enabled=True`` to also
+    log the snapshot as an MLflow artifact. Returns the path to the written
+    ``seeds.json`` and raises :class:`RuntimeError` on I/O failure.
     """
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / "seeds.json"


### PR DESCRIPTION
## Summary
- disable implicit MLflow logging for seed snapshots; `ensure_local_artifacts` now logs seeds only when explicitly enabled

## Testing
- `pre-commit run --files src/codex_ml/tracking/mlflow_utils.py`
- `nox -s tests` *(fails: RuntimeError: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b55b3e9d948331857e5c31b63427e5