### PR TITLE
fix config loader and hydra config paths

### DIFF
--- a/src/codex_ml/cli/main.py
+++ b/src/codex_ml/cli/main.py
@@ -50,7 +50,7 @@ except Exception:  # pragma: no cover
         return None
 
 
-@hydra.main(version_base="1.3", config_path="../../configs", config_name="config")
+@hydra.main(version_base="1.3", config_path="../../../configs", config_name="config")
 def main(cfg: DictConfig) -> None:  # pragma: no cover - simple dispatcher
     """Dispatch pipeline steps defined in the Hydra config."""
     print(OmegaConf.to_yaml(cfg))

--- a/src/codex_ml/utils/config_loader.py
+++ b/src/codex_ml/utils/config_loader.py
@@ -8,7 +8,7 @@ from hydra import compose, initialize_config_dir
 from hydra.errors import MissingConfigException
 from omegaconf import DictConfig, OmegaConf
 
-_CFG_DIR = Path("configs/training")  # resolved relative to cwd at call time
+_CFG_DIR = Path("configs/training")
 _PRIMARY = "base"
 
 
@@ -48,7 +48,7 @@ def load_training_cfg(
 
     overrides = overrides or []
 
-    cfg_dir = Path.cwd() / _CFG_DIR
+    cfg_dir = Path(__file__).resolve().parents[3] / _CFG_DIR
     if cfg_dir.is_dir() and (cfg_dir / f"{_PRIMARY}.yaml").is_file():
         # Hydra Compose API: https://hydra.cc/docs/advanced/compose_api/
         with initialize_config_dir(version_base=None, config_dir=str(cfg_dir)):


### PR DESCRIPTION
## Summary
- resolve training config directory relative to module to avoid Hydra run-dir issues
- point CLI hydra entry to repository configs

## Testing
- `pre-commit run --files src/codex_ml/utils/config_loader.py src/codex_ml/cli/main.py`
- `mypy --follow-imports=skip src/codex_ml/utils/config_loader.py src/codex_ml/cli/main.py`
- `nox -s tests` *(fails: unrecognized arguments in tests/config/test_override_propagation.py::test_override_file)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5c4178348331b28a8291aef37970