### PR TITLE
Add fast-tests target and CI env helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,8 @@ codex-gates:
 
 .PHONY: wheelhouse
 wheelhouse:
-	@tools/bootstrap_wheelhouse.sh
+        @tools/bootstrap_wheelhouse.sh
+
+.PHONY: fast-tests
+fast-tests:
+        @PIP_CACHE_DIR=.cache/pip nox -r -s tests

--- a/tools/ci_env.sh
+++ b/tools/ci_env.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Standard environment toggles for local CI / Codex runs.
+# - PIP_CACHE_DIR: ensures pip (and uv's pip interface) reuse a stable cache path.
+# - NOX_PREFER_UV: opt-in to `uv`-backed workflows when available.
+# - UV_SYNC_FILE: default sync target for `uv pip sync` (tests_sys session).
+#
+# Usage:
+#   source tools/ci_env.sh
+#   make fast-tests
+#
+# Refs:
+#   Nox reuse & backends / --no-venv: official docs. :contentReference[oaicite:8]{index=8}
+#   uv pip sync/compile (lockfile-driven installs). :contentReference[oaicite:9]{index=9}
+#   pip cache env var (PIP_CACHE_DIR). :contentReference[oaicite:10]{index=10}
+
+# Prefer a project-local cache to persist wheels across runs.
+export PIP_CACHE_DIR="${PIP_CACHE_DIR:-$(pwd)/.cache/pip}"
+
+# Opt-in to uv as preferred backend and installer if available.
+export NOX_PREFER_UV="${NOX_PREFER_UV:-1}"
+
+# Default sync target if not already set; only used when file exists.
+if [[ -z "${UV_SYNC_FILE:-}" ]]; then
+  if [[ -f "requirements.txt" ]]; then
+    export UV_SYNC_FILE="requirements.txt"
+  fi
+fi
+
+echo "PIP_CACHE_DIR=${PIP_CACHE_DIR}"
+echo "NOX_PREFER_UV=${NOX_PREFER_UV}"
+echo "UV_SYNC_FILE=${UV_SYNC_FILE:-<unset>}"


### PR DESCRIPTION
## Summary
- add `fast-tests` target to Makefile to reuse nox envs with cache
- enhance nox sessions with uv sync default, heavy package detection, and module checker
- add `tools/ci_env.sh` to set cache and uv defaults for fast local CI loops

## Testing
- `pre-commit run --files Makefile noxfile.py tools/ci_env.sh`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'click')*


------
https://chatgpt.com/codex/tasks/task_e_68b90a134e548331a44478fc0b4343b4