### PR TITLE
feat: improve offline model loading and psutil warning

### DIFF
--- a/tests/models/test_models_registry_api.py
+++ b/tests/models/test_models_registry_api.py
@@ -22,7 +22,8 @@ def test_get_hf_model(monkeypatch) -> None:
         def forward(self, *args, **kwargs):  # pragma: no cover - dummy
             return None
 
-    def fake_from_pretrained(name):  # pragma: no cover - patched
+    def fake_from_pretrained(name, **kwargs):  # pragma: no cover - patched
+        assert kwargs.get("local_files_only") is True
         return DummyModel()
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- load HuggingFace models in offline mode and provide clearer error guidance
- warn once when psutil is missing so system metrics are skipped gracefully
- cover registry via dedicated unit test

## Testing
- `pre-commit run --files src/codex_ml/models/registry.py src/codex_ml/monitoring/codex_logging.py tests/models/test_models_registry_api.py` *(fails: bandit/pip-audit hooks interrupted)*
- `nox -s tests` *(fails: ConfigCompositionException in tests/config/test_override_propagation.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfa5901c8833190a504ceb0832e32