### PR TITLE
feat: add training device and mlflow defaults

### DIFF
--- a/codex_ml/tracking/mlflow_utils.py
+++ b/codex_ml/tracking/mlflow_utils.py
@@ -1,39 +1,56 @@
 # BEGIN: CODEX_MLFLOW_UTILS
 # MLflow wrappers (no-op if mlflow missing)
 from __future__ import annotations
+
 from pathlib import Path
 from typing import Iterable
 
+
 def start_run(tracking_uri: str | None = None, experiment_name: str | None = None):
+    """Start an MLflow run using a safe offline default.
+
+    If ``tracking_uri`` is not provided, runs log to ``./mlruns`` to avoid
+    accidental network calls. Any import or runtime failure results in a
+    silent ``None`` return so training can proceed without MLflow.
+    """
+
     try:
         import mlflow
-        if tracking_uri:
-            mlflow.set_tracking_uri(tracking_uri)
+
+        mlflow.set_tracking_uri(tracking_uri or "./mlruns")
         if experiment_name:
             mlflow.set_experiment(experiment_name)
         return mlflow.start_run()
     except Exception:
         return None
 
+
 def log_params(params: dict):
     try:
         import mlflow
+
         mlflow.log_params(params)
     except Exception:
         pass
 
+
 def log_metrics(metrics: dict, step: int | None = None):
     try:
         import mlflow
+
         mlflow.log_metrics(metrics, step=step)
     except Exception:
         pass
 
+
 def log_artifacts(paths: Iterable[Path]):
     try:
         import mlflow
+
         for p in paths:
             mlflow.log_artifact(str(p))
     except Exception:
         pass
+
+
 # END: CODEX_MLFLOW_UTILS

--- a/codex_ml/utils/checkpointing.py
+++ b/codex_ml/utils/checkpointing.py
@@ -1,16 +1,21 @@
 # BEGIN: CODEX_CKPT_RNG_SEED
 from __future__ import annotations
-import json, random
+
+import json
+import random
 from pathlib import Path
+
 
 def set_seed(seed: int) -> None:
     try:
         import numpy as np
+
         np.random.seed(seed)
     except Exception:
         pass
     try:
         import torch
+
         torch.manual_seed(seed)
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(seed)
@@ -18,15 +23,26 @@ def set_seed(seed: int) -> None:
         pass
     random.seed(seed)
 
+    # Persist seed for reproducibility
+    try:
+        path = Path(".codex")
+        path.mkdir(exist_ok=True)
+        (path / "seeds.json").write_text(json.dumps({"seed": seed}), encoding="utf-8")
+    except Exception:
+        pass
+
+
 def save_rng(path: Path) -> None:
     state = {}
     try:
         import numpy as np
+
         state["numpy"] = np.random.get_state()[1][:].tolist()
     except Exception:
         pass
     try:
         import torch
+
         state["torch"] = torch.get_rng_state().tolist()
         if torch.cuda.is_available():
             state["torch_cuda"] = torch.cuda.get_rng_state().tolist()
@@ -35,13 +51,18 @@ def save_rng(path: Path) -> None:
     state["python"] = random.getstate()[1][:] if hasattr(random.getstate(), "__iter__") else None
     (path / "rng.json").write_text(json.dumps(state), encoding="utf-8")
 
+
 def load_rng(path: Path) -> None:
     f = path / "rng.json"
     if not f.exists():
         return
     try:
         state = json.loads(f.read_text(encoding="utf-8"))
-        import numpy as np, torch, random as pyrand
+        import random as pyrand
+
+        import numpy as np
+        import torch
+
         if "numpy" in state:
             np.random.seed(state["numpy"][0] if state["numpy"] else 0)
         if "torch" in state:
@@ -53,6 +74,7 @@ def load_rng(path: Path) -> None:
     except Exception:
         pass
 
+
 def verify_shapes(model, checkpoint_state: dict) -> None:
     try:
         missing, unexpected = model.load_state_dict(checkpoint_state, strict=False)
@@ -61,6 +83,9 @@ def verify_shapes(model, checkpoint_state: dict) -> None:
     except Exception as e:
         raise RuntimeError(f"Failed verifying shapes: {e}")
 
+
 def log_seed(path: Path, seed: int) -> None:
     (path / "seeds.json").write_text(json.dumps({"seed": seed}), encoding="utf-8")
+
+
 # END: CODEX_CKPT_RNG_SEED


### PR DESCRIPTION
## Summary
- add device and dtype flags to HF trainer and wire NDJSON metrics writer
- persist seeds.json for reproducibility
- default MLflow tracking to local `./mlruns`

## Testing
- `pre-commit run --files codex_ml/tracking/mlflow_utils.py codex_ml/utils/checkpointing.py training/engine_hf_trainer.py`
- `nox -s tests` *(fails: session interrupted during dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68b668b3596083318d4cd8bd43be6430