### PR TITLE
Add HuggingFace dataset support to evaluation loader

### DIFF
--- a/src/codex_ml/eval/datasets.py
+++ b/src/codex_ml/eval/datasets.py
@@ -51,10 +51,12 @@ def load_dataset(
             DeprecationWarning,
             stacklevel=2,
         )
-        if hf_input_field is None:
-            hf_input_field = hf_text_field
-        if hf_target_field is None:
-            hf_target_field = hf_text_field
+        if hf_input_field is not None or hf_target_field is not None:
+            raise ValueError(
+                "'hf_text_field' cannot be combined with 'hf_input_field' or 'hf_target_field'"
+            )
+        hf_input_field = hf_text_field
+        hf_target_field = hf_text_field
     if name_or_path in _PRESETS:
         data = list(_PRESETS[name_or_path])
     elif name_or_path.startswith("hf://"):
@@ -77,18 +79,6 @@ def load_dataset(
         else:
             ds_name, config = parts[0], None
             hf_ds = hf_load_dataset(ds_name, config, split=hf_split)
-        if hf_text_field is not None:
-            warnings.warn(
-                "'hf_text_field' is deprecated; use 'hf_input_field' and 'hf_target_field' instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if hf_input_field is not None or hf_target_field is not None:
-                raise ValueError(
-                    "'hf_text_field' cannot be combined with 'hf_input_field' or 'hf_target_field'"
-                )
-            hf_input_field = hf_text_field
-            hf_target_field = hf_text_field
         input_field = hf_input_field
         target_field = hf_target_field
         if input_field is None:


### PR DESCRIPTION
## Summary
- ensure deprecated `hf_text_field` alias raises on conflict with explicit input/target fields
- add regression test for `hf_text_field` conflict scenario

## Testing
- `pre-commit run --files src/codex_ml/eval/datasets.py tests/eval/test_hf_dataset_loader.py`
- `mypy src/codex_ml/eval/datasets.py --follow-imports=skip`
- `pytest tests/eval/test_hf_dataset_loader.py -o addopts=`
- `nox -s tests` *(interrupted: dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3983f84c8331b0f36ff8895a19b2