### PR TITLE
feat(training): add deterministic custom trainer and data utilities

### DIFF
--- a/.codex/change_log.md
+++ b/.codex/change_log.md
@@ -15791,3 +15791,25 @@ This repository includes CPU-friendly smoke tests for HF Trainer and end-to-end 
 ## 2025-09-06T00:00:00Z — README.md
 - **Action:** edit
 - **Rationale:** document tokenizer workflow for training and export.
+## 2025-09-06T08:59:55Z
+- **File:** training/functional_training.py
+- **Action:** create
+- **Rationale:** add deterministic custom training loop with logging and checkpointing
+- **File:** training/data_utils.py
+- **Action:** create
+- **Rationale:** provide deterministic split and caching helpers
+- **File:** src/codex/cli.py
+- **Action:** update
+- **Rationale:** allow selecting custom or hf_trainer engines with safe fallback
+- **File:** tests/training/test_custom_loop_overfit.py
+- **Action:** create
+- **Rationale:** ensure custom loop can overfit tiny corpus
+- **File:** tests/training/test_split_determinism.py
+- **Action:** create
+- **Rationale:** verify train/val split determinism
+- **File:** tests/training/test_checkpoint_resume.py
+- **Action:** create
+- **Rationale:** test checkpoint save and resume
+- **File:** tests/training/test_lora_optional.py
+- **Action:** create
+- **Rationale:** smoke test optional LoRA integration

--- a/tests/training/test_checkpoint_resume.py
+++ b/tests/training/test_checkpoint_resume.py
@@ -1,0 +1,48 @@
+from codex_ml.models import MiniLM, MiniLMConfig
+from training.data_utils import TextDataset, split_texts
+from training.functional_training import TrainCfg, run_custom_trainer
+
+
+class _Tok:
+    vocab = {str(i): i for i in range(6)}
+
+    def encode(self, txt: str) -> list[int]:
+        return [self.vocab[t] for t in txt.split()]
+
+
+def _build_ds():
+    texts = ["0 1 2 3 4 5"] * 4
+    train_txt, val_txt = split_texts(texts, seed=0)
+    tok = _Tok()
+    return (
+        tok,
+        TextDataset(train_txt, tok, block_size=6),
+        TextDataset(val_txt, tok, block_size=6),
+    )
+
+
+def test_checkpoint_resume(tmp_path) -> None:
+    tok, train_ds, val_ds = _build_ds()
+    model = MiniLM(MiniLMConfig(vocab_size=6, n_layers=1, d_model=16, n_heads=2, max_seq_len=6))
+    ckpt_dir = tmp_path / "ckpts"
+    cfg = TrainCfg(
+        epochs=1,
+        batch_size=2,
+        log_every=1,
+        save_every=2,
+        max_steps=2,
+        checkpoint_dir=str(ckpt_dir),
+    )
+    run_custom_trainer(model, tok, train_ds, val_ds, cfg)
+    ckpt = ckpt_dir / "step2.pt"
+    assert ckpt.exists()
+    cfg2 = TrainCfg(
+        epochs=1,
+        batch_size=2,
+        log_every=1,
+        max_steps=4,
+        checkpoint_dir=str(ckpt_dir),
+        resume_from=str(ckpt),
+    )
+    result = run_custom_trainer(model, tok, train_ds, val_ds, cfg2)
+    assert result["global_step"] >= 4

--- a/tests/training/test_custom_loop_overfit.py
+++ b/tests/training/test_custom_loop_overfit.py
@@ -1,0 +1,22 @@
+from codex_ml.models import MiniLM, MiniLMConfig
+from training.data_utils import TextDataset, split_texts
+from training.functional_training import TrainCfg, run_custom_trainer
+
+
+class _Tok:
+    vocab = {str(i): i for i in range(10)}
+
+    def encode(self, txt: str) -> list[int]:
+        return [self.vocab[t] for t in txt.split()]
+
+
+def test_overfit_tiny(tmp_path) -> None:
+    texts = ["0 1 2 3 4 5 6 7 8 9"] * 4
+    train_txt, val_txt = split_texts(texts, seed=0)
+    tok = _Tok()
+    train_ds = TextDataset(train_txt, tok, block_size=10)
+    val_ds = TextDataset(val_txt, tok, block_size=10)
+    model = MiniLM(MiniLMConfig(vocab_size=10, n_layers=1, d_model=16, n_heads=2, max_seq_len=10))
+    cfg = TrainCfg(epochs=3, batch_size=2, log_every=1, save_every=0, checkpoint_dir=str(tmp_path))
+    result = run_custom_trainer(model, tok, train_ds, val_ds, cfg)
+    assert result["history"][0] > result["history"][-1]

--- a/tests/training/test_lora_optional.py
+++ b/tests/training/test_lora_optional.py
@@ -1,0 +1,43 @@
+import pytest
+
+from codex_ml.models import MiniLM, MiniLMConfig
+from training.data_utils import TextDataset, split_texts
+from training.functional_training import TrainCfg, run_custom_trainer
+
+
+class _Tok:
+    vocab = {str(i): i for i in range(5)}
+
+    def encode(self, txt: str) -> list[int]:
+        return [self.vocab[t] for t in txt.split()]
+
+
+def _has_peft() -> bool:
+    try:  # pragma: no cover - optional dependency
+        import peft  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _has_peft(), reason="peft not installed")
+def test_lora_parameters_trainable(tmp_path) -> None:
+    texts = ["0 1 2 3 4"] * 2
+    train_txt, val_txt = split_texts(texts, seed=0)
+    tok = _Tok()
+    train_ds = TextDataset(train_txt, tok, block_size=5)
+    val_ds = TextDataset(val_txt, tok, block_size=5)
+    model = MiniLM(MiniLMConfig(vocab_size=5, n_layers=1, d_model=16, n_heads=2, max_seq_len=5))
+    cfg = TrainCfg(
+        epochs=1,
+        batch_size=2,
+        max_steps=1,
+        use_lora=True,
+        log_every=10,
+        checkpoint_dir=str(tmp_path),
+    )
+    run_custom_trainer(model, tok, train_ds, val_ds, cfg)
+    trainable = [n for n, p in model.named_parameters() if p.requires_grad]
+    assert any("lora" in n for n in trainable)
+    assert any("lora" not in n and not p.requires_grad for n, p in model.named_parameters())

--- a/tests/training/test_split_determinism.py
+++ b/tests/training/test_split_determinism.py
@@ -1,0 +1,10 @@
+from training.data_utils import split_texts
+
+
+def test_split_seed_reproducibility() -> None:
+    texts = ["a", "b", "c", "d", "e"]
+    t1, v1 = split_texts(texts, seed=123)
+    t2, v2 = split_texts(texts, seed=123)
+    t3, v3 = split_texts(texts, seed=321)
+    assert t1 == t2 and v1 == v2
+    assert (t1, v1) != (t3, v3)

--- a/training/data_utils.py
+++ b/training/data_utils.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Tuple
+
+import numpy as np
+import torch
+
+try:  # optional import from ingestion utilities
+    from ingestion import deterministic_shuffle  # type: ignore
+except Exception:  # pragma: no cover - fallback
+    import random
+
+    def deterministic_shuffle(seq: Iterable[Any], seed: int) -> List[Any]:
+        items = list(seq)
+        rnd = random.Random(seed)
+        rnd.shuffle(items)
+        return items
+
+
+def split_texts(
+    texts: Iterable[str],
+    train_ratio: float = 0.9,
+    seed: int = 0,
+    cache_path: str | None = None,
+) -> Tuple[List[str], List[str]]:
+    """Deterministically split ``texts`` into train/val lists.
+
+    When ``cache_path`` is provided the split is cached on disk to allow
+    reproducible reuse across runs.
+    """
+    items = list(texts)
+    if cache_path is not None:
+        p = Path(cache_path)
+        if p.exists():
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+                return list(data["train"]), list(data["val"])
+            except Exception:
+                pass
+    shuffled = deterministic_shuffle(items, seed)
+    split = int(len(shuffled) * train_ratio)
+    train, val = shuffled[:split], shuffled[split:]
+    if cache_path is not None:
+        try:
+            Path(cache_path).write_text(json.dumps({"train": train, "val": val}), encoding="utf-8")
+        except Exception:
+            pass
+    return train, val
+
+
+@dataclass
+class TextDataset(torch.utils.data.Dataset):
+    """Minimal text dataset producing next-token labels."""
+
+    texts: List[str]
+    tokenizer: Any
+    block_size: int = 128
+
+    def __post_init__(self) -> None:  # prepare tensor examples eagerly
+        self.examples: List[Dict[str, torch.Tensor]] = []
+        for txt in self.texts:
+            if hasattr(self.tokenizer, "encode"):
+                ids = self.tokenizer.encode(txt)
+            else:
+                ids = self.tokenizer(txt)["input_ids"]
+            ids = ids[: self.block_size + 1]
+            if len(ids) < 2:
+                continue
+            input_ids = ids[:-1]
+            labels = ids[1:]
+            attn = [1] * len(input_ids)
+            self.examples.append(
+                {
+                    "input_ids": torch.tensor(input_ids, dtype=torch.long),
+                    "labels": torch.tensor(labels, dtype=torch.long),
+                    "attention_mask": torch.tensor(attn, dtype=torch.long),
+                }
+            )
+
+    def __len__(self) -> int:
+        return len(self.examples)
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        ex = self.examples[idx]
+        return {k: v.clone() for k, v in ex.items()}
+
+
+def cache_dataset(ds: torch.utils.data.Dataset, cache_dir: str) -> None:
+    """Cache tokenised dataset ``ds`` under ``cache_dir`` as `.npz` shards."""
+    path = Path(cache_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    for i, sample in enumerate(ds):
+        arrs = {k: v.numpy() for k, v in sample.items()}
+        np.savez(path / f"{i}.npz", **arrs)
+
+
+def load_cached(cache_dir: str) -> Iterator[Dict[str, torch.Tensor]]:
+    """Yield cached samples stored by :func:`cache_dataset`."""
+    path = Path(cache_dir)
+    for npz in sorted(path.glob("*.npz")):
+        data = np.load(npz)
+        yield {k: torch.tensor(data[k]) for k in data.files}

--- a/training/functional_training.py
+++ b/training/functional_training.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import numpy as np
+import torch
+from torch.nn.utils import clip_grad_norm_
+from torch.utils.data import DataLoader
+
+from codex_ml.monitoring.codex_logging import (
+    CodexLoggers,
+    _codex_log_all,
+    _codex_logging_bootstrap,
+)
+from codex_ml.utils.checkpointing import load_checkpoint, save_checkpoint, set_seed
+
+try:  # optional LoRA support
+    from peft import LoraConfig, get_peft_model  # type: ignore
+except Exception:  # pragma: no cover - optional
+    LoraConfig = None  # type: ignore
+    get_peft_model = None  # type: ignore
+
+from training.engine_hf_trainer import _compute_metrics
+
+
+def _worker_init_fn(worker_id: int) -> None:
+    """Initialise worker seed deterministically."""
+    seed = torch.initial_seed() % 2**32
+    np.random.seed(seed + worker_id)
+
+
+@dataclass
+class TrainCfg:
+    epochs: int = 1
+    batch_size: int = 8
+    grad_accum: int = 1
+    lr: float = 5e-4
+    weight_decay: float = 0.0
+    warmup_steps: int = 0
+    max_steps: Optional[int] = None
+    max_grad_norm: Optional[float] = 1.0
+    dtype: str = "fp32"  # fp32|fp16|bf16
+    log_every: int = 50
+    save_every: int = 500
+    patience: int = 100
+    seed: int = 42
+    resume_from: Optional[str] = None
+    checkpoint_dir: str = "checkpoints"
+    use_lora: bool = False
+    device: Optional[str] = None
+    limit_train_batches: Optional[int] = None
+    limit_val_batches: Optional[int] = None
+
+
+def run_custom_trainer(model, tokenizer, train_ds, val_ds, cfg: TrainCfg) -> Dict[str, Any]:
+    """Train ``model`` on ``train_ds`` using a minimal deterministic loop."""
+
+    device = torch.device(cfg.device or ("cuda" if torch.cuda.is_available() else "cpu"))
+    model.to(device)
+    set_seed(cfg.seed)
+    loggers: CodexLoggers = _codex_logging_bootstrap(argparse.Namespace())
+
+    if cfg.use_lora and LoraConfig and get_peft_model:
+        try:
+            lcfg = LoraConfig(r=4, lora_alpha=16, lora_dropout=0.0, bias="none")
+            model = get_peft_model(model, lcfg)
+        except Exception:
+            pass
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+    scheduler = None
+    if cfg.warmup_steps and cfg.max_steps:
+
+        def lr_lambda(step: int) -> float:
+            if step < cfg.warmup_steps:
+                return step / float(max(1, cfg.warmup_steps))
+            return max(
+                0.0, (cfg.max_steps - step) / float(max(1, cfg.max_steps - cfg.warmup_steps))
+            )
+
+        scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+
+    start_epoch = 0
+    global_step = 0
+    best_val = float("inf")
+    if cfg.resume_from:
+        try:
+            start_epoch, extra = load_checkpoint(cfg.resume_from, model, optimizer, scheduler)
+            global_step = int(extra.get("global_step", 0))
+            best_val = float(extra.get("best_val", best_val))
+        except Exception:
+            pass
+
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=cfg.batch_size,
+        shuffle=True,
+        drop_last=True,
+        pin_memory=torch.cuda.is_available(),
+        worker_init_fn=_worker_init_fn,
+        generator=torch.Generator().manual_seed(cfg.seed),
+    )
+    val_loader = None
+    if val_ds is not None:
+        val_loader = DataLoader(
+            val_ds,
+            batch_size=cfg.batch_size,
+            shuffle=False,
+            drop_last=False,
+            pin_memory=torch.cuda.is_available(),
+            worker_init_fn=_worker_init_fn,
+            generator=torch.Generator().manual_seed(cfg.seed),
+        )
+
+    use_amp = cfg.dtype in {"fp16", "bf16"} and torch.cuda.is_available()
+    scaler = torch.cuda.amp.GradScaler(enabled=cfg.dtype == "fp16")
+    autocast_dtype = {
+        "fp16": torch.float16,
+        "bf16": torch.bfloat16,
+    }.get(cfg.dtype, torch.float32)
+
+    history: list[float] = []
+    patience_ctr = 0
+    for epoch in range(start_epoch, cfg.epochs):
+        model.train()
+        optimizer.zero_grad(set_to_none=True)
+        for step, batch in enumerate(train_loader):
+            if cfg.limit_train_batches and step >= cfg.limit_train_batches:
+                break
+            for k, v in batch.items():
+                batch[k] = v.to(device)
+            with torch.autocast(device_type=device.type, dtype=autocast_dtype, enabled=use_amp):
+                out = model(**batch)
+                loss = out["loss"] if isinstance(out, dict) else out.loss
+                loss = loss / cfg.grad_accum
+            if cfg.dtype == "fp16":
+                scaler.scale(loss).backward()
+            else:
+                loss.backward()
+            if (step + 1) % cfg.grad_accum == 0:
+                if cfg.max_grad_norm is not None:
+                    if cfg.dtype == "fp16":
+                        scaler.unscale_(optimizer)
+                    clip_grad_norm_(model.parameters(), cfg.max_grad_norm)
+                if cfg.dtype == "fp16":
+                    scaler.step(optimizer)
+                    scaler.update()
+                else:
+                    optimizer.step()
+                optimizer.zero_grad(set_to_none=True)
+                global_step += 1
+                if scheduler:
+                    scheduler.step()
+                if global_step % cfg.log_every == 0:
+                    loss_val = float(loss.detach().cpu().item() * cfg.grad_accum)
+                    history.append(loss_val)
+                    try:
+                        _codex_log_all(global_step, {"train_loss": loss_val}, loggers)
+                    except Exception:
+                        print(f"step {global_step}: loss {loss_val:.4f}")
+                if cfg.save_every and global_step % cfg.save_every == 0:
+                    ckpt = Path(cfg.checkpoint_dir) / f"step{global_step}.pt"
+                    save_checkpoint(
+                        ckpt,
+                        model,
+                        optimizer,
+                        scheduler,
+                        epoch,
+                        {"global_step": global_step, "best_val": best_val},
+                    )
+                if cfg.max_steps and global_step >= cfg.max_steps:
+                    break
+        if cfg.max_steps and global_step >= cfg.max_steps:
+            break
+        if val_loader is not None:
+            model.eval()
+            preds = []
+            labels = []
+            with torch.no_grad():
+                for j, vb in enumerate(val_loader):
+                    if cfg.limit_val_batches and j >= cfg.limit_val_batches:
+                        break
+                    for k, v in vb.items():
+                        vb[k] = v.to(device)
+                    outputs = model(**vb)
+                    logits = outputs["logits"] if isinstance(outputs, dict) else outputs.logits
+                    preds.append(logits.cpu().numpy())
+                    labels.append(vb["labels"].cpu().numpy())
+            if preds and labels:
+                metrics = _compute_metrics((np.concatenate(preds), np.concatenate(labels)))
+                val_ppl = metrics.get("perplexity", float("inf"))
+                if val_ppl < best_val:
+                    best_val = val_ppl
+                    patience_ctr = 0
+                    ckpt = Path(cfg.checkpoint_dir) / "best.pt"
+                    save_checkpoint(
+                        ckpt,
+                        model,
+                        optimizer,
+                        scheduler,
+                        epoch,
+                        {"global_step": global_step, "best_val": best_val},
+                    )
+                else:
+                    patience_ctr += 1
+                if patience_ctr >= cfg.patience:
+                    break
+    return {"global_step": global_step, "history": history, "best_val": best_val}
+
+
+def main(*cli_args: str) -> None:  # pragma: no cover - simple CLI wrapper
+    parser = argparse.ArgumentParser(description="Custom training loop")
+    parser.add_argument("texts", nargs="+", help="Inline training texts")
+    parser.add_argument("--epochs", type=int, default=1)
+    args = parser.parse_args(list(cli_args))
+
+    from codex_ml.models import MiniLM, MiniLMConfig
+    from training.data_utils import TextDataset, split_texts
+
+    class _Tok:
+        def __init__(self) -> None:
+            self.vocab: Dict[str, int] = {}
+
+        def encode(self, txt: str) -> list[int]:
+            ids = []
+            for tok in txt.split():
+                if tok not in self.vocab:
+                    self.vocab[tok] = len(self.vocab)
+                ids.append(self.vocab[tok])
+            return ids
+
+    tokenizer = _Tok()
+    train_txt, val_txt = split_texts(args.texts, seed=0)
+    # prime vocab
+    for t in train_txt + val_txt:
+        tokenizer.encode(t)
+    model = MiniLM(MiniLMConfig(vocab_size=len(tokenizer.vocab)))
+    train_ds = TextDataset(train_txt, tokenizer, block_size=16)
+    val_ds = TextDataset(val_txt, tokenizer, block_size=16)
+    cfg = TrainCfg(epochs=args.epochs, log_every=1)
+    run_custom_trainer(model, tokenizer, train_ds, val_ds, cfg)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add custom PyTorch training loop with checkpointing, LoRA, and metric logging
- provide deterministic data split and caching helpers
- expose engine switch in CLI with safe fallback to hf_trainer
- add tests for overfitting, deterministic splits, checkpoint resume, and optional LoRA

## Testing
- `pre-commit run --files .codex/change_log.md src/codex/cli.py training/data_utils.py training/functional_training.py tests/training/test_custom_loop_overfit.py tests/training/test_split_determinism.py tests/training/test_checkpoint_resume.py tests/training/test_lora_optional.py`
- `nox -s tests` *(failed: ModuleNotFoundError: No module named 'click' in coverage session)*
- `nox -s coverage` *(failed: test_rate_limit expected 429 but got 200)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf6c7743883318679a1f99bc461cc