### PR TITLE
fix: restore hf engine alias and improve checkpoint resume

### DIFF
--- a/.codex/change_log.md
+++ b/.codex/change_log.md
@@ -15813,3 +15813,14 @@ This repository includes CPU-friendly smoke tests for HF Trainer and end-to-end 
 - **File:** tests/training/test_lora_optional.py
 - **Action:** create
 - **Rationale:** smoke test optional LoRA integration
+## 2025-09-06T09:47:25Z — src/codex/cli.py
+- **Action:** edit
+- **Rationale:** accept legacy `hf` engine alias for backward compatibility
+
+## 2025-09-06T09:47:25Z — training/functional_training.py
+- **Action:** edit
+- **Rationale:** skip processed steps on resume and persist RNG state
+
+## 2025-09-06T09:47:25Z — tests/training/test_checkpoint_resume.py
+- **Action:** edit
+- **Rationale:** verify resumed training matches uninterrupted baseline

--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -103,9 +103,9 @@ def logs_query(sql: str, db: str) -> None:
 @cli.command("train", context_settings={"ignore_unknown_options": True})
 @click.option(
     "--engine",
-    type=click.Choice(["hf_trainer", "custom"]),
+    type=click.Choice(["hf_trainer", "hf", "custom"]),
     default="hf_trainer",
-    help="Training engine to use (hf_trainer or custom).",
+    help="Training engine to use (hf_trainer/hf or custom).",
 )
 @click.argument("engine_args", nargs=-1)
 def train_cmd(engine: str, engine_args: tuple[str, ...]) -> None:
@@ -117,7 +117,7 @@ def train_cmd(engine: str, engine_args: tuple[str, ...]) -> None:
     from codex_ml.utils.repro import set_reproducible
 
     set_reproducible()
-    if engine == "hf_trainer":
+    if engine in {"hf_trainer", "hf"}:
         from training.engine_hf_trainer import run_hf_trainer
 
         return run_hf_trainer(*engine_args)


### PR DESCRIPTION
## Summary
- accept legacy `hf` alias for `--engine` to preserve backward compatibility
- resume custom trainer without replaying processed batches by persisting batch index and RNG state
- add regression test verifying resumed training matches uninterrupted run

## Testing
- `pre-commit run --files .codex/change_log.md src/codex/cli.py training/functional_training.py tests/training/test_checkpoint_resume.py`
- `nox -s tests` *(failed: Command pytest -q --disable-warnings --maxfail=1 --cov --cov-branch --cov-report=term-missing --cov-fail-under=70 failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bc02c2d71083319dd0dab9c933daad