### PR TITLE
feat: add dataset split caching and trainer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,7 +702,7 @@ Utilities in `codex_ml.data_utils` help manage large text corpora deterministica
 ```python
 from codex_ml.data_utils import split_dataset, stream_texts
 
-train, val = split_dataset(lines, seed=42)
+train, val = split_dataset(lines, seed=42, cache_path="split.json")
 for chunk in stream_texts("corpus.txt", chunk_size=1024):
     ...
 ```

--- a/src/codex_ml/data_utils.py
+++ b/src/codex_ml/data_utils.py
@@ -8,29 +8,52 @@ engine and ease reproducible experiments.
 
 from __future__ import annotations
 
+import json
 import random
 from pathlib import Path
-from typing import Iterable, Iterator
+from typing import Iterable, Iterator, Tuple
 
 
 def split_dataset(
-    texts: Iterable[str], train_ratio: float = 0.9, seed: int = 0
-) -> tuple[list[str], list[str]]:
+    texts: Iterable[str],
+    train_ratio: float = 0.9,
+    seed: int = 0,
+    cache_path: str | Path | None = None,
+) -> Tuple[list[str], list[str]]:
     """Split ``texts`` into train and validation lists deterministically.
+
+    The split can optionally be cached to ``cache_path`` so repeated calls avoid
+    recomputing the shuffle.  When ``cache_path`` exists it is loaded and
+    returned as-is.
 
     Args:
         texts: Iterable of strings.
         train_ratio: Fraction of examples to allocate to the training set.
         seed: Random seed for deterministic shuffling.
+        cache_path: Optional path to a JSON file used to cache the split.
 
     Returns:
-        (train_texts, val_texts)
+        ``(train_texts, val_texts)``
     """
     items = list(texts)
+    if cache_path is not None:
+        p = Path(cache_path)
+        if p.exists():
+            try:
+                data = json.loads(p.read_text())
+                return data["train"], data["val"]
+            except Exception:
+                pass
     rng = random.Random(seed)
     rng.shuffle(items)
     split = int(len(items) * train_ratio)
-    return items[:split], items[split:]
+    train, val = items[:split], items[split:]
+    if cache_path is not None:
+        try:
+            Path(cache_path).write_text(json.dumps({"train": train, "val": val}))
+        except Exception:
+            pass
+    return train, val
 
 
 def stream_texts(

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -13,6 +13,18 @@ def test_split_dataset_deterministic():
     assert len(val1) == 2
 
 
+def test_split_dataset_cache(tmp_path: Path):
+    texts = [f"sample-{i}" for i in range(6)]
+    cache = tmp_path / "split.json"
+    train1, val1 = split_dataset(texts, train_ratio=0.5, seed=1, cache_path=cache)
+    # Alter input; cached result should still be returned
+    texts[0] = "changed"
+    train2, val2 = split_dataset(texts, train_ratio=0.5, seed=1, cache_path=cache)
+    assert train1 == train2
+    assert val1 == val2
+    assert cache.exists()
+
+
 def test_stream_texts(tmp_path: Path):
     content = "HelloWorld"
     file_path = tmp_path / "data.txt"


### PR DESCRIPTION
## Summary
- add optional caching to `split_dataset`
- allow `run_hf_trainer` to split datasets deterministically
- document caching in README
- test split caching behavior

## Testing
- `pre-commit run --files src/codex_ml/data_utils.py tests/test_data_utils.py training/engine_hf_trainer.py README.md`
- `nox -s tests` *(fails: Session coverage interrupted while installing dependencies)*
- `python3 -m pytest tests/test_data_utils.py -q` *(fails: coverage failure: total of 5 is less than fail-under=70)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd0b1bd7483319eae4825b8091f4a