### PR TITLE
Address review feedback: enforce MLflow steps and add batching

### DIFF
--- a/codex_ml/tracking/mlflow_utils.py
+++ b/codex_ml/tracking/mlflow_utils.py
@@ -34,11 +34,12 @@ def log_params(params: dict):
         pass
 
 
-def log_metrics(metrics: dict, step: int | None = None):
+def log_metrics(metrics: dict, step: int):
     try:
         import mlflow
 
-        mlflow.log_metrics(metrics, step=step)
+        for k, v in metrics.items():
+            mlflow.log_metric(k, float(v), step=step)
     except Exception:
         pass
 

--- a/scripts/deploy_codex_pipeline.py
+++ b/scripts/deploy_codex_pipeline.py
@@ -62,9 +62,7 @@ def install_requirements(req: Path, skip: bool) -> None:
     if skip:
         return
     if req.exists():
-        subprocess.run(
-            [sys.executable, "-m", "pip", "install", "-r", str(req)], check=True
-        )
+        subprocess.run([sys.executable, "-m", "pip", "install", "-r", str(req)], check=True)
 
 
 def log_env_info() -> None:
@@ -124,9 +122,7 @@ def load_corpus(path: Path) -> List[str]:
     except Exception:
         # Fallback: treat as plain text lines
         return [
-            line.strip()
-            for line in path.read_text(encoding="utf-8").splitlines()
-            if line.strip()
+            line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
         ]
 
 
@@ -158,9 +154,7 @@ def load_prefs(path: Path) -> List[Tuple[str, str, str, int]]:
             or not all(isinstance(obj[j], str) for j in range(3))
             or not isinstance(obj[3], int)
         ):
-            raise ValueError(
-                f"{path}: line {i} must be ['prompt', 'A', 'B', label (int)]"
-            )
+            raise ValueError(f"{path}: line {i} must be ['prompt', 'A', 'B', label (int)]")
         prefs.append((obj[0], obj[1], obj[2], obj[3]))
     return prefs
 
@@ -188,17 +182,13 @@ def persist_outputs(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Summary of the whole run
-    (output_dir / "summary.json").write_text(
-        json.dumps(summary, indent=2), encoding="utf-8"
-    )
+    (output_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
 
     # Per-stage checkpoints
     ckpt_dir = output_dir / "checkpoints"
     ckpt_dir.mkdir(exist_ok=True)
     for name, handle in summary.get("handles", {}).items():
-        (ckpt_dir / f"{name}.json").write_text(
-            json.dumps(handle, indent=2), encoding="utf-8"
-        )
+        (ckpt_dir / f"{name}.json").write_text(json.dumps(handle, indent=2), encoding="utf-8")
 
     # Metrics and auxiliary outputs
     token_counts = {
@@ -210,9 +200,7 @@ def persist_outputs(
         "losses": summary.get("losses", {}),
         "objective_U": summary.get("objective_U", {}),
     }
-    (output_dir / "metrics.json").write_text(
-        json.dumps(metrics, indent=2), encoding="utf-8"
-    )
+    (output_dir / "metrics.json").write_text(json.dumps(metrics, indent=2), encoding="utf-8")
 
     seeds = {
         "pretrain": summary["handles"]["M0"]["meta"].get("seed"),
@@ -220,9 +208,7 @@ def persist_outputs(
         "reward_model": summary["handles"]["RM"]["meta"].get("cfg", {}).get("seed"),
         "rlhf": summary["handles"]["M2"]["meta"].get("seed_rlhf"),
     }
-    (output_dir / "seeds.json").write_text(
-        json.dumps(seeds, indent=2), encoding="utf-8"
-    )
+    (output_dir / "seeds.json").write_text(json.dumps(seeds, indent=2), encoding="utf-8")
 
 
 def run_pipeline(args: argparse.Namespace) -> Dict[str, Any]:
@@ -237,9 +223,7 @@ def run_pipeline(args: argparse.Namespace) -> Dict[str, Any]:
     if args.enable_wandb:
         import wandb
 
-        wandb.init(
-            project=os.getenv("WANDB_PROJECT", "codex"), config={"alpha": args.alpha}
-        )
+        wandb.init(project=os.getenv("WANDB_PROJECT", "codex"), config={"alpha": args.alpha})
 
     mlf_cfg: MlflowConfig = mlflow_from_args(args)
 
@@ -314,7 +298,7 @@ def run_pipeline(args: argparse.Namespace) -> Dict[str, Any]:
                 import wandb
 
                 wandb.log({"gpu_util": util})
-            log_metrics({"gpu_util": float(util)}, enabled=mlf_cfg.enable)
+            log_metrics({"gpu_util": float(util)}, step=0, enabled=mlf_cfg.enable)
     except Exception:  # noqa: BLE001
         pass
 
@@ -331,19 +315,13 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="JSONL of raw code/text lines or TXT (one per line)",
     )
-    p.add_argument(
-        "--demos", required=True, help="JSONL of {'prompt':..., 'completion':...}"
-    )
+    p.add_argument("--demos", required=True, help="JSONL of {'prompt':..., 'completion':...}")
     p.add_argument("--prefs", required=True, help="JSONL of ['prompt','A','B',label]")
-    p.add_argument(
-        "--output-dir", required=True, help="Directory for summaries/checkpoints"
-    )
+    p.add_argument("--output-dir", required=True, help="Directory for summaries/checkpoints")
 
     p.add_argument(
         "--requirements",
-        default=str(
-            Path(__file__).resolve().parent.parent / "requirements" / "base.txt"
-        ),
+        default=str(Path(__file__).resolve().parent.parent / "requirements" / "base.txt"),
         help="Path to requirements file (default: requirements/base.txt)",
     )
     p.add_argument(
@@ -376,9 +354,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--rlhf-kl-penalty", type=float, default=0.1)
     p.add_argument("--rlhf-seed", type=int, default=0)
     p.add_argument("--tokenizer-name", default="gpt2", help="Pretrained tokenizer name")
-    p.add_argument(
-        "--tokenizer-path", help="Path to tokenizer directory or tokenizer.json"
-    )
+    p.add_argument("--tokenizer-path", help="Path to tokenizer directory or tokenizer.json")
 
     p.add_argument(
         "--engine",
@@ -389,12 +365,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--trainer-config",
-        default=str(
-            Path(__file__).resolve().parent.parent
-            / "configs"
-            / "training"
-            / "base.yaml"
-        ),
+        default=str(Path(__file__).resolve().parent.parent / "configs" / "training" / "base.yaml"),
         help="YAML file with TrainingArguments for hf_trainer",
     )
     p.add_argument(
@@ -407,9 +378,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Enable fp16 training when CUDA is available",
     )
-    p.add_argument(
-        "--enable-wandb", action="store_true", help="log to Weights & Biases"
-    )
+    p.add_argument("--enable-wandb", action="store_true", help="log to Weights & Biases")
     add_mlflow_flags(p)
     return p
 

--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -119,5 +119,21 @@ def run_task(task: str) -> None:
     ALLOWED_TASKS[task]()
 
 
+@cli.command("train")
+@click.option(
+    "--engine", type=click.Choice(["custom", "hf"]), default="custom", help="Training engine to use"
+)
+def train_cmd(engine: str) -> None:
+    """Train a model using the selected engine."""
+    if engine == "hf":
+        from training.engine_hf_trainer import train as hf_train
+
+        hf_train()
+    else:
+        from codex_ml.train_loop import train as custom_train
+
+        custom_train()
+
+
 if __name__ == "__main__":
     cli()

--- a/src/codex/logging/session_logger.py
+++ b/src/codex/logging/session_logger.py
@@ -103,6 +103,10 @@ def init_db(db_path: Optional[Path] = None):
     p.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(p)
     try:
+        conn.execute("PRAGMA journal_mode=WAL;")
+    except Exception:
+        pass
+    try:
         conn.execute(
             """CREATE TABLE IF NOT EXISTS session_events(
                    ts REAL NOT NULL,
@@ -191,10 +195,7 @@ def log_event(
 ):
     """Delegate to shared log_event if available, otherwise fallback."""
     if _shared_log_event is not None:
-        if (
-            getattr(_shared_log_event, "__module__", "")
-            == "codex.monkeypatch.log_adapters"
-        ):
+        if getattr(_shared_log_event, "__module__", "") == "codex.monkeypatch.log_adapters":
             _fallback_log_event(session_id, role, message, db_path=db_path, meta=meta)
             try:
                 _shared_log_event(session_id, role, message, db_path=db_path, meta=meta)
@@ -228,9 +229,7 @@ def get_session_id() -> str:
     return sid
 
 
-def fetch_messages(
-    session_id: str, db_path: Optional[Path] = None
-) -> List[Dict[str, Any]]:
+def fetch_messages(session_id: str, db_path: Optional[Path] = None) -> List[Dict[str, Any]]:
     path = Path(db_path or _default_db_path())
     return _fetch_messages_mod.fetch_messages(session_id, db_path=path)
 
@@ -316,9 +315,7 @@ def migrate_legacy_events(db_path: Optional[Path] = None) -> None:
     try:
         conn.execute("BEGIN")
         # Backfill seq for rows lacking it
-        cur = conn.execute(
-            "SELECT DISTINCT session_id FROM session_events WHERE seq IS NULL"
-        )
+        cur = conn.execute("SELECT DISTINCT session_id FROM session_events WHERE seq IS NULL")
         for (sid,) in cur.fetchall():
             max_seq = conn.execute(
                 "SELECT COALESCE(MAX(seq),0) FROM session_events WHERE session_id=?",
@@ -331,9 +328,7 @@ def migrate_legacy_events(db_path: Optional[Path] = None) -> None:
             ).fetchall()
             for row in rows:
                 max_seq += 1
-                conn.execute(
-                    "UPDATE session_events SET seq=? WHERE rowid=?", (max_seq, row[0])
-                )
+                conn.execute("UPDATE session_events SET seq=? WHERE rowid=?", (max_seq, row[0]))
         # Remove duplicate start/end events
         cur = conn.execute(
             "SELECT DISTINCT session_id FROM session_events "

--- a/src/codex_ml/cli/main.py
+++ b/src/codex_ml/cli/main.py
@@ -113,7 +113,7 @@ def main(cfg: DictConfig) -> None:
         rc = _dispatch_pipeline(cfg)
         summary = {"return_code": rc}
         ensure_local_artifacts(HY_OUT, summary, {"train_seed": getattr(cfg.train, "seed", 0)})
-        log_metrics({"return_code": float(rc)}, enabled=enabled)
+        log_metrics({"return_code": float(rc)}, step=0, enabled=enabled)
         if cfg.wandb.enable:
             wandb.log({"return_code": float(rc)})
             artifact = wandb.Artifact("hydra-run", type="hydra-output")
@@ -130,7 +130,7 @@ def main(cfg: DictConfig) -> None:
             util = pynvml.nvmlDeviceGetUtilizationRates(handle).gpu
             if cfg.wandb.enable:
                 wandb.log({"gpu_util": util})
-            log_metrics({"gpu_util": float(util)}, enabled=cfg.mlflow.enable)
+            log_metrics({"gpu_util": float(util)}, step=0, enabled=cfg.mlflow.enable)
     except Exception:  # noqa: BLE001
         pass
     sys.exit(rc)

--- a/src/codex_ml/tokenization/hf_tokenizer.py
+++ b/src/codex_ml/tokenization/hf_tokenizer.py
@@ -66,6 +66,35 @@ class HFTokenizerAdapter(TokenizerAdapter):
     def decode(self, ids: Sequence[int]) -> str:
         return self.tokenizer.decode(ids, clean_up_tokenization_spaces=False)
 
+    def batch_encode(
+        self,
+        texts: Sequence[str],
+        *,
+        max_length: Optional[int] = None,
+        return_tensors: str = "pt",
+        return_dict: bool = False,
+        padding: bool | str = True,
+        truncation: bool = True,
+    ):
+        """Encode a batch of ``texts`` using the underlying tokenizer.
+
+        Parameters are forwarded to the tokenizer with sane defaults for
+        padding and truncation. When ``return_dict`` is ``True`` the full
+        mapping produced by the tokenizer is returned, otherwise only the
+        ``input_ids`` list is returned.
+        """
+
+        enc = self.tokenizer(
+            list(texts),
+            padding="max_length" if padding == "max_length" or padding is True else False,
+            truncation=truncation,
+            max_length=max_length,
+            return_tensors=return_tensors,
+        )
+        if return_dict:
+            return enc
+        return enc["input_ids"].tolist()
+
     def add_special_tokens(self, tokens: Sequence[str]) -> Dict[str, int]:
         return self.tokenizer.add_special_tokens({"additional_special_tokens": list(tokens)})
 

--- a/src/codex_ml/tracking/mlflow_utils.py
+++ b/src/codex_ml/tracking/mlflow_utils.py
@@ -227,22 +227,18 @@ def log_params(d: Mapping[str, Any], *, enabled: Optional[bool] = None) -> None:
         raise RuntimeError("Failed to log parameters to MLflow") from exc
 
 
-def log_metrics(
-    d: Mapping[str, float], *, step: Optional[int] = None, enabled: Optional[bool] = None
-) -> None:
+def log_metrics(d: Mapping[str, float], *, step: int, enabled: Optional[bool] = None) -> None:
     """Log metrics mapping to MLflow when explicitly enabled.
 
-    ``step`` may be provided to associate a step index with the metrics. The
-    call is a no-op when ``enabled`` is ``None`` or ``False``.
+    ``step`` is required so each logged metric is associated with an explicit
+    index. The call is a no-op when ``enabled`` is ``None`` or ``False``.
     """
     ml = _mlflow_noop_or_raise(enabled)
     if ml is None:
         return
     try:
-        if step is None:
-            ml.log_metrics(dict(d))  # type: ignore[arg-type]
-        else:
-            ml.log_metrics(dict(d), step=step)  # type: ignore[arg-type]
+        for k, v in d.items():
+            ml.log_metric(k, float(v), step=step)  # type: ignore[arg-type]
     except Exception as exc:
         raise RuntimeError("Failed to log metrics to MLflow") from exc
 

--- a/src/codex_ml/utils/__init__.py
+++ b/src/codex_ml/utils/__init__.py
@@ -1,6 +1,7 @@
 """Utility modules for :mod:`codex_ml`."""
 
 from .checkpointing import CheckpointManager
+from .repro import set_reproducible
 from .seed import deterministic_shuffle
 
-__all__ = ["CheckpointManager", "deterministic_shuffle"]
+__all__ = ["CheckpointManager", "deterministic_shuffle", "set_reproducible"]

--- a/src/codex_ml/utils/checkpointing.py
+++ b/src/codex_ml/utils/checkpointing.py
@@ -20,6 +20,7 @@ CLI flags to integrate in a trainer:
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import pickle
 import random
@@ -28,8 +29,6 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from codex_ml.monitoring.codex_logging import _codex_sample_system
-
-from .checksums import write_checksum
 
 try:  # pragma: no cover - optional torch dependency
     import torch
@@ -46,18 +45,45 @@ except Exception:  # pragma: no cover - numpy missing
     NUMPY_AVAILABLE = False
 
 
+def _write_checksum_manifest(path: Path) -> None:
+    """Write SHA256 checksum and size for ``path`` into checksums.json."""
+    meta = {
+        "file": path.name,
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "bytes": path.stat().st_size,
+    }
+    (path.parent / "checksums.json").write_text(json.dumps(meta), encoding="utf-8")
 
 
-def save_checkpoint(path: str, model, optimizer, scheduler, epoch: int, extra: Dict[str, Any] | None = None):
+def _verify_checksum_manifest(directory: Path) -> None:
+    """Verify checksum manifest in ``directory`` if present."""
+    manifest = directory / "checksums.json"
+    if not manifest.exists():
+        return
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    target = directory / data.get("file", "")
+    if not target.exists():
+        raise RuntimeError("checkpoint file missing during checksum verify")
+    sha = hashlib.sha256(target.read_bytes()).hexdigest()
+    if sha != data.get("sha256") or target.stat().st_size != data.get("bytes"):
+        raise RuntimeError("checkpoint checksum mismatch")
+
+
+def save_checkpoint(
+    path: str, model, optimizer, scheduler, epoch: int, extra: Dict[str, Any] | None = None
+):
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
-    torch.save({
-        "model": model.state_dict(),
-        "optimizer": optimizer.state_dict() if optimizer else None,
-        "scheduler": scheduler.state_dict() if scheduler else None,
-        "epoch": epoch,
-        "extra": extra or {},
-    }, p)
+    torch.save(
+        {
+            "model": model.state_dict(),
+            "optimizer": optimizer.state_dict() if optimizer else None,
+            "scheduler": scheduler.state_dict() if scheduler else None,
+            "epoch": epoch,
+            "extra": extra or {},
+        },
+        p,
+    )
 
 
 def load_checkpoint(path: str, model, optimizer=None, scheduler=None, map_location="cpu"):
@@ -68,6 +94,7 @@ def load_checkpoint(path: str, model, optimizer=None, scheduler=None, map_locati
     if scheduler and ckpt.get("scheduler"):
         scheduler.load_state_dict(ckpt["scheduler"])
     return ckpt.get("epoch", 0), ckpt.get("extra", {})
+
 
 def _write_json(path: Path, data: Dict[str, Any]) -> None:
     path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
@@ -92,9 +119,7 @@ def _rng_dump() -> Dict[str, Any]:
     if TORCH_AVAILABLE:
         state["torch"] = {"cpu": torch.random.get_rng_state().tolist()}
         if torch.cuda.is_available():  # pragma: no cover - cuda optional
-            state["torch"]["cuda"] = [
-                s.tolist() for s in torch.cuda.get_rng_state_all()
-            ]
+            state["torch"]["cuda"] = [s.tolist() for s in torch.cuda.get_rng_state_all()]
     return state
 
 
@@ -114,9 +139,7 @@ def _rng_load(state: Dict[str, Any]) -> None:
             )
         )
     if TORCH_AVAILABLE and "torch" in state:
-        torch.random.set_rng_state(
-            torch.tensor(state["torch"]["cpu"], dtype=torch.uint8)
-        )
+        torch.random.set_rng_state(torch.tensor(state["torch"]["cpu"], dtype=torch.uint8))
         if (
             "cuda" in state["torch"] and torch.cuda.is_available()
         ):  # pragma: no cover - cuda optional
@@ -133,6 +156,7 @@ def dump_rng_state() -> Dict[str, Any]:
 def load_rng_state(state: Dict[str, Any]) -> None:
     """Restore RNG state saved by :func:`dump_rng_state`."""
     _rng_load(state)
+
 
 def set_seed(seed: int, out_dir: Optional[Path | str] = None) -> Dict[str, int]:
     """Set RNG seeds across libraries and optionally persist ``seeds.json``."""
@@ -215,7 +239,8 @@ class CheckpointManager:
                     with open(ep_dir / "tokenizer.pkl", "wb") as fh:
                         pickle.dump(tokenizer, fh)
 
-        write_checksum(ep_dir)
+        state_file = ep_dir / ("state.pt" if (ep_dir / "state.pt").exists() else "state.pkl")
+        _write_checksum_manifest(state_file)
 
         # last marker
         (self.root / "last").write_text(str(ep_dir), encoding="utf-8")
@@ -257,6 +282,7 @@ class CheckpointManager:
         if not path.exists():
             raise FileNotFoundError(f"resume path not found: {path}")
 
+        _verify_checksum_manifest(path)
         state = None
         if (path / "state.pt").exists() and TORCH_AVAILABLE:
             state = torch.load(path / "state.pt", map_location="cpu")
@@ -315,9 +341,7 @@ class CheckpointManager:
     # ------------------------------------------------------------------
     # Verification
     # ------------------------------------------------------------------
-    def _verify_state_dict(
-        self, model_sd: Dict[str, Any], loaded_sd: Dict[str, Any]
-    ) -> None:
+    def _verify_state_dict(self, model_sd: Dict[str, Any], loaded_sd: Dict[str, Any]) -> None:
         missing, unexpected, mismatched = [], [], []
         for k, v in model_sd.items():
             if k not in loaded_sd:
@@ -336,29 +360,21 @@ class CheckpointManager:
         if missing or unexpected or mismatched:
             msgs = []
             if missing:
-                msgs.append(
-                    f"missing: {missing[:10]}{' ...' if len(missing) > 10 else ''}"
-                )
+                msgs.append(f"missing: {missing[:10]}{' ...' if len(missing) > 10 else ''}")
             if unexpected:
                 msgs.append(
                     f"unexpected: {unexpected[:10]}{' ...' if len(unexpected) > 10 else ''}"
                 )
             if mismatched:
-                msgs.append(
-                    f"mismatched: {mismatched[:5]}{' ...' if len(mismatched) > 5 else ''}"
-                )
+                msgs.append(f"mismatched: {mismatched[:5]}{' ...' if len(mismatched) > 5 else ''}")
             raise ValueError("state_dict verification failed: " + "; ".join(msgs))
 
-    def _verify_optimizer_state(
-        self, optimizer: Any, loaded_sd: Dict[str, Any]
-    ) -> None:
+    def _verify_optimizer_state(self, optimizer: Any, loaded_sd: Dict[str, Any]) -> None:
         """Check optimizer param counts and tensor shapes before loading."""
         if not TORCH_AVAILABLE:
             return
 
-        params = [
-            p for group in optimizer.param_groups for p in group.get("params", [])
-        ]
+        params = [p for group in optimizer.param_groups for p in group.get("params", [])]
         loaded_groups = loaded_sd.get("param_groups", [])
         loaded_state = loaded_sd.get("state", {})
         loaded_param_ids = [pid for g in loaded_groups for pid in g.get("params", [])]
@@ -377,9 +393,7 @@ class CheckpointManager:
                 if torch.is_tensor(val) and tuple(val.shape) != tuple(param.shape):
                     mismatched.append((pid, key, tuple(param.shape), tuple(val.shape)))
 
-        unexpected = [
-            pid for pid in loaded_state.keys() if pid not in set(loaded_param_ids)
-        ]
+        unexpected = [pid for pid in loaded_state.keys() if pid not in set(loaded_param_ids)]
         if unexpected or mismatched:
             msgs = []
             if unexpected:
@@ -388,9 +402,7 @@ class CheckpointManager:
                 )
             if mismatched:
                 sample = [(pid, key, exp, got) for pid, key, exp, got in mismatched[:5]]
-                msgs.append(
-                    f"mismatched: {sample}{' ...' if len(mismatched) > 5 else ''}"
-                )
+                msgs.append(f"mismatched: {sample}{' ...' if len(mismatched) > 5 else ''}")
             raise ValueError("optimizer state verification failed: " + "; ".join(msgs))
 
 

--- a/src/codex_ml/utils/repro.py
+++ b/src/codex_ml/utils/repro.py
@@ -1,0 +1,31 @@
+def set_reproducible(seed: int = 42) -> None:
+    """Best-effort reproducibility settings.
+
+    Seeds Python, NumPy and torch (when available) and enables deterministic
+    algorithms where supported. cuDNN benchmarking is disabled and a default
+    ``CUBLAS_WORKSPACE_CONFIG`` is set when absent.
+    """
+    import os
+    import random
+
+    import numpy as np
+
+    try:
+        import torch
+    except Exception:  # pragma: no cover - torch missing
+        torch = None
+
+    random.seed(seed)
+    np.random.seed(seed)
+    if torch is not None:
+        torch.manual_seed(seed)
+        try:
+            torch.use_deterministic_algorithms(True)
+        except Exception:  # pragma: no cover - older torch
+            pass
+        try:
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+        except Exception:  # pragma: no cover - no cudnn
+            pass
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":16:8")

--- a/src/ingestion/utils.py
+++ b/src/ingestion/utils.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import random
 from pathlib import Path
-from typing import Any, List, Sequence, TypeVar, Tuple, Union, Optional
+from typing import List, Sequence, Tuple, TypeVar, Union
 
 T = TypeVar("T")
 
@@ -50,6 +50,7 @@ __all__ = [
     "read_text_file",
     "_detect_encoding",
     "REPO_READ_TEXT_AVAILABLE",
+    "write_manifest",
 ]
 
 
@@ -142,7 +143,9 @@ def seeded_shuffle(seq: Sequence[T], seed: int) -> List[T]:
     return deterministic_shuffle(seq, seed)
 
 
-def _manual_read_text(path: Union[str, Path], encoding: str = "utf-8", errors: str = "strict") -> Tuple[str, str]:
+def _manual_read_text(
+    path: Union[str, Path], encoding: str = "utf-8", errors: str = "strict"
+) -> Tuple[str, str]:
     """Read bytes and decode using provided encoding (or detect when 'auto').
 
     Returns (text, used_encoding)
@@ -254,3 +257,36 @@ def _detect_encoding_wrapper(path: Union[str, Path]) -> str:
 _detect_encoding = _detect_encoding  # type: ignore
 
 # End of file
+
+
+def write_manifest(
+    name: str,
+    sources: Sequence[str] | None,
+    seed: int,
+    split_cfg: dict,
+    out_dir: Union[str, Path],
+) -> Path:
+    """Write dataset provenance manifest under ``.codex/datasets``.
+
+    The manifest records data sources, random seed, split configuration and the
+    current git commit SHA when available.
+    """
+    import json
+    import subprocess
+
+    out = Path(out_dir) / ".codex" / "datasets"
+    out.mkdir(parents=True, exist_ok=True)
+    try:
+        sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except Exception:  # pragma: no cover - git absent
+        sha = None
+    manifest = {
+        "name": name,
+        "sources": list(sources) if sources else [],
+        "seed": seed,
+        "splits": split_cfg,
+        "commit": sha,
+    }
+    path = out / f"{name}.json"
+    path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return path

--- a/tests/test_checkpoint_checksum.py
+++ b/tests/test_checkpoint_checksum.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_ml.utils.checkpointing import CheckpointManager
+
+
+def test_checkpoint_checksum_verify(tmp_path: Path):
+    cm = CheckpointManager(tmp_path)
+    ckpt = cm.save(1, model=None)
+    meta = json.loads((ckpt / "checksums.json").read_text())
+    cm.resume_from(ckpt)
+    state_file = ckpt / meta["file"]
+    state_file.write_bytes(b"corrupt")
+    with pytest.raises(RuntimeError):
+        cm.resume_from(ckpt)

--- a/tests/test_cli_train_engine.py
+++ b/tests/test_cli_train_engine.py
@@ -1,0 +1,9 @@
+from click.testing import CliRunner
+
+from codex.cli import cli
+
+
+def test_cli_train_engine_option():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["train", "--help"])
+    assert "--engine" in result.output

--- a/tests/test_dataset_manifest.py
+++ b/tests/test_dataset_manifest.py
@@ -1,0 +1,11 @@
+import json
+from pathlib import Path
+
+from ingestion.utils import write_manifest
+
+
+def test_write_manifest(tmp_path: Path):
+    path = write_manifest("sample", ["src"], 42, {"train": 10}, tmp_path)
+    data = json.loads(path.read_text())
+    assert data["name"] == "sample" and data["seed"] == 42
+    assert "commit" in data

--- a/tests/test_mlflow_step_logging.py
+++ b/tests/test_mlflow_step_logging.py
@@ -1,0 +1,16 @@
+from codex_ml.tracking import mlflow_utils as MU
+
+
+def test_log_metrics_enforces_step(monkeypatch):
+    class Dummy:
+        def __init__(self):
+            self.logged = []
+
+        def log_metric(self, k, v, step=None):
+            self.logged.append((k, v, step))
+
+    dummy = Dummy()
+    monkeypatch.setattr(MU, "_mlf", dummy)
+    monkeypatch.setattr(MU, "_mlflow_noop_or_raise", lambda enabled: dummy)
+    MU.log_metrics({"loss": 1.2}, step=5, enabled=True)
+    assert dummy.logged == [("loss", 1.2, 5)]

--- a/tests/test_repro_helper.py
+++ b/tests/test_repro_helper.py
@@ -1,0 +1,26 @@
+import random
+
+import numpy as np
+
+try:
+    import torch
+except Exception:  # pragma: no cover - torch missing
+    torch = None
+
+from codex_ml.utils import set_reproducible
+
+
+def test_set_reproducible_cpu():
+    set_reproducible(123)
+    a1 = random.random()
+    n1 = np.random.rand()
+    t1 = torch.rand(1) if torch is not None else None
+
+    set_reproducible(123)
+    a2 = random.random()
+    n2 = np.random.rand()
+    t2 = torch.rand(1) if torch is not None else None
+
+    assert a1 == a2 and n1 == n2
+    if torch is not None:
+        assert torch.allclose(t1, t2)

--- a/tests/test_session_logger_wal.py
+++ b/tests/test_session_logger_wal.py
@@ -1,0 +1,12 @@
+import sqlite3
+
+from codex.logging import session_logger as sl
+
+
+def test_session_logger_enables_wal(tmp_path):
+    db = tmp_path / "logs.sqlite"
+    sl.init_db(db)
+    conn = sqlite3.connect(db)
+    mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+    conn.close()
+    assert mode.lower() == "wal"

--- a/tests/test_tokenizer_batch_encode.py
+++ b/tests/test_tokenizer_batch_encode.py
@@ -1,0 +1,22 @@
+from codex_ml.tokenization.hf_tokenizer import HFTokenizerAdapter
+
+
+def test_batch_encode_shapes(monkeypatch):
+    class DummyTok:
+        def __call__(self, texts, padding, truncation, max_length, return_tensors):
+            class Out(dict):
+                def __getitem__(self, key):
+                    return type(
+                        "T",
+                        (),
+                        {
+                            "shape": (len(texts), max_length or 4),
+                            "tolist": lambda self: [[0] * (max_length or 4)] * len(texts),
+                        },
+                    )()
+
+            return Out({"input_ids": None, "attention_mask": None})
+
+    adp = HFTokenizerAdapter(DummyTok())
+    enc = adp.batch_encode(["a", "bb"], max_length=6, return_dict=True)
+    assert enc["input_ids"].shape == enc["attention_mask"].shape

--- a/tests/tracking/test_mlflow_noop_default.py
+++ b/tests/tracking/test_mlflow_noop_default.py
@@ -27,7 +27,7 @@ def test_log_helpers_noop_with_mlflow_installed():
 
     # Should be no-ops when enabled is left as default (None)
     mfu.log_params({"a": 1})
-    mfu.log_metrics({"b": 2})
+    mfu.log_metrics({"b": 2}, step=0)
 
     # Cleanup to avoid leaking fake module to other tests
     sys.modules.pop("mlflow", None)


### PR DESCRIPTION
## Summary
- require explicit step when logging metrics to MLflow
- add `batch_encode` to the HF tokenizer adapter
- provide `set_reproducible` helper and enable SQLite WAL
- verify checkpoint integrity and expose dataset manifest writer
- expose `--engine` switch in CLI

## Testing
- `ruff check codex_ml/tracking/mlflow_utils.py src/codex_ml/tracking/mlflow_utils.py src/codex_ml/tokenization/hf_tokenizer.py src/codex_ml/utils/repro.py src/codex_ml/utils/__init__.py src/codex/logging/session_logger.py src/codex_ml/utils/checkpointing.py src/codex/cli.py scripts/deploy_codex_pipeline.py src/codex_ml/cli/main.py src/ingestion/utils.py tests/tracking/test_mlflow_noop_default.py tests/test_tokenizer_batch_encode.py tests/test_mlflow_step_logging.py tests/test_repro_helper.py tests/test_session_logger_wal.py tests/test_checkpoint_checksum.py tests/test_dataset_manifest.py tests/test_cli_train_engine.py`
- `black --check codex_ml/tracking/mlflow_utils.py src/codex_ml/tracking/mlflow_utils.py src/codex_ml/tokenization/hf_tokenizer.py src/codex_ml/utils/repro.py src/codex_ml/utils/__init__.py src/codex/logging/session_logger.py src/codex_ml/utils/checkpointing.py src/codex/cli.py scripts/deploy_codex_pipeline.py src/codex_ml/cli/main.py src/ingestion/utils.py tests/tracking/test_mlflow_noop_default.py tests/test_tokenizer_batch_encode.py tests/test_mlflow_step_logging.py tests/test_repro_helper.py tests/test_session_logger_wal.py tests/test_checkpoint_checksum.py tests/test_dataset_manifest.py tests/test_cli_train_engine.py`
- `isort --check-only codex_ml/tracking/mlflow_utils.py src/codex_ml/tracking/mlflow_utils.py src/codex_ml/tokenization/hf_tokenizer.py src/codex_ml/utils/repro.py src/codex_ml/utils/__init__.py src/codex/logging/session_logger.py src/codex_ml/utils/checkpointing.py src/codex/cli.py scripts/deploy_codex_pipeline.py src/codex_ml/cli/main.py src/ingestion/utils.py tests/tracking/test_mlflow_noop_default.py tests/test_tokenizer_batch_encode.py tests/test_mlflow_step_logging.py tests/test_repro_helper.py tests/test_session_logger_wal.py tests/test_checkpoint_checksum.py tests/test_dataset_manifest.py tests/test_cli_train_engine.py`
- `python -m pre_commit run --files codex_ml/tracking/mlflow_utils.py src/codex_ml/tracking/mlflow_utils.py src/codex_ml/tokenization/hf_tokenizer.py src/codex_ml/utils/repro.py src/codex_ml/utils/__init__.py src/codex/logging/session_logger.py src/codex_ml/utils/checkpointing.py src/codex/cli.py scripts/deploy_codex_pipeline.py src/codex_ml/cli/main.py src/ingestion/utils.py tests/tracking/test_mlflow_noop_default.py tests/test_tokenizer_batch_encode.py tests/test_mlflow_step_logging.py tests/test_repro_helper.py tests/test_session_logger_wal.py tests/test_checkpoint_checksum.py tests/test_dataset_manifest.py tests/test_cli_train_engine.py`
- `python -m nox -s tests` *(failed: coverage.exceptions.DataError: Can't combine statement coverage data with branch data)*

------
https://chatgpt.com/codex/tasks/task_e_68b715ce0ee88331b02a8ab713be89c5