### PR TITLE
Fix missing types import in HF trainer tests

### DIFF
--- a/tests/test_engine_hf_trainer.py
+++ b/tests/test_engine_hf_trainer.py
@@ -1,4 +1,5 @@
 import json
+import types
 from pathlib import Path
 
 import torch
@@ -117,9 +118,9 @@ def test_run_hf_trainer_passes_resume_from(monkeypatch, tmp_path):
         def __init__(self, *args, **kwargs):
             self.state = self.State()
 
-        def train(self, resume_from_checkpoint=None):
+        def train(self, *, resume_from_checkpoint=None, **k):
             captured["resume"] = resume_from_checkpoint
-            return type("O", (), {"metrics": {"train_loss": 0.0}})()
+            return types.SimpleNamespace(metrics={"train_loss": 0.0})
 
         def save_model(self):
             return None
@@ -182,7 +183,7 @@ def test_run_hf_trainer_ignores_missing_resume_from(tmp_path, monkeypatch):
 
         def train(self, *, resume_from_checkpoint=None, **k):
             captured["resume"] = resume_from_checkpoint
-            return type("O", (), {"metrics": {}})()
+            return types.SimpleNamespace(metrics={})
 
         def save_model(self):
             return None


### PR DESCRIPTION
## Summary
- import `types` in HF trainer tests
- return `types.SimpleNamespace` when capturing trainer metrics to avoid `NameError`

## Testing
- `pre-commit run --files tests/test_engine_hf_trainer.py`
- `PYTHONPATH=src pytest -q tests/test_engine_hf_trainer.py::test_run_hf_trainer_passes_resume_from -o addopts='' -c /dev/null`
- `PYTHONPATH=src pytest -q tests/test_engine_hf_trainer.py::test_run_hf_trainer_ignores_missing_resume_from -o addopts='' -c /dev/null`
- ⚠️ `nox -s tests` (Session tests-3.12 interrupted while installing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68b88a07ed188331a2c7b5780160bf41