### PR TITLE
Expose LoRA dropout and config-driven logging

### DIFF
--- a/src/codex_ml/interfaces/__init__.py
+++ b/src/codex_ml/interfaces/__init__.py
@@ -1,5 +1,5 @@
 # BEGIN: CODEX_IFACE_INIT
-from .registry import get, register
+from .registry import get, get_component, load_component, register
 from .reward_model import RewardModel
 from .rl import RLAgent
 from .tokenizer import HFTokenizer, TokenizerAdapter
@@ -11,5 +11,7 @@ __all__ = [
     "RLAgent",
     "register",
     "get",
+    "load_component",
+    "get_component",
 ]
 # END: CODEX_IFACE_INIT

--- a/src/codex_ml/interfaces/registry.py
+++ b/src/codex_ml/interfaces/registry.py
@@ -5,9 +5,10 @@ string keys. Interfaces are loaded on demand via entry-points or config.
 """
 from __future__ import annotations
 
+import os
+import warnings
 from importlib import import_module
 from typing import Any, Callable, Dict
-import warnings
 
 _REGISTRY: Dict[str, Callable[..., Any]] = {}
 
@@ -29,3 +30,19 @@ def get(name: str, *, fallback: str | None = None) -> Any:
         module, attr = fallback.split(":")
         return getattr(import_module(module), attr)
     raise KeyError(f"No registered component named {name}")
+
+
+def load_component(path: str) -> Any:
+    """Load a component from ``module:Class`` notation."""
+
+    module_name, class_name = path.split(":")
+    module = import_module(module_name)
+    return getattr(module, class_name)
+
+
+def get_component(cfg_key: str, default_path: str) -> Any:
+    """Instantiate component using env var ``cfg_key`` or ``default_path``."""
+
+    path = os.environ.get(cfg_key, default_path)
+    cls = load_component(path)
+    return cls()

--- a/tests/interfaces/test_registry_loader.py
+++ b/tests/interfaces/test_registry_loader.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+from codex_ml.interfaces import get_component, load_component
+
+
+def test_load_and_get_component(tmp_path):
+    module_path = tmp_path / "tmp_mod.py"
+    module_path.write_text(
+        "class Dummy:\n    def __init__(self):\n        self.flag = True\n"
+    )
+    sys.path.insert(0, str(tmp_path))
+    try:
+        cls = load_component("tmp_mod:Dummy")
+        assert cls.__name__ == "Dummy"
+        os.environ["CODEX_DUMMY_PATH"] = "tmp_mod:Dummy"
+        inst = get_component("CODEX_DUMMY_PATH", "tmp_mod:Dummy")
+        assert isinstance(inst, cls) and inst.flag
+    finally:
+        sys.path.remove(str(tmp_path))
+        os.environ.pop("CODEX_DUMMY_PATH", None)

--- a/tests/monitoring/test_codex_logging_cfg.py
+++ b/tests/monitoring/test_codex_logging_cfg.py
@@ -1,0 +1,35 @@
+import argparse
+import types
+
+from codex_ml.monitoring import codex_logging as cl
+
+
+def test_logging_bootstrap_hydra_cfg(monkeypatch, tmp_path):
+    called = {}
+
+    class DummyWriter:
+        def __init__(self, log_dir):
+            called["tb"] = log_dir
+
+        def add_scalar(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(cl, "SummaryWriter", DummyWriter)
+    dummy_wandb = types.SimpleNamespace(init=lambda **kw: called.setdefault("wb", kw))
+    monkeypatch.setattr(cl, "wandb", dummy_wandb)
+    dummy_mlflow = types.SimpleNamespace(
+        set_tracking_uri=lambda uri: called.setdefault("ml_uri", uri),
+        set_experiment=lambda exp: called.setdefault("ml_exp", exp),
+        start_run=lambda: called.setdefault("ml_run", True),
+    )
+    monkeypatch.setattr(cl, "mlflow", dummy_mlflow)
+
+    cfg = {
+        "tensorboard": {"enable": True, "logdir": str(tmp_path)},
+        "wandb": {"enable": True, "project": "proj"},
+        "mlflow": {"enable": True, "tracking_uri": "uri", "experiment": "exp"},
+    }
+    loggers = cl._codex_logging_bootstrap(argparse.Namespace(hydra_cfg=cfg))
+    assert called["tb"] == str(tmp_path)
+    assert called["wb"]["project"] == "proj"
+    assert loggers.mlflow_active and called["ml_uri"] == "uri" and called["ml_exp"] == "exp"

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -426,6 +426,8 @@ class HFTrainerConfig:
         LoRA rank parameter
     lora_alpha : int
         LoRA alpha parameter
+    lora_dropout : float, optional
+        LoRA dropout rate
     precision : str, optional
         Precision setting override
     gradient_accumulation_steps : int
@@ -561,6 +563,7 @@ def run_hf_trainer(
     bf16: bool = False,
     lora_r: Optional[int] = None,
     lora_alpha: int = 16,
+    lora_dropout: Optional[float] = None,
     precision: Optional[str] = None,
     device: str = "auto",
     dtype: str = "fp32",
@@ -671,7 +674,10 @@ def run_hf_trainer(
     # Setup LoRA via adapter when requested
     if lora_r:
         try:
-            model = apply_lora(model, {"r": int(lora_r), "lora_alpha": int(lora_alpha)})
+            cfg = {"r": int(lora_r), "lora_alpha": int(lora_alpha)}
+            if lora_dropout is not None:
+                cfg["lora_dropout"] = float(lora_dropout)
+            model = apply_lora(model, cfg)
         except Exception as exc:
             log_error("lora_import", str(exc), "peft")
 
@@ -848,4 +854,5 @@ def build_parser() -> argparse.ArgumentParser:
     )
     add("--lora-r", type=int, default=None, help="LoRA rank parameter")
     add("--lora-alpha", type=int, default=16, help="LoRA alpha parameter")
+    add("--lora-dropout", type=float, default=None, help="LoRA dropout rate")
     return _codex_patch_argparse(parser)


### PR DESCRIPTION
## Summary
- allow `engine_hf_trainer` and custom loop to accept `lora_dropout`
- add env-driven `load_component`/`get_component` registry helpers
- enable Hydra-config based TensorBoard/W&B/MLflow initialisation
- verify CUDA determinism in custom trainer

## Testing
- `pre-commit run --files src/codex_ml/interfaces/__init__.py src/codex_ml/interfaces/registry.py src/codex_ml/monitoring/codex_logging.py training/engine_hf_trainer.py training/functional_training.py tests/interfaces/test_registry_loader.py tests/monitoring/test_codex_logging_cfg.py`
- `nox -s tests` *(fails: import file mismatch in tests/models/test_registry.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf99411c083318a592807f80c7788