### PR TITLE
Add test for run_unit_tests error parsing and fix metrics

### DIFF
--- a/src/codex_ml/eval/metrics.py
+++ b/src/codex_ml/eval/metrics.py
@@ -96,9 +96,7 @@ def exact_match_strict(pred: str, ref: str) -> float:
     return 1.0 if norm(pred) == norm(ref) else 0.0
 
 
-def bleu(
-    candidates: List[str], references: List[str], lowercase: bool = True
-) -> Optional[float]:
+def bleu(candidates: List[str], references: List[str], lowercase: bool = True) -> Optional[float]:
     try:
         from nltk.translate.bleu_score import SmoothingFunction, corpus_bleu
     except Exception:
@@ -128,9 +126,7 @@ def rouge_l(
         candidates = [c.lower() for c in candidates]
         references = [r.lower() for r in references]
     scorer = rouge_scorer.RougeScorer(["rougeL"], use_stemmer=True)
-    scores = [
-        scorer.score(r, c)["rougeL"].fmeasure for c, r in zip(candidates, references)
-    ]
+    scores = [scorer.score(r, c)["rougeL"].fmeasure for c, r in zip(candidates, references)]
     if not scores:
         return None
     return {"rougeL_f": float(sum(scores) / len(scores))}
@@ -148,23 +144,16 @@ def run_unit_tests(code_str: str, tests_dir: str) -> Dict[str, int]:
         ["pytest", "-q", tests_dir], cwd=str(tmpdir), capture_output=True, text=True
     )
     out = proc.stdout + proc.stderr
-    # heuristic parse
-    passed = (
-        len(re.findall(r"\b(\d+) passed\b", out))
-        and int(re.findall(r"\b(\d+) passed\b", out)[-1])
-        or 0
-    )
-    failed = (
-        len(re.findall(r"\b(\d+) failed\b", out))
-        and int(re.findall(r"\b(\d+) failed\b", out)[-1])
-        or 0
-    )
-    errors = (
-        len(re.findall(r"\b(\d+) error\b", out))
-        and int(re.findall(r"\b(\d+) error\b", out)[-1])
-        or 0
-    )
-    return {"passed": passed, "failed": failed, "errors": errors}
+
+    def _count(pattern: str) -> int:
+        matches = re.findall(pattern, out)
+        return int(matches[-1]) if matches else 0
+
+    return {
+        "passed": _count(r"\b(\d+)\s+passed\b"),
+        "failed": _count(r"\b(\d+)\s+failed\b"),
+        "errors": _count(r"\b(\d+)\s+errors?\b"),
+    }
 
 
 # END: CODEX_METRICS

--- a/tests/eval/test_run_unit_tests.py
+++ b/tests/eval/test_run_unit_tests.py
@@ -1,0 +1,17 @@
+from codex_ml.eval.metrics import run_unit_tests
+
+
+def test_run_unit_tests_counts(tmp_path):
+    tests_dir = tmp_path / "t"
+    tests_dir.mkdir()
+    (tests_dir / "test_one.py").write_text(
+        "from candidate import buggy\n\n" "def test_one():\n" "    buggy()\n",
+        encoding="utf-8",
+    )
+    (tests_dir / "test_two.py").write_text(
+        "from candidate import buggy\n\n" "def test_two():\n" "    buggy()\n",
+        encoding="utf-8",
+    )
+    code = "def buggy():\n    raise RuntimeError('bug')\n"
+    summary = run_unit_tests(code, str(tests_dir))
+    assert summary == {"passed": 0, "failed": 0, "errors": 2}


### PR DESCRIPTION
## Summary
- ensure telemetry decorators imported in data loaders
- fix metrics.run_unit_tests to correctly parse plural `errors`
- add regression test covering plural error detection

## Testing
- `pytest tests/eval/test_run_unit_tests.py::test_run_unit_tests_counts -q --no-cov`
- `SKIP=bandit,pip-audit pre-commit run --files tests/eval/test_run_unit_tests.py src/codex_ml/eval/metrics.py src/codex_ml/data/loaders.py`
- `nox -s tests` *(fails: import file mismatch in tests/models/test_registry.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bdea302fe48331a5607e0fdc8eacbd