### PR TITLE
Codex status update 2025 09 03: test cleanup

### DIFF
--- a/tests/test_engine_hf_trainer.py
+++ b/tests/test_engine_hf_trainer.py
@@ -1,4 +1,5 @@
 import json
+import types
 from pathlib import Path
 
 import torch
@@ -168,25 +169,6 @@ def test_compute_metrics_smoke():
     labels = np.zeros((2, 3), dtype=np.int64)
     metrics = _compute_metrics((logits, labels))
     assert "token_accuracy" in metrics and "perplexity" in metrics
-
-
-def test_run_hf_trainer_passes_resume_from(tmp_path, monkeypatch):
-    texts = ["hi"]
-    ckpt = tmp_path / "ckpt"
-    ckpt.mkdir()
-    captured = {}
-
-    class DummyTrainer:
-        def __init__(self, *a, **k):
-            pass
-
-        def train(self, *, resume_from_checkpoint=None, **k):
-            captured["resume"] = resume_from_checkpoint
-            return types.SimpleNamespace(metrics={})
-
-    monkeypatch.setattr("training.engine_hf_trainer.Trainer", DummyTrainer)
-    run_hf_trainer(texts, tmp_path, model_name="sshleifer/tiny-gpt2", resume_from=str(ckpt))
-    assert captured["resume"] == str(ckpt)
 
 
 def test_run_hf_trainer_ignores_missing_resume_from(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- remove duplicate `test_run_hf_trainer_passes_resume_from` so mocked version runs
- add missing `types` import in HF trainer tests

## Testing
- `pre-commit run --files tests/test_engine_hf_trainer.py`
- `PYTHONPATH=src pytest -q -o addopts='' tests/test_engine_hf_trainer.py::test_run_hf_trainer_passes_resume_from`
- `nox -s tests` *(fails: multiple failing tests in suite)*

## Error Capture
```
Question from ChatGPT @codex:
While performing [Step 1: nox -s tests], encountered the following errors:
FAILED tests/test_codex_cli.py::test_cli_test_smoke - AssertionError: assert 2 == 0
FAILED tests/test_codex_cli.py::test_cli_audit_smoke - AssertionError: assert 2 == 0
FAILED tests/test_codex_maintenance.py::test_codex_maintenance_summary - AssertionError: assert '- ok: success' in ''
FAILED tests/test_dataset_manifest.py::test_write_manifest - AttributeError: 'NoneType' object has no attribute 'read_text'
FAILED tests/test_engine_hf_trainer.py::test_hf_trainer_smoke - TypeError: Accelerator.__init__() got an unexpected keyword argument 'project_dir'
FAILED tests/test_engine_hf_trainer.py::test_hf_trainer_writes_metrics - TypeError: Accelerator.__init__() got an unexpected keyword argument 'project_dir'
FAILED tests/test_engine_hf_trainer.py::test_run_hf_trainer_uses_tokenizer_path_and_flag - TypeError: Accelerator.__init__() got an unexpected keyword argument 'project_dir'
FAILED tests/test_engine_hf_trainer.py::test_run_hf_trainer_respects_grad_accum - TypeError: test_run_hf_trainer_respects_grad_accum.<locals>.DummyTrainer() takes no arguments
FAILED tests/test_engine_hf_trainer.py::test_run_hf_trainer_ignores_missing_resume_from - AttributeError: 'DummyTrainer' object has no attribute 'save_model'
FAILED tests/test_engine_hf_trainer_resume_arg.py::test_run_hf_trainer_passes_resume - TypeError: Accelerator.__init__() got an unexpected keyword argument 'project_dir'
FAILED tests/test_engine_hf_trainer_resume_arg.py::test_run_hf_trainer_ignores_missing_resume - TypeError: Accelerator.__init__() got an unexpected keyword argument 'project_dir'
FAILED tests/test_fetch_messages.py::test_fetch_messages[custom_path] - SystemExit: 0
FAILED tests/test_fetch_messages.py::test_fetch_messages[default_path] - SystemExit: 0
FAILED tests/test_hydra_cli.py::test_hydra_cli_smoke - subprocess.CalledProcessError: Command '['/workspace/_codex_/.nox/tests-3-12/bin/python', '-m', 'codex.cli', '--help']' returned non-zero exit status 1.
FAILED tests/test_hydra_cli.py::test_hydra_cli_help - subprocess.CalledProcessError: Command '['/workspace/_codex_/.nox/tests-3-12/bin/python', '-m', 'codex.cli', '--help']' returned non-zero exit status 1.
FAILED tests/test_logging_viewer_cli.py::test_cli_text_output - AssertionError: /workspace/_codex_/.nox/tests-3-12/bin/python: Error while finding module specification for 'src.codex.logging.viewer' (ModuleNotFoundError: No module named 'src')
FAILED tests/test_logging_viewer_cli.py::test_cli_json_output - AssertionError: /workspace/_codex_/.nox/tests-3-12/bin/python: Error while finding module specification for 'src.codex.logging.viewer' (ModuleNotFoundError: No module named 'src')
FAILED tests/test_mlflow_utils_root.py::test_start_run_missing_raises - Failed: DID NOT RAISE <class 'RuntimeError'>
FAILED tests/test_model_loader.py::test_lora_enabled_with_peft_available - FileNotFoundError: LoRA path 'path/to/lora/weights' does not exist
FAILED tests/test_training_arguments_flags.py::test_load_training_arguments_flags - ValueError: FP16 Mixed precision training requires a torch <-> cuda install
Context: running the full test suite; environment lacks optional dependencies and has incomplete test fixtures.
What are the possible causes, and how can this be resolved while preserving intended functionality?
```

------
https://chatgpt.com/codex/tasks/task_e_68b87fcfb8d483318945ef4fec74c388