### PR TITLE
fix(eval-runner): handle non-numeric metric outputs

### DIFF
--- a/src/codex_ml/eval/eval_runner.py
+++ b/src/codex_ml/eval/eval_runner.py
@@ -22,12 +22,14 @@ from .datasets import load_dataset
 
 def _bootstrap(
     fn, preds: Sequence[str], targets: Sequence[str], n: int, seed: int
-) -> tuple[float, float | None, float | None]:
+) -> tuple[float | None, float | None, float | None]:
     """Compute ``fn`` with optional bootstrap confidence interval."""
 
     val = fn(preds, targets)
-    if not isinstance(val, (int, float)) or n <= 0:
-        return float(val), None, None  # type: ignore[arg-type]
+    if not isinstance(val, (int, float)):
+        return None, None, None
+    if n <= 0:
+        return float(val), None, None
     rng = random.Random(seed)
     vals: List[float] = []
     for _ in range(n):

--- a/tests/eval/test_bleu_rouge_fallbacks.py
+++ b/tests/eval/test_bleu_rouge_fallbacks.py
@@ -1,9 +1,11 @@
 import builtins
+import json
 
+from codex_ml.eval.eval_runner import evaluate_datasets
 from codex_ml.metrics.registry import get_metric
 
 
-def test_bleu_rouge_fallbacks(monkeypatch):
+def test_bleu_rouge_fallbacks(monkeypatch, tmp_path):
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
@@ -16,3 +18,10 @@ def test_bleu_rouge_fallbacks(monkeypatch):
     rouge = get_metric("rougeL")
     assert bleu(["a"], ["a"]) is None
     assert rouge(["a"], ["a"]) is None
+
+    out = tmp_path
+    evaluate_datasets(["toy_copy_task"], ["bleu", "rougeL"], out)
+    nd = out / "metrics.ndjson"
+    rows = [json.loads(line) for line in nd.read_text().splitlines()]
+    assert len(rows) == 2
+    assert all(r["value"] is None for r in rows)


### PR DESCRIPTION
## Summary
- handle non-numeric metric results in `_bootstrap`
- test evaluation runner with optional metrics missing

## Testing
- `mypy --follow-imports=skip src/codex_ml/eval/eval_runner.py tests/eval/test_bleu_rouge_fallbacks.py`
- `pre-commit run --files src/codex_ml/eval/eval_runner.py tests/eval/test_bleu_rouge_fallbacks.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'click')*

------
https://chatgpt.com/codex/tasks/task_e_68bc02ff15dc83319675a62171f022dc