### PR TITLE
test: verify cudnn determinism

### DIFF
--- a/docs/repro.md
+++ b/docs/repro.md
@@ -1,1 +1,6 @@
-`set_reproducible()` seeds Python, NumPy and PyTorch, enables deterministic algorithms and disables cuDNN benchmarking.
+`set_reproducible()` seeds Python, NumPy and PyTorch, enables deterministic
+algorithms and disables cuDNN benchmarking. The custom training loop in
+`training/functional_training.py` asserts that `torch.backends.cudnn.deterministic`
+is set when CUDA is available, helping catch non-deterministic operations
+early. Call `set_reproducible()` or set `torch.backends.cudnn.deterministic = True`
+before training on GPU to satisfy this check.

--- a/tests/training/test_strict_determinism.py
+++ b/tests/training/test_strict_determinism.py
@@ -1,0 +1,47 @@
+import pytest
+import torch
+
+from codex_ml.models import MiniLM, MiniLMConfig
+from training.data_utils import TextDataset
+from training.functional_training import TrainCfg, run_custom_trainer
+
+
+class _Tok:
+    vocab = {str(i): i for i in range(5)}
+
+    def encode(self, txt: str) -> list[int]:
+        return [self.vocab[t] for t in txt.split()]
+
+
+def _setup(tmp_path):
+    tok = _Tok()
+    ds = TextDataset(["0 1"], tok, block_size=2)
+    model = MiniLM(
+        MiniLMConfig(vocab_size=5, n_layers=1, d_model=8, n_heads=1, max_seq_len=2)
+    )
+    cfg = TrainCfg(epochs=0, batch_size=1, max_steps=0, checkpoint_dir=str(tmp_path), device="cpu")
+    return model, tok, ds, cfg
+
+
+def _patch_cuda(monkeypatch, deterministic: bool) -> None:
+    calls = {"count": 0}
+
+    def fake_is_available() -> bool:
+        calls["count"] += 1
+        return calls["count"] == 1
+
+    monkeypatch.setattr(torch.cuda, "is_available", fake_is_available)
+    monkeypatch.setattr(torch.backends.cudnn, "deterministic", deterministic, raising=False)
+
+
+def test_passes_when_deterministic(monkeypatch, tmp_path):
+    model, tok, ds, cfg = _setup(tmp_path)
+    _patch_cuda(monkeypatch, True)
+    run_custom_trainer(model, tok, ds, None, cfg)
+
+
+def test_raises_when_nondeterministic(monkeypatch, tmp_path):
+    model, tok, ds, cfg = _setup(tmp_path)
+    _patch_cuda(monkeypatch, False)
+    with pytest.raises(AssertionError):
+        run_custom_trainer(model, tok, ds, None, cfg)


### PR DESCRIPTION
## Summary
- document and enforce deterministic cudnn requirement for custom loop
- test run_custom_trainer honoring cudnn deterministic flag

## Testing
- `pre-commit run --files docs/repro.md tests/training/test_strict_determinism.py`
- `mypy --ignore-missing-imports --follow-imports=skip tests/training/test_strict_determinism.py`
- `nox -s tests` *(failed: ConfigCompositionException: Could not override 'training.epochs')*


------
https://chatgpt.com/codex/tasks/task_e_68bef42c2b0483319f0b54fa8afe1637