### PR TITLE
chore(pre-commit): allow skipping formatting hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ GitHub Actions workflows exist under `.github/workflows/` but remain disabled; a
 - Security sweep: `make sec-scan`
 - Deterministic locks: `make lock-refresh` (uses Astral **uv**)
 
+To skip formatting hooks (Black/Ruff-format) during gates:
+`SKIP_FORMAT=1 CODEX_ENV=1 bash tools/run_quality_gates.sh`
+
 > Note: no GitHub Actions are enabled by this project policy; all checks run locally or on the Codex self-hosted runner.
 
 ## Makefile

--- a/tools/run_quality_gates.sh
+++ b/tools/run_quality_gates.sh
@@ -9,5 +9,13 @@ if [[ "${CODEX_ENV:-}" != "1" ]]; then
   echo "Skipping pre-commit run (CODEX_ENV!=1)"
   exit 0
 fi
+
+# Allow developers to disable formatting hooks when necessary.
+# Example: SKIP_FORMAT=1 bash tools/run_quality_gates.sh
+if [[ "${SKIP_FORMAT:-0}" == "1" ]]; then
+  export SKIP="${SKIP:+$SKIP,}black,ruff-format"
+  echo "[gates] formatting hooks disabled via SKIP_FORMAT"
+fi
+
 # local-only, non-fatal to preserve dev flow
 pre-commit run -a || true


### PR DESCRIPTION
## Summary
- allow disabling Black and Ruff-format pre-commit hooks via `SKIP_FORMAT` in quality gates
- document `SKIP_FORMAT` usage for local gates

## Testing
- `pre-commit run --files tools/run_quality_gates.sh README.md`
- `nox -s tests` *(fails: Command pytest ... exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bccd9190e88331844e62614f74091c