### PR TITLE
test: deduplicate resume checkpoint test

### DIFF
--- a/tests/test_engine_hf_trainer.py
+++ b/tests/test_engine_hf_trainer.py
@@ -93,7 +93,7 @@ def test_run_hf_trainer_uses_tokenizer_path_and_flag(monkeypatch, tmp_path):
     assert calls["use_fast"] is False
 
 
-def test_run_hf_trainer_passes_resume_from_with_mocks(monkeypatch, tmp_path):
+def test_run_hf_trainer_passes_resume_from(monkeypatch, tmp_path):
     captured = {}
 
     def fake_tok_from_pretrained(name, use_fast=True):


### PR DESCRIPTION
## Summary
- rename and deduplicate resume checkpoint test so mock trainer handles resume path

## Testing
- `pre-commit run --files tests/test_engine_hf_trainer.py`
- `PYTHONPATH=src pytest tests/test_engine_hf_trainer.py::test_run_hf_trainer_passes_resume_from -q -o addopts=`
- `nox -s tests` *(interrupted: Session tests-3.12 interrupted)*

## Questions
Question from ChatGPT @codex: 
While performing [Step 1: nox -s tests], encountered the following error:
Session tests-3.12 interrupted.
Context: dependency installation for the full test suite did not complete, so tests were not executed.
What are the possible causes, and how can this be resolved while preserving intended functionality?

------
https://chatgpt.com/codex/tasks/task_e_68b89d55faf88331b3d2a4d2d98d70c2