### PR TITLE
fix: guard eval and preserve trainer defaults

### DIFF
--- a/tests/test_codexml_cli.py
+++ b/tests/test_codexml_cli.py
@@ -15,28 +15,28 @@ def test_codexml_cli_skips_eval(monkeypatch):
 
     called = {"eval": False}
 
-    # Patch the evaluation entrypoint used by the CLI
-    monkeypatch.setattr("codex_ml.cli.main.evaluate_datasets", fake_eval)
-
-    # Explicitly disable evaluation via config; CLI should exit cleanly and not call evaluate
-    with pytest.raises(SystemExit) as excinfo:
-        cli(["pipeline.steps=[evaluate]", "eval=null", "hydra.run.dir=."])
-    assert excinfo.value.code == 0
-    assert called is False
-
     def fake_eval(*args, **kwargs):
         called["eval"] = True
 
     monkeypatch.setattr("codex_ml.cli.main.run_training", lambda cfg: None)
     monkeypatch.setattr("codex_ml.cli.main.evaluate_datasets", fake_eval)
 
+    # Explicitly disable evaluation via config; CLI should exit cleanly and not call evaluate
+    with pytest.raises(SystemExit) as excinfo:
+        cli(["pipeline.steps=[evaluate]", "eval=null", "hydra.run.dir=."])
+    assert excinfo.value.code == 0
+    assert called["eval"] is False
+
+    GlobalHydra.instance().clear()
+
     with pytest.raises(SystemExit):
         cli(["eval=null"])
+    assert called["eval"] is False
 
-    monkeypatch.setattr("codex_ml.cli.main.evaluate_datasets", fake_eval)
+    GlobalHydra.instance().clear()
 
     # With default config (no eval=null), the CLI should attempt evaluation
     with pytest.raises(SystemExit) as excinfo:
         cli(["hydra.run.dir=."])
     assert excinfo.value.code == 0
-    assert called is True
+    assert called["eval"] is True


### PR DESCRIPTION
## Summary
- ensure regression test defines `fake_eval` before patching, asserts eval flag, and resets Hydra between CLI calls

## Testing
- `pre-commit run --files tests/test_codexml_cli.py`
- `nox -s tests` *(failed: Command pytest ... exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4585de148331918d2843712ea789