### PR TITLE
0 c base : remove duplicate keys in root config

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -24,12 +24,6 @@ tokenizer:
   name: gpt2
   use_fast: true
 
-output_dir: ${oc.env:CODEX_OUTPUT_DIR, "runs/default"}
-
-eval:
-  datasets: []
-  metrics: []
-
 pipeline:
   steps: ["load_data", "tokenize", "train", "evaluate"]
 


### PR DESCRIPTION
## Summary
- remove repeated `output_dir` and `eval` entries from Hydra root config

## Testing
- `pre-commit run --files configs/config.yaml`
- `nox -s tests` *(fails: Command pytest -q --disable-warnings --maxfail=1 --cov --cov-branch --cov-report=term-missing --cov-fail-under=70 failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bd70a099fc8331a5c17d037f36c479