### PR TITLE
Codex/implement code improvements and features mb9xft - clarify MLflow step logging test

### DIFF
--- a/tests/test_mlflow_step_logging.py
+++ b/tests/test_mlflow_step_logging.py
@@ -1,3 +1,5 @@
+"""Test utilities for enforcing explicit MLflow step logging."""
+
 from codex_ml.tracking import mlflow_utils as MU
 
 

--- a/tests/test_repro_branches.py
+++ b/tests/test_repro_branches.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import torch
+
+from codex_ml.utils.repro import set_reproducible
+
+
+def test_set_reproducible_handles_failures(monkeypatch):
+    def boom(*_, **__):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(torch, "use_deterministic_algorithms", boom)
+
+    class CudnnStub:
+        def __setattr__(self, name, value):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(torch, "backends", type("B", (), {"cudnn": CudnnStub()})())
+
+    # Should swallow the internal errors and still set up determinism guards
+    set_reproducible(123)


### PR DESCRIPTION
## Summary
- Document MLflow step logging expectations in the unit test for clarity
- Add regression test ensuring `set_reproducible` handles backend failures gracefully

## Testing
- `pre-commit run --files tests/test_repro_branches.py`
- `nox -s tests -- tests/test_repro_branches.py tests/test_repro_determinism.py` *(fails: Required test coverage of 70% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68b747158068833196e276f284d7fada