### PR TITLE
feat(training): add default training config

### DIFF
--- a/configs/training/base.yaml
+++ b/configs/training/base.yaml
@@ -1,14 +1,23 @@
-# Primary training config (Hydra)
-# See: https://hydra.cc/docs/tutorials/basic/your_first_app/config_file/
-defaults: []
+"""Default training configuration for HuggingFace Trainer.
 
-training:
-  seed: 42
-  lr: 0.001
-  batch_size: 32
-  epochs: 3
+This file provides a minimal set of sensible defaults for the training
+engine tests. Values can be overridden at runtime via CLI flags or Hydra
+configuration. Only keys understood by ``transformers.TrainingArguments``
+or consumed by helper utilities should be declared here.
+"""
 
-logging:
-  enable_tensorboard: false
-  enable_wandb: false
-  mlflow_enable: false
+# Number of training epochs
+num_train_epochs: 1
+
+# Optimizer hyperparameters
+learning_rate: 0.001
+
+# Effective batch size will be
+# ``per_device_train_batch_size * gradient_accumulation_steps``
+per_device_train_batch_size: 2
+gradient_accumulation_steps: 1
+
+# Optional precision / LoRA fields parsed separately
+precision: fp32
+lora_r: null
+lora_alpha: 16

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -225,9 +225,7 @@ def build_trainer(
         num_steps = (
             max_steps
             if max_steps > 0
-            else int(args.num_train_epochs * steps_per_epoch)
-            if steps_per_epoch
-            else None
+            else int(args.num_train_epochs * steps_per_epoch) if steps_per_epoch else None
         )
         trainer.create_scheduler(num_training_steps=num_steps)
         if scheduler_name:
@@ -482,6 +480,11 @@ def load_training_arguments(
     cfg.setdefault("output_dir", str(output_dir))
     cfg["output_dir"] = str(output_dir)
 
+    # Provide sane defaults when config is missing or incomplete
+    cfg.setdefault("num_train_epochs", 1)
+    cfg.setdefault("learning_rate", 5e-4)
+    cfg.setdefault("per_device_train_batch_size", 8)
+
     if precision:
         p = precision.lower()
         if p == "fp16":
@@ -522,6 +525,7 @@ def load_training_arguments(
         "logging",
         "checkpoint",
         "training",
+        "early_stopping_patience",
     ):
         cfg.pop(extra, None)
 


### PR DESCRIPTION
## Summary
- add minimal HuggingFace Trainer base config
- ensure `load_training_arguments` uses sane defaults when config is missing

## Testing
- `pre-commit run --files configs/training/base.yaml training/engine_hf_trainer.py`
- `nox -s typecheck` (fails: Module "codex_ml.tracking.mlflow_utils" has no attribute "ensure_local_artifacts")
- `nox -s tests` (fails: ModuleNotFoundError: No module named 'typer')

------
https://chatgpt.com/codex/tasks/task_e_68bceb6eb7b083318956e1acfe379dd2