### PR TITLE
Add backward-compatible hf_text_field alias

### DIFF
--- a/src/codex_ml/eval/datasets.py
+++ b/src/codex_ml/eval/datasets.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List
@@ -41,6 +42,7 @@ def load_dataset(
     hf_split: str = "train",
     hf_input_field: str | None = None,
     hf_target_field: str | None = None,
+    hf_text_field: str | None = None,
 ) -> List[Example]:
     """Load a dataset by preset name, HuggingFace hub name, or JSONL/NDJSON file."""
     if name_or_path in _PRESETS:
@@ -65,6 +67,18 @@ def load_dataset(
         else:
             ds_name, config = parts[0], None
             hf_ds = hf_load_dataset(ds_name, config, split=hf_split)
+        if hf_text_field is not None:
+            warnings.warn(
+                "'hf_text_field' is deprecated; use 'hf_input_field' and 'hf_target_field' instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if hf_input_field is not None or hf_target_field is not None:
+                raise ValueError(
+                    "'hf_text_field' cannot be combined with 'hf_input_field' or 'hf_target_field'"
+                )
+            hf_input_field = hf_text_field
+            hf_target_field = hf_text_field
         input_field = hf_input_field
         target_field = hf_target_field
         if input_field is None:


### PR DESCRIPTION
## Summary
- accept deprecated `hf_text_field` alongside `hf_input_field`/`hf_target_field`
- test for deprecated `hf_text_field` path

## Testing
- `pre-commit run --files src/codex_ml/eval/datasets.py tests/eval/test_hf_dataset_loader.py`
- `mypy src/codex_ml/eval/datasets.py --follow-imports=skip`
- `pytest tests/eval/test_hf_dataset_loader.py -o addopts=`
- `nox -s tests` *(fails: Command pytest ... failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bd366b61d08331a0baad9db99e9d46