### PR TITLE
docs: add wheelhouse runbook and expand nox sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,7 @@
 - Applied fallback_patch_4.1-4.8 with safe sanitize→apply fallbacks; preserved intended functionality.
 - Normalized line endings/BOM; stripped markdown/email artifacts from patch.
 - Conformed to local gates (pre-commit/Black/isort/tests), Codex-only (no GitHub Actions). - Ensure test dependencies (including `langchain`) are installed so `nox -s tests` passes.
+- Add runbook for offline wheelhouse usage at `docs/runbooks/offline_wheelhouse.md`.
+- Add smoke test proving `nox -s tests` delegates to `coverage`.
+- Add `wheelhouse` alias in `Makefile` for bootstrap script.
+- Expand `noxfile.py` with `tests_sys` and `tests_ssp` sessions, optional `uv|virtualenv` backend, `PIP_CACHE_DIR` default.

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,7 @@ include codex.mk
 ## Run local gates with the exact same entrypoint humans and bots use
 codex-gates:
 	@bash ci_local.sh
+
+.PHONY: wheelhouse
+wheelhouse:
+	@tools/bootstrap_wheelhouse.sh

--- a/docs/runbooks/offline_wheelhouse.md
+++ b/docs/runbooks/offline_wheelhouse.md
@@ -1,0 +1,69 @@
+# Offline Build & Use of a Wheelhouse (1-page runbook)
+
+**Purpose:** Enable **hermetic, offline installs** and faster local CI by pre-building wheels into a project-local `./wheelhouse/`, then installing with `--no-index --find-links`. Uses `uv` when present, with safe fallbacks to `pip`.
+**Why:** Avoid network slowness/variance and rebuild churn; let Codex pick “fastest vs isolated” per task.
+
+---
+
+## Quick start
+
+```bash
+# Build/update wheelhouse & constraints (uses uv if available, else pip)
+tools/bootstrap_wheelhouse.sh
+
+# Install from wheelhouse completely offline (example)
+python -m pip install --no-index --find-links ./wheelhouse -r requirements.txt
+```
+
+Refs: `pip download` produces a directory suitable for later `pip install --find-links` offline installs; `--no-index` ensures no network usage. :contentReference[oaicite:1]{index=1}
+
+---
+
+## Fast paths vs isolation
+
+**Fastest loop (not isolated):**
+- `nox --no-venv -s tests_sys` → run in the current interpreter; no env creation. Shortcut for `--force-venv-backend none`. :contentReference[oaicite:2]{index=2}
+
+**Balanced speed & isolation:**
+- `nox -r -s tests` → reuse virtualenvs and skip reinstalls; `tests` delegates to the `coverage` gate. :contentReference[oaicite:3]{index=3}
+
+**Most isolated / fully offline:**
+- Install strictly from `./wheelhouse` using `--no-index --find-links`. :contentReference[oaicite:4]{index=4}
+
+---
+
+## Build the wheelhouse
+
+```bash
+# Detects common requirements files and generates/updates:
+#   ./wheelhouse/  (wheels)
+#   ./constraints.txt  (pins via uv compile or pip freeze)
+tools/make_wheelhouse.sh -r requirements.txt -r requirements-dev.txt
+```
+
+Notes:
+- If `uv` is available, we **compile** requirements into a lock/constraints file (`uv pip compile`); else fallback uses a temp venv + `pip freeze`. :contentReference[oaicite:5]{index=5}
+- Wheels are downloaded with `pip download` because `uv` doesn’t implement `download/wheel` subcommands; later installs can still use `uv pip`. :contentReference[oaicite:6]{index=6}
+
+---
+
+## Install strategy in sessions
+
+1) Prefer `uv`:
+   - `uv pip sync <lock-or-reqs.txt>` (idempotent sync to a file) or
+   - `uv pip install -r requirements.txt`
+   :contentReference[oaicite:7]{index=7}
+
+2) Fallback to `pip` with cache:
+   - respect `PIP_CACHE_DIR` (e.g., `./.cache/pip`) for warm wheels. :contentReference[oaicite:8]{index=8}
+
+3) Fully offline:
+   - `python -m pip install --no-index --find-links ./wheelhouse -r requirements.txt` (all deps must be present). :contentReference[oaicite:9]{index=9}
+
+---
+
+## Pitfalls & tips
+
+- Mixed **branch vs statement** coverage artifacts can’t be combined. We enforce **branch** everywhere via `.coveragerc` + `--cov-branch` in tox/nox. :contentReference[oaicite:10]{index=10}
+- Prefer `uv` for speed but be aware of minor compatibility differences vs `pip`. :contentReference[oaicite:11]{index=11}
+- When using **wheelhouse**, include build tools (`setuptools`, `wheel`) as needed for sdists or PEP 517 backends. :contentReference[oaicite:12]{index=12}

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 import os
 from contextlib import suppress
+from pathlib import Path
 
 import nox
 
@@ -7,7 +8,17 @@ import nox
 # CLI equivalent: `nox -r` (alias of --reuse-existing-virtualenvs / --reuse-venv=yes).
 # See Nox docs for reuse & backends (including `uv` and `--no-venv`).
 # https://nox.thea.codes/en/stable/usage.html
-nox.options.reuse_existing_virtualenvs = True
+nox.options.reuse_existing_virtualenvs = (
+    True  # `nox -r` equivalent (reuse venvs). :contentReference[oaicite:14]{index=14}
+)
+
+# Optional: prefer `uv`, with automatic fallback to `virtualenv` if uv is unavailable.
+# Enable by exporting NOX_PREFER_UV=1 on runners where uv is ubiquitous.
+if os.environ.get("NOX_PREFER_UV") == "1":
+    # Allows "uv|virtualenv" fallback selection (first available is used).
+    nox.options.default_venv_backend = (
+        "uv|virtualenv"  # also settable via CLI/env. :contentReference[oaicite:15]{index=15}
+    )
 
 
 def _has_uv(session: nox.Session) -> bool:
@@ -29,8 +40,14 @@ def _install(session: nox.Session, *pkgs: str) -> None:
         session.install(*pkgs)
 
 
+def _ensure_pip_cache(session: nox.Session) -> None:
+    """Default PIP_CACHE_DIR for faster, repeatable installs."""
+    session.env.setdefault("PIP_CACHE_DIR", str(Path(".cache/pip").resolve()))
+
+
 @nox.session
 def lint(session):
+    _ensure_pip_cache(session)
     _install(session, "ruff", "black", "isort")
     session.run("ruff", "check", ".")
     session.run("black", "--check", ".")
@@ -53,7 +70,8 @@ def quality(session):
 
 @nox.session
 def coverage(session):
-    _install(session, "pytest", "pytest-cov")
+    _ensure_pip_cache(session)
+    _install(session, "pytest", "pytest-cov", "fastapi", "httpx", "torch")
     # Use .coveragerc for sources; keep branch mode consistent everywhere.
     # --cov (no value) respects .coveragerc 'source'; --cov-branch enforces branch data.
     # Fail-under remains 70 unless overridden via env.
@@ -77,6 +95,66 @@ def tests(session):
     `nox -s tests` simply delegates to the 'coverage' gate.
     """
     session.notify("coverage")
+
+
+@nox.session(
+    venv_backend="none"
+)  # run directly in the current interpreter; no venv. :contentReference[oaicite:16]{index=16}
+def tests_sys(session):
+    """
+    Run tests in the *Codex initial* environment for minimal overhead.
+    Prefers `uv` tooling with a safe fallback to pip, and honors PIP_CACHE_DIR.
+    """
+    _ensure_pip_cache(session)
+    # If a lock/requirements file is provided, prefer idempotent sync.
+    sync_target = os.environ.get("UV_SYNC_FILE")  # e.g., "requirements.txt"
+    if _has_uv(session) and sync_target and Path(sync_target).is_file():
+        session.run(
+            "uv", "pip", "sync", sync_target, external=True
+        )  # idempotent. :contentReference[oaicite:17]{index=17}
+    else:
+        # Fall back to installing minimal deps if pytest isn't available.
+        with suppress(Exception):
+            session.run("pytest", "--version")
+        if session.last_result and session.last_result.exit_code != 0:
+            # Install basics quickly (uses cache); if uv present, it's fast.
+            _install(session, "pytest", "pytest-cov")
+    # Now run tests from the system env (no venv).
+    fail_under = os.environ.get("COV_FAIL_UNDER", "70")
+    session.run(
+        "pytest",
+        "-q",
+        "--disable-warnings",
+        "--maxfail=1",
+        "--cov",
+        "--cov-branch",
+        "--cov-report=term-missing",
+        f"--cov-fail-under={fail_under}",
+        external=True,  # using tools from the host env
+    )
+
+
+@nox.session(
+    venv_backend="venv", venv_params=["--system-site-packages"]
+)  # let venv see base packages. :contentReference[oaicite:18]{index=18}
+def tests_ssp(session):
+    """
+    Tests in an isolated venv that *can see* system site-packages.
+    Useful if base env already has heavy libs (CUDA, torch, etc.).
+    """
+    _ensure_pip_cache(session)
+    _install(session, "pytest", "pytest-cov")
+    fail_under = os.environ.get("COV_FAIL_UNDER", "70")
+    session.run(
+        "pytest",
+        "-q",
+        "--disable-warnings",
+        "--maxfail=1",
+        "--cov",
+        "--cov-branch",
+        "--cov-report=term-missing",
+        f"--cov-fail-under={fail_under}",
+    )
 
 
 @nox.session

--- a/tests/test_nox_tests_delegation.py
+++ b/tests/test_nox_tests_delegation.py
@@ -1,0 +1,21 @@
+import importlib
+
+
+class _DummySession:
+    """Minimal stand-in for nox.Session just to capture notify() calls."""
+
+    def __init__(self) -> None:
+        self.notified = []
+
+    # nox exposes Session.notify(name: str), we only need the name
+    def notify(self, name: str) -> None:  # pragma: no cover - trivial
+        self.notified.append(name)
+
+
+def test_tests_session_delegates_to_coverage():
+    # Import user noxfile; the decorated function remains callable.
+    noxfile = importlib.import_module("noxfile")
+    sess = _DummySession()
+    # Call the session function directly; ensure delegation happens.
+    noxfile.tests(sess)
+    assert "coverage" in sess.notified, "nox 'tests' session must notify 'coverage'"


### PR DESCRIPTION
## Summary
- document offline wheelhouse workflow and fast path guidance
- add smoke test showing `nox -s tests` delegates to `coverage`
- add `wheelhouse` make target and broaden nox sessions (`tests_sys`, `tests_ssp`, `uv|virtualenv` backend, `PIP_CACHE_DIR`)

## Testing
- `pre-commit run --files docs/runbooks/offline_wheelhouse.md tests/test_nox_tests_delegation.py Makefile noxfile.py CHANGELOG.md`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'click')*


------
https://chatgpt.com/codex/tasks/task_e_68b90217b6c883319d423945791ad927