### PR TITLE
Handle DatasetDict loading and wire training entry

### DIFF
--- a/tests/test_codexml_cli.py
+++ b/tests/test_codexml_cli.py
@@ -40,3 +40,27 @@ def test_codexml_cli_skips_eval(monkeypatch):
         cli(["hydra.run.dir=."])
     assert excinfo.value.code == 0
     assert called["eval"] is True
+
+
+def test_run_training_invokes_functional_entry(monkeypatch):
+    from omegaconf import OmegaConf
+
+    from codex_ml.cli import main as cli_main
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_main(argv: list[str] | None) -> int:
+        captured["argv"] = argv or []
+        return 0
+
+    monkeypatch.setattr(cli_main, "_functional_training_main", fake_main)
+
+    cfg = OmegaConf.create(
+        {"epochs": 2, "texts": ["hi"], "val_texts": ["bye"], "lr": 1e-5}
+    )
+    cli_main.run_training(cfg)
+
+    assert captured["argv"][:2] == ["--texts", "hi"]
+    assert "--val-texts" in captured["argv"]
+    assert "training.epochs=2" in captured["argv"]
+    assert "training.lr=1e-05" in captured["argv"]


### PR DESCRIPTION
## Summary
- invoke `training.functional_training.main` from Hydra CLI and translate config values to CLI overrides
- add a regression test confirming the Hydra CLI forwards training config to the functional entry point

## Testing
- `pre-commit run --files src/codex_ml/cli/main.py tests/test_codexml_cli.py` *(failed: pip-audit skipped via SKIP)*
- `mypy src/codex_ml/cli/main.py tests/test_codexml_cli.py` *(failed: codex_ml/utils/checkpointing.py:12: error: Argument 1 to "module_from_spec" has incompatible type "ModuleSpec | None"; expected "ModuleSpec")*
- `nox -s tests` *(interrupted: Session coverage interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bd576fbb908331bfd4ed7c6a7dbe22