### PR TITLE
Fix MLflow run closure in experiment logger

### DIFF
--- a/src/codex_ml/tracking/init_experiment.py
+++ b/src/codex_ml/tracking/init_experiment.py
@@ -112,7 +112,7 @@ class ExperimentLogger:
                 pass
         if self._mlflow_run is not None:
             try:
-                mlflow.end_run()
+                mlflow.end_run(run_id=self._mlflow_run.info.run_id)
             except Exception:
                 pass
         if self._wandb_run is not None:

--- a/tests/test_tracking_init_experiment.py
+++ b/tests/test_tracking_init_experiment.py
@@ -5,6 +5,11 @@ from pathlib import Path
 ie = importlib.import_module("codex_ml.tracking.init_experiment")
 
 
+class DummyRun:
+    def __init__(self, run_id: str = "dummy_run"):
+        self.info = type("info", (), {"run_id": run_id})()
+
+
 class DummyMlflow:
     def __init__(self):
         self.logged = {}
@@ -14,7 +19,9 @@ class DummyMlflow:
 
     def start_run(self, run_name=None):
         self.logged["run_name"] = run_name
-        return object()
+        run = DummyRun()
+        self.logged["run_id"] = run.info.run_id
+        return run
 
     def set_tags(self, tags):
         self.logged["tags"] = tags
@@ -22,8 +29,8 @@ class DummyMlflow:
     def log_metrics(self, metrics, step=None):
         self.logged["mlflow_metrics"] = (metrics, step)
 
-    def end_run(self):
-        self.logged["ended"] = True
+    def end_run(self, run_id=None):
+        self.logged["ended"] = run_id
 
 
 def test_init_experiment_logging(tmp_path, monkeypatch):
@@ -79,4 +86,5 @@ def test_init_experiment_logging(tmp_path, monkeypatch):
     data = (Path(tmp_path) / "metrics.ndjson").read_text().strip().splitlines()
     assert json.loads(data[0])["loss"] == 1.0
     assert dummy_mlflow.logged["experiment"] == "exp"
+    assert dummy_mlflow.logged["ended"] == dummy_mlflow.logged["run_id"]
     assert dummy_wandb.logged["metrics"][0]["loss"] == 1.0


### PR DESCRIPTION
## Summary
- ensure `ExperimentLogger.close` terminates the specific MLflow run it opened
- adjust MLflow dummy and test to verify run IDs are passed to `end_run`

## Testing
- `pre-commit run --files src/codex_ml/tracking/init_experiment.py tests/test_tracking_init_experiment.py`
- `mypy --hide-error-context --follow-imports=skip src/codex_ml/tracking/init_experiment.py tests/test_tracking_init_experiment.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'datasets')*


------
https://chatgpt.com/codex/tasks/task_e_68bbd7dd3e308331af9fafe06bc8ea33