### PR TITLE
Handle DatasetDict loading and wire training entry

### DIFF
--- a/training/functional_training.py
+++ b/training/functional_training.py
@@ -67,6 +67,8 @@ def main(argv: list[str] | None = None) -> int:
         tokenized = tokenizer(list(texts), padding=True, return_tensors="pt")
         # mirror inputs into `labels` so `AutoModelForCausalLM` computes loss
         tokenized["labels"] = tokenized["input_ids"].clone()
+        tokenized["labels"][tokenized["attention_mask"] == 0] = -100
+        tokenized = {k: v.numpy() for k, v in tokenized.items()}
         train_ds = Dataset.from_dict(tokenized)
         train_cfg = TrainCfg(
             epochs=int(training_cfg.get("epochs", 1)),


### PR DESCRIPTION
## Summary
- support `datasets.DatasetDict` when loading evaluation datasets from disk with optional split selection
- connect `training.functional_training.main` to run Hugging Face trainer or custom trainer based on config
- cover new behaviors with tests
- mask padded tokens when constructing `labels` for the custom training engine

## Testing
- `pre-commit run --files training/functional_training.py tests/training/test_functional_training_main.py`
- `mypy training/functional_training.py tests/training/test_functional_training_main.py` *(fails: training/engine_hf_trainer.py:536: error: Argument 1 to "TrainingArguments" has incompatible type "**dict[str, object]"; expected "list[str] | None" [arg-type])* 
- `nox -s tests` *(fails: tests/checkpointing/test_periodic_and_trim.py::test_periodic_and_trim - AssertionError: assert ['ckpt-10.pt'..., 'ckpt-8.pt'] == ['ckpt-6.pt'..., 'ckpt-10.pt'])*


------
https://chatgpt.com/codex/tasks/task_e_68bd1c4aedc88331bf99f9d7242745cc