### PR TITLE
feat: introduce plugin registry framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,28 @@ export CODEX_SQLITE_POOL=1
 python -m codex.logging.viewer --session-id S123 --format text
 python -m codex.logging.export S123 --format json
 
+# Registering a toy tokenizer
+```python
+from codex_ml.plugins import tokenizers
+from codex_ml.interfaces.tokenizer import TokenizerAdapter, get_tokenizer
+
+@tokenizers.register("toy")
+class ToyTokenizer(TokenizerAdapter):
+    __codex_ext_api__ = "v1"
+
+    def encode(self, text: str, *, add_special_tokens: bool = True):
+        return [1]
+
+    def decode(self, ids, *, skip_special_tokens: bool = True):
+        return "toy"
+
+    @property
+    def vocab_size(self) -> int:
+        return 0
+
+tk = get_tokenizer("toy")
+```
+
 ## Logging: Querying transcripts
 
 This repository includes a CLI to query a SQLite database and render chat transcripts, auto-detecting tables and columns.

--- a/docs/modules/plugins.md
+++ b/docs/modules/plugins.md
@@ -1,0 +1,60 @@
+# Plugin System
+
+Codex ML exposes a lightweight plugin API with two discovery mechanisms:
+
+1. **In-process registry** – register classes or factories directly using
+   decorators.
+2. **Optional entry-point loading** – when the environment variable
+   `CODEX_PLUGINS_ENTRYPOINTS=1` is set, entry points such as
+   `codex_ml.tokenizers` are discovered via `importlib.metadata`.
+
+Plugins should declare a compatibility marker:
+
+```python
+__codex_ext_api__ = "v1"
+```
+
+## Registering a plugin locally
+
+```python
+from codex_ml.plugins import tokenizers
+from codex_ml.interfaces.tokenizer import TokenizerAdapter
+
+@tokenizers.register("toy")
+class ToyTokenizer(TokenizerAdapter):
+    __codex_ext_api__ = "v1"
+
+    def encode(self, text: str, *, add_special_tokens: bool = True):
+        return [1, 2, 3]
+
+    def decode(self, ids, *, skip_special_tokens: bool = True):
+        return "toy"
+
+    @property
+    def vocab_size(self) -> int:
+        return 0
+```
+
+Invoke via the helper factory:
+
+```python
+from codex_ml.interfaces.tokenizer import get_tokenizer
+
+tk = get_tokenizer("toy")
+```
+
+## Declaring an entry point
+
+In `pyproject.toml`:
+
+```toml
+[project.entry-points."codex_ml.tokenizers"]
+my_toy = "my_pkg.toy:ToyTokenizer"
+```
+
+Enable discovery:
+
+```bash
+export CODEX_PLUGINS_ENTRYPOINTS=1
+python -m codex_ml.cli.plugins_cli list tokenizers
+```

--- a/src/codex_ml/cli/plugins_cli.py
+++ b/src/codex_ml/cli/plugins_cli.py
@@ -1,0 +1,74 @@
+"""CLI utilities for inspecting plugin registries."""
+
+from __future__ import annotations
+
+import inspect
+
+import typer
+
+from codex_ml.plugins import registries
+
+app = typer.Typer(help="Inspect codex_ml plugin registries")
+
+_GROUPS = {
+    "tokenizers": registries.tokenizers,
+    "models": registries.models,
+    "datasets": registries.datasets,
+    "metrics": registries.metrics,
+    "trainers": registries.trainers,
+    "reward_models": registries.reward_models,
+    "rl_agents": registries.rl_agents,
+}
+
+
+def _get_registry(group: str):
+    reg = _GROUPS.get(group)
+    if not reg:
+        raise typer.BadParameter(f"unknown group: {group}")
+    return reg
+
+
+@app.command()
+def list(group: str) -> None:
+    """List registered plugin names for ``group``."""
+
+    reg = _get_registry(group)
+    for name in reg.names():
+        typer.echo(name)
+
+
+@app.command()
+def diagnose(group: str, use_entry_points: bool = False) -> None:
+    """Diagnose plugin loading for ``group``."""
+
+    reg = _get_registry(group)
+    errors = {}
+    if use_entry_points:
+        _, errors = reg.load_from_entry_points(f"codex_ml.{group}", require_api="v1")
+    typer.echo(f"registered={len(reg.names())}")
+    for k, v in errors.items():
+        typer.echo(f"{k}: {v}")
+
+
+@app.command()
+def explain(group: str, name: str) -> None:
+    """Show details for a specific plugin."""
+
+    reg = _get_registry(group)
+    item = reg.get(name)
+    if not item:
+        raise typer.Exit(code=1)
+    obj = item.obj
+    typer.echo(f"module: {obj.__module__}")
+    doc = inspect.getdoc(obj) or ""
+    if doc:
+        typer.echo(doc)
+    try:
+        sig = inspect.signature(obj)
+        typer.echo(str(sig))
+    except ValueError:  # pragma: no cover - builtins may not have signature
+        pass
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    app()

--- a/src/codex_ml/plugins/__init__.py
+++ b/src/codex_ml/plugins/__init__.py
@@ -1,0 +1,35 @@
+"""Plugin registry utilities for codex_ml."""
+
+from .registries import (
+    datasets,
+    load_dataset_entry_points,
+    load_metric_entry_points,
+    load_model_entry_points,
+    load_reward_model_entry_points,
+    load_rl_agent_entry_points,
+    load_tokenizer_entry_points,
+    load_trainer_entry_points,
+    metrics,
+    models,
+    reward_models,
+    rl_agents,
+    tokenizers,
+    trainers,
+)
+
+__all__ = [
+    "tokenizers",
+    "models",
+    "datasets",
+    "metrics",
+    "trainers",
+    "reward_models",
+    "rl_agents",
+    "load_tokenizer_entry_points",
+    "load_model_entry_points",
+    "load_dataset_entry_points",
+    "load_metric_entry_points",
+    "load_trainer_entry_points",
+    "load_reward_model_entry_points",
+    "load_rl_agent_entry_points",
+]

--- a/src/codex_ml/plugins/registries.py
+++ b/src/codex_ml/plugins/registries.py
@@ -1,0 +1,57 @@
+"""Concrete plugin registries used by codex_ml."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from .registry import Registry
+
+
+def _load(
+    reg: Registry, group: str, flag: bool, require_api: str = "v1"
+) -> Tuple[int, dict[str, str]]:
+    if flag:
+        return reg.load_from_entry_points(group, require_api=require_api)
+    return 0, {}
+
+
+# Individual registries ----------------------------------------------------
+
+tokenizers = Registry("tokenizers")
+models = Registry("models")
+datasets = Registry("datasets")
+metrics = Registry("metrics")
+trainers = Registry("trainers")
+reward_models = Registry("reward_models")
+rl_agents = Registry("rl_agents")
+
+
+# Entry-point loaders ------------------------------------------------------
+
+
+def load_tokenizer_entry_points(flag: bool = False, group: str = "codex_ml.tokenizers"):
+    return _load(tokenizers, group, flag)
+
+
+def load_model_entry_points(flag: bool = False, group: str = "codex_ml.models"):
+    return _load(models, group, flag)
+
+
+def load_dataset_entry_points(flag: bool = False, group: str = "codex_ml.datasets"):
+    return _load(datasets, group, flag)
+
+
+def load_metric_entry_points(flag: bool = False, group: str = "codex_ml.metrics"):
+    return _load(metrics, group, flag)
+
+
+def load_trainer_entry_points(flag: bool = False, group: str = "codex_ml.trainers"):
+    return _load(trainers, group, flag)
+
+
+def load_reward_model_entry_points(flag: bool = False, group: str = "codex_ml.reward_models"):
+    return _load(reward_models, group, flag)
+
+
+def load_rl_agent_entry_points(flag: bool = False, group: str = "codex_ml.rl_agents"):
+    return _load(rl_agents, group, flag)

--- a/src/codex_ml/plugins/registry.py
+++ b/src/codex_ml/plugins/registry.py
@@ -1,0 +1,99 @@
+"""Lightweight plugin registry with optional entry-point discovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib.metadata import entry_points
+from typing import Any, Callable, Dict, Tuple
+
+
+def _norm(name: str) -> str:
+    """Normalize plugin names (case-insensitive, hyphen tolerant)."""
+    return name.lower().replace("-", "_")
+
+
+@dataclass
+class _Item:
+    obj: Any
+    meta: Dict[str, Any]
+
+
+class Registry:
+    """In-process registry supporting entry-point loading."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._items: Dict[str, _Item] = {}
+        self._ep_loaded: Dict[str, bool] = {}
+
+    # ------------------------------------------------------------------
+    def register(self, name: str, **meta: Any) -> Callable[[Any], Any]:
+        key = _norm(name)
+
+        def deco(obj: Any) -> Any:
+            # Local registrations take precedence over entry points
+            self._items[key] = _Item(obj=obj, meta={"name": key, **meta})
+            return obj
+
+        return deco
+
+    # ------------------------------------------------------------------
+    def get(self, name: str) -> _Item | None:
+        return self._items.get(_norm(name))
+
+    def names(self) -> list[str]:
+        return sorted(self._items.keys())
+
+    def clear(self) -> None:
+        self._items.clear()
+        self._ep_loaded.clear()
+
+    # ------------------------------------------------------------------
+    def load_from_entry_points(
+        self, group: str, require_api: str | None = None
+    ) -> Tuple[int, Dict[str, str]]:
+        """Load plugins from entry points.
+
+        Returns a tuple of (count, errors) where errors maps entry point names to
+        failure reasons. Local registrations always take precedence.
+        """
+
+        errors: Dict[str, str] = {}
+        try:
+            eps = entry_points().select(group=group)
+        except Exception as exc:  # pragma: no cover - platform variation
+            return 0, {"<entry_points>": str(exc)}
+        count = 0
+        for ep in eps:
+            if ep.name in self._ep_loaded:
+                continue
+            key = _norm(ep.name)
+            if key in self._items:
+                # Local registration overrides entry point
+                self._ep_loaded[ep.name] = True
+                continue
+            try:
+                obj = ep.load()
+                api = getattr(obj, "__codex_ext_api__", None)
+                if require_api and api != require_api:
+                    errors[ep.name] = f"incompatible api: {api} != {require_api}"
+                    continue
+                self._items[key] = _Item(
+                    obj=obj,
+                    meta={"entry_point": group, "module": ep.value, "name": key},
+                )
+                self._ep_loaded[ep.name] = True
+                count += 1
+            except Exception as exc:  # pragma: no cover - plugin failure
+                errors[ep.name] = str(exc)
+        return count, errors
+
+    # ------------------------------------------------------------------
+    def resolve_and_instantiate(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        item = self.get(name)
+        if not item:
+            raise KeyError(f"{self.name}: plugin '{name}' not found; available: {self.names()}")
+        obj = item.obj
+        if not callable(obj):
+            raise TypeError(f"{self.name}: registered object for '{name}' is not callable")
+        return obj(*args, **kwargs)

--- a/tests/plugins/test_entry_point_discovery.py
+++ b/tests/plugins/test_entry_point_discovery.py
@@ -1,0 +1,37 @@
+import types
+
+from codex_ml.plugins.registry import Registry
+
+
+def test_entry_point_discovery(monkeypatch) -> None:
+    class Ep:
+        def __init__(self, name: str, obj, fail: bool = False, api: str = "v1") -> None:
+            self.name = name
+            self.value = "mod:obj"
+            self._obj = obj
+            self._fail = fail
+            self._api = api
+
+        def load(self):
+            if self._fail:
+                raise RuntimeError("boom")
+            self._obj.__codex_ext_api__ = self._api
+            return self._obj
+
+    def fake_entry_points():
+        class Eps:
+            def select(self, group: str):
+                ok = Ep("ok", types.SimpleNamespace())
+                bad = Ep("bad", types.SimpleNamespace(), fail=True)
+                inc = Ep("inc", types.SimpleNamespace(), api="v0")
+                return [ok, bad, inc]
+
+        return Eps()
+
+    monkeypatch.setattr("importlib.metadata.entry_points", fake_entry_points)
+
+    reg = Registry("x")
+    count, errs = reg.load_from_entry_points("codex_ml.x", require_api="v1")
+    assert count == 1
+    assert "bad" in errs and "boom" in errs["bad"]
+    assert "inc" in errs and "incompatible" in errs["inc"]

--- a/tests/plugins/test_factory_vs_class.py
+++ b/tests/plugins/test_factory_vs_class.py
@@ -1,0 +1,23 @@
+from codex_ml.plugins.registry import Registry
+
+
+def test_factory_and_class() -> None:
+    reg = Registry("x")
+
+    @reg.register("cls")
+    class C:
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+    @reg.register("factory")
+    def make(value: int):
+        class D:
+            def __init__(self, v: int) -> None:
+                self.value = v
+
+        return D(value)
+
+    c = reg.resolve_and_instantiate("cls", 1)
+    f = reg.resolve_and_instantiate("factory", 2)
+    assert c.value == 1
+    assert f.value == 2

--- a/tests/plugins/test_registry_basic.py
+++ b/tests/plugins/test_registry_basic.py
@@ -1,0 +1,28 @@
+from codex_ml.plugins.registry import Registry
+
+
+def test_register_and_get() -> None:
+    reg = Registry("x")
+
+    @reg.register("Foo")
+    class Foo:
+        pass
+
+    assert "foo" in reg.names()
+    item = reg.get("foo")
+    assert item is not None
+    assert item.obj is Foo
+
+
+def test_case_insensitive_override() -> None:
+    reg = Registry("x")
+
+    @reg.register("a")
+    class A:
+        pass
+
+    @reg.register("A")
+    class B:
+        pass
+
+    assert reg.get("a").obj is B


### PR DESCRIPTION
## Summary
- add reusable Registry class with entry-point loading and name normalization
- expose concrete registries and CLI utilities for plugin inspection
- wire tokenizer and model loaders to plugin registries and document usage

## Testing
- `pre-commit run --files src/codex_ml/plugins/__init__.py src/codex_ml/plugins/registry.py src/codex_ml/plugins/registries.py src/codex_ml/interfaces/tokenizer.py src/codex_ml/models/__init__.py src/codex_ml/cli/plugins_cli.py docs/modules/plugins.md README.md tests/plugins/test_registry_basic.py tests/plugins/test_entry_point_discovery.py tests/plugins/test_factory_vs_class.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'click' in tests/test_cli.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf7b154c88331abf0cbe4c6166ee2