### PR TITLE
Fix Makefile tabs for wheelhouse and fast-tests targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ codex-gates:
 
 .PHONY: wheelhouse
 wheelhouse:
-        @tools/bootstrap_wheelhouse.sh
+	@tools/bootstrap_wheelhouse.sh
 
 .PHONY: fast-tests
 fast-tests:
-        @PIP_CACHE_DIR=.cache/pip nox -r -s tests
+	@PIP_CACHE_DIR=.cache/pip nox -r -s tests


### PR DESCRIPTION
## Summary
- use tab indentation for `wheelhouse` recipe to run `tools/bootstrap_wheelhouse.sh`
- use tab indentation for `fast-tests` recipe to invoke `nox`

## Testing
- `pre-commit run --files Makefile`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'click')*

------
https://chatgpt.com/codex/tasks/task_e_68b90eeb1e3483318c7ea766fdd8362f