### PR TITLE
feat: allow hydra to configure lora

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -39,6 +39,7 @@ symbolic_pipeline:
 trainer:
   lora_r: null
   lora_alpha: 16
+  lora_dropout: null
   precision: fp32
   checkpoint_dir: null
   save_steps: 100

--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -128,7 +128,7 @@ def train_cmd(engine: str, engine_args: tuple[str, ...]) -> None:
         parser.add_argument("--gradient-accumulation-steps", type=int, default=1)
         parser.add_argument("--precision", choices=["fp32", "fp16", "bf16"], default=None)
         parser.add_argument("--lora-r", type=int, default=None)
-        parser.add_argument("--lora-alpha", type=int, default=16)
+        parser.add_argument("--lora-alpha", type=int, default=None)
         parser.add_argument("--seed", type=int, default=0)
 
         args = parser.parse_args(list(engine_args))

--- a/tests/training/test_engine_hf_trainer_lora_cfg.py
+++ b/tests/training/test_engine_hf_trainer_lora_cfg.py
@@ -1,0 +1,56 @@
+import types
+
+import torch
+
+from training.engine_hf_trainer import run_hf_trainer
+
+
+def test_hf_trainer_hydra_lora_cfg(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_tok_from_pretrained(name, use_fast=True):
+        class Tok:
+            pad_token = None
+            eos_token = "</s>"
+            pad_token_id = 0
+
+            def __call__(self, text, truncation=True):
+                return {"input_ids": [0]}
+
+            def save_pretrained(self, output_dir):
+                return None
+
+        return Tok()
+
+    def fake_model_from_pretrained(name):
+        class M(torch.nn.Module):
+            def forward(self, input_ids=None, labels=None):
+                return types.SimpleNamespace(loss=torch.tensor(0.0))
+
+        return M()
+
+    def fake_train(self, resume_from_checkpoint=None):
+        return types.SimpleNamespace(metrics={"train_loss": 0.0})
+
+    def fake_apply_lora(model, cfg):
+        captured["cfg"] = cfg
+        return model
+
+    monkeypatch.setattr(
+        "training.engine_hf_trainer.AutoTokenizer.from_pretrained", fake_tok_from_pretrained
+    )
+    monkeypatch.setattr(
+        "training.engine_hf_trainer.AutoModelForCausalLM.from_pretrained", fake_model_from_pretrained
+    )
+    monkeypatch.setattr("training.engine_hf_trainer.Trainer.train", fake_train)
+    monkeypatch.setattr("training.engine_hf_trainer.apply_lora", fake_apply_lora)
+
+    run_hf_trainer(
+        ["hi"],
+        tmp_path,
+        model_name="sshleifer/tiny-gpt2",
+        hydra_cfg={"lora_r": 2, "lora_alpha": 32, "lora_dropout": 0.1},
+        distributed=False,
+    )
+
+    assert captured["cfg"] == {"r": 2, "lora_alpha": 32, "lora_dropout": 0.1}


### PR DESCRIPTION
## Summary
- let HF trainer pull LoRA params from Hydra config
- default CLI LoRA alpha to None so config can override
- add regression test for Hydra-driven LoRA config

## Testing
- `pre-commit run --files training/engine_hf_trainer.py src/codex/cli.py configs/config.yaml tests/training/test_engine_hf_trainer_lora_cfg.py` (fails: pip-audit interrupted)
- `nox -s tests` (fails: Could not override 'training.epochs')


------
https://chatgpt.com/codex/tasks/task_e_68beea2e95b88331bf568ada25dbc498