### PR TITLE
Handle pip-audit absence and exit codes

### DIFF
--- a/tools/pip_audit_wrapper.py
+++ b/tools/pip_audit_wrapper.py
@@ -38,7 +38,11 @@ def main() -> int:
     if not have_network() and not any(CACHE.iterdir()):
         sys.stdout.write("[pip-audit] offline & empty cache -> skipping gracefully.\n")
         return 0
-    result = subprocess.call(args)  # noqa: S603
+    try:
+        result = subprocess.call(args)  # noqa: S603
+    except FileNotFoundError:
+        sys.stdout.write("[pip-audit] command not found -> skipping gracefully.\n")
+        return 0
     if result != 0 and not any(CACHE.iterdir()):
         sys.stdout.write(
             "[pip-audit] failed (likely offline) & empty cache -> skipping gracefully.\n"

--- a/tools/select_precommit.py
+++ b/tools/select_precommit.py
@@ -31,4 +31,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Skip pip-audit gracefully when command is missing
- Propagate exit status from select_precommit via SystemExit

## Testing
- `pre-commit run --files tools/pip_audit_wrapper.py tools/select_precommit.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'click')*

------
https://chatgpt.com/codex/tasks/task_e_68ba26dd348c8331a1737b5302bc03ec