### PR TITLE
feat: include local hooks in lint presets

### DIFF
--- a/.pre-commit-hybrid.yaml
+++ b/.pre-commit-hybrid.yaml
@@ -22,3 +22,15 @@ repos:
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: local
+    hooks:
+      - id: codex-block-large-generated
+        name: Block large generated files in .codex
+        entry: python tools/precommit_block_large.py
+        language: system
+        pass_filenames: true

--- a/.pre-commit-ruff.yaml
+++ b/.pre-commit-ruff.yaml
@@ -14,3 +14,15 @@ repos:
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: local
+    hooks:
+      - id: codex-block-large-generated
+        name: Block large generated files in .codex
+        entry: python tools/precommit_block_large.py
+        language: system
+        pass_filenames: true


### PR DESCRIPTION
## Summary
- include whitespace fixers and codex-specific guard in ruff and hybrid pre-commit presets

## Testing
- `pre-commit run --files .pre-commit-ruff.yaml .pre-commit-hybrid.yaml Makefile`
- `nox -s tests` *(fails: Command pytest -q --import-mode=importlib --cov-config=pyproject.toml --cov-branch --cov=src/codex_ml --cov-report=term --cov-report=xml --cov-fail-under=80 failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c9f2a5008331a60e78a568c75ef9