### PR TITLE
Add HuggingFace dataset support to evaluation loader

### DIFF
--- a/src/codex_ml/eval/datasets.py
+++ b/src/codex_ml/eval/datasets.py
@@ -96,13 +96,19 @@ def load_dataset(
             )
 
         if target_field is None:
-            if "target" in hf_ds.column_names:
-                target_field = "target"
-            elif "text" in hf_ds.column_names:
+            for candidate in [
+                "target",
+                "output",
+                "answer",
+                "label",
+                "text",
+            ]:
+                if candidate in hf_ds.column_names and candidate != input_field:
+                    target_field = candidate
+                    break
+            if target_field is None and input_field == "text" and "text" in hf_ds.column_names:
                 target_field = "text"
-            elif input_field in hf_ds.column_names:
-                target_field = input_field
-            else:
+            if target_field is None:
                 raise ValueError(
                     f"No suitable target column found in dataset columns {hf_ds.column_names}"
                 )


### PR DESCRIPTION
## Summary
- allow `load_dataset` to map distinct input/target fields when fetching `hf://` datasets
- expand HuggingFace loader tests with custom field coverage

## Testing
- `pre-commit run --files src/codex_ml/eval/datasets.py tests/eval/test_hf_dataset_loader.py`
- `mypy src/codex_ml/eval/datasets.py --follow-imports=skip`
- `pytest tests/eval/test_hf_dataset_loader.py -o addopts=`
- `nox -s tests` *(fails: interrupted during large dependency download)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3177a1f88331b0e58769ac4cc02d