### PR TITLE
fix: guard evaluation step without DictConfig truthiness

### DIFF
--- a/codex_ml/cli/main.py
+++ b/codex_ml/cli/main.py
@@ -29,8 +29,8 @@ def main(cfg: DictConfig) -> None:  # pragma: no cover - simple dispatcher
         if step == "train":
             run_training(cfg.train)
         elif step == "evaluate":
-            eval_cfg = cfg.get("eval")
-            if eval_cfg:
+            eval_cfg = cfg.get("eval", None)
+            if eval_cfg is not None:
                 evaluate_datasets(eval_cfg.datasets, eval_cfg.metrics, cfg.output_dir)
     sys.exit(0)
 

--- a/tests/test_codexml_cli.py
+++ b/tests/test_codexml_cli.py
@@ -22,3 +22,17 @@ def test_codexml_cli_skips_evaluation_when_eval_missing(monkeypatch):
         cli(["eval=null", "hydra.run.dir=."])
     assert excinfo.value.code == 0
     assert called is False
+
+
+def test_codexml_cli_runs_evaluation_by_default(monkeypatch):
+    called = False
+
+    def fake_eval(*args, **kwargs):  # pragma: no cover - stub
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("codex_ml.cli.main.evaluate_datasets", fake_eval)
+    with pytest.raises(SystemExit) as excinfo:
+        cli(["hydra.run.dir=."])
+    assert excinfo.value.code == 0
+    assert called is True


### PR DESCRIPTION
## Summary
- avoid DictConfig truthiness when deciding to run evaluation
- test CLI runs evaluation with default config

## Testing
- `pre-commit run --files codex_ml/cli/main.py tests/test_codexml_cli.py` *(fails: bandit reports security issues)*
- `mypy --explicit-package-bases codex_ml/cli/main.py tests/test_codexml_cli.py`
- `nox -s coverage --reuse-existing-virtualenvs` *(fails: tests/eval/test_eval_runner_smoke.py::test_eval_runner_smoke - assert 2 == 0)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2d1269848331a343ee84714a7ca0