### PR TITLE
feat: add config, safety filter, evaluation and model registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,12 @@ See [docs/architecture.md](docs/architecture.md) for a high-level module and dat
   ```bash
   python -m training.engine_hf_trainer --max-steps 20 --tensorboard true
   ```
+  Default hyperparameters reside in `configs/training/base.yaml` and are used when available.
 
 - Evaluate a checkpoint with the evaluation runner
 
   ```bash
-  python -m codex_ml.eval.eval_runner run --datasets toy_copy_task --metrics ppl --output_dir runs/eval
+  python -m codex_ml.eval.eval_runner run --datasets toy_copy_task --metrics ppl --output-dir runs/eval --max-samples 1
   ```
 
 - Train a tokenizer offline
@@ -833,7 +834,7 @@ export MLFLOW_TRACKING_URI="file:./mlruns"
 
 ## Data Handling
 
-Utilities in `codex_ml.data_utils` help manage large text corpora deterministically.
+Utilities in `codex_ml.data_utils` help manage large text corpora deterministically and redact basic PII/secret patterns before splitting.
 
 ```python
 from codex_ml.data_utils import split_dataset, stream_texts
@@ -888,8 +889,10 @@ No GitHub Actions are enabled; all checks execute in this local environment.
 
 The `codex_ml.models.decoder_only` module provides a tiny GPT-style network
 implemented purely in PyTorch.  It supports rotary embeddings, causal
-attention, optional LoRA adapters and a small generation helper.  The model is
-intended for tests and local smoke experiments rather than production use.
+attention, optional LoRA adapters and a small generation helper.  Models can
+also be discovered via `codex_ml.models.registry.get_model`; the MiniLM config
+is registered as `"minilm"`.  The model is intended for tests and local smoke
+experiments rather than production use.
 
 Example smoke test:
 

--- a/configs/training/base.yaml
+++ b/configs/training/base.yaml
@@ -1,28 +1,18 @@
-# Minimal base training configuration for Codex.
-# Provides sane defaults for tests and small-scale experiments.
-model_name: "sshleifer/tiny-gpt2"
-tokenizer_name: null  # Use model_name
-tokenizer_path: null  # Optional local tokenizer path
-use_fast_tokenizer: true
-precision: "fp16"
+# Default hyperparameters for HF trainer
+output_dir: ${oc.env:CODEX_OUTPUT_DIR, "runs/default"}
+num_train_epochs: 3
+per_device_train_batch_size: 8
+per_device_eval_batch_size: 8
+learning_rate: 3e-5
+weight_decay: 0.01
 gradient_accumulation_steps: 1
-epochs: 3
-val_split: 0.1
-test_split: 0.0
-logging:
-  tensorboard: true
-  mlflow_enable: false
-  wandb_enable: false
-checkpoint:
-  dir: "./checkpoints"
-  save_steps: 100
-# TrainingArguments defaults
-output_dir: ./outputs
-overwrite_output_dir: true
-per_device_train_batch_size: 2
-num_train_epochs: 1
-logging_steps: 1
-save_steps: 1
-lora_r: null
-lora_alpha: 16
-checkpoint_dir: null
+logging_steps: 10
+save_steps: 50
+evaluation_strategy: "steps"
+eval_steps: 50
+fp16: false
+lora:
+  enable: false
+  r: 4
+  alpha: 16
+  dropout: 0.1

--- a/src/codex_ml/data_utils.py
+++ b/src/codex_ml/data_utils.py
@@ -13,6 +13,8 @@ import random
 from pathlib import Path
 from typing import Iterable, Iterator, Tuple
 
+from codex_ml.safety import SafetyConfig, sanitize_prompt
+
 
 def split_dataset(
     texts: Iterable[str],
@@ -36,6 +38,9 @@ def split_dataset(
         ``(train_texts, val_texts)``
     """
     items = list(texts)
+    # Apply safety sanitisation before splitting
+    cfg = SafetyConfig()
+    items = [sanitize_prompt(t, cfg).get("text", t) for t in items]
     if cache_path is not None:
         p = Path(cache_path)
         if p.exists():

--- a/src/codex_ml/eval/eval_runner.py
+++ b/src/codex_ml/eval/eval_runner.py
@@ -53,6 +53,7 @@ def evaluate_datasets(
     *,
     bootstrap: int = 0,
     seed: int = 0,
+    max_samples: int = 0,
 ) -> None:
     """Evaluate metrics over datasets and write NDJSON/CSV logs to output_dir."""
     out = Path(output_dir)
@@ -69,6 +70,7 @@ def evaluate_datasets(
                 "dataset",
                 "split",
                 "step",
+                "epoch",
                 "metric",
                 "value",
                 "n",
@@ -81,7 +83,7 @@ def evaluate_datasets(
         writer.writeheader()
 
         for name in datasets:
-            examples = load_dataset(name)
+            examples = load_dataset(name, max_samples=max_samples if max_samples > 0 else None)
             preds = [ex.input for ex in examples]
             targets = [ex.target for ex in examples]
             for metric_name in metrics:
@@ -92,6 +94,7 @@ def evaluate_datasets(
                     "dataset": name,
                     "split": "eval",
                     "step": 0,
+                    "epoch": 0,
                     "metric": metric_name,
                     "value": val,
                     "n": len(examples),
@@ -115,17 +118,17 @@ if typer is not None:  # pragma: no cover
         datasets: str = typer.Option(..., help="Comma-separated dataset names"),
         metrics: str = typer.Option(..., help="Comma-separated metric names"),
         output_dir: str = typer.Option("runs/eval", help="Output directory"),
-        max_samples: int = typer.Option(0, help="Maximum samples per split"),  # unused placeholder
+        max_samples: int = typer.Option(0, help="Maximum samples per split"),
         seed: int = typer.Option(0, help="Random seed"),
         bootstrap: int = typer.Option(0, help="Bootstrap resamples for CI"),
     ) -> None:
-        _ = max_samples  # placeholder for parity with spec
         evaluate_datasets(
             datasets=[d.strip() for d in datasets.split(",") if d.strip()],
             metrics=[m.strip() for m in metrics.split(",") if m.strip()],
             output_dir=output_dir,
             bootstrap=bootstrap,
             seed=seed,
+            max_samples=max_samples,
         )
 
     if __name__ == "__main__":

--- a/src/codex_ml/models/minilm.py
+++ b/src/codex_ml/models/minilm.py
@@ -12,7 +12,10 @@ from typing import Optional
 import torch
 from torch import nn
 
+from .registry import register_model
 
+
+@register_model("minilm")
 @dataclass
 class MiniLMConfig:
     vocab_size: int
@@ -79,9 +82,7 @@ class MiniLM(nn.Module):
         torch.save(self.state_dict(), path / "pytorch_model.bin")
 
     @classmethod
-    def from_pretrained(
-        cls, path: str | Path, *, device: Optional[str] = None
-    ) -> "MiniLM":
+    def from_pretrained(cls, path: str | Path, *, device: Optional[str] = None) -> "MiniLM":
         path = Path(path)
         with (path / "config.json").open() as f:
             cfg = MiniLMConfig(**json.load(f))

--- a/src/codex_ml/models/registry.py
+++ b/src/codex_ml/models/registry.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+MODELS: Dict[str, Callable[..., object]] = {}
+
+
+def register_model(name: str) -> Callable[[Callable[..., object]], Callable[..., object]]:
+    def deco(fn: Callable[..., object]) -> Callable[..., object]:
+        MODELS[name] = fn
+        return fn
+
+    return deco
+
+
+def get_model(name: str) -> Callable[..., object]:
+    if name not in MODELS:
+        raise KeyError(f"Unknown model: {name}")
+    return MODELS[name]
+
+
+__all__ = ["register_model", "get_model"]

--- a/tests/data/test_safety_filter_split.py
+++ b/tests/data/test_safety_filter_split.py
@@ -1,0 +1,7 @@
+from codex_ml.data_utils import split_dataset
+
+
+def test_split_dataset_redacts_sensitive_text():
+    texts = ["my ssn is 123-45-6789", "hello"]
+    train, val = split_dataset(texts, train_ratio=1.0, seed=0)
+    assert "123-45-6789" not in train[0]

--- a/tests/eval/test_eval_runner_max_samples.py
+++ b/tests/eval/test_eval_runner_max_samples.py
@@ -1,0 +1,11 @@
+import json
+from pathlib import Path
+
+from codex_ml.eval.eval_runner import evaluate_datasets
+
+
+def test_evaluate_datasets_max_samples(tmp_path: Path):
+    evaluate_datasets(["toy_copy_task"], ["exact_match"], tmp_path, max_samples=1)
+    ndjson_path = tmp_path / "metrics.ndjson"
+    record = json.loads(ndjson_path.read_text().strip().splitlines()[0])
+    assert record["n"] == 1

--- a/tests/modeling/test_model_registry.py
+++ b/tests/modeling/test_model_registry.py
@@ -1,0 +1,7 @@
+from codex_ml.models import minilm
+from codex_ml.models.registry import get_model
+
+
+def test_get_model_returns_minilm_config():
+    cfg_cls = get_model("minilm")
+    assert cfg_cls is minilm.MiniLMConfig

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -474,8 +474,11 @@ def load_training_arguments(
     # Load base config from Hydra when provided
     if hydra_cfg is not None:
         cfg.update(hydra_cfg)
-    elif path is not None and path.exists():
-        cfg.update(yaml.safe_load(path.read_text()))
+    elif path is not None:
+        if path.exists():
+            cfg.update(yaml.safe_load(path.read_text()))
+        else:
+            print(f"[warning] config {path} missing, using default training args")
     cfg.setdefault("output_dir", str(output_dir))
     cfg["output_dir"] = str(output_dir)
 


### PR DESCRIPTION
## Summary
- add default training config and warn when config missing
- apply safety sanitization before dataset splitting
- extend eval runner with max sample limit and epoch field
- introduce simple model registry and register MiniLM
- document new options in README

## Testing
- `SKIP=pip-audit pre-commit run --files configs/training/base.yaml training/engine_hf_trainer.py src/codex_ml/data_utils.py src/codex_ml/eval/eval_runner.py src/codex_ml/models/registry.py src/codex_ml/models/minilm.py tests/data/test_safety_filter_split.py tests/eval/test_eval_runner_max_samples.py tests/modeling/test_model_registry.py README.md`
- `nox -s tests` *(fails: large dependency downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7ef6bae083319667c4636a762a13