### PR TITLE
Codex status update 2025 09 03: deduplicate resume test

### DIFF
--- a/tests/test_engine_hf_trainer.py
+++ b/tests/test_engine_hf_trainer.py
@@ -93,7 +93,7 @@ def test_run_hf_trainer_uses_tokenizer_path_and_flag(monkeypatch, tmp_path):
     assert calls["use_fast"] is False
 
 
-def test_run_hf_trainer_passes_resume_from(monkeypatch, tmp_path):
+def test_run_hf_trainer_passes_resume_from_with_mocks(monkeypatch, tmp_path):
     captured = {}
 
     def fake_tok_from_pretrained(name, use_fast=True):


### PR DESCRIPTION
## Summary
- ensure the resume checkpoint test uses a unique name so monkeypatched mocks aren't shadowed by duplicate definitions

## Testing
- `pre-commit run --files tests/test_engine_hf_trainer.py`
- `PYTHONPATH=src pytest -c /dev/null /workspace/_codex_/tests/test_engine_hf_trainer.py::test_run_hf_trainer_passes_resume_from_with_mocks -q`
- ❌ `nox -s tests` *(session tests-3.12 interrupted while installing dependencies; full suite not executed)*


------
https://chatgpt.com/codex/tasks/task_e_68b89aac0d348331889cf07cb19e97fa