### PR TITLE
Use parser.error when training texts missing

### DIFF
--- a/training/functional_training.py
+++ b/training/functional_training.py
@@ -63,7 +63,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     texts = args.texts or training_cfg.get("texts")
     if not texts:
-        raise ValueError("`cfg.training.texts` must be provided to run training.")
+        parser.error("Provide training texts via --texts or config.training.texts")
     val_texts = args.val_texts or training_cfg.get("val_texts")
     seed = int(training_cfg.get("seed", 0))
 


### PR DESCRIPTION
## Summary
- raise a friendly argparse error if training texts are omitted

## Testing
- `SKIP=bandit,detect-secrets,safety,pip-audit pre-commit run --files training/functional_training.py`
- `mypy --follow-imports=skip training/functional_training.py`
- `nox -s tests` *(fails: unrecognized arguments in tests/config/test_override_propagation.py::test_override_file)*

------
https://chatgpt.com/codex/tasks/task_e_68bd79421da08331ac95c37b232624b0