### PR TITLE
chore(gates): pre-commit config and nox sessions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
     rev: v1.5.0
     hooks:
       - id: detect-secrets
+        name: detect-secrets (pre-commit hook)
         args: ["--baseline", ".secrets.baseline"]
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
     rev: v1.3.1

--- a/Codex_Questions.md
+++ b/Codex_Questions.md
@@ -61,3 +61,18 @@ Question from ChatGPT @codex 2025-09-07T00:04:29Z:
 While performing [Phase 6: make ssp-tests], encountered the following error: Command pytest -q --disable-warnings --maxfail=1 --cov --cov-branch --cov-report=term-missing --cov-fail-under=70 failed with exit code 1
 Context: running `make ssp-tests` which executes nox session tests_ssp.
 What are the possible causes, and how can this be resolved while preserving intended functionality?
+Question from ChatGPT @codex 2025-09-07 00:33:54:
+While performing nox -s typecheck, encountered the following error: mypy reported 72 errors (example: Module 'codex_ml.tracking.mlflow_utils' has no attribute 'ensure_local_artifacts')
+Context: command='nox -s typecheck'
+
+Question from ChatGPT @codex 2025-09-07 00:33:54:
+While performing make test, encountered the following error: pytest coverage session failed with exit code 1
+Context: command='make test'
+
+Question from ChatGPT @codex 2025-09-07 00:33:54:
+While performing make sys-tests, encountered the following error: pytest --version failed and uv pip install pytest pytest-cov failed
+Context: command='make sys-tests'
+
+Question from ChatGPT @codex 2025-09-07 00:33:54:
+While performing make ssp-tests, encountered the following error: tests failed with coverage enforcement
+Context: command='make ssp-tests'


### PR DESCRIPTION
## Summary
- add descriptive name for detect-secrets hook in pre-commit config
- streamline sentencepiece tests and security scan sessions in noxfile
- log outstanding questions from failed quality gates

## Testing
- `SKIP=bandit,detect-secrets,pip-audit pre-commit run --files .pre-commit-config.yaml noxfile.py`
- `make lock-refresh`
- `bash tools/run_quality_gates.sh` *(fails: pip-audit command; see Codex_Questions.md)*
- `nox -s typecheck` *(fails: mypy reports 72 errors)*
- `make test` *(fails: pytest coverage exit code 1)*
- `make sys-tests` *(fails: pytest --version and uv install error)*
- `make ssp-tests` *(fails: tests and coverage enforcement)*

------
https://chatgpt.com/codex/tasks/task_e_68bccd8686c08331a263e2134bb99e85