### PR TITLE
Codex status update 2025 09 03: address review feedback

### DIFF
--- a/src/codex_ml/modeling/codex_model_loader.py
+++ b/src/codex_ml/modeling/codex_model_loader.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Optional
 
 from transformers import AutoModelForCausalLM
@@ -46,9 +45,6 @@ def load_model_with_optional_lora(
         if torch_dtype is None:
             raise ValueError(f"Unknown dtype: {dtype}")
 
-    if device_map not in (None, "auto", "cpu", "cuda"):
-        raise ValueError(f"Unsupported device_map: {device_map}")
-
     # Load base model
     model = AutoModelForCausalLM.from_pretrained(
         name_or_path, torch_dtype=torch_dtype, device_map=device_map, **kw
@@ -65,8 +61,6 @@ def load_model_with_optional_lora(
         return model
 
     if lora_path:
-        if not Path(lora_path).exists():
-            raise FileNotFoundError(f"LoRA path {lora_path} does not exist")
         try:  # pragma: no cover - optional dependency may fail
             return PeftModel.from_pretrained(model, lora_path)
         except Exception:

--- a/tests/test_engine_hf_trainer.py
+++ b/tests/test_engine_hf_trainer.py
@@ -93,10 +93,11 @@ def test_run_hf_trainer_passes_resume_from(monkeypatch, tmp_path):
     captured = {}
 
     class DummyTrainer:
-        def __init__(self, *args, resume_from_checkpoint=None, **kwargs):
-            captured["resume"] = resume_from_checkpoint
+        def __init__(self, *args, **kwargs):
+            pass
 
-        def train(self):
+        def train(self, resume_from_checkpoint=None):
+            captured["resume"] = resume_from_checkpoint
             return type("O", (), {"metrics": {"train_loss": 0.0}})()
 
     monkeypatch.setattr("training.engine_hf_trainer.Trainer", DummyTrainer)

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -462,6 +462,8 @@ def run_hf_trainer(
     set_seed(seed, output_dir)
     log_env_info(output_dir / "env.json")
     resume_ckpt = resume_from
+    if resume_ckpt and not Path(resume_ckpt).exists():
+        resume_ckpt = None
 
     # Resolve tokenizer configuration
     cfg: Dict[str, object] = {}


### PR DESCRIPTION
## Summary
- ignore non-existent resume checkpoints and test trainer resume logic via `train`
- relax HF model loader checks for `device_map` and remote LoRA adapters

## Testing
- `pre-commit run --files src/codex_ml/modeling/codex_model_loader.py training/engine_hf_trainer.py tests/test_engine_hf_trainer.py`
- `mypy src/codex_ml/modeling/codex_model_loader.py training/engine_hf_trainer.py tests/test_engine_hf_trainer.py` *(fails: missing types-PyYAML, duplicate module name)*
- `pytest tests/test_peft_adapter.py::test_apply_lora_with_peft tests/test_query_logs_tail.py::test_tail_option tests/test_readme_examples.py::test_readme_session_logger_example tests/test_requirements_lock.py::test_requirements_lock_exists tests/test_search_providers.py::test_internal_search_finds_known_string tests/test_sentencepiece_adapter.py::test_train_or_load_requires_sentencepiece tests/test_sentencepiece_adapter.py::test_load_requires_sentencepiece tests/test_sentencepiece_adapter.py::test_assert_vocab_size tests/test_tokenizer_batch_encode.py::test_batch_encode_shapes tests/test_train_loop.py::test_record_metrics_writes_json tests/test_training_arguments_flags.py::test_load_training_arguments_flags tests/tokenization/test_sentencepiece_adapter.py::test_import_error -q` *(fails: multiple assertion and import errors; coverage below threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68b8575f71dc8331a7724fe93f6e6a02