### PR TITLE
feat: add reproducibility CLI utilities

### DIFF
--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -186,6 +187,61 @@ def tokenizer_stats(tokenizer_path: str | None) -> None:
 
     tk = load_tokenizer(path=tokenizer_path)
     click.echo(f"vocab_size={tk.vocab_size}")
+
+
+@cli.group("repro")
+def repro_group() -> None:
+    """Reproducibility utilities."""
+    pass
+
+
+@repro_group.command("seed")
+@click.option("--seed", type=int, default=42, show_default=True, help="Seed value")
+@click.option(
+    "--out-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Directory to write seeds.json",
+)
+def repro_seed(seed: int, out_dir: Path | None) -> None:
+    """Seed RNGs across libraries and optionally persist seeds.json."""
+    from codex_ml.utils.checkpointing import set_seed
+
+    set_seed(seed, out_dir)
+    click.echo(f"seed={seed}")
+
+
+@repro_group.command("env")
+@click.option(
+    "--path",
+    type=click.Path(path_type=Path),
+    default="env.json",
+    show_default=True,
+    help="Output path for environment info",
+)
+def repro_env(path: Path) -> None:
+    """Record git commit and installed packages."""
+    from codex_utils.repro import log_env_info
+
+    log_env_info(path)
+    click.echo(f"wrote {path}")
+
+
+@repro_group.command("system")
+@click.option(
+    "--path",
+    type=click.Path(path_type=Path),
+    default="system.json",
+    show_default=True,
+    help="Output path for system metrics",
+)
+def repro_system(path: Path) -> None:
+    """Capture CPU/GPU system metrics."""
+    from codex_ml.monitoring.codex_logging import _codex_sample_system
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_codex_sample_system()), encoding="utf-8")
+    click.echo(f"wrote {path}")
 
 
 if __name__ == "__main__":

--- a/tests/test_repro_cli.py
+++ b/tests/test_repro_cli.py
@@ -1,0 +1,42 @@
+import importlib
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+cli_module = importlib.import_module("codex.cli")
+
+
+def test_repro_seed(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        ["repro", "seed", "--seed", "123", "--out-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 0
+    seeds = json.loads((tmp_path / "seeds.json").read_text())
+    assert seeds["python"] == 123
+
+
+def test_repro_env(tmp_path: Path) -> None:
+    runner = CliRunner()
+    path = tmp_path / "env.json"
+    result = runner.invoke(
+        cli_module.cli,
+        ["repro", "env", "--path", str(path)],
+    )
+    assert result.exit_code == 0
+    data = json.loads(path.read_text())
+    assert "git_commit" in data
+
+
+def test_repro_system(tmp_path: Path) -> None:
+    runner = CliRunner()
+    path = tmp_path / "system.json"
+    result = runner.invoke(
+        cli_module.cli,
+        ["repro", "system", "--path", str(path)],
+    )
+    assert result.exit_code == 0
+    data = json.loads(path.read_text())
+    assert isinstance(data, dict)


### PR DESCRIPTION
## Summary
- add `repro` group to CLI with seed, env, and system subcommands
- test CLI helpers for seed, environment snapshot, and system metrics

## Testing
- `pre-commit run --files src/codex/cli.py tests/test_repro_cli.py`
- `mypy src/codex/cli.py tests/test_repro_cli.py --ignore-missing-imports --follow-imports=skip`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_68bcde0a69e88331bf5036fb098cb418