### PR TITLE
Codex status update 2025 09 03

### DIFF
--- a/tests/test_engine_hf_trainer.py
+++ b/tests/test_engine_hf_trainer.py
@@ -1,4 +1,5 @@
 import json
+import types
 from pathlib import Path
 
 import torch
@@ -168,25 +169,6 @@ def test_compute_metrics_smoke():
     labels = np.zeros((2, 3), dtype=np.int64)
     metrics = _compute_metrics((logits, labels))
     assert "token_accuracy" in metrics and "perplexity" in metrics
-
-
-def test_run_hf_trainer_passes_resume_from(tmp_path, monkeypatch):
-    texts = ["hi"]
-    ckpt = tmp_path / "ckpt"
-    ckpt.mkdir()
-    captured = {}
-
-    class DummyTrainer:
-        def __init__(self, *a, **k):
-            pass
-
-        def train(self, *, resume_from_checkpoint=None, **k):
-            captured["resume"] = resume_from_checkpoint
-            return types.SimpleNamespace(metrics={})
-
-    monkeypatch.setattr("training.engine_hf_trainer.Trainer", DummyTrainer)
-    run_hf_trainer(texts, tmp_path, model_name="sshleifer/tiny-gpt2", resume_from=str(ckpt))
-    assert captured["resume"] == str(ckpt)
 
 
 def test_run_hf_trainer_ignores_missing_resume_from(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- remove duplicated `test_run_hf_trainer_passes_resume_from` to keep monkeypatched trainer and avoid real model/tokenizer downloads
- import `types` in HF trainer tests for helper use

## Testing
- `pre-commit run --files tests/test_engine_hf_trainer.py`
- `PYTHONPATH=src pytest -c /dev/null tests/test_engine_hf_trainer.py::test_run_hf_trainer_passes_resume_from -q`
- `nox -s tests` *(fail: multiple missing dependencies and configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b87f58b8888331935641e334513cae