### PR TITLE
Fix accelerate shim to drop new kwargs on legacy versions

### DIFF
--- a/tests/test_accelerate_shim.py
+++ b/tests/test_accelerate_shim.py
@@ -25,3 +25,36 @@ def test_accelerate_shim_prints_path(capsys, monkeypatch):
         assert "mapped logging_dir -> project_dir" in out
     else:
         assert "v<0.30: using legacy kwargs path" in out
+
+
+def test_accelerate_shim_handles_new_kwargs_on_legacy(capsys, monkeypatch):
+    import accelerate
+
+    accelerate = importlib.reload(accelerate)
+
+    # Simulate legacy accelerate by removing DataLoaderConfiguration and patching __init__
+    monkeypatch.delattr(accelerate.utils, "DataLoaderConfiguration", raising=False)
+
+    def legacy_init(self, *args, **kwargs):
+        self.kwargs = kwargs
+
+    monkeypatch.setattr(accelerate.Accelerator, "__init__", legacy_init, raising=True)
+    monkeypatch.delitem(sys.modules, "training.engine_hf_trainer", raising=False)
+    eng = importlib.import_module("training.engine_hf_trainer")
+
+    class DummyDLC:
+        dispatch_batches = True
+        split_batches = False
+        even_batches = True
+
+    acc = eng._make_accelerator(project_dir="/tmp/logs", dataloader_config=DummyDLC())
+    out = capsys.readouterr().out
+    assert "mapped project_dir -> logging_dir" in out
+    assert "translated dataloader_config -> legacy kwargs" in out
+    assert "v<0.30: using legacy kwargs path" in out
+    assert acc.kwargs["logging_dir"] == "/tmp/logs"
+    assert acc.kwargs["dispatch_batches"] is True
+    assert acc.kwargs["split_batches"] is False
+    assert acc.kwargs["even_batches"] is True
+    assert "project_dir" not in acc.kwargs
+    assert "dataloader_config" not in acc.kwargs


### PR DESCRIPTION
## Summary
- translate `project_dir` and `dataloader_config` to legacy accelerate kwargs when `DataLoaderConfiguration` is absent
- add regression test ensuring shim handles new kwargs on legacy paths

## Testing
- `pre-commit run --files training/engine_hf_trainer.py tests/test_accelerate_shim.py`
- `mypy --follow-imports=skip training/engine_hf_trainer.py tests/test_accelerate_shim.py`
- `nox -s tests` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e31a54548331a88ad664113e12dd