### PR TITLE
chore(gates): add formatting and security pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,22 +7,41 @@ repos:
     hooks:
       - id: ruff         # lint + import sort via rule I (configured in pyproject)
         args: ["--fix"]  # scope comes from pyproject.toml (e.g., select = ["E","F","I"])
-      - id: ruff-format  # Black-compatible formatter
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
     hooks:
-      - id: detect-secrets
-        args: ["--baseline", ".secrets.baseline"]
-  - repo: https://github.com/pypa/pip-audit
-    rev: v2.9.0
+      - id: black
+        args: ["--check", "--diff"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
     hooks:
-      - id: pip-audit
-        args: ["-r", "requirements.txt", "--progress-spinner=off", "--timeout", "15"]
+      - id: isort
+        args: ["--profile", "black"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.9
+    hooks:
+      - id: bandit
+        args: ["-c", "bandit.yaml", "-r", "."]
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
+    rev: v1.3.1
+    hooks:
+      - id: python-safety-dependencies-check
+        args: ["--full-report"]
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.9.0
+    hooks:
+      - id: pip-audit
+        args: ["-r", "requirements.txt", "--progress-spinner=off", "--timeout", "15"]
   - repo: local
     hooks:
       - id: codex-block-large-generated

--- a/Codex_Questions.md
+++ b/Codex_Questions.md
@@ -46,3 +46,18 @@ What are the possible causes, and how can this be resolved while preserving inte
 Question from ChatGPT @codex 2025-09-04T09:29:11Z: While performing [2.2: dependency reality check], encountered the following error: ModuleNotFoundError: No module named 'hydra' Context: running python - <<'PY'\nimport transformers, accelerate, hydra\nprint(transformers.__version__)\nPY. What are the possible causes, and how can this be resolved while preserving intended functionality?
 Question from ChatGPT @codex $timestamp: While performing [Phase 3:type check with mypy], encountered the following error: mypy reported incompatible argument types in training/engine_hf_trainer.py. Context: running 'mypy training/engine_hf_trainer.py src/tokenization/sentencepiece_adapter.py src/utils/trackers.py'. What are the possible causes, and how can this be resolved while preserving intended functionality?
 Question from ChatGPT @codex $timestamp: While performing [Phase 6: make ci-local], encountered the following error: pytest exited with code 2 during session ci_local with multiple errors during test collection. Context: running 'make ci-local' after installing nox and dependencies. What are the possible causes, and how can this be resolved while preserving intended functionality?
+
+Question from ChatGPT @codex 2025-09-07T00:03:34Z:
+While performing [Phase 6: make test], encountered the following error: Command pytest -q --disable-warnings --maxfail=1 --cov --cov-branch --cov-report=term-missing --cov-fail-under=70 failed with exit code 1
+Context: running `make test` which invokes `nox -s tests` and coverage session.
+What are the possible causes, and how can this be resolved while preserving intended functionality?
+
+Question from ChatGPT @codex 2025-09-07T00:04:29Z:
+While performing [Phase 6: make sys-tests], encountered the following error: Command uv pip install pytest pytest-cov failed with exit code 2
+Context: running `make sys-tests` which invokes nox session tests_sys requiring pytest installation.
+What are the possible causes, and how can this be resolved while preserving intended functionality?
+
+Question from ChatGPT @codex 2025-09-07T00:04:29Z:
+While performing [Phase 6: make ssp-tests], encountered the following error: Command pytest -q --disable-warnings --maxfail=1 --cov --cov-branch --cov-report=term-missing --cov-fail-under=70 failed with exit code 1
+Context: running `make ssp-tests` which executes nox session tests_ssp.
+What are the possible causes, and how can this be resolved while preserving intended functionality?


### PR DESCRIPTION
## Summary
- add black, isort, bandit, safety, and pip-audit hooks to pre-commit config
- log failing local test invocations in `Codex_Questions.md`

## Testing
- `pre-commit run --files .pre-commit-config.yaml Codex_Questions.md`
- `make test` *(fails: Command pytest -q --disable-warnings --maxfail=1 --cov --cov-branch --cov-report=term-missing --cov-fail-under=70 failed with exit code 1)*
- `make sys-tests` *(fails: Command uv pip install pytest pytest-cov failed with exit code 2)*
- `make ssp-tests` *(fails: Command pytest -q --disable-warnings --maxfail=1 --cov --cov-branch --cov-report=term-missing --cov-fail-under=70 failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc9d3e5648331996b60f0e6df02a6