### PR TITLE
fix config loader path and remove duplicate keys

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -24,12 +24,6 @@ tokenizer:
   name: gpt2
   use_fast: true
 
-output_dir: ${oc.env:CODEX_OUTPUT_DIR, "runs/default"}
-
-eval:
-  datasets: []
-  metrics: []
-
 pipeline:
   steps: ["load_data", "tokenize", "train", "evaluate"]
 

--- a/src/codex_ml/utils/config_loader.py
+++ b/src/codex_ml/utils/config_loader.py
@@ -9,9 +9,18 @@ from hydra import compose, initialize_config_dir
 from hydra.errors import MissingConfigException
 from omegaconf import DictConfig, OmegaConf
 
-_CFG_DIR = (
-    Path(__file__).resolve().parents[3] / "configs" / "training"
-)  # resolved relative to repo root
+
+def _find_cfg_dir() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "configs" / "training"
+        if candidate.is_dir():
+            return candidate
+    # default to repo-relative path if not found
+    return here.parents[4] / "configs" / "training"
+
+
+_CFG_DIR = _find_cfg_dir()
 _PRIMARY = "base"
 
 


### PR DESCRIPTION
## Summary
- remove duplicate `output_dir` and `eval` blocks from root Hydra config
- make training config loader search ancestor directories for `configs/training`

## Testing
- `pre-commit run --files configs/config.yaml src/codex_ml/utils/config_loader.py`
- `mypy --follow-imports=skip src/codex_ml/utils/config_loader.py`
- `nox -s tests` *(fails: subprocess.CalledProcessError in tests/config/test_override_propagation.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bd709456d883318bcc5d18bf3a0f54