### PR TITLE
Add toy length-based reward model

### DIFF
--- a/src/codex_ml/reward_models/__init__.py
+++ b/src/codex_ml/reward_models/__init__.py
@@ -1,0 +1,5 @@
+"""Built-in reward model implementations."""
+
+from .simple import LengthRewardModel
+
+__all__ = ["LengthRewardModel"]

--- a/src/codex_ml/reward_models/simple.py
+++ b/src/codex_ml/reward_models/simple.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from codex_ml.interfaces.reward_model import RewardModel
+
+
+class LengthRewardModel(RewardModel):
+    """Toy reward model that scores completions by length.
+
+    This implementation is intentionally simple and is intended for tests and
+    examples. The reward is the number of characters in the completion.
+    """
+
+    def evaluate(
+        self,
+        prompt: str,
+        completion: str,
+        *,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> float:
+        """Return the length of ``completion`` as the reward."""
+        return float(len(completion))
+
+    def learn(self, data: Any) -> dict[str, float]:
+        """Dummy learn method returning a placeholder metric."""
+        return {"loss": 0.0}

--- a/tests/reward_models/test_length_reward_model.py
+++ b/tests/reward_models/test_length_reward_model.py
@@ -1,0 +1,16 @@
+from codex_ml.reward_models import LengthRewardModel
+
+
+def test_length_reward_model_basic():
+    rm = LengthRewardModel()
+    short = rm.evaluate("p", "hi")
+    long = rm.evaluate("p", "hello")
+    assert long > short
+
+
+def test_length_reward_model_batch_and_learn():
+    rm = LengthRewardModel()
+    scores = rm.batch_evaluate([("p", "ab"), ("p", "abcd")])
+    assert scores == [2.0, 4.0]
+    metrics = rm.learn([("p", "a")])
+    assert metrics == {"loss": 0.0}


### PR DESCRIPTION
## Summary
- add `LengthRewardModel` providing a trivial length-based reward
- expose reward model in `codex_ml.reward_models`
- test basic evaluation, batching, and learn API

## Testing
- `pre-commit run --files src/codex_ml/reward_models/simple.py src/codex_ml/reward_models/__init__.py tests/reward_models/test_length_reward_model.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68bcf6e45c2483319713030a1eb6d246