### PR TITLE
Add coverage stub and align coverage settings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+parallel = True
+source =
+    tools
+    codex_utils
+
+[report]
+show_missing = True
+skip_empty = True

--- a/tox.ini
+++ b/tox.ini
@@ -10,12 +10,15 @@ deps =
     pytest
     pytest-cov
 commands =
-    pytest -q --disable-warnings --maxfail=1 --cov=tools --cov=codex_utils --cov-report=term-missing
+    pytest -q --disable-warnings --maxfail=1 \
+        --cov --cov-report=term-missing --cov-branch \
+        --cov-fail-under={env:COV_FAIL_UNDER:70}
 passenv =
     *
 setenv =
     PYTHONHASHSEED=0
     NO_NETWORK=1
+    COV_FAIL_UNDER=70
 
 [testenv:quality]
 deps =


### PR DESCRIPTION
## Summary
- reuse existing virtualenvs in nox and funnel `tests` through the coverage gate
- enforce branch coverage consistently via `.coveragerc`
- align tox with the unified coverage and threshold settings

## Testing
- `pre-commit run --files noxfile.py tox.ini .coveragerc`
- `mypy noxfile.py`
- `nox -s tests` *(fails: 35 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ef3a565c8331acf6dad2d95f0728