### PR TITLE
refactor: hydra config loader and tests

### DIFF
--- a/src/codex_ml/utils/config_loader.py
+++ b/src/codex_ml/utils/config_loader.py
@@ -4,11 +4,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hydra import compose, initialize
+from hydra import compose, initialize_config_dir
 from hydra.errors import MissingConfigException
 from omegaconf import DictConfig, OmegaConf
 
-_CFG_DIR = Path("configs/training")
+_CFG_DIR = Path("configs/training")  # resolved relative to cwd at call time
 _PRIMARY = "base"
 
 
@@ -48,9 +48,10 @@ def load_training_cfg(
 
     overrides = overrides or []
 
-    if _CFG_DIR.is_dir() and (_CFG_DIR / f"{_PRIMARY}.yaml").is_file():
+    cfg_dir = Path.cwd() / _CFG_DIR
+    if cfg_dir.is_dir() and (cfg_dir / f"{_PRIMARY}.yaml").is_file():
         # Hydra Compose API: https://hydra.cc/docs/advanced/compose_api/
-        with initialize(version_base=None, config_path=str(_CFG_DIR)):
+        with initialize_config_dir(version_base=None, config_dir=str(cfg_dir)):
             return compose(config_name=_PRIMARY, overrides=overrides)
 
     if not allow_fallback:

--- a/tests/training/test_config_loading.py
+++ b/tests/training/test_config_loading.py
@@ -45,11 +45,12 @@ def test_loader_file_and_fallback(ensure_cfg_dir, with_file):
 
 
 def test_compose_api_when_file_exists(ensure_cfg_dir):
-    from hydra import compose, initialize
+    from hydra import compose, initialize_config_dir
 
     CFG_DIR.mkdir(parents=True, exist_ok=True)
     BASE.write_text("defaults: []\ntraining:\n  lr: 0.003\n", encoding="utf-8")
-    with initialize(version_base=None, config_path=str(CFG_DIR)):
+    with initialize_config_dir(version_base=None, config_dir=str(CFG_DIR.resolve())):
+        # Compose API with simple override to ensure dynamic config handling
         cfg = compose(config_name="base", overrides=["training.batch_size=8"])
     assert cfg.training.lr == 0.003
     assert cfg.training.batch_size == 8
@@ -66,8 +67,8 @@ def test_missing_config_hard_fail(ensure_cfg_dir):
 
 @pytest.mark.skipif(not BASE.exists(), reason="Config file missing; skip file-only invariant")
 def test_file_mode_invariant(ensure_cfg_dir):
-    from hydra import compose, initialize
+    from hydra import compose, initialize_config_dir
 
-    with initialize(version_base=None, config_path=str(CFG_DIR)):
+    with initialize_config_dir(version_base=None, config_dir=str(CFG_DIR.resolve())):
         cfg = compose(config_name="base")
         assert "training" in cfg


### PR DESCRIPTION
## Summary
- integrate `load_training_cfg` into training entry and resolve configs relative to cwd
- add tests for Hydra Compose/fallback modes
- note Compose API usage in tests

## Testing
- `pre-commit run --files training/functional_training.py tests/training/test_config_loading.py src/codex_ml/utils/config_loader.py`
- `pytest tests/training/test_config_loading.py -q` *(fails: Coverage failure: total of 7 is less than fail-under=70)*

------
https://chatgpt.com/codex/tasks/task_e_68bcacc48e6483318a00ec42d93624cc