### PR TITLE
chore: prevent coverage data mismatch

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import nox
 
 COV_THRESHOLD = 80
@@ -26,6 +28,8 @@ def quality(session):
 
 @nox.session(python=["3.12"])
 def tests(session):
+    for cov_file in Path(".").glob(".coverage*"):
+        cov_file.rename(cov_file.with_suffix(cov_file.suffix + ".bak"))
     session.install(
         "pytest",
         "pytest-cov",


### PR DESCRIPTION
## Summary
- move existing coverage artifacts aside before running tests to avoid branch/statement data mixing

## Testing
- `pre-commit run --files noxfile.py`
- `nox -s tests -- --cov-fail-under=0 tests/test_model_loader.py tests/interfaces/test_tokenizer_hf.py tests/monitoring/test_monitoring_mlflow_utils.py tests/monitoring/test_mlflow_monitoring_utils.py tests/safety/test_risk_score.py`


------
https://chatgpt.com/codex/tasks/task_e_68b739cbbb38833186b45a417bc9a7d6