### PR TITLE
feat: add dataset split helper with caching

### DIFF
--- a/tests/test_ingestion_split_cache.py
+++ b/tests/test_ingestion_split_cache.py
@@ -1,0 +1,13 @@
+from codex_ml.data.cache import SimpleCache
+from ingestion.utils import split_dataset
+
+
+def test_split_dataset_deterministic_and_cache():
+    seq = list(range(10))
+    cache = SimpleCache()
+    train1, val1, test1 = split_dataset(seq, val_frac=0.2, test_frac=0.2, seed=123, cache=cache)
+    train2, val2, test2 = split_dataset(seq, val_frac=0.2, test_frac=0.2, seed=123, cache=cache)
+    assert (train1, val1, test1) == (train2, val2, test2)
+    key = (tuple(seq), 0.2, 0.2, 123)
+    assert cache.get(key) == (train1, val1, test1)
+    assert len(train1) + len(val1) + len(test1) == len(seq)


### PR DESCRIPTION
## Summary
- add `split_dataset` utility to partition sequences into train/val/test with optional in-memory caching
- cover deterministic behavior and cache usage with new unit test

## Testing
- `pre-commit run --files src/ingestion/utils.py tests/test_ingestion_split_cache.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'click')*
- `pytest tests/test_ingestion_split_cache.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68bb3e91e6508331804e8921f3056bf0