### PR TITLE
fix(tokenization): package top-level module for distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["codex*"]
+include = ["codex*", "tokenization"]
 
 [project.optional-dependencies]
 cli = ["typer>=0.9", "rich>=13"]


### PR DESCRIPTION
## Summary
- include `tokenization` package in setuptools configuration so `codex-tokenizer` entry point works after installation

## Testing
- `pre-commit run --files pyproject.toml`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'click')*

------
https://chatgpt.com/codex/tasks/task_e_68bbe075215483318a3ec820065f18ff