### PR TITLE
refactor: decouple optional deps for cli and training

### DIFF
--- a/src/codex_ml/cli/codex_cli.py
+++ b/src/codex_ml/cli/codex_cli.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import click
 
 from codex_ml.telemetry import start_metrics_server
-from training.functional_training import TrainCfg, run_custom_trainer
 
 
 @click.group()
@@ -19,6 +18,8 @@ def train(text: list[str]):
         return
     model = "sshleifer/tiny-gpt2"
     from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    from training.functional_training import TrainCfg, run_custom_trainer
 
     tokenizer = AutoTokenizer.from_pretrained(model)
     model = AutoModelForCausalLM.from_pretrained(model)


### PR DESCRIPTION
## Summary
- make training functional robust to missing optional deps by wrapping imports and providing fallbacks
- lazy load training module in CLI to avoid import-time errors

## Testing
- `pytest -q tests/telemetry tests/connectors tests/cli tests/multilingual tests/privacy --no-cov`
- `pre-commit run --files training/functional_training.py src/codex_ml/cli/codex_cli.py` *(fails: pip-audit step interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfa7e03d883319a40efcbac8e5677