### PR TITLE
0 c base: fix checkpoint callback model handling

### DIFF
--- a/tests/training/test_checkpoint_manager_callback.py
+++ b/tests/training/test_checkpoint_manager_callback.py
@@ -15,11 +15,12 @@ def test_callback_saves_and_prunes(tmp_path):
     cb = mgr.callback()
     state = TrainerState()
     control = TrainerControl()
+    cb.on_train_begin(None, state, control, model=model, optimizer=opt, lr_scheduler=sched)
 
     for step in range(3):
         state.global_step = step + 1
         state.epoch = step + 1
-        cb.on_step_end(None, state, control, model=model, optimizer=opt, lr_scheduler=sched)
+        cb.on_step_end(None, state, control)
 
     ckpts = sorted(p.name for p in tmp_path.glob("step-*.pt"))
     assert ckpts == ["step-2.pt", "step-3.pt"]

--- a/training/checkpoint_manager.py
+++ b/training/checkpoint_manager.py
@@ -9,6 +9,7 @@ checkpoints based on a chosen metric (not yet implemented).
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 try:  # pragma: no cover - transformers optional
     from transformers import TrainerCallback, TrainerControl, TrainerState
@@ -32,20 +33,33 @@ class CheckpointManager:
         manager = self
 
         class _Callback(TrainerCallback):  # type: ignore[misc]
+            def __init__(self) -> None:
+                self.model: Any | None = None
+                self.optimizer: Any | None = None
+                self.lr_scheduler: Any | None = None
+
+            def on_train_begin(self, args, state: TrainerState, control: TrainerControl, **kwargs):
+                self.model = kwargs.get("model")
+                self.optimizer = kwargs.get("optimizer")
+                self.lr_scheduler = kwargs.get("lr_scheduler")
+                return control
+
             def on_step_end(self, args, state: TrainerState, control: TrainerControl, **kwargs):
                 if state.global_step and state.global_step % manager.save_steps == 0:
+                    if self.model is None or self.optimizer is None:
+                        raise RuntimeError("CheckpointManager callback missing model or optimizer")
                     ckpt_path = manager.directory / f"step-{state.global_step}.pt"
                     save_checkpoint(
                         str(ckpt_path),
-                        kwargs.get("model"),
-                        kwargs.get("optimizer"),
-                        kwargs.get("lr_scheduler"),
+                        self.model,
+                        self.optimizer,
+                        self.lr_scheduler,
                         int(state.epoch or 0),
                         {},
                     )
                     ckpts = sorted(
                         manager.directory.glob("step-*.pt"),
-                        key=lambda p: p.stat().st_mtime,
+                        key=lambda p: int(p.stem.split("-")[1]),
                         reverse=True,
                     )
                     for old in ckpts[manager.keep_last :]:


### PR DESCRIPTION
## Summary
- store model, optimizer, and lr scheduler on training start for checkpoint callback
- prune checkpoints deterministically by step index and adjust tests

## Testing
- `pre-commit run --files training/checkpoint_manager.py tests/training/test_checkpoint_manager_callback.py`
- `mypy training/checkpoint_manager.py tests/training/test_checkpoint_manager_callback.py` *(fails: Source file found twice under different module names)*
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'click')*
- `pytest tests/training/test_checkpoint_manager_callback.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68bbe65649dc83319173b0c444bb6fe0