### PR TITLE
feat: add eval defaults and guard evaluate step

### DIFF
--- a/tests/test_codexml_cli.py
+++ b/tests/test_codexml_cli.py
@@ -11,7 +11,14 @@ def test_codexml_cli_help():
 
 
 def test_codexml_cli_skips_eval(monkeypatch):
+    from hydra._internal.hydra import GlobalHydra
+
     called = {"eval": False}
+
+    # `test_codexml_cli_help` already invoked the Hydra-decorated CLI entry
+    # point. Hydra disallows re-initialization within the same process, so we
+    # clear any existing global state before invoking the CLI again.
+    GlobalHydra.instance().clear()
 
     def fake_eval(*args, **kwargs):
         called["eval"] = True


### PR DESCRIPTION
## Summary
- add eval section to default Hydra config
- skip evaluate step when eval config absent
- add CLI regression test for missing eval config
- reset Hydra state between CLI invocations in tests

## Testing
- `pre-commit run --files tests/test_codexml_cli.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_68bd17f6318483318ed92776b2d769f4