### PR TITLE
fix: install global Accelerate shim

### DIFF
--- a/tests/test_accelerate_shim.py
+++ b/tests/test_accelerate_shim.py
@@ -1,0 +1,25 @@
+def test_accelerate_shim_prints_path(capsys, monkeypatch):
+    # Force a fresh import so the shim installs
+    import sys
+
+    monkeypatch.delitem(sys.modules, "training.engine_hf_trainer", raising=False)
+    import accelerate
+
+    import training.engine_hf_trainer as eng
+
+    has_dlc = hasattr(getattr(accelerate, "utils", object()), "DataLoaderConfiguration")
+
+    # Construct via our helper (same class as what Trainer will see)
+    _ = eng._make_accelerator(
+        dispatch_batches=True,
+        split_batches=True,
+        even_batches=True,
+        logging_dir="/tmp/logs",
+    )
+    out = capsys.readouterr().out
+
+    if has_dlc:
+        assert "v>=0.30: using DataLoaderConfiguration path" in out
+        assert "mapped logging_dir -> project_dir" in out
+    else:
+        assert "v<0.30: using legacy kwargs path" in out

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -24,6 +24,59 @@ Features:
 
 from __future__ import annotations
 
+# ruff: noqa: E402
+
+
+# --- Accelerate compatibility shim (must run before importing transformers.Trainer) ---
+def _install_accelerate_compat() -> None:
+    """Install a monkey-patched Accelerator accepting legacy and new kwargs."""
+    try:
+        import accelerate  # type: ignore
+        from accelerate import Accelerator as _BaseAccelerator  # type: ignore
+
+        DataLoaderConfiguration = getattr(
+            getattr(accelerate, "utils", object()), "DataLoaderConfiguration", None
+        )
+    except Exception as e:  # pragma: no cover
+        print(f"[codex][accelerate] failed to inspect accelerate: {e}")
+        return
+
+    class _CompatAccelerator(_BaseAccelerator):  # type: ignore[misc, override]
+        def __init__(self, *args, **kwargs):
+            if "logging_dir" in kwargs and "project_dir" not in kwargs:
+                kwargs["project_dir"] = kwargs.pop("logging_dir")
+                print("[codex][accelerate] mapped logging_dir -> project_dir")
+
+            if DataLoaderConfiguration is not None:
+                dispatch = kwargs.pop("dispatch_batches", None)
+                split = kwargs.pop("split_batches", None)
+                even = kwargs.pop("even_batches", None)
+                dlc = None
+                if any(x is not None for x in (dispatch, split, even)):
+                    dlc = DataLoaderConfiguration(
+                        dispatch_batches=bool(dispatch) if dispatch is not None else False,
+                        split_batches=bool(split) if split is not None else False,
+                        even_batches=bool(even) if even is not None else False,
+                    )
+                if "dataloader_config" not in kwargs and dlc is not None:
+                    kwargs["dataloader_config"] = dlc
+                    print("[codex][accelerate] v>=0.30: using DataLoaderConfiguration path")
+                else:
+                    print(
+                        "[codex][accelerate] v>=0.30: using provided dataloader_config or defaults"
+                    )
+            else:
+                print("[codex][accelerate] v<0.30: using legacy kwargs path")
+
+            super().__init__(*args, **kwargs)
+
+    setattr(accelerate, "Accelerator", _CompatAccelerator)  # type: ignore[attr-defined]
+    print("[codex][accelerate] installed compat Accelerator shim")
+
+
+# Install the shim BEFORE importing transformers/Trainer
+_install_accelerate_compat()
+
 import argparse
 import json
 import math
@@ -37,7 +90,6 @@ from typing import Any, Dict, Iterable, Optional
 import numpy as np
 import torch
 import yaml
-from accelerate import Accelerator
 from datasets import Dataset
 from packaging.version import parse as _v
 from transformers import (
@@ -62,12 +114,6 @@ from codex_ml.utils.error_log import log_error
 from codex_ml.utils.repro import set_reproducible
 from codex_utils.repro import log_env_info
 
-try:
-    # Newer Accelerate path (preferred)
-    from accelerate.utils import DataLoaderConfiguration  # type: ignore
-except Exception:  # pragma: no cover
-    DataLoaderConfiguration = None  # type: ignore
-
 # Optional dependencies with graceful fallbacks
 try:  # optional checkpoint callback
     from training.checkpoint_manager import CheckpointManager
@@ -81,42 +127,11 @@ except Exception:  # pragma: no cover - optional dep
     SummaryWriter = None
 
 
-def _make_accelerator(
-    *,
-    dispatch_batches: Optional[bool] = None,
-    split_batches: Optional[bool] = None,
-    **kwargs: Any,
-) -> Accelerator:
-    """
-    Create an Accelerator that works across Accelerate versions.
-    Prints which path is used so CI logs show the decision.
-    """
-    # drop legacy keys from kwargs if present
-    kwargs.pop("dispatch_batches", None)
-    kwargs.pop("split_batches", None)
+def _make_accelerator(**accelerate_kwargs: Any):
+    """Construct an Accelerator using the global compatibility shim."""
+    from accelerate import Accelerator
 
-    if DataLoaderConfiguration is not None:
-        dl_cfg = DataLoaderConfiguration(
-            **({} if dispatch_batches is None else {"dispatch_batches": bool(dispatch_batches)}),
-            **({} if split_batches is None else {"split_batches": bool(split_batches)}),
-        )
-        acc = Accelerator(dataloader_config=dl_cfg, **kwargs)
-        print(
-            "[codex][accelerate] path=new(dataloader_config) "
-            f"dispatch_batches={dispatch_batches} split_batches={split_batches}"
-        )
-        return acc
-    else:  # Legacy fallback
-        if dispatch_batches is not None:
-            kwargs["dispatch_batches"] = bool(dispatch_batches)
-        if split_batches is not None:
-            kwargs["split_batches"] = bool(split_batches)
-        acc = Accelerator(**kwargs)
-        print(
-            "[codex][accelerate] path=legacy(kwargs) "
-            f"dispatch_batches={dispatch_batches} split_batches={split_batches}"
-        )
-        return acc
+    return Accelerator(**accelerate_kwargs)
 
 
 __all__ = [
@@ -591,12 +606,10 @@ def run_hf_trainer(
     # Initialize logging
     loggers: CodexLoggers = _codex_logging_bootstrap(log_args or argparse.Namespace())
 
-    # normalize deprecated Accelerate args
     accelerate_kwargs: Dict[str, object] = {}
-    if "logging_dir" in accelerate_kwargs and "project_dir" not in accelerate_kwargs:
-        accelerate_kwargs["project_dir"] = accelerate_kwargs.pop("logging_dir")
-        print("[codex][accelerate] mapped logging_dir -> project_dir")
     _accelerator = _make_accelerator(**accelerate_kwargs)
+    # Keep _accelerator alive if used later; Trainer builds its own Accelerator.
+    # Global shim ensures Trainer's internal construction is compatible.
 
     # Create and run trainer
     trainer = Trainer(


### PR DESCRIPTION
## Summary
- install Accelerator compatibility shim before Trainer import
- add regression test validating shim path selection

## Testing
- `pre-commit run --files training/engine_hf_trainer.py tests/test_accelerate_shim.py`
- `mypy training/engine_hf_trainer.py tests/test_accelerate_shim.py` *(fails: Source file found twice under different module names)*
- `PYTHONPATH=src pytest tests/test_engine_hf_trainer.py::test_run_hf_trainer_passes_resume_from -q -o addopts=''`
- `pytest tests/test_accelerate_shim.py::test_accelerate_shim_prints_path -q -o addopts=''`
- `nox -s tests` *(interrupted: session tests-3.12)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d0ac10d88331a1c5ef6647840b9b