### PR TITLE
fix: guard eval and preserve trainer defaults

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -27,12 +27,6 @@ tokenizer:
 pipeline:
   steps: ["load_data", "tokenize", "train", "evaluate"]
 
-output_dir: ./outputs
-
-eval:
-  datasets: []
-  metrics: []
-
 symbolic_pipeline:
   enabled: false
 


### PR DESCRIPTION
## Summary
- preserve runtime overrides when training config is missing
- guard CLI evaluate step and add default eval config
- add regression test for missing eval config
- remove duplicate output_dir and eval entries in base config

## Testing
- `pre-commit run --files configs/config.yaml`
- `nox -s tests` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68bd3a19b85c8331990749056406022e