### PR TITLE
fix: honor split=None when loading remote datasets

### DIFF
--- a/src/codex_ml/eval/datasets.py
+++ b/src/codex_ml/eval/datasets.py
@@ -72,7 +72,12 @@ def load_dataset(
                 for row in ds
             ]
         elif HAS_DATASETS:
-            ds = hf_load_dataset(name_or_path, split=split or "train")
+            if split is None:
+                ds = hf_load_dataset(name_or_path)
+                if isinstance(ds, DatasetDict):
+                    ds = ds[next(iter(ds.keys()))]
+            else:
+                ds = hf_load_dataset(name_or_path, split=split)
             data = [
                 Example(
                     str(row.get("input", row.get("text", ""))),

--- a/tests/eval/test_datasets_hf_disk.py
+++ b/tests/eval/test_datasets_hf_disk.py
@@ -32,3 +32,18 @@ def test_load_datasetdict_default_and_split(tmp_path: Path):
     assert test_examples == [Example("b", "b")]
     with pytest.raises(ValueError):
         load_dataset(str(dd_path), split="missing")
+
+
+def test_load_remote_dataset_selects_first_split(monkeypatch: pytest.MonkeyPatch):
+    datasets = pytest.importorskip("datasets")
+    dd = datasets.DatasetDict(
+        {"validation": datasets.Dataset.from_dict({"input": ["v"], "target": ["v"]})}
+    )
+
+    def fake_load_dataset(name_or_path, **kwargs):
+        assert "split" not in kwargs
+        return dd
+
+    monkeypatch.setattr("codex_ml.eval.datasets.hf_load_dataset", fake_load_dataset)
+    examples = load_dataset("dummy", split=None)
+    assert examples == [Example("v", "v")]


### PR DESCRIPTION
## Summary
- load remote datasets without specifying a split when `split=None`
- test automatic split selection for remote datasets

## Testing
- `SKIP=bandit,detect-secrets,safety,pip-audit pre-commit run --files src/codex_ml/eval/datasets.py tests/eval/test_datasets_hf_disk.py`
- `nox -s typecheck` *(fails: Module "codex_ml.tracking.mlflow_utils" has no attribute "ensure_local_artifacts")*
- `nox -s tests` *(fails: AssertionError in tests/checkpointing/test_periodic_and_trim.py::test_periodic_and_trim)*

------
https://chatgpt.com/codex/tasks/task_e_68bd312812ec8331a2d8db8dacc1e547