### PR TITLE
fix: allow arbitrary device map values

### DIFF
--- a/src/codex_ml/modeling/codex_model_loader.py
+++ b/src/codex_ml/modeling/codex_model_loader.py
@@ -46,11 +46,6 @@ def load_model_with_optional_lora(
         if torch_dtype is None:
             raise ValueError(f"Unknown dtype: {dtype}")
 
-    if device_map is not None and not isinstance(device_map, dict):
-        allowed = {"auto", "balanced", "balanced_low_0"}
-        if device_map not in allowed:
-            raise ValueError(f"Unsupported device_map: {device_map}")
-
     # Load base model
     model = AutoModelForCausalLM.from_pretrained(
         name_or_path, torch_dtype=torch_dtype, device_map=device_map, **kw


### PR DESCRIPTION
## Summary
- drop restrictive `device_map` whitelist so any value is forwarded to `AutoModelForCausalLM`
- add regression test confirming arbitrary device maps reach the model loader

## Testing
- `pre-commit run --files src/codex_ml/modeling/codex_model_loader.py tests/test_model_loader.py tests/test_engine_hf_trainer.py`
- `PYTHONPATH=src pytest -c /dev/null tests/test_model_loader.py::test_device_map_passes_through -q`
- `PYTHONPATH=src pytest -c /dev/null tests/test_engine_hf_trainer.py::test_run_hf_trainer_passes_resume_from -q`
- `mypy src/codex_ml/modeling/codex_model_loader.py` *(terminated)*
- `nox -s tests` *(session tests-3.12 interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a3dbb41c83319edd30de5bac9fc8