### PR TITLE
Expose LoRA parameters in inference CLI tools

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,10 +27,10 @@ The minimal trainer supports optional LoRA adapters and mixed precision. Example
 
 ```bash
 python -m training.engine_hf_trainer \
-  --lora_r 8 --lora_alpha 16 --precision bf16
+  --lora_r 8 --lora_alpha 16 --lora_dropout 0.05 --precision bf16
 ```
 
-`--lora_r` enables LoRA when >0. Use `--precision fp16` or `bf16` for half/mixed precision.
+`--lora_r` enables LoRA when >0. Adjust `--lora_alpha` and `--lora_dropout` to tune adapter capacity and regularisation. Use `--precision fp16` or `bf16` for half/mixed precision.
 
 ## Checkpointing
 

--- a/src/codex_ml/cli/generate.py
+++ b/src/codex_ml/cli/generate.py
@@ -20,6 +20,11 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--temperature", type=float, default=1.0)
     parser.add_argument("--top-k", type=int, default=0)
     parser.add_argument("--top-p", type=float, default=1.0)
+    parser.add_argument("--lora-r", type=int, default=0, help="LoRA rank; 0 disables")
+    parser.add_argument("--lora-alpha", type=int, default=16, help="LoRA alpha")
+    parser.add_argument(
+        "--lora-dropout", type=float, default=0.05, help="LoRA dropout probability"
+    )
     args = parser.parse_args(argv)
 
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
@@ -30,7 +35,13 @@ def main(argv: list[str] | None = None) -> None:
         "n_layers": 2,
         "max_seq_len": 128,
     }
-    model = load_model_with_optional_lora(args.model, model_config=model_cfg)
+    lora_kwargs = {
+        "lora_enabled": args.lora_r > 0,
+        "lora_r": args.lora_r,
+        "lora_alpha": args.lora_alpha,
+        "lora_dropout": args.lora_dropout,
+    }
+    model = load_model_with_optional_lora(args.model, model_config=model_cfg, **lora_kwargs)
     prompt = args.prompt
     if args.safety:
         from codex_ml.safety import SafetyConfig, sanitize_output, sanitize_prompt

--- a/tests/cli/test_infer_cli_lora.py
+++ b/tests/cli/test_infer_cli_lora.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+
+from codex_ml.cli import infer
+
+
+def test_infer_passes_lora_args(monkeypatch, tmp_path: Path) -> None:
+    called: dict[str, object] = {}
+
+    class DummyModel:
+        def to(self, device: str) -> "DummyModel":
+            return self
+
+        def generate(self, *args, **kwargs):
+            return torch.zeros((1, 1), dtype=torch.long)
+
+    def fake_loader(name_or_path: str, **kw):
+        called.update(kw)
+        return DummyModel()
+
+    class DummyTokenizer:
+        vocab_size = 10
+        eos_token_id = 0
+        pad_token_id = 0
+
+        def encode(self, text: str, return_tensors: str = "pt"):
+            return torch.ones((1, 1), dtype=torch.long)
+
+        def decode(self, ids, skip_special_tokens: bool = True) -> str:
+            return "hi"
+
+    class DummyAutoTokenizer:
+        @staticmethod
+        def from_pretrained(name: str) -> DummyTokenizer:  # pragma: no cover - simple stub
+            return DummyTokenizer()
+
+    monkeypatch.setattr(infer, "AutoTokenizer", DummyAutoTokenizer)
+    monkeypatch.setattr(infer, "load_model_with_optional_lora", fake_loader)
+    monkeypatch.setenv("ARTIFACTS_DIR", str(tmp_path))
+
+    infer.main([
+        "--lora-r",
+        "4",
+        "--lora-alpha",
+        "32",
+        "--lora-dropout",
+        "0.1",
+    ])
+
+    assert called["lora_enabled"] is True
+    assert called["lora_r"] == 4
+    assert called["lora_alpha"] == 32
+    assert called["lora_dropout"] == 0.1


### PR DESCRIPTION
## Summary
- allow `infer` and `generate` CLI to configure LoRA rank, alpha, and dropout
- document `--lora_dropout` in getting-started guide
- add test ensuring `infer` forwards LoRA CLI args to model loader

## Testing
- `pre-commit run --files src/codex_ml/cli/infer.py src/codex_ml/cli/generate.py docs/getting-started.md tests/cli/test_infer_cli_lora.py`
- `nox -s tests` *(fails: ConfigCompositionException: Could not override 'training.epochs')*
- `pytest --no-cov tests/cli/test_infer_cli_lora.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bef3ffa82c83319d959c4749a8e781