### PR TITLE
Refresh Codex log DB utility

### DIFF
--- a/tools/codex_db.py
+++ b/tools/codex_db.py
@@ -9,7 +9,6 @@ import json
 import os
 import pathlib
 import sqlite3
-from typing import Optional
 
 DEFAULT_DB = os.environ.get("CODEX_DB", ".codex/codex.sqlite")
 
@@ -41,19 +40,17 @@ CREATE INDEX IF NOT EXISTS idx_results_task ON results(task);
 """
 
 
-def init_db(db_path: Optional[str] = None) -> None:
+def init_db(db_path: str = DEFAULT_DB) -> None:
     """Initialize the SQLite database with the schema."""
-    path = db_path or DEFAULT_DB
     # Ensure parent directory exists
-    pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(path) as cx:
+    pathlib.Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as cx:
         cx.executescript(SCHEMA)
 
 
-def run_query(sql: str, db_path: Optional[str] = None) -> None:
+def run_query(sql: str, db_path: str = DEFAULT_DB) -> None:
     """Run a SQL query against the specified database and print results as JSON lines."""
-    path = db_path or DEFAULT_DB
-    with sqlite3.connect(path) as cx:
+    with sqlite3.connect(db_path) as cx:
         cx.row_factory = sqlite3.Row
         for row in cx.execute(sql):
             print(json.dumps(dict(row), ensure_ascii=False))


### PR DESCRIPTION
## Summary
- modernize `codex_db.py` for SQLite-backed change and result logs
- ensure scripts support init and query operations

## Testing
- `python3 tools/codex_db.py --init --db .codex/codex.sqlite`
- `python3 tools/codex_ingest_md.py --changes .codex/change_log.md --results .codex/results.md --branch $(git rev-parse --abbrev-ref HEAD) --db .codex/codex.sqlite`
- `python3 src/codex/cli.py logs query --sql "SELECT ts, substr(summary,1,80) FROM change_log ORDER BY ts DESC LIMIT 10" --db .codex/codex.sqlite`
- `pre-commit run --files tools/codex_db.py`
- `ruff check tools/codex_db.py`
- `black tools/codex_db.py`
- `isort tools/codex_db.py`
- `pytest` *(fails: 11 errors during collection)*
- `pre-commit run --all-files` *(fails: multiple lint errors across repository)*
- `ruff check .` *(fails: 317 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b635773ad083319a73cc8bbf6ef5c1