### PR TITLE
Add CLI for model evaluation with log summarization

### DIFF
--- a/src/codex_ml/eval/run_eval.py
+++ b/src/codex_ml/eval/run_eval.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+from .evaluator import run_evaluator
+
+
+def _load_texts(path: str) -> List[str]:
+    """Load text records from ``path``.
+
+    Supports plain text files (one example per line), NDJSON/JSONL with a
+    ``text`` field and CSV files with a ``text`` column.
+    """
+    p = Path(path)
+    if p.suffix in {".txt"}:
+        return [line for line in p.read_text(encoding="utf-8").splitlines() if line]
+    if p.suffix in {".ndjson", ".jsonl"}:
+        return [
+            json.loads(line)["text"] for line in p.read_text(encoding="utf-8").splitlines() if line
+        ]
+    if p.suffix == ".csv":
+        with p.open(newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            column = "text" if "text" in reader.fieldnames else reader.fieldnames[0]
+            return [row[column] for row in reader]
+    raise ValueError(f"Unsupported data format: {p.suffix}")
+
+
+def _summarise_log(path: str) -> None:
+    """Read a metrics log and print per-epoch averages."""
+    p = Path(path)
+    if p.suffix in {".ndjson", ".jsonl"}:
+        records = [json.loads(line) for line in p.read_text(encoding="utf-8").splitlines() if line]
+    elif p.suffix == ".csv":
+        with p.open(newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            records = list(reader)
+    else:
+        raise ValueError(f"Unsupported log format: {p.suffix}")
+    summary: dict[int, List[float]] = {}
+    for rec in records:
+        epoch = int(rec.get("epoch", 0))
+        # Pick first numeric metric value in record
+        val = None
+        for key, value in rec.items():
+            try:
+                val = float(value)
+                break
+            except (TypeError, ValueError):
+                continue
+        if val is None:
+            continue
+        summary.setdefault(epoch, []).append(val)
+    for epoch, vals in sorted(summary.items()):
+        avg = sum(vals) / len(vals)
+        print(json.dumps({"epoch": epoch, "metric": avg}))
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    ap = argparse.ArgumentParser(description="Evaluate a model on a text dataset")
+    ap.add_argument("--model", required=True, help="Model name or path")
+    ap.add_argument("--data", required=True, help="Path to dataset (txt, ndjson, csv)")
+    ap.add_argument("--metrics-log", dest="metrics_log", help="Optional metrics log to summarise")
+    args = ap.parse_args(argv)
+
+    texts = _load_texts(args.data)
+    metrics = run_evaluator(args.model, texts)
+    print(json.dumps(metrics))
+    if args.metrics_log:
+        _summarise_log(args.metrics_log)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_run_eval_cli.py
+++ b/tests/test_run_eval_cli.py
@@ -1,0 +1,28 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_run_eval_cli(tmp_path):
+    pytest.importorskip("datasets")
+    data = tmp_path / "data.txt"
+    data.write_text("hello world\nsecond line", encoding="utf-8")
+    cmd = [
+        sys.executable,
+        "-m",
+        "codex_ml.eval.run_eval",
+        "--model",
+        "sshleifer/tiny-gpt2",
+        "--data",
+        str(data),
+    ]
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {"PYTHONPATH": str(repo_root / "src")}
+    out = subprocess.check_output(cmd, text=True, cwd=repo_root, env={**env, **os.environ})
+    metrics = json.loads(out.strip().splitlines()[0])
+    assert "perplexity" in metrics
+    assert "token_accuracy" in metrics


### PR DESCRIPTION
## Summary
- add `codex_ml.eval.run_eval` CLI to evaluate a model on text datasets and summarise metrics logs
- test CLI evaluation end-to-end on a tiny dataset

## Testing
- `pre-commit run --files src/codex_ml/eval/run_eval.py tests/test_run_eval_cli.py`
- `PYTEST_ADDOPTS=tests/test_run_eval_cli.py COV_FAIL_UNDER=0 nox -s coverage`

------
https://chatgpt.com/codex/tasks/task_e_68bbd0b1bd7483319eae4825b8091f4a