### PR TITLE
fix: guard eval and preserve trainer defaults

### DIFF
--- a/codex_ml/cli/main.py
+++ b/codex_ml/cli/main.py
@@ -28,7 +28,7 @@ def main(cfg: DictConfig) -> None:  # pragma: no cover - simple dispatcher
     for step in cfg.pipeline.steps:
         if step == "train":
             run_training(cfg.train)
-        elif step == "evaluate" and cfg.get("eval"):
+        elif step == "evaluate" and cfg.get("eval") is not None:
             evaluate_datasets(cfg.eval.datasets, cfg.eval.metrics, cfg.output_dir)
     sys.exit(0)
 


### PR DESCRIPTION
## Summary
- avoid DictConfig truthiness when guarding eval step

## Testing
- `pre-commit run --files codex_ml/cli/main.py`
- `mypy codex_ml/cli/main.py`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'hydra')*


------
https://chatgpt.com/codex/tasks/task_e_68bd2cc104a48331b42fd75b2de004f9