### PR TITLE
fix(eval): allow separate prediction field in runner

### DIFF
--- a/tests/eval/test_eval_runner_smoke.py
+++ b/tests/eval/test_eval_runner_smoke.py
@@ -1,3 +1,4 @@
+import csv as csv_mod
 import json
 
 from typer.testing import CliRunner
@@ -7,14 +8,17 @@ from codex_ml.eval import eval_runner
 
 def test_eval_runner_smoke(tmp_path):
     runner = CliRunner()
+    # create dataset with mismatched predictions
+    ds_path = tmp_path / "ds.jsonl"
+    ds_path.write_text(json.dumps({"input": "a", "target": "b", "prediction": "c"}) + "\n")
     out_dir = tmp_path / "out"
     result = runner.invoke(
         eval_runner.app,
         [
             "--datasets",
-            "toy_copy_task",
+            str(ds_path),
             "--metrics",
-            "exact_match,accuracy@token",
+            "exact_match",
             "--output-dir",
             str(out_dir),
         ],
@@ -25,9 +29,8 @@ def test_eval_runner_smoke(tmp_path):
     assert ndjson_path.exists() and csv_path.exists()
     data = json.loads(ndjson_path.read_text().strip().splitlines()[0])
     assert {"run_id", "dataset", "split", "metric", "value"}.issubset(data)
-    import csv as csv_mod
-
     with csv_path.open() as fh:
         reader = csv_mod.DictReader(fh)
         row = next(reader)
     assert row["metric"] == data["metric"]
+    assert float(row["value"]) == 0.0

--- a/tests/eval/test_schema_compat.py
+++ b/tests/eval/test_schema_compat.py
@@ -8,12 +8,14 @@ from codex_ml.eval import eval_runner
 
 def test_schema_compat(tmp_path):
     runner = CliRunner()
+    ds_path = tmp_path / "ds.jsonl"
+    ds_path.write_text(json.dumps({"input": "x", "target": "x", "prediction": "x"}) + "\n")
     out_dir = tmp_path / "out"
     result = runner.invoke(
         eval_runner.app,
         [
             "--datasets",
-            "toy_copy_task",
+            str(ds_path),
             "--metrics",
             "exact_match",
             "--output-dir",


### PR DESCRIPTION
## Summary
- allow evaluation runner to read prediction field separate from targets
- update tests to supply predictions and verify metrics

## Testing
- `pre-commit run --files src/codex_ml/eval/eval_runner.py tests/eval/test_eval_runner_smoke.py tests/eval/test_schema_compat.py`
- `nox -s tests -- tests/eval/test_registry_determinism.py tests/eval/test_bleu_rouge_fallbacks.py tests/eval/test_eval_runner_smoke.py tests/eval/test_schema_compat.py` *(failed: Command pytest -q --disable-warnings --maxfail=1 --cov --cov-branch --cov-report=term-missing --cov-fail-under=70 failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0dbd383483319d78d0ad10abe955