### PR TITLE
Analyzed Codex Log Resolver

### DIFF
--- a/.pre-commit-hybrid.yaml
+++ b/.pre-commit-hybrid.yaml
@@ -1,0 +1,20 @@
+repos:
+ - repo: https://github.com/astral-sh/ruff-pre-commit
+   rev: v0.6.9
+   hooks:
+   - id: ruff
+     args: ["--fix"]
+ - repo: https://github.com/pycqa/isort
+   rev: 5.13.2
+   hooks:
+   - id: isort
+     args: ["--profile","black"]
+ - repo: https://github.com/psf/black
+   rev: 24.8.0
+   hooks:
+   - id: black
+ - repo: https://github.com/Yelp/detect-secrets
+   rev: v1.5.0
+   hooks:
+   - id: detect-secrets
+     args: ["--baseline",".secrets.baseline"]

--- a/.pre-commit-ruff.yaml
+++ b/.pre-commit-ruff.yaml
@@ -1,0 +1,12 @@
+repos:
+ - repo: https://github.com/astral-sh/ruff-pre-commit
+   rev: v0.6.9
+   hooks:
+   - id: ruff
+     args: ["--fix"] # (tamed in Commit 2; no ALL here)
+   - id: ruff-format
+ - repo: https://github.com/Yelp/detect-secrets
+   rev: v1.5.0
+   hooks:
+   - id: detect-secrets
+     args: ["--baseline",".secrets.baseline"]

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,17 @@ include codex.mk
 ## Run local gates with the exact same entrypoint humans and bots use
 codex-gates:
 	@bash ci_local.sh
+
+
+lint-policy:
+	@python tools/lint_policy_probe.py
+	@python tools/select_precommit.py
+
+lint-ruff:
+	@LINT_POLICY=ruff python tools/select_precommit.py && pre-commit run -a || true
+
+lint-hybrid:
+	@LINT_POLICY=hybrid python tools/select_precommit.py && pre-commit run -a || true
+
+lint-auto:
+	@$(MAKE) -s lint-policy && pre-commit run -a || true

--- a/tools/lint_policy_probe.py
+++ b/tools/lint_policy_probe.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Pick 'ruff' or 'hybrid' based on isort complexity and a quick import-sorting probe."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT = ROOT / ".codex" / "lint-policy.json"
+
+
+def _complex_isort() -> bool:
+    text = ""
+    for cfg in ("pyproject.toml", ".isort.cfg", "setup.cfg"):
+        p = ROOT / cfg
+        if p.exists():
+            text += p.read_text(encoding="utf-8", errors="ignore")
+    hits = re.findall(
+        r"^(known_\w+|sections|force_\w+|skip(?:_glob)?|order_by|lines_after_imports)\s*=",
+        text,
+        flags=re.M,
+    )
+    return len(set(hits)) > 3
+
+
+def main() -> int:
+    policy, reason = "ruff", "Default to Ruff"
+    if _complex_isort():
+        policy, reason = "hybrid", "Complex isort config detected"
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps({"policy": policy, "reason": reason}, indent=2), encoding="utf-8")
+    print(json.dumps({"policy": policy, "reason": reason}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/select_precommit.py
+++ b/tools/select_precommit.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> None:
+    requested = os.environ.get("LINT_POLICY")
+    if requested not in (None, "", "ruff", "hybrid"):
+        raise SystemExit(f"Unknown LINT_POLICY={requested}")
+    policy = requested or (
+        json.loads((ROOT / ".codex/lint-policy.json").read_text()).get("policy", "hybrid")
+        if (ROOT / ".codex/lint-policy.json").exists()
+        else "hybrid"
+    )
+    shutil.copyfile(ROOT / f".pre-commit-{policy}.yaml", ROOT / ".pre-commit-config.yaml")
+    print(f"[pre-commit] selected policy: {policy}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add switchable pre-commit presets for Ruff-only and hybrid linting
- probe repository config to auto-select lint policy and copy preset via helper script
- wire new lint-policy, lint-ruff, lint-hybrid and lint-auto targets in Makefile

## Testing
- `pre-commit run --files .pre-commit-ruff.yaml .pre-commit-hybrid.yaml tools/lint_policy_probe.py tools/select_precommit.py Makefile`
- `nox -s tests` *(fails: Session tests-3.12 interrupted during dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a182d3c48331a4b5f2c06d96a181