### PR TITLE
Add patch troubleshooting guide and helper script

### DIFF
--- a/docs/patch-troubleshooting.md
+++ b/docs/patch-troubleshooting.md
@@ -1,0 +1,43 @@
+# Handling "patch with only garbage" Errors
+
+When applying patches, you may see errors like:
+
+```
+patch: **** Only garbage was found in the patch input.
+```
+
+This usually indicates that Git or `patch` cannot parse the patch file.
+
+## Common Causes
+
+- Patch lacks proper Git diff headers (`diff --git`, `index`, `@@` hunks).
+- Patch is an email/mbox patch (`From <sha>`) that should be applied with `git am`.
+- Encoding or line-ending issues (e.g., UTF-16, BOM, or CRLF line endings).
+- Patch was generated without `--binary` when binary changes are present.
+- Patch is in a different format (e.g., `diff -ruN`) meant for the `patch` tool.
+- Color codes, HTML, or other noise in the patch file.
+
+## Recovery Checklist
+
+1. **Inspect the header** to determine the patch type:
+   ```bash
+   head -20 your_patch.diff
+   ```
+2. **Normalize encoding and line endings** using tools like `iconv` or `dos2unix`.
+3. **Strip color codes or HTML** if the patch was copied from a web page or generated with color.
+4. **Apply with the correct tool**:
+   - `git am` for email patches.
+   - `git apply` for Git diffs.
+   - `patch -p1` for generic unified diffs.
+5. **Regenerate the patch with `--binary`** if it includes binary files.
+6. **Check if changes are already applied** using `git apply --reverse --check`.
+
+## Automated Helper Script
+
+The repository includes a helper script to automate these steps:
+
+```bash
+./tools/patch_apply_safe.sh path/to/patch.diff
+```
+
+The script normalizes the patch and chooses the appropriate application method (`git apply`, `git am`, or `patch`).

--- a/tools/patch_apply_safe.sh
+++ b/tools/patch_apply_safe.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PATCH="${1:-fallback_patch_4.1-4.8.diff}"
+
+if [[ ! -f "$PATCH" ]]; then
+  echo "Patch not found: $PATCH" >&2
+  exit 64
+fi
+
+echo "==> Inspecting header..."
+HEAD1="$(head -n1 "$PATCH" || true)"
+
+# Normalize encoding & line endings
+echo "==> Normalizing encoding and EOL..."
+if file "$PATCH" | grep -qi 'UTF-16'; then
+  iconv -f UTF-16 -t UTF-8 "$PATCH" > "$PATCH.tmp" && mv "$PATCH.tmp" "$PATCH"
+fi
+# strip BOM
+awk 'NR==1{sub(/^\xEF\xBB\xBF/,"")}1' "$PATCH" > "$PATCH.tmp" && mv "$PATCH.tmp" "$PATCH"
+# normalize CRLF -> LF if dos2unix exists
+command -v dos2unix >/dev/null 2>&1 && dos2unix -q "$PATCH" || true
+
+# If color codes appear, strip them
+if grep -Pq "\x1B\[[0-9;]*[mK]" "$PATCH" 2>/dev/null; then
+  sed -r 's/\x1B\[[0-9;]*[mK]//g' "$PATCH" > "$PATCH.tmp" && mv "$PATCH.tmp" "$PATCH"
+fi
+
+# Already applied?
+if git apply --reverse --check "$PATCH" >/dev/null 2>&1; then
+  echo "Patch appears already applied. Skipping."
+  exit 0
+fi
+
+# Choose strategy
+if [[ "$HEAD1" =~ ^From[[:space:]]+[0-9a-f]{7,40} ]]; then
+  echo "==> Detected email patch; using git am"
+  git am --reject --3way --keep-cr "$PATCH"
+elif grep -q "^diff --git " "$PATCH"; then
+  echo "==> Detected git unified diff; using git apply"
+  git apply --index --reject --whitespace=fix --verbose "$PATCH"
+elif grep -q "^--- " "$PATCH" && grep -q "^\*\*\* " "$PATCH"; then
+  echo "==> Detected context diff; using patch -p1"
+  patch --dry-run -p1 < "$PATCH"
+  patch -p1 < "$PATCH"
+else
+  echo "Unrecognized patch format. Try regenerating with:"
+  echo "  git diff --binary --no-color <BASE>..<HEAD> > new.patch"
+  exit 65
+fi
+
+echo "==> Patch applied."


### PR DESCRIPTION
## Summary
- document common causes and fixes for the "patch with only garbage" error
- add `patch_apply_safe.sh` script to normalize and apply patches safely

## Testing
- `pre-commit run --files docs/patch-troubleshooting.md tools/patch_apply_safe.sh`
- `nox -s tests` *(failed: Command pytest -q --import-mode=importlib --cov-config=pyproject.toml --cov-branch --cov=src/codex_ml --cov-report=term --cov-report=xml --cov-fail-under=80 failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b78a1bdc7483318cba3111057a8519