### PR TITLE
feat(config): add hydra loader with fallback

### DIFF
--- a/configs/training/base.yaml
+++ b/configs/training/base.yaml
@@ -1,3 +1,18 @@
+# Primary training config (Hydra)
+# See: https://hydra.cc/docs/tutorials/basic/your_first_app/config_file/
+defaults: []
+
+training:
+  seed: 42
+  lr: 0.001
+  batch_size: 32
+  epochs: 3
+
+logging:
+  enable_tensorboard: false
+  enable_wandb: false
+  mlflow_enable: false
+
 # Default hyperparameters for HF trainer
 output_dir: ${oc.env:CODEX_OUTPUT_DIR, "runs/default"}
 num_train_epochs: 3

--- a/docs/ops/training_args.md
+++ b/docs/ops/training_args.md
@@ -5,7 +5,9 @@
 - **gradient_accumulation_steps**: accumulate before optimizer step.
 - **early_stopping**: enable with patience/min_delta; wire to callbacks.EarlyStopping in your trainer loop.
 
-The repository ships with a base configuration at `configs/training/base.yaml`.
+This module **prefers Hydra configs** under `configs/training/` (`base.yaml` as primary).
+If the file is missing, the training entry uses a **deterministic programmatic fallback**
+via `codex_ml.utils.config_loader.load_training_cfg()`; when the file exists, Hydra **Compose API** is used.
 Override any field with Hydra-style CLI arguments, e.g.:
 
 ```bash

--- a/src/codex_ml/utils/config_loader.py
+++ b/src/codex_ml/utils/config_loader.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hydra import compose, initialize
+from hydra.errors import MissingConfigException
+from omegaconf import DictConfig, OmegaConf
+
+_CFG_DIR = Path("configs/training")
+_PRIMARY = "base"
+
+
+@dataclass
+class TrainingDefaults:
+    seed: int = 42
+    lr: float = 1e-3
+    batch_size: int = 32
+    epochs: int = 3
+    logging: Dict[str, Any] | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "training": {
+                "seed": self.seed,
+                "lr": self.lr,
+                "batch_size": self.batch_size,
+                "epochs": self.epochs,
+            },
+            "logging": self.logging
+            or {
+                "enable_tensorboard": False,
+                "enable_wandb": False,
+                "mlflow_enable": False,
+            },
+        }
+
+
+def load_training_cfg(
+    *, allow_fallback: bool = True, overrides: Optional[list[str]] = None
+) -> DictConfig:
+    """Load Hydra config from ``configs/training/base.yaml`` with fallback.
+
+    When the config file is missing and ``allow_fallback`` is ``True`` a
+    deterministic programmatic configuration is returned.
+    """
+
+    overrides = overrides or []
+
+    if _CFG_DIR.is_dir() and (_CFG_DIR / f"{_PRIMARY}.yaml").is_file():
+        # Hydra Compose API: https://hydra.cc/docs/advanced/compose_api/
+        with initialize(version_base=None, config_path=str(_CFG_DIR)):
+            return compose(config_name=_PRIMARY, overrides=overrides)
+
+    if not allow_fallback:
+        raise MissingConfigException(
+            missing_cfg_file=f"{_CFG_DIR}/{_PRIMARY}.yaml",
+            message="Config file missing",
+        )
+
+    base = TrainingDefaults().to_dict()
+    cfg = OmegaConf.create(base)
+    if overrides:
+        for item in overrides:
+            key, value = item.split("=", 1)
+            OmegaConf.update(cfg, key, OmegaConf.create(value), merge=True)
+    return cfg

--- a/tests/training/test_config_loading.py
+++ b/tests/training/test_config_loading.py
@@ -1,0 +1,73 @@
+import shutil
+from pathlib import Path
+
+import pytest
+from omegaconf import DictConfig
+
+from codex_ml.utils.config_loader import load_training_cfg
+
+CFG_DIR = Path("configs/training")
+BASE = CFG_DIR / "base.yaml"
+
+
+@pytest.fixture
+def ensure_cfg_dir(tmp_path, monkeypatch):
+    """Work inside a temp copy of the repo root."""
+
+    cwd = Path.cwd()
+    tmp_repo = tmp_path / "repo"
+    shutil.copytree(cwd, tmp_repo, dirs_exist_ok=True)
+    monkeypatch.chdir(tmp_repo)
+    yield tmp_repo
+
+
+@pytest.mark.parametrize("with_file", [True, False], ids=["file_based", "no_file_fallback"])
+def test_loader_file_and_fallback(ensure_cfg_dir, with_file):
+    if with_file:
+        CFG_DIR.mkdir(parents=True, exist_ok=True)
+        BASE.write_text(
+            "defaults: []\n"
+            "training:\n"
+            "  seed: 123\n"
+            "  lr: 0.002\n"
+            "  batch_size: 16\n"
+            "  epochs: 1\n",
+            encoding="utf-8",
+        )
+    else:
+        if BASE.exists():
+            BASE.unlink()
+
+    cfg: DictConfig = load_training_cfg(allow_fallback=True)
+    assert "training" in cfg
+    expected_lr = 0.002 if with_file else 0.001
+    assert pytest.approx(cfg.training.lr) == expected_lr
+
+
+def test_compose_api_when_file_exists(ensure_cfg_dir):
+    from hydra import compose, initialize
+
+    CFG_DIR.mkdir(parents=True, exist_ok=True)
+    BASE.write_text("defaults: []\ntraining:\n  lr: 0.003\n", encoding="utf-8")
+    with initialize(version_base=None, config_path=str(CFG_DIR)):
+        cfg = compose(config_name="base", overrides=["training.batch_size=8"])
+    assert cfg.training.lr == 0.003
+    assert cfg.training.batch_size == 8
+
+
+def test_missing_config_hard_fail(ensure_cfg_dir):
+    from hydra.errors import MissingConfigException
+
+    if BASE.exists():
+        BASE.unlink()
+    with pytest.raises(MissingConfigException):
+        load_training_cfg(allow_fallback=False)
+
+
+@pytest.mark.skipif(not BASE.exists(), reason="Config file missing; skip file-only invariant")
+def test_file_mode_invariant(ensure_cfg_dir):
+    from hydra import compose, initialize
+
+    with initialize(version_base=None, config_path=str(CFG_DIR)):
+        cfg = compose(config_name="base")
+        assert "training" in cfg

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -521,6 +521,7 @@ def load_training_arguments(
         "test_split",
         "logging",
         "checkpoint",
+        "training",
     ):
         cfg.pop(extra, None)
 


### PR DESCRIPTION
## Summary
- scaffold primary Hydra training config with basic defaults and logging flags
- add a reusable `load_training_cfg` helper that falls back to programmatic defaults
- document new loader and add tests for file-based and fallback config paths

## Testing
- `pre-commit run --files configs/training/base.yaml docs/ops/training_args.md training/engine_hf_trainer.py src/codex_ml/utils/config_loader.py tests/training/test_config_loading.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'typer')*
- `.nox/coverage/bin/pip install typer`
- `.nox/coverage/bin/pip install hydra-core omegaconf`
- `.nox/coverage/bin/pytest -q --disable-warnings --maxfail=1 --cov --cov-branch --cov-report=term-missing --cov-fail-under=70` *(fails: tests/checkpointing/test_periodic_and_trim.py::test_periodic_and_trim)*

------
https://chatgpt.com/codex/tasks/task_e_68bca0bccef4833187c70216c861ce9d