### PR TITLE
feat: improve codex db utilities

### DIFF
--- a/tools/codex_db.py
+++ b/tools/codex_db.py
@@ -9,6 +9,7 @@ import json
 import os
 import pathlib
 import sqlite3
+from typing import Optional
 
 DEFAULT_DB = os.environ.get("CODEX_DB", ".codex/codex.sqlite")
 
@@ -40,17 +41,19 @@ CREATE INDEX IF NOT EXISTS idx_results_task ON results(task);
 """
 
 
-def init_db(db_path: str = DEFAULT_DB) -> None:
+def init_db(db_path: Optional[str] = None) -> None:
     """Initialize the SQLite database with the schema."""
+    path = db_path or DEFAULT_DB
     # Ensure parent directory exists
-    pathlib.Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(db_path) as cx:
+    pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as cx:
         cx.executescript(SCHEMA)
 
 
-def run_query(sql: str, db_path: str = DEFAULT_DB) -> None:
+def run_query(sql: str, db_path: Optional[str] = None) -> None:
     """Run a SQL query against the specified database and print results as JSON lines."""
-    with sqlite3.connect(db_path) as cx:
+    path = db_path or DEFAULT_DB
+    with sqlite3.connect(path) as cx:
         cx.row_factory = sqlite3.Row
         for row in cx.execute(sql):
             print(json.dumps(dict(row), ensure_ascii=False))


### PR DESCRIPTION
## Summary
- allow overriding database path in codex_db utilities
- document logs CLI usage

## Testing
- `python3 tools/codex_db.py --init --db .codex/codex.sqlite`
- `python3 tools/codex_ingest_md.py --changes .codex/change_log.md --results .codex/results.md --branch $(git rev-parse --abbrev-ref HEAD)`
- `python3 src/codex/cli.py logs query --sql "SELECT ts, substr(summary,1,80) FROM change_log ORDER BY ts DESC LIMIT 10"`
- `ruff check tools/codex_db.py`
- `black tools/codex_db.py`
- `isort --check-only tools/codex_db.py`
- `pre-commit run --files tools/codex_db.py`
- `pre-commit run --all-files` *(fails: trailing-whitespace on multiple files)*
- `pytest` *(fails: SyntaxError in training and tools modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b632add3c08331862c08ede3c28773