### PR TITLE
0 c base 

### DIFF
--- a/tests/test_cli_train_engine.py
+++ b/tests/test_cli_train_engine.py
@@ -20,3 +20,34 @@ def test_cli_train_custom_engine_forwards_args(monkeypatch):
     result = runner.invoke(cli, ["train", "--engine", "custom", "--output-dir", "out"])
     assert result.exit_code == 0
     assert captured["argv"] == ["--engine", "custom", "--output-dir", "out"]
+
+
+def test_cli_train_hf_engine_parses_args(monkeypatch, tmp_path):
+    runner = CliRunner()
+    captured: dict[str, object] = {}
+
+    def fake_run(texts, output_dir, **kw):
+        captured["texts"] = list(texts)
+        captured["output_dir"] = output_dir
+        captured["kw"] = kw
+
+    monkeypatch.setattr("training.engine_hf_trainer.run_hf_trainer", fake_run)
+
+    result = runner.invoke(
+        cli,
+        [
+            "train",
+            "--engine",
+            "hf",
+            "--texts",
+            "hi",
+            "--output-dir",
+            str(tmp_path),
+            "--seed",
+            "123",
+        ],
+    )
+    assert result.exit_code == 0
+    assert captured["texts"] == ["hi"]
+    assert captured["output_dir"] == tmp_path
+    assert captured["kw"]["seed"] == 123


### PR DESCRIPTION
## Summary
- parse Hugging Face training flags in the `codex train` CLI instead of forwarding raw strings, routing options through an argparse parser before invoking `run_hf_trainer`
- add a regression test ensuring the HF path accepts `--texts`, `--output-dir`, and propagates the seed value

## Testing
- `pre-commit run --files src/codex/cli.py tests/test_cli_train_engine.py`
- `mypy --follow-imports=skip src/codex/cli.py tests/test_cli_train_engine.py`
- `nox -s tests` *(fails: tests/config/test_override_propagation.py::test_override_file – unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68bd673187f48331bcf75486d71ce722