### PR TITLE
fix(tokenization): remove unsupported encode options

### DIFF
--- a/src/codex_ml/tokenization/cli.py
+++ b/src/codex_ml/tokenization/cli.py
@@ -21,12 +21,7 @@ def _train(args: argparse.Namespace) -> None:
 
 def _encode(args: argparse.Namespace) -> None:
     adapter = SentencePieceAdapter(Path(args.model)).load()
-    ids = adapter.encode(
-        args.text,
-        padding=args.padding,
-        truncation=args.truncation,
-        max_length=args.max_length,
-    )
+    ids = adapter.encode(args.text)
     print(" ".join(str(i) for i in ids))
 
 
@@ -55,9 +50,6 @@ def main(argv: list[str] | None = None) -> None:
     p_encode = sub.add_parser("encode", help="encode text with a model")
     p_encode.add_argument("model", help="path to tokenizer model")
     p_encode.add_argument("text", help="text to encode")
-    p_encode.add_argument("--max-length", type=int, default=None)
-    p_encode.add_argument("--padding", default=None)
-    p_encode.add_argument("--truncation", default=None)
     p_encode.set_defaults(func=_encode)
 
     p_decode = sub.add_parser("decode", help="decode ids with a model")

--- a/tests/tokenization/test_tokenizer_cli.py
+++ b/tests/tokenization/test_tokenizer_cli.py
@@ -33,7 +33,7 @@ def test_train_cli(tmp_path, monkeypatch):
     assert (tmp_path / "tok.tokenizer.json").exists()
 
 
-def test_encode_cli_padding(monkeypatch, capsys):
+def test_encode_cli(monkeypatch, capsys):
     class DummyAdapter:
         def __init__(self, model):
             pass
@@ -41,29 +41,15 @@ def test_encode_cli_padding(monkeypatch, capsys):
         def load(self):
             return self
 
-        def encode(self, text, padding=None, truncation=None, max_length=None):
-            assert padding == "max_length"
-            assert truncation == "only_first"
-            assert max_length == 4
-            return [1, 2, 0, 0]
+        def encode(self, text):
+            assert text == "hi"
+            return [1, 2]
 
     monkeypatch.setattr(cli, "SentencePieceAdapter", DummyAdapter)
 
-    cli.main(
-        [
-            "encode",
-            "m.model",
-            "hi",
-            "--max-length",
-            "4",
-            "--padding",
-            "max_length",
-            "--truncation",
-            "only_first",
-        ]
-    )
+    cli.main(["encode", "m.model", "hi"])
     out = capsys.readouterr().out.strip()
-    assert out == "1 2 0 0"
+    assert out == "1 2"
 
 
 def test_stats_cli(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- drop padding, truncation, and max-length flags from tokenizer CLI `encode`
- update encode CLI test accordingly

## Testing
- `pre-commit run --files src/codex_ml/tokenization/cli.py tests/tokenization/test_tokenizer_cli.py`
- `nox -s coverage` *(fails: tests/test_api_rate_limit.py::test_rate_limit - assert 200 == 429)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcba92f988331bb9c7ea3ac49fbf5