### PR TITLE
fix: flush token cache by buffered rows

### DIFF
--- a/tests/data/test_cache_flush_threshold.py
+++ b/tests/data/test_cache_flush_threshold.py
@@ -1,0 +1,21 @@
+import pytest
+
+from training.cache import TokenCache
+
+
+def test_cache_flush_threshold(tmp_path):
+    np = pytest.importorskip("numpy")
+    cache = TokenCache(tmp_path, rows_per_shard=3)
+    batch = {
+        "input_ids": np.zeros((2, 2), dtype=np.int64),
+        "attention_mask": np.zeros((2, 2), dtype=np.int64),
+        "labels": np.zeros((2, 2), dtype=np.int64),
+    }
+    cache.add_batch(batch)
+    assert not list(tmp_path.glob("shard_*.npz"))
+    cache.add_batch(batch)
+    shards = list(tmp_path.glob("shard_*.npz"))
+    assert len(shards) == 1
+    batches = list(TokenCache.iter_batches(tmp_path))
+    assert len(batches) == 1
+    assert batches[0]["input_ids"].shape[0] == 4


### PR DESCRIPTION
## Summary
- flush token cache once cumulative buffered rows exceed threshold
- add regression test to ensure automatic flushing

## Testing
- `pre-commit run --files training/cache.py tests/data/test_cache_flush_threshold.py`
- `mypy --explicit-package-bases training/cache.py tests/data/test_cache_flush_threshold.py`
- `nox -s tests` *(fails: assert 200 == 429 in tests/test_api_rate_limit.py::test_rate_limit)*

------
https://chatgpt.com/codex/tasks/task_e_68bc071f9460833191abdb53bbf8a798