### PR TITLE
feat: add registry helpers for pluggable interfaces

### DIFF
--- a/docs/architecture/interfaces.md
+++ b/docs/architecture/interfaces.md
@@ -14,6 +14,16 @@ This project defines abstract interfaces to allow **swappable implementations** 
 
 1. Provide implementation import paths (e.g., `pkg.module:Class`) via environment:
    - `CODEX_TOKENIZER_PATH`, `CODEX_REWARD_PATH`, `CODEX_RL_PATH`
+   - Example:
+
+     ```bash
+     export CODEX_TOKENIZER_PATH="yourpkg.tokenizers.hf:HFTokenizer"
+     export CODEX_REWARD_PATH="yourpkg.rewards:RewardModel"
+     export CODEX_RL_PATH="yourpkg.rl:RLAgent"
+     ```
+
+     The helper :func:`codex_ml.interfaces.get_component` reads these variables
+     and instantiates the referenced classes.
 1. Or maintain a config like `configs/interfaces.yaml` and load them at runtime.
 
 ## Optional Plugins (entry points)

--- a/tests/interfaces/test_registry_loader.py
+++ b/tests/interfaces/test_registry_loader.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import pytest
+
 from codex_ml.interfaces import get_component, load_component
 
 
@@ -19,3 +21,10 @@ def test_load_and_get_component(tmp_path):
     finally:
         sys.path.remove(str(tmp_path))
         os.environ.pop("CODEX_DUMMY_PATH", None)
+
+
+def test_invalid_component_paths():
+    with pytest.raises(ValueError):
+        load_component("nope")
+    with pytest.raises(RuntimeError):
+        get_component("CODEX_BAD_PATH", "missing:Thing")


### PR DESCRIPTION
## Summary
- handle invalid import paths in interface component loader
- document environment variables for swapping components
- test registry helpers

## Testing
- `pre-commit run --files src/codex_ml/interfaces/registry.py tests/interfaces/test_registry_loader.py docs/architecture/interfaces.md`
- `nox -s tests` *(fails: ConfigCompositionException: Could not override 'training.epochs')*


------
https://chatgpt.com/codex/tasks/task_e_68bef42c2b0483319f0b54fa8afe1637