### PR TITLE
0 c base

### DIFF
--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -139,6 +139,8 @@ def train_cmd(engine: str, engine_args: tuple[str, ...]) -> None:
             "lora_r": args.lora_r,
             "lora_alpha": args.lora_alpha,
             "seed": args.seed,
+            "device": args.device,
+            "dtype": args.dtype,
         }
         return run_hf_trainer(args.texts, args.output_dir, **kw)
     else:

--- a/src/codex_ml/utils/config_loader.py
+++ b/src/codex_ml/utils/config_loader.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+import yaml
 from hydra import compose, initialize_config_dir
 from hydra.errors import MissingConfigException
 from omegaconf import DictConfig, OmegaConf
@@ -67,5 +68,6 @@ def load_training_cfg(
     if overrides:
         for item in overrides:
             key, value = item.split("=", 1)
-            OmegaConf.update(cfg, key, OmegaConf.create(value), merge=True)
+            parsed = yaml.safe_load(value)
+            OmegaConf.update(cfg, key, parsed, merge=True)
     return cfg

--- a/tests/eval/test_datasets_hf_disk.py
+++ b/tests/eval/test_datasets_hf_disk.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -26,7 +25,7 @@ def test_load_dataset_from_hf_disk_datasetdict(tmp_path: Path):
         }
     )
     ds_path = tmp_path / "dsdd"
-    dd.save_to_disk(ds_path)
+    ds.save_to_disk(ds_path)
     train_examples = load_dataset(str(ds_path))
     assert train_examples == [Example("a", "b")]
     test_examples = load_dataset(str(ds_path), hf_split="test")

--- a/tests/test_cli_train_engine.py
+++ b/tests/test_cli_train_engine.py
@@ -45,9 +45,15 @@ def test_cli_train_hf_engine_parses_args(monkeypatch, tmp_path):
             str(tmp_path),
             "--seed",
             "123",
+            "--device",
+            "cpu",
+            "--dtype",
+            "bf16",
         ],
     )
     assert result.exit_code == 0
     assert captured["texts"] == ["hi"]
     assert captured["output_dir"] == tmp_path
     assert captured["kw"]["seed"] == 123
+    assert captured["kw"]["device"] == "cpu"
+    assert captured["kw"]["dtype"] == "bf16"

--- a/tests/training/test_config_loading.py
+++ b/tests/training/test_config_loading.py
@@ -72,3 +72,15 @@ def test_file_mode_invariant(ensure_cfg_dir):
     with initialize_config_dir(version_base=None, config_dir=str(CFG_DIR.resolve())):
         cfg = compose(config_name="base")
         assert "training" in cfg
+
+
+def test_fallback_overrides_keep_types(ensure_cfg_dir):
+    if BASE.exists():
+        BASE.unlink()
+    cfg = load_training_cfg(
+        allow_fallback=True, overrides=["training.batch_size=2", "training.lr=0.5"]
+    )
+    assert cfg.training.batch_size == 2
+    assert isinstance(cfg.training.batch_size, int)
+    assert cfg.training.lr == 0.5
+    assert isinstance(cfg.training.lr, float)


### PR DESCRIPTION
## Summary
- parse fallback overrides using YAML to preserve numeric types
- forward `--device` and `--dtype` options from the `codex train` CLI to the HF trainer and fix DatasetDict disk test
- add tests validating typed overrides and argument forwarding

## Testing
- `pre-commit run --files src/codex_ml/utils/config_loader.py src/codex/cli.py tests/eval/test_datasets_hf_disk.py tests/test_cli_train_engine.py tests/training/test_config_loading.py`
- `mypy --follow-imports=skip src/codex_ml/utils/config_loader.py src/codex/cli.py tests/eval/test_datasets_hf_disk.py tests/test_cli_train_engine.py tests/training/test_config_loading.py`
- `nox -s tests` *(dependency installation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6bd986148331bf1ae791f1915aa3