### PR TITLE
Codex/implement code improvements and features mb9xft

### DIFF
--- a/src/codex_ml/tokenization/hf_tokenizer.py
+++ b/src/codex_ml/tokenization/hf_tokenizer.py
@@ -81,7 +81,7 @@ class HFTokenizerAdapter(TokenizerAdapter):
             self.tokenizer.pad_token = self.tokenizer.eos_token
         enc = self.tokenizer(
             list(texts),
-            padding="max_length" if isinstance(padding, str) else padding,
+            padding=padding,
             truncation=truncation,
             max_length=max_length,
             return_tensors=return_tensors,

--- a/tests/test_tokenizer_batch_encode.py
+++ b/tests/test_tokenizer_batch_encode.py
@@ -22,3 +22,21 @@ def test_batch_encode_truncation(hf_tok):
     adp = HFTokenizerAdapter(hf_tok)
     enc = adp.batch_encode(["one two three four five"], max_length=3, return_dict=True)
     assert enc["input_ids"].shape[-1] == 3
+
+
+def test_batch_encode_respects_string_padding(hf_tok):
+    adp = HFTokenizerAdapter(hf_tok)
+    texts = ["a", "longer sentence"]
+    max_len = max(len(hf_tok.encode(t)) for t in texts)
+
+    enc_longest = adp.batch_encode(texts, padding="longest", return_dict=True)
+    assert enc_longest["input_ids"].shape[-1] == max_len
+
+    enc_no_pad = adp.batch_encode(
+        texts,
+        padding="do_not_pad",
+        return_tensors=None,
+        return_dict=True,
+    )
+    lengths = [len(ids) for ids in enc_no_pad["input_ids"]]
+    assert lengths == [len(hf_tok.encode(t)) for t in texts]


### PR DESCRIPTION
## Summary
- Preserve caller-provided string padding modes in `HFTokenizerAdapter.batch_encode`
- Test that `HFTokenizerAdapter` honors padding strings like `longest` and `do_not_pad`

## Testing
- `pre-commit run --files src/codex_ml/tokenization/hf_tokenizer.py tests/test_tokenizer_batch_encode.py`
- `nox -s tests` *(fails: Command pytest -q --import-mode=importlib --cov-config=pyproject.toml --cov-branch --cov=src/codex_ml --cov-report=term --cov-report=xml --cov-fail-under=80 exited with 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b7798e46448331bdc2f865fd151263