### PR TITLE
fix: skip scheduler when dataset length unknown

### DIFF
--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -207,16 +207,25 @@ def build_trainer(
     if hasattr(trainer, "create_scheduler"):
         max_steps = getattr(args, "max_steps", 0)
         batch_size = max(1, getattr(args, "train_batch_size", 8))
-        steps_per_epoch = math.ceil(len(train_ds) / batch_size)
-        num_steps = max_steps if max_steps > 0 else int(args.num_train_epochs * steps_per_epoch)
-        trainer.create_scheduler(num_training_steps=num_steps)
-        if scheduler_name:
-            trainer.lr_scheduler = get_scheduler(
-                name=scheduler_name,
-                optimizer=trainer.optimizer,
-                num_warmup_steps=getattr(args, "warmup_steps", 0),
-                num_training_steps=num_steps,
-            )
+        steps_per_epoch = (
+            math.ceil(len(train_ds) / batch_size) if hasattr(train_ds, "__len__") else 0
+        )
+        num_steps = (
+            max_steps
+            if max_steps > 0
+            else int(args.num_train_epochs * steps_per_epoch)
+            if steps_per_epoch
+            else None
+        )
+        if num_steps and num_steps > 0:
+            trainer.create_scheduler(num_training_steps=num_steps)
+            if scheduler_name:
+                trainer.lr_scheduler = get_scheduler(
+                    name=scheduler_name,
+                    optimizer=trainer.optimizer,
+                    num_warmup_steps=getattr(args, "warmup_steps", 0),
+                    num_training_steps=num_steps,
+                )
     return trainer
 
 


### PR DESCRIPTION
## Summary
- avoid calling `create_scheduler` when dataset length cannot be determined
- compute training steps from dataset size when `max_steps` is unset

## Testing
- `pre-commit run --files training/engine_hf_trainer.py`
- `nox -s tests` *(fails: Command pytest ... exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ba217e071c8331b0decbb07d35b344