### PR TITLE
Codex  status update 2025 09 03

### DIFF
--- a/tests/test_engine_hf_trainer.py
+++ b/tests/test_engine_hf_trainer.py
@@ -93,7 +93,7 @@ def test_run_hf_trainer_uses_tokenizer_path_and_flag(monkeypatch, tmp_path):
     assert calls["use_fast"] is False
 
 
-def test_run_hf_trainer_forwards_resume_checkpoint(monkeypatch, tmp_path):
+def test_run_hf_trainer_passes_resume_from(monkeypatch, tmp_path):
     captured = {}
 
     def fake_tok_from_pretrained(name, use_fast=True):


### PR DESCRIPTION
### Summary
- Rename resume checkpoint test to prevent duplicate definitions and ensure mocks are applied during Hugging Face trainer runs

### Testing
- `pre-commit run --files tests/test_engine_hf_trainer.py`
- `PYTHONPATH=src pytest tests/test_engine_hf_trainer.py::test_run_hf_trainer_passes_resume_from -q -o addopts=''`
- `nox -s tests` *(fails: TypeError: Accelerator.__init__() got an unexpected keyword argument 'dispatch_batches')*

### Error Capture
```
@codex fix comments 
That occurred while performing [Step 1: nox -s tests], encountered the following error:
TypeError: Accelerator.__init__() got an unexpected keyword argument 'dynamo_backend'
Context: running the full test suite without optional dependencies (e.g., sentencepiece, httpx) and with incomplete test fixtures.
What are the possible causes, and how can this be resolved while preserving intended functionality?
```

------
https://chatgpt.com/codex/tasks/task_e_68b897917dfc8331958a9b7905493bd3