### PR TITLE
0 c base: handle DatasetDict and training main

### DIFF
--- a/src/codex_ml/eval/datasets.py
+++ b/src/codex_ml/eval/datasets.py
@@ -10,10 +10,11 @@ from typing import List
 try:  # pragma: no cover - optional dependency
     from datasets import DatasetDict, load_from_disk  # isort: skip
     from datasets import load_dataset as hf_load_dataset  # isort: skip
+    from datasets import load_dataset_builder as hf_load_dataset_builder  # isort: skip
 
     HAS_DATASETS = True
 except Exception:  # pragma: no cover
-    hf_load_dataset = load_from_disk = DatasetDict = None  # type: ignore
+    hf_load_dataset = load_from_disk = DatasetDict = hf_load_dataset_builder = None  # type: ignore
     HAS_DATASETS = False
 
 
@@ -73,9 +74,12 @@ def load_dataset(
             ]
         elif HAS_DATASETS:
             if split is None:
-                ds = hf_load_dataset(name_or_path)
-                if isinstance(ds, DatasetDict):
-                    ds = ds[next(iter(ds.keys()))]
+                builder = hf_load_dataset_builder(name_or_path)
+                if builder.info.splits:
+                    first = next(iter(builder.info.splits))
+                    ds = hf_load_dataset(name_or_path, split=first)
+                else:
+                    ds = hf_load_dataset(name_or_path)
             else:
                 ds = hf_load_dataset(name_or_path, split=split)
             data = [


### PR DESCRIPTION
## Summary
- probe available splits via `load_dataset_builder` when `split=None` before loading remote datasets
- mock `load_dataset_builder` and `load_dataset` in regression test to ensure first split is selected without a default `train`

## Testing
- `pre-commit run --files src/codex_ml/eval/datasets.py tests/eval/test_datasets_hf_disk.py`
- `nox -s typecheck` *(fails: Module "codex_ml.tracking.mlflow_utils" has no attribute "ensure_local_artifacts")*
- `nox -s tests` *(fails: AssertionError in tests/checkpointing/test_periodic_and_trim.py::test_periodic_and_trim)*

------
https://chatgpt.com/codex/tasks/task_e_68bd35c2a794833197944acd786e39ba