### PR TITLE
feat: add tokenizer training script and CLI tools

### DIFF
--- a/configs/train_tokenizer.yaml
+++ b/configs/train_tokenizer.yaml
@@ -1,0 +1,6 @@
+# Configuration for tokenization training
+input_file: corpus.txt
+output_dir: tokenizer
+vocab_size: 32000
+character_coverage: 0.9995
+model_type: bpe

--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -149,5 +149,44 @@ def run_task(task: str) -> None:
     ALLOWED_TASKS[task]()
 
 
+@cli.group("tokenizer")
+def tokenizer_group() -> None:
+    """Tokenization utilities."""
+    pass
+
+
+@tokenizer_group.command("encode")
+@click.argument("text")
+@click.option("--tokenizer", "tokenizer_path", default=None, help="Tokenizer path")
+def tokenizer_encode(text: str, tokenizer_path: str | None) -> None:
+    """Encode TEXT and print token ids."""
+    from codex_ml.tokenization import load_tokenizer
+
+    tk = load_tokenizer(path=tokenizer_path)
+    ids = tk.encode(text)
+    click.echo(" ".join(str(i) for i in ids))
+
+
+@tokenizer_group.command("decode")
+@click.argument("ids", nargs=-1, type=int)
+@click.option("--tokenizer", "tokenizer_path", default=None, help="Tokenizer path")
+def tokenizer_decode(ids: tuple[int, ...], tokenizer_path: str | None) -> None:
+    """Decode integer token IDS and print text."""
+    from codex_ml.tokenization import load_tokenizer
+
+    tk = load_tokenizer(path=tokenizer_path)
+    click.echo(tk.decode(list(ids)))
+
+
+@tokenizer_group.command("stats")
+@click.option("--tokenizer", "tokenizer_path", default=None, help="Tokenizer path")
+def tokenizer_stats(tokenizer_path: str | None) -> None:
+    """Show basic tokenizer statistics."""
+    from codex_ml.tokenization import load_tokenizer
+
+    tk = load_tokenizer(path=tokenizer_path)
+    click.echo(f"vocab_size={tk.vocab_size}")
+
+
 if __name__ == "__main__":
     cli()

--- a/src/codex_ml/tokenization/train_tokenizer.py
+++ b/src/codex_ml/tokenization/train_tokenizer.py
@@ -1,0 +1,77 @@
+"""Utilities for training and inspecting tokenizers."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import hydra
+    from omegaconf import MISSING
+except Exception:  # pragma: no cover - optional dependency
+    hydra = None
+    MISSING = object()  # type: ignore
+
+from . import BOS_TOKEN, EOS_TOKEN, PAD_TOKEN, UNK_TOKEN
+from .sentencepiece_adapter import SentencePieceAdapter
+
+
+@dataclass
+class TrainTokenizerConfig:
+    """Configuration for :func:`main`."""
+
+    input_file: str = MISSING  # type: ignore[assignment]
+    output_dir: str = "tokenizer"
+    vocab_size: int = 32000
+    character_coverage: float = 0.9995
+    model_type: str = "bpe"
+
+
+def _export_hf_tokenizer(model_path: Path, output_dir: Path) -> None:
+    """Attempt to export a ``tokenizer.json`` using ``transformers``."""
+    try:  # pragma: no cover - optional dependency
+        from transformers import PreTrainedTokenizerFast
+
+        tok = PreTrainedTokenizerFast(tokenizer_file=str(model_path))
+        tok.add_special_tokens(
+            {
+                "pad_token": PAD_TOKEN,
+                "bos_token": BOS_TOKEN,
+                "eos_token": EOS_TOKEN,
+                "unk_token": UNK_TOKEN,
+            }
+        )
+        tok.save_pretrained(str(output_dir))
+    except Exception as exc:  # pragma: no cover - best effort
+        logging.warning("Could not export tokenizer.json via transformers: %s", exc)
+
+
+def run(cfg: TrainTokenizerConfig) -> None:
+    """Entry point for training a SentencePiece tokenizer."""
+    output = Path(cfg.output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    model_path = output / "tokenizer.model"
+    adapter = SentencePieceAdapter(model_path)
+    adapter.train_or_load(
+        cfg.input_file,
+        vocab_size=cfg.vocab_size,
+        character_coverage=cfg.character_coverage,
+        model_type=cfg.model_type,
+    )
+    _export_hf_tokenizer(model_path, output)
+    logging.info("Tokenizer written to %s", output)
+
+
+if hydra is not None:  # pragma: no cover - hydra integration
+
+    @hydra.main(config_path="../../configs", config_name="train_tokenizer", version_base=None)
+    def main(cfg: TrainTokenizerConfig) -> None:  # type: ignore[misc]
+        run(cfg)
+else:  # pragma: no cover - fallback when hydra missing
+
+    def main(cfg: TrainTokenizerConfig) -> None:  # type: ignore[override]
+        run(cfg)
+
+
+__all__ = ["TrainTokenizerConfig", "run", "main"]

--- a/tests/test_hf_tokenizer_padding.py
+++ b/tests/test_hf_tokenizer_padding.py
@@ -15,3 +15,17 @@ def test_encode_truncates_without_padding():
     assert len(ids) == 2
     # when not padding, pad_id should not appear
     assert tok.pad_id not in ids
+
+
+def test_encode_truncates_with_padding():
+    tok = HFTokenizerAdapter.load()
+    ids = tok.encode("one two three four", pad_to_max=True, max_length=3)
+    assert len(ids) == 3
+    # long input should be truncated without pad tokens
+    assert tok.pad_id not in ids
+
+
+def test_encode_zero_max_length():
+    tok = HFTokenizerAdapter.load()
+    ids = tok.encode("hello", pad_to_max=True, max_length=0)
+    assert ids == []


### PR DESCRIPTION
## Summary
- add Hydra-based SentencePiece tokenizer training utility
- expose tokenization encode/decode/stats via `codex` CLI
- cover padding edge cases for tokenizer adapter

## Testing
- `pre-commit run --files src/codex_ml/tokenization/train_tokenizer.py configs/train_tokenizer.yaml src/codex/cli.py tests/test_hf_tokenizer_padding.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'click')*


------
https://chatgpt.com/codex/tasks/task_e_68bbc5df54988331b8a7249de38ec35b