### PR TITLE
feat: expose lora params via cli

### DIFF
--- a/docs/modules/training_engine.md
+++ b/docs/modules/training_engine.md
@@ -11,5 +11,6 @@ The training engine abstracts model optimization.
 - `--max-steps` limit total updates
 - `--checkpoint-dir` directory for periodic checkpoints
 - `--resume-from` resume training from a checkpoint
+- `--lora-r`, `--lora-alpha`, `--lora-dropout` configure optional LoRA adapters
 
 Both modes log metrics to TensorBoard when `--tensorboard true` is supplied.

--- a/tests/training/test_functional_training_main.py
+++ b/tests/training/test_functional_training_main.py
@@ -120,3 +120,32 @@ def test_main_passes_lora_config(monkeypatch, tmp_path: Path):
     ft.main(["--output-dir", str(tmp_path), "--engine", "hf"])
     assert called["lora_r"] == 8
     assert called["lora_alpha"] == 32
+
+
+def test_main_cli_overrides_lora(monkeypatch, tmp_path: Path):
+    cfg = OmegaConf.create({"training": {"texts": ["hi"]}})
+    monkeypatch.setattr(ft, "load_training_cfg", lambda **kwargs: cfg)
+    called: dict[str, Any] = {}
+
+    def fake_run(texts, output_dir, **kwargs):
+        called.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(ft, "run_hf_trainer", fake_run)
+    ft.main(
+        [
+            "--output-dir",
+            str(tmp_path),
+            "--engine",
+            "hf",
+            "--lora-r",
+            "4",
+            "--lora-alpha",
+            "32",
+            "--lora-dropout",
+            "0.2",
+        ]
+    )
+    assert called["lora_r"] == 4
+    assert called["lora_alpha"] == 32
+    assert called["lora_dropout"] == 0.2

--- a/training/functional_training.py
+++ b/training/functional_training.py
@@ -88,6 +88,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=None,
         help="Hydra-style overrides for load_training_cfg",
     )
+    parser.add_argument("--lora-r", type=int, default=None, help="LoRA rank parameter")
+    parser.add_argument("--lora-alpha", type=int, default=None, help="LoRA alpha parameter")
+    parser.add_argument("--lora-dropout", type=float, default=None, help="LoRA dropout rate")
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     cfg: DictConfig = load_training_cfg(allow_fallback=True, overrides=args.overrides)
@@ -114,6 +117,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             kw["lora_r"] = lora_cfg.get("r")
             kw["lora_alpha"] = lora_cfg.get("alpha", 16)
             kw["lora_dropout"] = lora_cfg.get("dropout")
+        if args.lora_r is not None:
+            kw["lora_r"] = args.lora_r
+        if args.lora_alpha is not None:
+            kw["lora_alpha"] = args.lora_alpha
+        if args.lora_dropout is not None:
+            kw["lora_dropout"] = args.lora_dropout
         run_hf_trainer(texts, args.output_dir, val_texts=val_texts, **kw)
     else:
         # Minimal custom path that mirrors HF inputs and labels suitable for CausalLM


### PR DESCRIPTION
## Summary
- allow overriding LoRA hyperparameters from functional training CLI
- document LoRA flags in training engine module
- test CLI overrides for LoRA configuration

## Testing
- `pre-commit run --files training/functional_training.py tests/training/test_functional_training_main.py docs/modules/training_engine.md`
- `nox -s tests` *(fails: interrupted during dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68bef3ffa82c83319d959c4749a8e781