### PR TITLE
fix: propagate lint target failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,13 @@ lint-policy:
 	@python tools/select_precommit.py
 
 lint-ruff:
-	@LINT_POLICY=ruff python tools/select_precommit.py && pre-commit run -a || true
+	@LINT_POLICY=ruff python tools/select_precommit.py && pre-commit run -a
 
 lint-hybrid:
-	@LINT_POLICY=hybrid python tools/select_precommit.py && pre-commit run -a || true
+	@LINT_POLICY=hybrid python tools/select_precommit.py && pre-commit run -a
 
 lint-auto:
-	@$(MAKE) -s lint-policy && pre-commit run -a || true
+	@$(MAKE) -s lint-policy && pre-commit run -a
 
 fix-shebangs:
 	@python tools/shebang_exec_guard.py


### PR DESCRIPTION
## Summary
- ensure lint Makefile targets fail on lint errors by removing final `|| true`

## Testing
- `pre-commit run --files Makefile`
- `nox -s tests` *(fails: Command pytest -q --import-mode=importlib --cov-config=pyproject.toml --cov-branch --cov=src/codex_ml --cov-report=term --cov-report=xml --cov-fail-under=80 failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e6a785d48331b2fb1a1a3c9dc691