### PR TITLE
fix: pass engine args list to functional_training.main

### DIFF
--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -130,7 +130,8 @@ def train_cmd(engine: str, engine_args: tuple[str, ...]) -> None:
             from training.engine_hf_trainer import run_hf_trainer
 
             return run_hf_trainer(*engine_args)
-        return run_custom_train(*engine_args)
+        argv = list(engine_args) if engine_args else None
+        return run_custom_train(argv)
 
 
 @cli.command("tasks")

--- a/tests/test_cli_train_engine.py
+++ b/tests/test_cli_train_engine.py
@@ -7,3 +7,16 @@ def test_cli_train_engine_option():
     runner = CliRunner()
     result = runner.invoke(cli, ["train", "--help"])
     assert "--engine" in result.output
+
+
+def test_cli_train_custom_engine_forwards_args(monkeypatch):
+    runner = CliRunner()
+    captured: dict[str, list[str] | None] = {}
+
+    def fake_main(argv=None):
+        captured["argv"] = argv
+
+    monkeypatch.setattr("training.functional_training.main", fake_main)
+    result = runner.invoke(cli, ["train", "--engine", "custom", "--output-dir", "out"])
+    assert result.exit_code == 0
+    assert captured["argv"] == ["--output-dir", "out"]


### PR DESCRIPTION
## Summary
- forward engine args as a single list to functional training entrypoint
- test custom engine CLI path forwards arguments

## Testing
- `pre-commit run --files src/codex/cli.py tests/test_cli_train_engine.py`
- `mypy src/codex/cli.py tests/test_cli_train_engine.py` *(fails: Interrupted)*
- `nox -s tests` *(fails: Session coverage interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bd327ebc2083318b1d442d8551dbb4