### PR TITLE
feat: log system metrics and cuda version for reproducibility

### DIFF
--- a/src/codex_ml/utils/provenance.py
+++ b/src/codex_ml/utils/provenance.py
@@ -52,4 +52,18 @@ def snapshot_hydra_config(
     commit = _git_commit()
     if commit:
         info["git_commit"] = commit
+    try:  # pragma: no cover - optional deps
+        from codex_ml.monitoring.codex_logging import _codex_sample_system
+
+        info["system"] = _codex_sample_system()
+    except Exception:
+        pass
+    try:  # pragma: no cover - torch optional
+        import torch
+
+        cuda = getattr(torch.version, "cuda", None)
+        if cuda:
+            info["cuda_version"] = cuda
+    except Exception:
+        pass
     (out_dir / "provenance.json").write_text(json.dumps(info, indent=2))

--- a/tests/test_env_logging.py
+++ b/tests/test_env_logging.py
@@ -1,5 +1,10 @@
 import json
 
+try:
+    import torch
+except Exception:  # pragma: no cover - torch optional
+    torch = None
+
 from codex_utils.repro import log_env_info
 from functional_training import run_functional_training
 
@@ -10,6 +15,9 @@ def test_log_env_info(tmp_path):
     data = json.loads(path.read_text())
     assert data.get("git_commit")
     assert "packages" in data and data["packages"]
+    assert "system" in data
+    if torch is not None and getattr(torch.version, "cuda", None):
+        assert "cuda_version" in data
 
 
 def test_functional_training_logs_env(tmp_path):


### PR DESCRIPTION
## Summary
- capture system metrics and CUDA version when snapshotting configs and logging environment info
- verify environment capture in env logging tests

## Testing
- `SKIP=bandit pre-commit run --files codex_utils/repro.py src/codex_ml/utils/provenance.py tests/test_env_logging.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68bcf83e91c08331b1bc020ed6ab50f2