### PR TITLE
fix: forward output_dir to training entrypoint

### DIFF
--- a/src/codex_ml/cli/main.py
+++ b/src/codex_ml/cli/main.py
@@ -19,17 +19,28 @@ except Exception:  # pragma: no cover - training optional
     _functional_training_main = None
 
 
-def run_training(cfg: DictConfig | None) -> None:
-    """Invoke the functional training entry point with overrides from cfg."""
+def run_training(cfg: DictConfig | None, output_dir: str | None = None) -> None:
+    """Invoke the functional training entry point with overrides from cfg.
+
+    Parameters
+    ----------
+    cfg:
+        Training configuration block.
+    output_dir:
+        Fallback path for training artifacts if not specified in ``cfg``.
+    """
     if _functional_training_main is None:  # pragma: no cover - safety fallback
         raise RuntimeError("training.functional_training.main is unavailable")
 
     cfg_dict = {} if cfg is None else dict(OmegaConf.to_container(cfg, resolve=True))
     texts = cfg_dict.pop("texts", None)
     val_texts = cfg_dict.pop("val_texts", None)
+    cfg_output = cfg_dict.pop("output_dir", None) or output_dir
     overrides = [f"training.{k}={v}" for k, v in cfg_dict.items()]
 
     argv: list[str] = []
+    if cfg_output:
+        argv.extend(["--output-dir", str(cfg_output)])
     if texts:
         argv.extend(["--texts", *[str(t) for t in texts]])
     if val_texts:
@@ -54,7 +65,7 @@ def main(cfg: DictConfig) -> None:  # pragma: no cover - simple dispatcher
     print(OmegaConf.to_yaml(cfg))
     for step in cfg.pipeline.steps:
         if step == "train":
-            run_training(cfg.train)
+            run_training(cfg.train, cfg.get("output_dir"))
         elif step == "evaluate":
             eval_cfg = OmegaConf.select(cfg, "eval")
             if eval_cfg is None:

--- a/tests/test_codexml_cli.py
+++ b/tests/test_codexml_cli.py
@@ -18,7 +18,7 @@ def test_codexml_cli_skips_eval(monkeypatch):
     def fake_eval(*args, **kwargs):
         called["eval"] = True
 
-    monkeypatch.setattr("codex_ml.cli.main.run_training", lambda cfg: None)
+    monkeypatch.setattr("codex_ml.cli.main.run_training", lambda cfg, output_dir=None: None)
     monkeypatch.setattr("codex_ml.cli.main.evaluate_datasets", fake_eval)
 
     # Explicitly disable evaluation via config; CLI should exit cleanly and not call evaluate
@@ -56,11 +56,17 @@ def test_run_training_invokes_functional_entry(monkeypatch):
     monkeypatch.setattr(cli_main, "_functional_training_main", fake_main)
 
     cfg = OmegaConf.create(
-        {"epochs": 2, "texts": ["hi"], "val_texts": ["bye"], "lr": 1e-5}
+        {
+            "output_dir": "my_runs",
+            "epochs": 2,
+            "texts": ["hi"],
+            "val_texts": ["bye"],
+            "lr": 1e-5,
+        }
     )
-    cli_main.run_training(cfg)
+    cli_main.run_training(cfg, output_dir="ignored_root")
 
-    assert captured["argv"][:2] == ["--texts", "hi"]
+    assert captured["argv"][:4] == ["--output-dir", "my_runs", "--texts", "hi"]
     assert "--val-texts" in captured["argv"]
     assert "training.epochs=2" in captured["argv"]
     assert "training.lr=1e-05" in captured["argv"]


### PR DESCRIPTION
## Summary
- propagate configured output directory to `training.functional_training.main`
- update `codex_ml` CLI tests for new `run_training` signature

## Testing
- `pre-commit run --files src/codex_ml/cli/main.py tests/test_codexml_cli.py`
- `mypy --follow-imports=skip src/codex_ml/cli/main.py tests/test_codexml_cli.py`
- `nox -s tests` *(fails: unrecognized arguments in tests/config/test_override_propagation.py::test_override_file)*

------
https://chatgpt.com/codex/tasks/task_e_68bd61dd96608331bb23750c785c42e5