### PR TITLE
Fix risk_score formatting and test dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 ## [Unreleased] - 2025-09-02
 - Format `src/codex_ml/safety/risk_score.py` with Black.
 - Correct README typos and complete environment description.
-- Pin `peft` dependency to ensure `nox -s tests` passes.
+ - Ensure test dependencies (including `langchain`) are installed so `nox -s tests` passes.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `codex-universal` is a reference implementation of the base Docker image available in OpenAI Codex.
 
-This repository is intended to help developers customize environments in Codex, by providing a similar image that can be pulled and run locally. This is not an identical environment but should help for debugging and development.
+This repository is intended to help developers customize environments in Codex by providing a similar image that can be pulled and run locally. This is not an identical environment but should help for debugging and development.
 
 > **Policy:** No GitHub-hosted Actions. Run `make codex-gates` locally or on a self-hosted runner (ephemeral runners recommended).
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,6 +29,7 @@ def tests(session):
     session.install(
         "pytest",
         "pytest-cov",
+        "langchain",
         "charset-normalizer>=3.0.0",
         "chardet>=5.0.0",
         "-r",

--- a/src/codex_ml/safety/risk_score.py
+++ b/src/codex_ml/safety/risk_score.py
@@ -1,9 +1,10 @@
-"""Simple safety classifier with optional transformer backend.
+"""Simple safety classifier with an optional transformer backend.
 
 The function attempts to load a tiny sentiment model via ``transformers`` to
-produce a probabilistic risk score. When the dependency or model is
-unavailable, it falls back to a logistic model based on keyword matches.
-Scores are always in the ``[0.0, 1.0]`` range."""
+produce a probabilistic risk score. When the dependency or model is unavailable,
+it falls back to a logistic model based on keyword matches. Scores are always in
+the ``[0.0, 1.0]`` range.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- clarify risk_score docstring and keep Black formatting
- correct README environment description
- include langchain in nox test dependencies

## Testing
- `pre-commit run --files CHANGELOG.md README.md noxfile.py src/codex_ml/safety/risk_score.py`
- `nox -s tests` *(fails: coverage.exceptions.DataError: Can't combine statement coverage data with branch data)*
- `pytest -q` *(fails: coverage.exceptions.DataError: Can't combine statement coverage data with branch data)*

------
https://chatgpt.com/codex/tasks/task_e_68b70c2ef1e883319fbdef52ed04e287