### PR TITLE
Add quick-start notebook and module documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,52 @@ python -m codex.cli run ingest       # ingest example data
 python -m codex.cli run ci           # run nox -s tests
 ```
 
+## Quick Start
+
+**Notebook (CPU, offline)**
+
+```bash
+python scripts/make_quickstart_notebook.py
+jupyter notebook notebooks/quick_start.ipynb
+```
+
+**Headless (CLI only)**
+
+```bash
+python -m training.engine_hf_trainer --max-steps 20 --tensorboard true
+tensorboard --logdir runs/tb
+```
+
+## Architecture Overview
+
+See [docs/architecture.md](docs/architecture.md) for a high-level module and data-flow diagram.
+
+## Examples
+
+- Train with HF Trainer on a tiny corpus
+
+  ```bash
+  python -m training.engine_hf_trainer --max-steps 20 --tensorboard true
+  ```
+
+- Evaluate a checkpoint with the evaluation runner
+
+  ```bash
+  python -m codex_ml.eval.eval_runner run --datasets toy_copy_task --metrics ppl --output_dir runs/eval
+  ```
+
+- Train a tokenizer offline
+
+  ```bash
+  python -m codex_ml.tokenization.train_tokenizer --input-file corpus.txt --output-dir runs/tokenizer --vocab-size 8000
+  ```
+
+- View TensorBoard logs
+
+  ```bash
+  tensorboard --logdir runs/tb
+  ```
+
 ## Evaluation & Metrics
 
 `codex_ml.eval.eval_runner` offers a tiny evaluation loop and a registry of

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Documentation Index
+
+- [System Architecture](./architecture.md)
+- Modules
+  - [Training Engine](./modules/training_engine.md)
+  - [Evaluation Runner](./modules/evaluation_runner.md)
+  - [Checkpoint Manager](./modules/checkpoint_manager.md)
+  - [Tokenizer Trainer](./modules/tokenizer_trainer.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,13 +1,20 @@
-# Architecture Overview
+# System Architecture
 
 ```mermaid
-graph TD
-    Client -->|REST| API[FastAPI Service]
-    API --> Queue
-    Queue --> Trainer[Training Jobs]
-    Trainer --> Artifacts
+flowchart LR
+    A[Ingestion] --> B[Tokenizer]
+    B --> C[Datasets]
+    C --> D[Model Loader]
+    D --> E{Training Engine}
+    E --> F[Metrics]
+    F --> G[Logging]
+    G --> H[Experiment Tracking]
+    E --> I[Checkpoint Manager]
 ```
 
-The FastAPI service exposes `/infer`, `/train`, and `/evaluate` endpoints.
-Requests are enqueued and processed by background workers that write
-artifacts and metrics to disk for offline inspection.
+**Legend**
+
+- Solid nodes are required.
+- Dashed arrows/nodes (not shown) can represent optional components such as LoRA/PEFT adapters, offline trackers (TensorBoard, MLflow, W&B), and the async NDJSON writer.
+
+The flow begins with raw data ingestion, followed by tokenization and dataset creation. A model loader prepares either a tiny in-repo model or a cached Hugging Face checkpoint. The training engine (HF Trainer or a custom loop) consumes datasets and produces metrics. Metrics feed into logging and optional experiment tracking backends while checkpoints enable resume and evaluation.

--- a/docs/modules/checkpoint_manager.md
+++ b/docs/modules/checkpoint_manager.md
@@ -1,0 +1,10 @@
+# Checkpoint Manager
+
+`CheckpointManager` keeps recent and best checkpoints.
+
+- `keep_last`: number of recent checkpoints to retain.
+- `keep_best`: retain checkpoints with best metric.
+- `save(step, model, optimizer, scheduler, metrics=...)` persists state.
+- `resume_from(path, ...)` restores model and optimizer.
+
+Checkpoints include RNG state for deterministic resume.

--- a/docs/modules/evaluation_runner.md
+++ b/docs/modules/evaluation_runner.md
@@ -1,0 +1,11 @@
+# Evaluation Runner
+
+`codex_ml.eval.eval_runner` evaluates saved models or generic text outputs.
+
+## Usage
+
+```bash
+python -m codex_ml.eval.eval_runner run --datasets toy_copy_task --metrics exact_match,ppl --output_dir runs/eval
+```
+
+It writes `metrics.ndjson` and `metrics.csv` with optional bootstrap confidence intervals (`--bootstrap N`). The runner loads datasets via `codex_ml.eval.dataset_loader` and metrics from `codex_ml.metrics.registry`.

--- a/docs/modules/tokenizer_trainer.md
+++ b/docs/modules/tokenizer_trainer.md
@@ -1,0 +1,11 @@
+# Tokenizer Trainer
+
+`codex_ml.tokenization.train_tokenizer` trains a SentencePiece tokenizer and exports `tokenizer.json`.
+
+## CLI
+
+```bash
+python -m codex_ml.tokenization.train_tokenizer --input-file corpus.txt --output-dir runs/tokenizer --vocab-size 8000
+```
+
+It produces a `tokenizer.model` and HF-compatible artifacts that can be loaded with `interfaces.tokenizer.HFTokenizer`.

--- a/docs/modules/training_engine.md
+++ b/docs/modules/training_engine.md
@@ -1,0 +1,15 @@
+# Training Engine
+
+The training engine abstracts model optimization.
+
+## Modes
+- `hf_trainer`: wraps `transformers.Trainer` for causal language modeling.
+- `custom`: a minimal deterministic loop in `training/functional_training.py`.
+
+## Key Options
+- `--engine hf_trainer|custom`
+- `--max-steps` limit total updates
+- `--checkpoint-dir` directory for periodic checkpoints
+- `--resume-from` resume training from a checkpoint
+
+Both modes log metrics to TensorBoard when `--tensorboard true` is supplied.

--- a/notebooks/quick_start.ipynb
+++ b/notebooks/quick_start.ipynb
@@ -1,0 +1,205 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8e165f02",
+   "metadata": {},
+   "source": [
+    "# Codex Quick‑Start (Offline)\n",
+    "\n",
+    "This notebook trains a tiny model on a synthetic dataset and logs metrics to TensorBoard. It is designed to run **offline** on CPU in under two minutes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa7ecdba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "import os\n",
+    "import random\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import torch\n",
+    "from datasets import Dataset\n",
+    "from transformers import DataCollatorForLanguageModeling, Trainer, TrainingArguments\n",
+    "\n",
+    "from codex_ml.modeling.codex_model_loader import load_model_with_optional_lora\n",
+    "from codex_ml.tokenization.train_tokenizer import TrainTokenizerConfig\n",
+    "from codex_ml.tokenization.train_tokenizer import run as train_tokenizer\n",
+    "from interfaces.tokenizer import HFTokenizer\n",
+    "\n",
+    "random.seed(0)\n",
+    "torch.manual_seed(0)\n",
+    "print(\"PyTorch\", torch.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "454e9af8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 1) Build a tiny in-memory corpus\n",
+    "texts = [\"hello world\", \"foo bar\", \"lorem ipsum\"] * 100\n",
+    "Path(\"runs\").mkdir(exist_ok=True)\n",
+    "with open(\"runs/tiny_corpus.txt\", \"w\", encoding=\"utf-8\") as fh:\n",
+    "    fh.write(\"\\n\".join(texts))\n",
+    "texts[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e45f23a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 2) Train a tokenizer from the corpus (offline)\n",
+    "cfg = TrainTokenizerConfig(\n",
+    "    input_file=\"runs/tiny_corpus.txt\", output_dir=\"runs/tokenizer\", vocab_size=50\n",
+    ")\n",
+    "train_tokenizer(cfg)\n",
+    "tk = HFTokenizer(\n",
+    "    name_or_path=None,\n",
+    "    artifacts_dir=\"runs/tokenizer\",\n",
+    "    max_length=64,\n",
+    "    padding=\"max_length\",\n",
+    "    truncation=True,\n",
+    ")\n",
+    "print(\"Vocab size\", tk.vocab_size)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93351af9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 3) Prepare datasets\n",
+    "\n",
+    "ds = Dataset.from_dict({\"text\": texts})\n",
+    "\n",
+    "\n",
+    "def encode(batch):\n",
+    "    ids = tk.batch_encode(batch[\"text\"])\n",
+    "    return {\"input_ids\": ids, \"labels\": ids}\n",
+    "\n",
+    "\n",
+    "tokenized = ds.map(encode, batched=True, remove_columns=[\"text\"])\n",
+    "split = tokenized.train_test_split(test_size=0.2, seed=0)\n",
+    "train_ds, val_ds = split[\"train\"], split[\"test\"]\n",
+    "len(train_ds), len(val_ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b476e2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 4) Load a tiny decoder-only model\n",
+    "model = load_model_with_optional_lora(\n",
+    "    \"decoder_only\",\n",
+    "    model_config={\n",
+    "        \"vocab_size\": tk.vocab_size,\n",
+    "        \"d_model\": 32,\n",
+    "        \"n_heads\": 4,\n",
+    "        \"n_layers\": 2,\n",
+    "        \"max_seq_len\": 64,\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10a151b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 5) Train with HF Trainer\n",
+    "collator = DataCollatorForLanguageModeling(tk._tk, mlm=False)\n",
+    "args = TrainingArguments(\n",
+    "    output_dir=\"runs/quickstart\",\n",
+    "    per_device_train_batch_size=4,\n",
+    "    per_device_eval_batch_size=4,\n",
+    "    max_steps=20,\n",
+    "    eval_steps=10,\n",
+    "    logging_steps=5,\n",
+    "    save_steps=20,\n",
+    "    report_to=[\"tensorboard\"],\n",
+    "    logging_dir=\"runs/tb\",\n",
+    "    remove_unused_columns=False,\n",
+    ")\n",
+    "trainer = Trainer(\n",
+    "    model=model, args=args, train_dataset=train_ds, eval_dataset=val_ds, data_collator=collator\n",
+    ")\n",
+    "trainer.train()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe7d1129",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 6) Evaluate and log perplexity\n",
+    "import csv\n",
+    "\n",
+    "metrics = trainer.evaluate()\n",
+    "ppl = math.exp(metrics[\"eval_loss\"])\n",
+    "with open(\"runs/eval.csv\", \"w\", newline=\"\", encoding=\"utf-8\") as f:\n",
+    "    writer = csv.writer(f)\n",
+    "    writer.writerow([\"metric\", \"value\"])\n",
+    "    writer.writerow([\"perplexity\", ppl])\n",
+    "print(\"Perplexity\", ppl)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "712cca79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 7) Inspect generated checkpoints\n",
+    "os.listdir(\"runs/quickstart\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61392d35",
+   "metadata": {},
+   "source": [
+    "TensorBoard logs are written under `runs/tb`.\n",
+    "Launch with:\n",
+    "\n",
+    "```\n",
+    "tensorboard --logdir runs/tb\n",
+    "```\n",
+    "\n",
+    "Remove the `runs/` directory to clean up.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/noxfile.py
+++ b/noxfile.py
@@ -265,3 +265,26 @@ def sec_scan(session):
     session.run("bandit", "-c", "bandit.yaml", "-r", ".")
     session.run("detect-secrets", "scan", "--baseline", ".secrets.baseline", ".")
     session.run("pip-audit", "-r", "requirements.txt")
+
+
+@nox.session
+def docs_smoke(session):
+    _ensure_pip_cache(session)
+    _install(session, "nbformat")
+    session.run(
+        "python",
+        "-c",
+        "import nbformat; nbformat.read('notebooks/quick_start.ipynb', as_version=4)",
+    )
+    session.run(
+        "python",
+        "-c",
+        (
+            "from pathlib import Path,sys,re;"
+            "arch=Path('docs/architecture.md').read_text(encoding='utf-8');"
+            "assert '```mermaid' in arch;"
+            "readme=Path('README.md').read_text(encoding='utf-8');"
+            "missing=[p for p in re.findall(r'\\[(?:[^\\]]+)\\]\\((docs/[^)]+)\\)', readme) if not Path(p).exists()];"
+            "sys.exit('Missing docs: '+', '.join(missing)) if missing else None"
+        ),
+    )

--- a/scripts/make_quickstart_notebook.py
+++ b/scripts/make_quickstart_notebook.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import nbformat as nbf
+
+
+def main() -> None:
+    nb = nbf.v4.new_notebook()
+    nb.metadata["kernelspec"] = {
+        "display_name": "Python 3",
+        "language": "python",
+        "name": "python3",
+    }
+    nb.metadata["language_info"] = {"name": "python", "pygments_lexer": "ipython3"}
+
+    cells = []
+    cells.append(
+        nbf.v4.new_markdown_cell(
+            """# Codex Quick‑Start (Offline)
+
+This notebook trains a tiny model on a synthetic dataset and logs metrics to TensorBoard. It is designed to run **offline** on CPU in under two minutes.
+"""
+        )
+    )
+    cells.append(
+        nbf.v4.new_code_cell(
+            """import os, random, math
+from pathlib import Path
+import torch
+from datasets import Dataset
+from transformers import DataCollatorForLanguageModeling, Trainer, TrainingArguments
+from codex_ml.modeling.codex_model_loader import load_model_with_optional_lora
+from codex_ml.tokenization.train_tokenizer import TrainTokenizerConfig, run as train_tokenizer
+from interfaces.tokenizer import HFTokenizer
+random.seed(0)
+torch.manual_seed(0)
+print('PyTorch', torch.__version__)
+"""
+        )
+    )
+    cells.append(
+        nbf.v4.new_code_cell(
+            """# 1) Build a tiny in-memory corpus
+texts = ['hello world', 'foo bar', 'lorem ipsum'] * 100
+Path('runs').mkdir(exist_ok=True)
+with open('runs/tiny_corpus.txt', 'w', encoding='utf-8') as fh:
+    fh.write('\\n'.join(texts))
+texts[:3]
+"""
+        )
+    )
+    cells.append(
+        nbf.v4.new_code_cell(
+            """# 2) Train a tokenizer from the corpus (offline)
+cfg = TrainTokenizerConfig(input_file='runs/tiny_corpus.txt', output_dir='runs/tokenizer', vocab_size=50)
+train_tokenizer(cfg)
+tk = HFTokenizer(name_or_path=None, artifacts_dir='runs/tokenizer', max_length=64, padding='max_length', truncation=True)
+print('Vocab size', tk.vocab_size)
+"""
+        )
+    )
+    cells.append(
+        nbf.v4.new_code_cell(
+            """# 3) Prepare datasets
+
+ds = Dataset.from_dict({'text': texts})
+
+def encode(batch):
+    ids = tk.batch_encode(batch['text'])
+    return {'input_ids': ids, 'labels': ids}
+
+tokenized = ds.map(encode, batched=True, remove_columns=['text'])
+split = tokenized.train_test_split(test_size=0.2, seed=0)
+train_ds, val_ds = split['train'], split['test']
+len(train_ds), len(val_ds)
+"""
+        )
+    )
+    cells.append(
+        nbf.v4.new_code_cell(
+            """# 4) Load a tiny decoder-only model
+model = load_model_with_optional_lora('decoder_only', model_config={'vocab_size': tk.vocab_size, 'd_model':32, 'n_heads':4, 'n_layers':2, 'max_seq_len':64})
+"""
+        )
+    )
+    cells.append(
+        nbf.v4.new_code_cell(
+            """# 5) Train with HF Trainer
+collator = DataCollatorForLanguageModeling(tk._tk, mlm=False)
+args = TrainingArguments(
+    output_dir='runs/quickstart',
+    per_device_train_batch_size=4,
+    per_device_eval_batch_size=4,
+    max_steps=20,
+    eval_steps=10,
+    logging_steps=5,
+    save_steps=20,
+    report_to=['tensorboard'],
+    logging_dir='runs/tb',
+    remove_unused_columns=False,
+)
+trainer = Trainer(model=model, args=args, train_dataset=train_ds, eval_dataset=val_ds, data_collator=collator)
+trainer.train()
+"""
+        )
+    )
+    cells.append(
+        nbf.v4.new_code_cell(
+            """# 6) Evaluate and log perplexity
+import csv
+metrics = trainer.evaluate()
+ppl = math.exp(metrics['eval_loss'])
+with open('runs/eval.csv', 'w', newline='', encoding='utf-8') as f:
+    writer = csv.writer(f)
+    writer.writerow(['metric', 'value'])
+    writer.writerow(['perplexity', ppl])
+print('Perplexity', ppl)
+"""
+        )
+    )
+    cells.append(
+        nbf.v4.new_code_cell(
+            """# 7) Inspect generated checkpoints
+import os
+os.listdir('runs/quickstart')
+"""
+        )
+    )
+    cells.append(
+        nbf.v4.new_markdown_cell(
+            """TensorBoard logs are written under `runs/tb`.
+Launch with:
+
+```
+tensorboard --logdir runs/tb
+```
+
+Remove the `runs/` directory to clean up.
+"""
+        )
+    )
+
+    nb.cells = cells
+    nbf.write(nb, "notebooks/quick_start.ipynb")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add offline quick-start notebook and generation script
- document system architecture and module guides
- extend README with quick start, architecture overview, and examples
- add docs smoke nox session

## Testing
- `pre-commit run --files README.md docs/architecture.md noxfile.py docs/README.md docs/modules/training_engine.md docs/modules/evaluation_runner.md docs/modules/checkpoint_manager.md docs/modules/tokenizer_trainer.md scripts/make_quickstart_notebook.py notebooks/quick_start.ipynb`
- `nox -s tests` *(fails: ImportError in tests/checkpointing/test_atomicity_and_resume.py)*
- `nox -s docs_smoke`

------
https://chatgpt.com/codex/tasks/task_e_68bc13558bc08331ab2f2fcaa9e91c53