### PR TITLE
Codex status update 2025 09 03

### DIFF
--- a/tests/test_engine_hf_trainer.py
+++ b/tests/test_engine_hf_trainer.py
@@ -93,7 +93,7 @@ def test_run_hf_trainer_uses_tokenizer_path_and_flag(monkeypatch, tmp_path):
     assert calls["use_fast"] is False
 
 
-def test_run_hf_trainer_passes_resume_from(monkeypatch, tmp_path):
+def test_run_hf_trainer_forwards_resume_checkpoint(monkeypatch, tmp_path):
     captured = {}
 
     def fake_tok_from_pretrained(name, use_fast=True):


### PR DESCRIPTION
## Summary
- rename resume checkpoint test to ensure stubbed version is used

## Testing
- `pre-commit run --files tests/test_engine_hf_trainer.py`
- `PYTHONPATH=src pytest -q -c /dev/null tests/test_engine_hf_trainer.py::test_run_hf_trainer_forwards_resume_checkpoint`
- `nox -s tests` *(fails: Session tests-3.12 interrupted during dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68b8941d11888331b9e3aec144c10b3f