### PR TITLE
Fix formatting and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## [Unreleased] - 2025-09-02
+- Format `src/codex_ml/safety/risk_score.py` with Black.
+- Correct README typos and complete environment description.
+- Pin `peft` dependency to ensure `nox -s tests` passes.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `codex-universal` is a reference implementation of the base Docker image available in OpenAI Codex.
 
-This repository is intended to help developers cutomize environments in Codex, by providing a similar image that can be pulled and run locally. This is not an identical environment but should help for debugging and development.
+This repository is intended to help developers customize environments in Codex, by providing a similar image that can be pulled and run locally. This is not an identical environment but should help for debugging and development.
 
 > **Policy:** No GitHub-hosted Actions. Run `make codex-gates` locally or on a self-hosted runner (ephemeral runners recommended).
 

--- a/README_UPDATED.md
+++ b/README_UPDATED.md
@@ -2,7 +2,7 @@
 
 `codex-universal` is a reference implementation of the base Docker image available in [OpenAI Codex](http://platform.openai.com/docs/codex).
 
-This repository is intended to help developers cutomize environments in Codex, by providing a similar image that can be pulled and run locally. This is not an identical environment but should help for debugging and development.
+This repository is intended to help developers customize environments in Codex, by providing a similar image that can be pulled and run locally. This is not an identical environment but should help for debugging and development.
 
 For more details on environment setup, see [OpenAI Codex](http://platform.openai.com/docs/codex).
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,7 @@ def tests(session):
         "requirements/base.txt",
         "mlflow",
         "httpx",
-        "peft",
+        "peft==0.10.0",
         "click",
         "fastapi",
         "accelerate>=0.27.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 duckdb==0.10.1
 torch==2.3.1
 transformers==4.36.2
+peft==0.10.0
 accelerate>=0.27.0
 datasets==2.16.1
 numpy==1.26.4

--- a/src/codex_ml/peft/peft_adapter.py
+++ b/src/codex_ml/peft/peft_adapter.py
@@ -1,5 +1,5 @@
 # [Integration]: LoRA adapter integration with graceful fallbacks
-> Generated: 2025-08-31 08:51:51 | Author: mbaetiong
+# Generated: 2025-08-31 08:51:51 | Author: mbaetiong
 """LoRA integration for Codex models.
 
 This module provides a lightweight, optional integration with the `peft` package
@@ -25,7 +25,7 @@ after attaching the merged configuration for inspection.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 # Optional dependency: peft
 try:  # pragma: no cover - optional dependency
@@ -84,14 +84,14 @@ def apply_lora(model: Any, cfg: Optional[Dict[str, Any]] = None, /, **overrides:
     --------
     >>> # Basic usage with defaults
     >>> adapted = apply_lora(model)
-    
+
     >>> # Custom configuration
     >>> config = {"r": 16, "lora_alpha": 32, "target_modules": ["q_proj", "v_proj"]}
     >>> adapted = apply_lora(model, config)
-    
+
     >>> # Override parameters
     >>> adapted = apply_lora(model, lora_dropout=0.1, bias="lora_only")
-    
+
     >>> # Check applied configuration
     >>> print(adapted.peft_config)
     """

--- a/src/codex_ml/safety/risk_score.py
+++ b/src/codex_ml/safety/risk_score.py
@@ -4,6 +4,7 @@ The function attempts to load a tiny sentiment model via ``transformers`` to
 produce a probabilistic risk score. When the dependency or model is
 unavailable, it falls back to a logistic model based on keyword matches.
 Scores are always in the ``[0.0, 1.0]`` range."""
+
 from __future__ import annotations
 
 from math import exp

--- a/src/ingestion/csv_ingestor.py
+++ b/src/ingestion/csv_ingestor.py
@@ -4,7 +4,7 @@ import csv
 from pathlib import Path
 from typing import List, Union
 
-from .io_text import _detect_encoding
+from .io_text import detect_encoding
 
 
 def load_csv(path: Union[str, Path], *, encoding: str = "utf-8", **kwargs) -> List[list[str]]:
@@ -22,7 +22,7 @@ def load_csv(path: Union[str, Path], *, encoding: str = "utf-8", **kwargs) -> Li
     """
     p = Path(path)
     if encoding == "auto":
-        encoding = _detect_encoding(p)
+        encoding = detect_encoding(p)
     with p.open("r", encoding=encoding, newline="") as fh:
         reader = csv.reader(fh, **kwargs)
         return list(reader)

--- a/src/ingestion/file_ingestor.py
+++ b/src/ingestion/file_ingestor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Union
 
-from .io_text import _detect_encoding
+from .io_text import detect_encoding
 
 
 def read_file(path: Union[str, Path], *, encoding: str = "utf-8") -> str:
@@ -19,5 +19,5 @@ def read_file(path: Union[str, Path], *, encoding: str = "utf-8") -> str:
     """
     p = Path(path)
     if encoding == "auto":
-        encoding = _detect_encoding(p)
+        encoding = detect_encoding(p)
     return p.read_text(encoding=encoding)

--- a/src/ingestion/json_ingestor.py
+++ b/src/ingestion/json_ingestor.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any, Union
 
-from .io_text import _detect_encoding
+from .io_text import detect_encoding
 
 
 def load_json(path: Union[str, Path], *, encoding: str = "utf-8") -> Any:
@@ -20,6 +20,6 @@ def load_json(path: Union[str, Path], *, encoding: str = "utf-8") -> Any:
     """
     p = Path(path)
     if encoding == "auto":
-        encoding = _detect_encoding(p)
+        encoding = detect_encoding(p)
     with p.open("r", encoding=encoding) as fh:
         return json.load(fh)


### PR DESCRIPTION
## Summary
- format `risk_score.py` with Black
- correct README environment description
- pin `peft` version and fix ingestion utilities imports

## Testing
- `pre-commit run --files CHANGELOG.md README.md README_UPDATED.md requirements/base.txt noxfile.py src/codex_ml/safety/risk_score.py src/codex_ml/peft/peft_adapter.py src/ingestion/csv_ingestor.py src/ingestion/file_ingestor.py src/ingestion/json_ingestor.py`
- `nox -s tests` *(fails: coverage.exceptions.DataError: Can't combine statement coverage data with branch data)*

------
https://chatgpt.com/codex/tasks/task_e_68b688ce5c78833192018cd393cf9e65