### PR TITLE
Preserve best checkpoint during pruning

### DIFF
--- a/tests/checkpointing/test_best_not_pruned.py
+++ b/tests/checkpointing/test_best_not_pruned.py
@@ -1,0 +1,14 @@
+import os
+
+from training.checkpoint_manager import CheckpointManager
+
+
+def test_best_not_pruned(tmp_path):
+    mgr = CheckpointManager(tmp_path, keep_last=1, metric="loss", mode="min")
+    mgr.save_now(1, b"x", {"loss": 1.0})
+    # Save a worse checkpoint that would trigger pruning
+    mgr.save_now(2, b"y", {"loss": 2.0})
+    best_link = tmp_path / "best"
+    assert os.readlink(best_link) == "ckpt-1.pt"
+    assert (tmp_path / "ckpt-1.pt").exists()
+    assert (tmp_path / "ckpt-2.pt").exists()

--- a/training/checkpoint_manager.py
+++ b/training/checkpoint_manager.py
@@ -131,7 +131,15 @@ class CheckpointManager:
             return
         pattern = f"{prefix}-*.pt"
         ckpts = sorted(self.root.glob(pattern), key=self._extract_step)
+        best_path: Optional[Path] = None
+        if self._best_file.is_symlink():
+            try:
+                best_path = self.root / os.readlink(self._best_file)
+            except OSError:
+                best_path = None
         for p in ckpts[: -self.keep_last]:
+            if best_path is not None and p == best_path:
+                continue
             try:
                 p.unlink()
             except FileNotFoundError:


### PR DESCRIPTION
## Summary
- skip pruning checkpoint referenced by `best` symlink
- add regression test ensuring best checkpoint survives trim

## Testing
- `pre-commit run --files training/checkpoint_manager.py tests/checkpointing/test_best_not_pruned.py`
- `mypy training/checkpoint_manager.py tests/checkpointing/test_best_not_pruned.py` *(fails: Module "codex_ml.utils.checkpointing" has no attribute "build_payload_bytes")*
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'typer')*
- `pytest tests/checkpointing/test_best_not_pruned.py -q -o addopts=`


------
https://chatgpt.com/codex/tasks/task_e_68bc6c25fd748331a7604d4772847535