### PR TITLE
Codex/implement code improvements and features mb9xft: address review comments

### DIFF
--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -129,13 +129,18 @@ def run_task(task: str) -> None:
 def train_cmd(engine, *args, **kwargs):
     """Train a model with the selected engine."""
     if engine == "hf":
-        from training.engine_hf_trainer import train as hf_train
+        # ``training.engine_hf_trainer`` exposes ``run_hf_trainer`` as the entry
+        # point rather than ``train``. Import the real callable to avoid import
+        # errors when invoking the CLI.
+        from training.engine_hf_trainer import run_hf_trainer
 
-        return hf_train(*args, **kwargs)
+        return run_hf_trainer(*args, **kwargs)
     else:
-        from codex_ml.train_loop import train as custom_train
+        # ``codex_ml.train_loop`` provides ``main`` as the training entry point.
+        # Import it directly so the CLI can dispatch correctly.
+        from codex_ml.train_loop import main as run_custom_train
 
-        return custom_train(*args, **kwargs)
+        return run_custom_train(*args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/src/codex_ml/tokenization/hf_tokenizer.py
+++ b/src/codex_ml/tokenization/hf_tokenizer.py
@@ -76,12 +76,15 @@ class HFTokenizerAdapter(TokenizerAdapter):
         truncation: bool = True,
     ):
         """Vectorised encode that mirrors HF tokenizer semantics."""
-        if padding and getattr(self.tokenizer, "pad_token", None) is None:
+        if (
+            padding not in (False, "do_not_pad")
+            and getattr(self.tokenizer, "pad_token", None) is None
+        ):
             # GPT-2 tokenizers lack a pad token by default; use eos for padding
             self.tokenizer.pad_token = self.tokenizer.eos_token
         enc = self.tokenizer(
             list(texts),
-            padding="max_length" if isinstance(padding, str) else padding,
+            padding=padding,
             truncation=truncation,
             max_length=max_length,
             return_tensors=return_tensors,


### PR DESCRIPTION
## Summary
- fix `codex.cli train` to import the actual training entrypoints (`run_hf_trainer` and `main`)
- allow `HFTokenizerAdapter.batch_encode` to honor any string padding mode instead of forcing `max_length`

## Testing
- `pre-commit run --files src/codex/cli.py src/codex_ml/tokenization/hf_tokenizer.py`
- `mypy src/codex/cli.py src/codex_ml/tokenization/hf_tokenizer.py` *(fails: Argument 1 to "TrainingArguments" has incompatible type "**dict[str, object]"; expected "int | None")*
- `nox -s tests` *(session tests-3.12 interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b779880b58833199c9e715f7f029b6