### PR TITLE
chore: expand hydra root defaults

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -3,6 +3,11 @@
 defaults:
   - env: ubuntu
   - model: base
+  - data: base
+  - logging: base
+  - training: base
+  - tokenization: base
+  - tracking: base
 
 env:
   name: ubuntu

--- a/configs/tracking/base.yaml
+++ b/configs/tracking/base.yaml
@@ -1,0 +1,6 @@
+mlflow:
+  enabled: false
+  tracking_uri: ./mlruns
+wandb:
+  enabled: false
+  mode: offline


### PR DESCRIPTION
## Summary
- reference data, logging, training, tokenization, and tracking groups in Hydra root defaults
- add tracking base config for experiment logging flags

## Testing
- `pre-commit run --files configs/config.yaml configs/tracking/base.yaml` (command not found)
- `PYTHONPATH=src pytest tests/tokenization/test_adapter.py -q -c /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_68bdfa16f52083318c371c87379327af