### PR TITLE
feat: expand eval dataset loader

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -109,6 +109,9 @@ def coverage(session):
         "click",
         "transformers",
         "datasets",
+        "typer",
+        "omegaconf",
+        "hydra-core",
         "accelerate",
         "duckdb",
     )

--- a/tests/eval/test_datasets_hf_disk.py
+++ b/tests/eval/test_datasets_hf_disk.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+import pytest
+
+from codex_ml.eval.datasets import Example, load_dataset
+
+
+def test_load_dataset_from_hf_disk(tmp_path: Path):
+    datasets = pytest.importorskip("datasets")
+    ds = datasets.Dataset.from_dict({"input": ["x"], "target": ["y"]})
+    ds_path = tmp_path / "ds"
+    ds.save_to_disk(ds_path)
+    examples = load_dataset(str(ds_path))
+    assert examples == [Example("x", "y")]


### PR DESCRIPTION
## Summary
- extend eval dataset loader with Hugging Face `datasets` support
- add regression test for loading datasets saved to disk
- ensure coverage session installs typer, omegaconf, and hydra-core

## Testing
- `pre-commit run --files src/codex_ml/eval/datasets.py tests/eval/test_datasets_hf_disk.py noxfile.py` *(fails: bandit hook interrupted)*
- `nox -s tests` *(fails: CheckpointManager retention test fails)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf6af5fa88331bf5c1776ba5c1be8