### PR TITLE
docs: expand tokenization and config guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@
 - Executed pre-commit and nox quality gate sessions.
 - Add dataset loader supporting TXT/NDJSON/CSV with caching and safety filtering.
 - feat(model): introduce model registry with optional LoRA configuration and tests.
+- docs: document tokenizer adapter, Hydra configuration groups, and data loading utilities.

--- a/README.md
+++ b/README.md
@@ -771,7 +771,10 @@ them.
 
 ## Hydra Configuration & CLI
 
-This project uses Hydra for configuration.
+This project uses Hydra for configuration.  The root configuration lives at
+`configs/config.yaml` and composes several groups (`model`, `data`, `tokenizer`,
+`logging`, `training`, `tracking`).  Each group has a `base.yaml` defining
+defaults that can be overridden on the command line.
 
 ### Run (dry)
 

--- a/docs/modules/configuration.md
+++ b/docs/modules/configuration.md
@@ -1,0 +1,43 @@
+# Configuration Hierarchy
+
+`_codex_` uses [Hydra](https://hydra.cc) for configuration management.  The
+root configuration file is `configs/config.yaml` which composes a series of
+group configurations via its `defaults` list:
+
+```yaml
+defaults:
+  - env: ubuntu
+  - model: base
+  - data: base
+  - logging: base
+  - training: base
+  - tokenization: base
+  - tracking: base
+```
+
+Each item corresponds to a directory under `configs/` containing one or more
+YAML files.  For example, `configs/model/base.yaml` defines the default model
+settings and can be overridden on the command line:
+
+```bash
+python -m codex_ml.cli.main model.name=MiniLM training.epochs=1
+```
+
+### Fallback Loader
+
+Some lightweight scripts may operate without Hydra.  These call
+`codex_ml.utils.config_loader.load_training_cfg`, which attempts to compose the
+Hydra config but falls back to a minimal dictionary when Hydra is not
+available.  This ensures offline operation while preserving a consistent
+interface.
+
+### Adding New Groups
+
+To introduce a new configuration group:
+
+1. Create a directory under `configs/<group_name>/` containing a `base.yaml`.
+2. Reference the group in `configs/config.yaml`'s `defaults` list.
+3. Document the available keys in this file.
+
+Hydra's override syntax (`group.option=value`) allows experimentation without
+editing YAML files directly.

--- a/docs/modules/data_handling.md
+++ b/docs/modules/data_handling.md
@@ -1,3 +1,33 @@
 # Data Handling
 
-Datasets may include a `language` column. Use the `language` key in `configs/data/base.yaml` to filter examples when loading.
+Utilities under `src/codex_ml/data/` provide flexible ingestion of text
+datasets.  `load_dataset` automatically detects the input format:
+
+- **Plain text (`.txt`/`.md`)** – one example per line.
+- **NDJSON (`.jsonl`/`.ndjson`)** – expects a `text` field in each object.
+- **CSV (`.csv`)** – expects a `text` column.
+
+Loaded examples can be cached to disk by supplying a `cache_dir`; subsequent
+calls reuse the cached file for deterministic results.  Optional safety
+filtering is available via the `safety_filter_enabled` flag which applies the
+redaction filters in `codex_ml.safety.filters`.
+
+Dataset splitting and shuffling are handled by `codex_ml.data_utils.split_dataset`.
+Passing a `seed` ensures reproducible splits across runs.
+
+Configuration keys for these features live in `configs/data/base.yaml`:
+
+```yaml
+dataset_path: null
+val_split: 0.1
+test_split: 0.1
+cache_dataset: false
+safety_filter_enabled: false
+encoding: utf-8
+```
+
+Setting `cache_dataset=true` enables on-disk caching, while
+`safety_filter_enabled=true` redacts sensitive content during loading.
+
+Datasets may optionally include a `language` column.  Use the `language` key in
+`configs/data/base.yaml` to filter examples when loading.

--- a/docs/modules/tokenisation.md
+++ b/docs/modules/tokenisation.md
@@ -1,3 +1,36 @@
 # Tokenisation
 
-Multilingual tokenisation is supported via Hugging Face's `bert-base-multilingual-cased` model. Configure with `configs/tokenizer/multilingual.yaml`.
+`_codex_` uses a small adapter layer to provide a consistent interface across
+different tokeniser back‑ends.  All tokenisers implement the abstract
+`TokenizerAdapter` interface with four core methods: `encode`, `decode`,
+`batch_encode`, and `save_pretrained`.
+
+Two concrete adapters are available:
+
+- **HFTokenizerAdapter** – wraps a Hugging Face `PreTrainedTokenizer`.  Select a
+  model via `pretrained_model_name_or_path` and optionally supply
+  `special_tokens` (BOS/EOS/PAD/UNK) in the Hydra config.
+- **WhitespaceTokenizer** – a minimal whitespace splitter used for quick tests
+  and smoke runs.
+
+Tokeniser selection is configured through Hydra.  The base config lives in
+`configs/tokenizer/multilingual.yaml` or `configs/tokenizer/base.yaml` (when
+added) and exposes the following keys:
+
+```yaml
+type: hf            # or "whitespace"
+pretrained_model_name_or_path: gpt2
+special_tokens: {}
+```
+
+To override from the command line:
+
+```bash
+python -m codex_ml.cli.main tokenizer.type=whitespace
+```
+
+To add a new tokeniser backend, subclass `TokenizerAdapter` and register it in
+`TokenizerAdapter.from_config`.
+
+Multilingual tokenisation remains available via the Hugging Face
+`bert-base-multilingual-cased` model using `configs/tokenizer/multilingual.yaml`.


### PR DESCRIPTION
## Summary
- document TokenizerAdapter interface and Hydra selection
- describe configuration hierarchy and data loading utilities
- note config groups in README

## Testing
- `SKIP=pip-audit pre-commit run --files docs/modules/tokenisation.md docs/modules/configuration.md docs/modules/data_handling.md README.md CHANGELOG.md`
- `pytest -q` *(fails: tests/monitoring/test_engine_bootstrap.py, tests/test_deploy_codex_pipeline.py, tests/test_determinism.py, tests/test_engine_hf_trainer.py, tests/test_engine_hf_trainer_grad_accum.py, tests/test_ndjson_writer.py, tests/test_training_arguments_flags.py, tests/training/test_base_config.py, tests/training/test_config_loading.py, tests/training/test_functional_training_main.py)*

------
https://chatgpt.com/codex/tasks/task_e_68be347d6bc0833189186cbadcefa351