### PR TITLE
0 c base: handle DatasetDict and training main

### DIFF
--- a/src/codex_ml/eval/datasets.py
+++ b/src/codex_ml/eval/datasets.py
@@ -107,6 +107,17 @@ def load_dataset(
                         ds = hf_load_dataset(name_or_path)  # type: ignore[misc]
             else:
                 ds = hf_load_dataset(name_or_path, split=split)  # type: ignore[misc]
+            # If the loader returned a DatasetDict, select the desired split
+            if isinstance(ds, DatasetDict) or hasattr(ds, "keys"):
+                if split is None:
+                    chosen = "train" if "train" in ds else next(iter(ds.keys()))
+                else:
+                    chosen = split
+                if chosen not in ds:
+                    raise ValueError(
+                        f"Split '{chosen}' not found in dataset; available: {list(ds.keys())}"
+                    )
+                ds = ds[chosen]
             data = [
                 Example(
                     str(row.get("input", row.get("text", ""))),


### PR DESCRIPTION
## Summary
- handle DatasetDict returned by remote dataset fallback by selecting the requested or first available split
- add regression test covering DatasetDict returned when HF builder fails

## Testing
- `SKIP=bandit,detect-secrets,safety,pip-audit pre-commit run --files src/codex_ml/eval/datasets.py tests/eval/test_datasets_hf_disk.py`
- `nox -s typecheck` *(fails: Module "codex_ml.utils.checkpointing" has no attribute "set_seed" and others)*
- `nox -s tests` *(fails: AssertionError in tests/checkpointing/test_periodic_and_trim.py::test_periodic_and_trim)*

------
https://chatgpt.com/codex/tasks/task_e_68bd401cbeec8331a4e4ae8f301b2340