### PR TITLE
feat(tracking): add experiment initialization helper

### DIFF
--- a/src/codex_ml/tracking/__init__.py
+++ b/src/codex_ml/tracking/__init__.py
@@ -1,4 +1,5 @@
 # BEGIN: CODEX_MLFLOW_INIT
+from .init_experiment import init_experiment
 from .mlflow_utils import (
     MlflowConfig,
     ensure_local_artifacts,
@@ -17,5 +18,6 @@ __all__ = [
     "log_artifacts",
     "ensure_local_artifacts",
     "seed_snapshot",
+    "init_experiment",
 ]
 # END: CODEX_MLFLOW_INIT

--- a/src/codex_ml/tracking/init_experiment.py
+++ b/src/codex_ml/tracking/init_experiment.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+try:  # Optional TensorBoard
+    from torch.utils.tensorboard import SummaryWriter  # type: ignore
+except Exception:  # pragma: no cover - optional dependency missing
+    SummaryWriter = None  # type: ignore
+
+try:  # Optional MLflow
+    import mlflow  # type: ignore
+
+    HAS_MLFLOW = True
+except Exception:  # pragma: no cover - optional dependency missing
+    HAS_MLFLOW = False
+    mlflow = None  # type: ignore
+
+try:  # Optional Weights & Biases
+    import wandb  # type: ignore
+
+    HAS_WANDB = True
+except Exception:  # pragma: no cover - optional dependency missing
+    HAS_WANDB = False
+    wandb = None  # type: ignore
+
+
+def init_experiment(
+    name: str,
+    *,
+    log_dir: str | Path = "runs",
+    use_tensorboard: bool = False,
+    use_mlflow: bool = False,
+    use_wandb: bool = False,
+) -> Dict[str, Any]:
+    """Initialise experiment tracking backends.
+
+    Parameters
+    ----------
+    name:
+        Experiment name.
+    log_dir:
+        Directory for local artifacts and NDJSON metrics.
+    use_tensorboard, use_mlflow, use_wandb:
+        Enable respective tracking integrations when possible.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary containing a ``log_metrics`` callable and metadata such as
+        ``ndjson_path`` and the TensorBoard writer (if active).
+    """
+
+    log_path = Path(log_dir)
+    log_path.mkdir(parents=True, exist_ok=True)
+    ndjson_path = log_path / f"{name}.ndjson"
+
+    writer = None
+    if use_tensorboard and SummaryWriter is not None:
+        try:  # pragma: no cover - depends on tensorboard availability
+            tb_dir = log_path / "tensorboard" / name
+            tb_dir.mkdir(parents=True, exist_ok=True)
+            writer = SummaryWriter(log_dir=str(tb_dir))
+        except Exception:
+            writer = None
+
+    if use_mlflow and HAS_MLFLOW:
+        try:  # pragma: no cover - optional backend
+            mlflow.set_experiment(name)
+            mlflow.start_run(run_name=name)
+        except Exception:
+            pass
+
+    if use_wandb and HAS_WANDB:
+        try:  # pragma: no cover - optional backend
+            wandb.init(project=name, name=name, mode=os.getenv("WANDB_MODE", "offline"))
+        except Exception:
+            pass
+
+    def log_metrics(step: int, metrics: Dict[str, Any]) -> None:
+        rec = {"step": int(step), **metrics}
+        with ndjson_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec) + "\n")
+        if writer is not None:
+            for k, v in metrics.items():
+                if isinstance(v, (int, float)):
+                    try:
+                        writer.add_scalar(k, v, step)
+                    except Exception:
+                        pass
+
+    return {"log_metrics": log_metrics, "ndjson_path": ndjson_path, "tensorboard": writer}

--- a/tests/tracking/test_init_experiment.py
+++ b/tests/tracking/test_init_experiment.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from codex_ml.tracking import init_experiment
+
+
+def test_init_experiment_writes_ndjson(tmp_path: Path) -> None:
+    tracker = init_experiment("exp", log_dir=tmp_path)
+    tracker["log_metrics"](1, {"loss": 0.5})
+    data = (tmp_path / "exp.ndjson").read_text().strip()
+    assert '"loss": 0.5' in data


### PR DESCRIPTION
## Summary
- add `init_experiment` utility to bootstrap TensorBoard/MLflow/W&B and NDJSON metrics
- expose helper in `codex_ml.tracking` and cover with unit test

## Testing
- `pre-commit run --files src/codex_ml/tracking/__init__.py src/codex_ml/tracking/init_experiment.py tests/tracking/test_init_experiment.py`
- `mypy --follow-imports=skip src/codex_ml/tracking/init_experiment.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'click')*
- `nox -s tests_sys` *(fails: Command uv pip install pytest pytest-cov failed with exit code 2)*
- `COV_FAIL_UNDER=0 pytest tests/tracking/test_init_experiment.py -q` *(fails: Required test coverage of 70% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd0b1bd7483319eae4825b8091f4a