### PR TITLE
fix: honor top-level training config keys

### DIFF
--- a/training/functional_training.py
+++ b/training/functional_training.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 import torch
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 from torch.nn.utils import clip_grad_norm_
 from torch.utils.data import DataLoader
 
@@ -56,7 +56,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     cfg: DictConfig = load_training_cfg(allow_fallback=True, overrides=args.cfg_override)
-    training_cfg = getattr(cfg, "training", {})
+    training_cfg: Dict[str, Any] = OmegaConf.to_container(cfg, resolve=True)  # type: ignore[assignment]
+    nested = training_cfg.pop("training", {})
+    if isinstance(nested, dict):
+        training_cfg.update(nested)
 
     if args.engine == "hf":
         kw: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- merge top-level and nested Hydra training config values

## Testing
- `pre-commit run --files training/functional_training.py`
- `mypy --follow-imports=skip training/functional_training.py`
- `nox -s tests` *(fails: tests/checkpointing/test_periodic_and_trim.py::test_periodic_and_trim)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2c1f0804833193e67a91b59e2aca