### PR TITLE
fix(infer): allow custom artifacts path

### DIFF
--- a/src/codex_ml/cli/infer.py
+++ b/src/codex_ml/cli/infer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from datetime import datetime
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -65,7 +66,8 @@ def main(argv: list[str] | None = None) -> None:
     text = tokenizer.decode(out_ids[0], skip_special_tokens=True)
     print(text)
 
-    art_dir = Path("/artifacts/infer")
+    art_root = Path(os.getenv("ARTIFACTS_DIR", "artifacts"))
+    art_dir = art_root / "infer"
     art_dir.mkdir(parents=True, exist_ok=True)
     ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
     (art_dir / f"{ts}.txt").write_text(text, encoding="utf-8")


### PR DESCRIPTION
## Summary
- derive inference artifact directory from `ARTIFACTS_DIR` env var with a relative fallback

## Testing
- `pre-commit run --files src/codex_ml/cli/infer.py`
- `mypy src/codex_ml/cli/infer.py` *(fails: Incompatible return value type in src/codex_ml/tokenization/__init__.py)*
- `nox -s tests` *(fails: test_api_rate_limit expected 429 but got 200)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0bd7c7ac833180562724173cadf8