### PR TITLE
feat: add eval defaults and guard evaluate step

### DIFF
--- a/tests/test_codexml_cli.py
+++ b/tests/test_codexml_cli.py
@@ -15,10 +15,12 @@ def test_codexml_cli_skips_eval(monkeypatch):
 
     called = {"eval": False}
 
-    # `test_codexml_cli_help` already invoked the Hydra-decorated CLI entry
-    # point. Hydra disallows re-initialization within the same process, so we
-    # clear any existing global state before invoking the CLI again.
-    GlobalHydra.instance().clear()
+    # `test_codexml_cli_help` may have already invoked the Hydra-decorated CLI
+    # entry point. Hydra disallows re-initialization within the same process,
+    # so clear any existing global state before invoking the CLI again.
+    gh = GlobalHydra.instance()
+    if gh.is_initialized():
+        gh.clear()
 
     def fake_eval(*args, **kwargs):
         called["eval"] = True


### PR DESCRIPTION
## Summary
- add eval section to default Hydra config
- skip evaluate step when eval config absent
- add CLI regression test for missing eval config
- reset Hydra state conditionally in CLI regression test

## Testing
- `pre-commit run --files tests/test_codexml_cli.py`
- `nox -s tests` *(fails: AssertionError in tests/eval/test_eval_runner_smoke.py::test_eval_runner_smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1bca2fa083318e4f543a5918ff33