### PR TITLE
Clarify base training config

### DIFF
--- a/configs/training/base.yaml
+++ b/configs/training/base.yaml
@@ -1,4 +1,5 @@
-# Default training configuration for Codex.
+# Minimal base training configuration for Codex.
+# Provides sane defaults for tests and small-scale experiments.
 model_name: "sshleifer/tiny-gpt2"
 tokenizer_name: null  # Use model_name
 tokenizer_path: null  # Optional local tokenizer path


### PR DESCRIPTION
## Summary
- document base training configuration for Codex tests and small experiments

## Testing
- `nox -s tests` *(fails: required packages like torch would need large downloads)*
- `pre-commit run --files configs/training/base.yaml` *(fails: KeyboardInterrupt during environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bc79b33df483318c5fdb6054c18a5e