### PR TITLE
Resolve merge conflicts and refine HF trainer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: format lint test build type setup venv env-info codex-gates wheelhouse fast-tests sys-tests ssp-tests sec-scan sec-audit lock-refresh ci-local coverage gates lint-policy lint-ruff lint-hybrid lint-auto quality fix-shebangs
+.PHONY: format lint test build type setup venv env-info codex-gates wheelhouse fast-tests sys-tests ssp-tests sec-scan sec-audit \
+ lock-refresh ci-local coverage gates lint-policy lint-ruff lint-hybrid lint-auto quality fix-shebangs
 
 format:
         pre-commit run --all-files

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -211,18 +211,17 @@ def build_trainer(
             )
         )
     if hasattr(trainer, "create_scheduler"):
-        num_steps = getattr(args, "max_steps", 0) if getattr(args, "max_steps", 0) > 0 else None
+        max_steps = getattr(args, "max_steps", 0)
+        batch_size = max(1, getattr(args, "train_batch_size", 8))
+        steps_per_epoch = math.ceil(len(train_ds) / batch_size)
+        num_steps = max_steps if max_steps > 0 else int(args.num_train_epochs * steps_per_epoch)
         trainer.create_scheduler(num_training_steps=num_steps)
         if scheduler_name:
             trainer.lr_scheduler = get_scheduler(
                 name=scheduler_name,
                 optimizer=trainer.optimizer,
                 num_warmup_steps=getattr(args, "warmup_steps", 0),
-                num_training_steps=num_steps
-                or (
-                    args.num_train_epochs
-                    * (len(train_ds) // max(1, getattr(args, "train_batch_size", 8)) + 1)
-                ),
+                num_training_steps=num_steps,
             )
     return trainer
 


### PR DESCRIPTION
## Summary
- restore pre-commit templates with repo metadata and local hooks
- consolidate Makefile targets and add `fix-shebangs`
- guard optional `accelerate` import and refine scheduler step calculation

## Testing
- `SKIP=pip-audit pre-commit run --files Makefile .pre-commit-hybrid.yaml .pre-commit-ruff.yaml tools/lint_policy_probe.py tools/pip_audit_wrapper.py tools/select_precommit.py src/tokenization/sentencepiece_adapter.py tests/tokenization/test_sentencepiece_adapter_edges.py training/engine_hf_trainer.py`
- `nox -s tests` *(fails: large dependency downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68ba21d84ea883319602a4b461a3b95d