### PR TITLE
feat: wire interface config and lora settings

### DIFF
--- a/configs/interfaces.example.yaml
+++ b/configs/interfaces.example.yaml
@@ -1,6 +1,12 @@
 # BEGIN: CODEX_IFACE_CONFIG
 # Example mapping of interface groups to concrete implementations
-tokenizer: yourpkg.tokenizers.hf:HFTokenizer   # TODO: replace with actual module:class
-reward_model: yourpkg.rewards.simple:SimpleReward
-rl_agent: yourpkg.rl.ppo:PPOAgent
+tokenizer:
+  path: yourpkg.tokenizers.hf:HFTokenizer   # TODO: replace with actual module:class
+  kwargs: {}
+reward_model:
+  path: yourpkg.rewards.simple:SimpleReward
+  kwargs: {}
+rl_agent:
+  path: yourpkg.rl.ppo:PPOAgent
+  kwargs: {}
 # END: CODEX_IFACE_CONFIG

--- a/configs/interfaces.yaml
+++ b/configs/interfaces.yaml
@@ -1,0 +1,10 @@
+# Map interface names to implementation paths and optional kwargs.
+# tokenizer:
+#   path: yourpkg.tokenizers.hf:HFTokenizer
+#   kwargs: {}
+# reward_model:
+#   path: yourpkg.rewards.simple:SimpleReward
+#   kwargs: {}
+# rl_agent:
+#   path: yourpkg.rl.ppo:PPOAgent
+#   kwargs: {}

--- a/tests/training/test_functional_training_main.py
+++ b/tests/training/test_functional_training_main.py
@@ -103,3 +103,20 @@ def test_main_populates_labels_for_custom_engine(monkeypatch, tmp_path: Path) ->
     assert captured["labels"].tolist() == [5, 6, -100]
     assert captured["val_labels"].tolist() == [5, 6, -100]
     assert captured["grad_accum"] == 3
+
+
+def test_main_passes_lora_config(monkeypatch, tmp_path: Path):
+    cfg = OmegaConf.create(
+        {"training": {"texts": ["hi"], "lora": {"enable": True, "r": 8, "alpha": 32}}}
+    )
+    monkeypatch.setattr(ft, "load_training_cfg", lambda **kwargs: cfg)
+    called: dict[str, Any] = {}
+
+    def fake_run(texts, output_dir, **kwargs):
+        called.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(ft, "run_hf_trainer", fake_run)
+    ft.main(["--output-dir", str(tmp_path), "--engine", "hf"])
+    assert called["lora_r"] == 8
+    assert called["lora_alpha"] == 32

--- a/tools/apply_interfaces.py
+++ b/tools/apply_interfaces.py
@@ -53,17 +53,17 @@ def log_change(action: str, path: Path, why: str, preview: str = "") -> None:
 
 
 def q5(step: str, err: str, ctx: str) -> None:
-    rq = textwrap.dedent(f"""\
+    rq = textwrap.dedent(
+        f"""\
     Question for ChatGPT-5 {ts()}:
     While performing [{step}], encountered the following error:
     {err}
     Context: {ctx}
     What are the possible causes, and how can this be resolved while preserving intended functionality?
-    """)
+    """
+    )
     with ERRORS.open("a", encoding="utf-8") as fh:
-        fh.write(
-            json.dumps({"ts": ts(), "step": step, "error": err, "context": ctx}) + "\n"
-        )
+        fh.write(json.dumps({"ts": ts(), "step": step, "error": err, "context": ctx}) + "\n")
     sys.stderr.write(rq + "\n")
 
 
@@ -192,13 +192,37 @@ __all__ = ["TokenizerAdapter", "RewardModel", "RLAgent"]
 
 # ---------------- Tests ----------------
 S_TESTS = "# BEGIN: CODEX_IFACE_TESTS"
-TESTS = f"""{S_TESTS}
-import os, importlib, types, pytest
+TESTS = (
+    S_TESTS
+    + """
+import importlib, json, os, types, pytest, yaml
 from typing import Any, Mapping, Optional
 from codex_ml.interfaces import TokenizerAdapter, RewardModel, RLAgent
 
 # Configuration:
 # Provide module paths via environment or a config file consumed elsewhere.
+CFG_PATH = os.getenv("CODEX_INTERFACES_CFG", "configs/interfaces.yaml")
+if os.path.exists(CFG_PATH):
+    with open(CFG_PATH, "r", encoding="utf-8") as fh:
+        _cfg = yaml.safe_load(fh) or {{}}
+    _map = {{
+        "tokenizer": ("CODEX_TOKENIZER_PATH", "CODEX_TOKENIZER_KWARGS"),
+        "reward_model": ("CODEX_REWARD_PATH", "CODEX_REWARD_KWARGS"),
+        "rl_agent": ("CODEX_RL_PATH", "CODEX_RL_KWARGS"),
+    }}
+    for k, (p_env, k_env) in _map.items():
+        if k in _cfg:
+            entry = _cfg[k]
+            if isinstance(entry, str):
+                os.environ.setdefault(p_env, entry)
+            else:
+                path = entry.get("path")
+                kwargs = entry.get("kwargs")
+                if path:
+                    os.environ.setdefault(p_env, path)
+                if kwargs:
+                    os.environ.setdefault(k_env, json.dumps(kwargs))
+
 TOK_PATH = os.getenv("CODEX_TOKENIZER_PATH")   # e.g., "yourpkg.tokenizers.hf:HFTokenizer"
 RWD_PATH = os.getenv("CODEX_REWARD_PATH")      # e.g., "yourpkg.rewards.simple:SimpleReward"
 RL_PATH  = os.getenv("CODEX_RL_PATH")          # e.g., "yourpkg.rl.ppo:PPOAgent"
@@ -208,10 +232,18 @@ def _load(path: str) -> Any:
     m = importlib.import_module(mod)
     return getattr(m, cls)
 
+def _kwargs(env: str) -> dict:
+    data = os.getenv(env)
+    return json.loads(data) if data else {{}}
+
+TOK_KW = _kwargs("CODEX_TOKENIZER_KWARGS")
+RWD_KW = _kwargs("CODEX_REWARD_KWARGS")
+RL_KW = _kwargs("CODEX_RL_KWARGS")
+
 @pytest.mark.skipif(TOK_PATH is None, reason="Tokenizer implementation not provided")
 def test_tokenizer_adapter_contract():
     cls = _load(TOK_PATH)
-    inst = cls()  # TODO: supply kwargs if needed
+    inst = cls(**TOK_KW)
     assert isinstance(inst, TokenizerAdapter)
     ids = inst.encode("hello")
     assert isinstance(ids, list) and all(isinstance(i, int) for i in ids)
@@ -224,7 +256,7 @@ def test_tokenizer_adapter_contract():
 @pytest.mark.skipif(RWD_PATH is None, reason="RewardModel implementation not provided")
 def test_reward_model_contract():
     cls = _load(RWD_PATH)
-    inst = cls()  # TODO: supply kwargs if needed
+    inst = cls(**RWD_KW)
     score = inst.evaluate("prompt", "completion")
     assert isinstance(score, float)
     metrics = inst.learn([("prompt", "completion", 1.0)])
@@ -233,7 +265,7 @@ def test_reward_model_contract():
 @pytest.mark.skipif(RL_PATH is None, reason="RLAgent implementation not provided")
 def test_rl_agent_contract(tmp_path):
     cls = _load(RL_PATH)
-    inst = cls()  # TODO: supply kwargs if needed
+    inst = cls(**RL_KW)
     a = inst.act({{"obs": 1}})
     assert a is not None
     metrics = inst.update({{"states": [], "actions": [], "rewards": []}})
@@ -283,21 +315,28 @@ def test_rl_agent_abc(tmp_path):
     assert p.exists()
     agent.load(str(p))
 
-# --- Codex prompts (for future completion) ---
-# TODO[Codex]: If your implementations require constructor arguments, update tests to pass minimal viable config.
-# TODO[Codex]: Wire a config reader to set CODEX_*_PATH from configs/interfaces.yaml during pytest collection.
 # END: CODEX_IFACE_TESTS
 """
+)
 
 # ---------------- Config example ----------------
 S_CFG = "# BEGIN: CODEX_IFACE_CONFIG"
-CFG = f"""{S_CFG}
+CFG = (
+    S_CFG
+    + """
 # Example mapping of interface groups to concrete implementations
-tokenizer: yourpkg.tokenizers.hf:HFTokenizer   # TODO: replace with actual module:class
-reward_model: yourpkg.rewards.simple:SimpleReward
-rl_agent: yourpkg.rl.ppo:PPOAgent
+tokenizer:
+  path: yourpkg.tokenizers.hf:HFTokenizer   # TODO: replace with actual module:class
+  kwargs: {}
+reward_model:
+  path: yourpkg.rewards.simple:SimpleReward
+  kwargs: {}
+rl_agent:
+  path: yourpkg.rl.ppo:PPOAgent
+  kwargs: {}
 # END: CODEX_IFACE_CONFIG
 """
+)
 
 # ---------------- Docs ----------------
 S_DOCS = "<!-- BEGIN: CODEX_IFACE_DOCS -->"
@@ -430,9 +469,7 @@ def main():
         action="store_true",
         help="create interfaces, compat tests, docs, and entry-point stubs",
     )
-    ap.add_argument(
-        "--validate", action="store_true", help="run local validations (mypy/pytest)"
-    )
+    ap.add_argument("--validate", action="store_true", help="run local validations (mypy/pytest)")
     args = ap.parse_args()
     if args.apply:
         apply()

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -846,4 +846,6 @@ def build_parser() -> argparse.ArgumentParser:
         choices=["fp32", "fp16", "bf16"],
         help="Numerical precision",
     )
+    add("--lora-r", type=int, default=None, help="LoRA rank parameter")
+    add("--lora-alpha", type=int, default=16, help="LoRA alpha parameter")
     return _codex_patch_argparse(parser)


### PR DESCRIPTION
## Summary
- allow interfaces tests to load implementation paths and kwargs from a config file
- expose LoRA hyperparameters in training utilities and CLI
- provide empty interfaces config stub for customization

## Testing
- `mypy tools/apply_interfaces.py training/functional_training.py training/engine_hf_trainer.py tests/test_interfaces_compat.py tests/training/test_functional_training_main.py && echo 'mypy success'`
- `pre-commit run --files tools/apply_interfaces.py tests/test_interfaces_compat.py configs/interfaces.example.yaml configs/interfaces.yaml training/functional_training.py training/engine_hf_trainer.py tests/training/test_functional_training_main.py` *(fails: bandit triggers repository-wide security warnings)*
- `nox -s tests` *(fails: required dependencies download >1GB)*

------
https://chatgpt.com/codex/tasks/task_e_68bdebe6910c83319735bd735ed29a51