### PR TITLE
0 c base - address review comments

### DIFF
--- a/tests/training/test_functional_training_main.py
+++ b/tests/training/test_functional_training_main.py
@@ -28,3 +28,5 @@ def test_main_invokes_hf_trainer(monkeypatch, tmp_path: Path):
     assert called["output_dir"] == tmp_path
     assert called["kwargs"]["seed"] == 7
     assert called["kwargs"]["gradient_accumulation_steps"] == 3
+    assert called["kwargs"]["hydra_cfg"]["seed"] == 7
+    assert called["kwargs"]["hydra_cfg"]["gradient_accumulation_steps"] == 3

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -574,6 +574,7 @@ def run_hf_trainer(
     distributed: bool = True,
     tensorboard: bool = False,
     accelerate_kwargs: Optional[Dict[str, object]] = None,
+    hydra_cfg: Optional[Dict[str, object]] = None,
     log_args: Optional[argparse.Namespace] = None,
 ) -> Dict[str, float]:
     """Train a causal LM using HuggingFace ``Trainer``."""
@@ -660,6 +661,7 @@ def run_hf_trainer(
         gradient_accumulation_steps=gradient_accumulation_steps,
         tensorboard=tensorboard,
         has_eval=eval_ds is not None,
+        hydra_cfg=hydra_cfg,
     )
 
     # Setup LoRA via adapter when requested

--- a/training/functional_training.py
+++ b/training/functional_training.py
@@ -62,7 +62,7 @@ def main(argv: list[str] | None = None) -> int:
         training_cfg.update(nested)
 
     if args.engine == "hf":
-        kw: Dict[str, Any] = {}
+        kw: Dict[str, Any] = {"hydra_cfg": training_cfg}
         for key in (
             "seed",
             "gradient_accumulation_steps",


### PR DESCRIPTION
## Summary
- forward flattened Hydra configs to the HF trainer via new `hydra_cfg` parameter
- expose the same config map in the functional training entrypoint and update tests

## Testing
- `pre-commit run --files training/functional_training.py training/engine_hf_trainer.py tests/training/test_functional_training_main.py`
- `mypy --follow-imports=skip training/functional_training.py training/engine_hf_trainer.py tests/training/test_functional_training_main.py`
- `nox -s tests` *(fails: tests/checkpointing/test_periodic_and_trim.py::test_periodic_and_trim)*

------
https://chatgpt.com/codex/tasks/task_e_68bd30fb83888331900a63b4120ac432