### PR TITLE
Fix HF dataset loader recursion and config parsing

### DIFF
--- a/tests/eval/test_hf_dataset_loader.py
+++ b/tests/eval/test_hf_dataset_loader.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from codex_ml.eval.datasets import Example, load_dataset
 
@@ -10,20 +10,21 @@ def test_load_hf_dataset() -> None:
         def __getitem__(self, key: str):  # pragma: no cover - simple stub
             return ["a", "b", "c"]
 
-    with patch(
-        "codex_ml.eval.datasets.hf_load_dataset",
-        return_value=DummyHFDS(),
-    ) as mock_load:
+    def loader(dataset_name: str, config: str | None, *, split: str):
+        if dataset_name == "hf-internal-testing" and config == "tiny-wikitext-2":
+            raise FileNotFoundError
+        return DummyHFDS()
+
+    with patch("codex_ml.eval.datasets.hf_load_dataset", side_effect=loader) as mock_load:
         data = load_dataset(
             "hf://hf-internal-testing/tiny-wikitext-2",
             max_samples=2,
             hf_split="train",
         )
-        mock_load.assert_called_once_with(
-            "hf-internal-testing/tiny-wikitext-2",
-            None,
-            split="train",
-        )
+        assert mock_load.call_args_list == [
+            call("hf-internal-testing", "tiny-wikitext-2", split="train"),
+            call("hf-internal-testing/tiny-wikitext-2", None, split="train"),
+        ]
         assert len(data) == 2
         assert all(isinstance(item, Example) for item in data)
         assert data[0].input == data[0].target
@@ -39,4 +40,17 @@ def test_load_hf_dataset_with_owner_and_config() -> None:
     with patch("codex_ml.eval.datasets.hf_load_dataset", return_value=DummyHFDS()) as mock_load:
         data = load_dataset("hf://openai/gsm8k/main", max_samples=1)
         mock_load.assert_called_once_with("openai/gsm8k", "main", split="train")
+        assert data == [Example("sample", "sample")]
+
+
+def test_load_hf_dataset_with_config_only() -> None:
+    class DummyHFDS:
+        column_names = ["text"]
+
+        def __getitem__(self, key: str):  # pragma: no cover - simple stub
+            return ["sample"]
+
+    with patch("codex_ml.eval.datasets.hf_load_dataset", return_value=DummyHFDS()) as mock_load:
+        data = load_dataset("hf://glue/mrpc", max_samples=1)
+        mock_load.assert_called_once_with("glue", "mrpc", split="train")
         assert data == [Example("sample", "sample")]


### PR DESCRIPTION
## Summary
- alias HuggingFace `load_dataset` to avoid recursive calls
- parse dataset configs after final slash and test owner/config paths

## Testing
- `mypy src/codex_ml/eval/datasets.py --follow-imports=skip`
- `pytest tests/eval/test_hf_dataset_loader.py -o addopts=`
- `pre-commit run --files src/codex_ml/eval/datasets.py tests/eval/test_hf_dataset_loader.py` *(fails: bandit scan interrupted)*
- `nox -s tests` *(fails: interrupted due to large dependency download)*

------
https://chatgpt.com/codex/tasks/task_e_68bd136097c48331b727dc8ab01c6d9f