### PR TITLE
Improve SentencePiece dependency handling

### DIFF
--- a/src/tokenization/sentencepiece_adapter.py
+++ b/src/tokenization/sentencepiece_adapter.py
@@ -1,15 +1,20 @@
 import pathlib
 from typing import List, Optional
 
-try:
+try:  # pragma: no cover - optional dependency
     import sentencepiece as spm
-except Exception:
+except Exception as exc:  # pragma: no cover
     spm = None
+    _SPM_ERROR = exc
+else:  # pragma: no cover - import succeeded
+    _SPM_ERROR = None
 
 
 class SentencePieceAdapter:
     def __init__(self, model_path: str, special_tokens: Optional[List[str]] = None):
         self.model_path = pathlib.Path(model_path)
+        if spm is None:
+            raise ImportError("sentencepiece is not installed") from _SPM_ERROR
         self.sp = spm.SentencePieceProcessor()
         self.sp.Load(str(self.model_path))
         self.special_tokens = special_tokens or []


### PR DESCRIPTION
## Summary
- raise a clear ImportError when sentencepiece is missing in SentencePieceAdapter

## Testing
- `pre-commit run --files src/tokenization/sentencepiece_adapter.py tests/tokenization/test_sentencepiece_adapter_edges.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'click')*

------
https://chatgpt.com/codex/tasks/task_e_68ba26e5c6548331811813a40d4ea93b