### PR TITLE
0 b base

### DIFF
--- a/src/codex_ml/monitoring/mlflow_utils.py
+++ b/src/codex_ml/monitoring/mlflow_utils.py
@@ -20,7 +20,23 @@ mlflow = _tracking_mlflow_utils._mlf
 __all__ = _tracking_mlflow_utils.__all__ + ["maybe_start_run", "mlflow"]
 
 
-def maybe_start_run(experiment: Optional[str] = None):
+def _env_enabled(value: Optional[str]) -> bool:
+    """Return ``True`` if *value* represents a truthy setting.
+
+    Accepts common representations such as ``1``, ``true``, ``yes`` and ``on``
+    (case-insensitive). Any other value is treated as ``False``.
+    """
+
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def maybe_start_run(
+    experiment: Optional[str] = None,
+    *,
+    enabled: Optional[bool] = None,
+):
     """Conditionally start an MLflow run based on environment variables.
 
     Returns the context manager from :func:`mlflow.start_run` when tracking is
@@ -28,7 +44,9 @@ def maybe_start_run(experiment: Optional[str] = None):
     A ``RuntimeError`` is raised if MLflow is requested but not installed.
     """
 
-    if os.getenv("CODEX_ENABLE_MLFLOW") != "1":
+    if enabled is None:
+        enabled = _env_enabled(os.environ.get("CODEX_ENABLE_MLFLOW"))
+    if not enabled:
         return None
 
     tracking_uri = os.getenv("MLFLOW_TRACKING_URI")

--- a/tests/monitoring/test_mlflow_monitoring_utils.py
+++ b/tests/monitoring/test_mlflow_monitoring_utils.py
@@ -19,9 +19,20 @@ def test_maybe_start_run_respects_env_disable(monkeypatch):
 
 def test_maybe_start_run_starts_with_uri_when_enabled(monkeypatch):
     monkeypatch.setenv("MLFLOW_TRACKING_URI", "file:/tmp/mlruns")
-    monkeypatch.setenv("CODEX_ENABLE_MLFLOW", "1")
+    monkeypatch.setenv("CODEX_ENABLE_MLFLOW", "true")
     with mock.patch.object(mlflow_utils, "mlflow") as m:
         run = object()
         m.start_run.return_value = run
         assert mlflow_utils.maybe_start_run("r1") is run
+        m.set_tracking_uri.assert_called_once_with("file:/tmp/mlruns")
+
+
+def test_maybe_start_run_arg_overrides_env(monkeypatch):
+    """Explicit argument should override environment flag."""
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "file:/tmp/mlruns")
+    monkeypatch.setenv("CODEX_ENABLE_MLFLOW", "0")
+    with mock.patch.object(mlflow_utils, "mlflow") as m:
+        run = object()
+        m.start_run.return_value = run
+        assert mlflow_utils.maybe_start_run("r2", enabled=True) is run
         m.set_tracking_uri.assert_called_once_with("file:/tmp/mlruns")

--- a/tests/monitoring/test_monitoring_mlflow_utils.py
+++ b/tests/monitoring/test_monitoring_mlflow_utils.py
@@ -19,9 +19,20 @@ def test_maybe_start_run_respects_env_disable(monkeypatch):
 
 def test_maybe_start_run_starts_with_uri_when_enabled(monkeypatch):
     monkeypatch.setenv("MLFLOW_TRACKING_URI", "file:/tmp/mlruns")
-    monkeypatch.setenv("CODEX_ENABLE_MLFLOW", "1")
+    monkeypatch.setenv("CODEX_ENABLE_MLFLOW", "true")
     with mock.patch.object(mlflow_utils, "mlflow") as m:
         run = object()
         m.start_run.return_value = run
         assert mlflow_utils.maybe_start_run("r1") is run
+        m.set_tracking_uri.assert_called_once_with("file:/tmp/mlruns")
+
+
+def test_maybe_start_run_arg_overrides_env(monkeypatch):
+    """Explicit argument should override environment flag."""
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "file:/tmp/mlruns")
+    monkeypatch.setenv("CODEX_ENABLE_MLFLOW", "0")
+    with mock.patch.object(mlflow_utils, "mlflow") as m:
+        run = object()
+        m.start_run.return_value = run
+        assert mlflow_utils.maybe_start_run("r2", enabled=True) is run
         m.set_tracking_uri.assert_called_once_with("file:/tmp/mlruns")


### PR DESCRIPTION
## Summary
- add `_env_enabled` helper and optional `enabled` parameter to `maybe_start_run` for backward-compatible MLflow toggling
- expand MLflow shim tests to exercise truthy env values and explicit argument overrides

## Testing
- `pre-commit run --files src/codex_ml/monitoring/mlflow_utils.py tests/monitoring/test_monitoring_mlflow_utils.py tests/monitoring/test_mlflow_monitoring_utils.py`
- `pytest --override-ini="addopts=" tests/monitoring/test_monitoring_mlflow_utils.py tests/monitoring/test_mlflow_monitoring_utils.py`
- ⚠️ `nox -s tests -- tests/monitoring/test_monitoring_mlflow_utils.py tests/monitoring/test_mlflow_monitoring_utils.py` (environment setup interrupted during dependency installation)


------
https://chatgpt.com/codex/tasks/task_e_68b65f0034b8833180850a82030ac7fa