### PR TITLE
Codex fix comments for Branch 0C

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ authors = [{ name = "Aries-Serpent" }]
 requires-python = ">=3.10"
 readme = "README.md"
 dependencies = [
-    "accelerate>=0.30",
+    # Support both legacy and new Accelerate via runtime shim
+    "accelerate>=0.20.1",
     "transformers>=4.41",
     "torch",
     "hydra-core>=1.3",

--- a/tests/test_accelerate_shim.py
+++ b/tests/test_accelerate_shim.py
@@ -1,11 +1,13 @@
+import importlib
+import sys
+
+
 def test_accelerate_shim_prints_path(capsys, monkeypatch):
     # Force a fresh import so the shim installs
-    import sys
-
     monkeypatch.delitem(sys.modules, "training.engine_hf_trainer", raising=False)
+    eng = importlib.import_module("training.engine_hf_trainer")
     import accelerate
-
-    import training.engine_hf_trainer as eng
+    from accelerate import Accelerator  # noqa: F401
 
     has_dlc = hasattr(getattr(accelerate, "utils", object()), "DataLoaderConfiguration")
 

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -29,11 +29,17 @@ from __future__ import annotations
 
 # --- Accelerate compatibility shim (must run before importing transformers.Trainer) ---
 def _install_accelerate_compat() -> None:
-    """Install a monkey-patched Accelerator accepting legacy and new kwargs."""
+    """
+    Monkey-patch ``accelerate.Accelerator`` to accept both legacy kwargs
+    (``dispatch_batches``, ``split_batches``, ``even_batches``, ``logging_dir``)
+    and the new API (``dataloader_config``, ``project_dir``). Prints which path
+    is chosen for CI visibility.
+    """
     try:
         import accelerate  # type: ignore
         from accelerate import Accelerator as _BaseAccelerator  # type: ignore
 
+        # presence of DataLoaderConfiguration indicates new-style API (v0.30+)
         DataLoaderConfiguration = getattr(
             getattr(accelerate, "utils", object()), "DataLoaderConfiguration", None
         )
@@ -43,11 +49,13 @@ def _install_accelerate_compat() -> None:
 
     class _CompatAccelerator(_BaseAccelerator):  # type: ignore[misc, override]
         def __init__(self, *args, **kwargs):
+            # Normalize project_dir
             if "logging_dir" in kwargs and "project_dir" not in kwargs:
                 kwargs["project_dir"] = kwargs.pop("logging_dir")
                 print("[codex][accelerate] mapped logging_dir -> project_dir")
 
             if DataLoaderConfiguration is not None:
+                # New API path: build dataloader_config from legacy kwargs if present
                 dispatch = kwargs.pop("dispatch_batches", None)
                 split = kwargs.pop("split_batches", None)
                 even = kwargs.pop("even_batches", None)
@@ -58,6 +66,7 @@ def _install_accelerate_compat() -> None:
                         split_batches=bool(split) if split is not None else False,
                         even_batches=bool(even) if even is not None else False,
                     )
+                # Respect explicit dataloader_config if the caller provided one
                 if "dataloader_config" not in kwargs and dlc is not None:
                     kwargs["dataloader_config"] = dlc
                     print("[codex][accelerate] v>=0.30: using DataLoaderConfiguration path")
@@ -66,10 +75,13 @@ def _install_accelerate_compat() -> None:
                         "[codex][accelerate] v>=0.30: using provided dataloader_config or defaults"
                     )
             else:
+                # Legacy path: leave legacy kwargs as-is
                 print("[codex][accelerate] v<0.30: using legacy kwargs path")
 
             super().__init__(*args, **kwargs)
 
+    # Monkey-patch the module attribute so any downstream `from accelerate import Accelerator`
+    # after this point will see the compat subclass.
     setattr(accelerate, "Accelerator", _CompatAccelerator)  # type: ignore[attr-defined]
     print("[codex][accelerate] installed compat Accelerator shim")
 
@@ -85,7 +97,7 @@ import random
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional, cast
 
 import numpy as np
 import torch
@@ -458,6 +470,7 @@ def run_hf_trainer(
     val_texts: Optional[Iterable[str]] = None,
     distributed: bool = True,
     tensorboard: bool = False,
+    accelerate_kwargs: Optional[Dict[str, object]] = None,
     log_args: Optional[argparse.Namespace] = None,
 ) -> Dict[str, float]:
     """Train a causal LM using HuggingFace ``Trainer``.
@@ -510,6 +523,8 @@ def run_hf_trainer(
         Enable multi-GPU training via ``torch.distributed``. Requires NCCL and driver support when using CUDA. Set to ``False`` to disable.
     tensorboard : bool, default=False
         If ``True``, log final metrics to TensorBoard when available.
+    accelerate_kwargs : Dict[str, object], optional
+        Extra keyword arguments passed to ``accelerate.Accelerator``.
     log_args : argparse.Namespace, optional
         Logging configuration arguments.
 
@@ -534,9 +549,9 @@ def run_hf_trainer(
             cfg = yaml.safe_load(config_path.read_text()) or {}
         except Exception:
             cfg = {}
-    tokenizer_path = tokenizer_path or cfg.get("tokenizer_path")
-    use_fast_tokenizer = cfg.get("use_fast_tokenizer", use_fast_tokenizer)
-    tokenizer_name = tokenizer_name or cfg.get("tokenizer_name") or model_name
+    tokenizer_path = tokenizer_path or cast(Optional[str], cfg.get("tokenizer_path"))
+    use_fast_tokenizer = cast(bool, cfg.get("use_fast_tokenizer", use_fast_tokenizer))
+    tokenizer_name = tokenizer_name or cast(Optional[str], cfg.get("tokenizer_name")) or model_name
     source = tokenizer_path or tokenizer_name
     tokenizer = AutoTokenizer.from_pretrained(source, use_fast=use_fast_tokenizer)
     if tokenizer.pad_token is None:
@@ -606,10 +621,11 @@ def run_hf_trainer(
     # Initialize logging
     loggers: CodexLoggers = _codex_logging_bootstrap(log_args or argparse.Namespace())
 
-    accelerate_kwargs: Dict[str, object] = {}
+    # If this code path needs an Accelerator (e.g., for non-Trainer ops), construct it via the shim.
+    accelerate_kwargs = dict(accelerate_kwargs or {})
     _accelerator = _make_accelerator(**accelerate_kwargs)
-    # Keep _accelerator alive if used later; Trainer builds its own Accelerator.
-    # Global shim ensures Trainer's internal construction is compatible.
+    # Keep _accelerator alive if we use it later; no need to pass into Trainer (Trainer builds its own).
+    # The global shim ensures Trainer's internal construction is also compatible.
 
     # Create and run trainer
     trainer = Trainer(


### PR DESCRIPTION
## Summary
- add a global Accelerate shim that normalizes legacy kwargs before Trainer import
- accept optional accelerate_kwargs in run_hf_trainer and broaden dependency to accelerate>=0.20.1
- add hermetic test verifying the shim prints chosen path

## Testing
- `pre-commit run --files training/engine_hf_trainer.py tests/test_accelerate_shim.py pyproject.toml`
- `mypy --follow-imports=skip training/engine_hf_trainer.py tests/test_accelerate_shim.py`
- `nox -s tests` *(fails: Coverage XML written to file coverage.xml
FAIL Required test coverage of 80% not reached. Total coverage: 74.67%; multiple tests failed)*


------
https://chatgpt.com/codex/tasks/task_e_68b8d9d60abc8331a5b33b0ab4b8ff0e