### PR TITLE
Add basic tests for metrics, reproducibility, and logging

### DIFF
--- a/tests/interfaces/test_loader_tokenizer_env.py
+++ b/tests/interfaces/test_loader_tokenizer_env.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+from codex_ml.interfaces import get_component
+
+
+def test_get_component_uses_env(tmp_path):
+    mod = tmp_path / "dummy_tok.py"
+    mod.write_text("class DummyTok:\n    def __init__(self):\n        self.ok = True\n")
+    sys.path.insert(0, str(tmp_path))
+    try:
+        os.environ["CODEX_TOKENIZER_PATH"] = "dummy_tok:DummyTok"
+        inst = get_component("CODEX_TOKENIZER_PATH", "dummy_tok:DummyTok")
+        assert getattr(inst, "ok", False)
+    finally:
+        sys.path.remove(str(tmp_path))
+        os.environ.pop("CODEX_TOKENIZER_PATH", None)

--- a/tests/monitoring/test_logging_bootstrap_real.py
+++ b/tests/monitoring/test_logging_bootstrap_real.py
@@ -1,0 +1,27 @@
+from argparse import Namespace
+
+import pytest
+
+from codex_ml.monitoring import codex_logging as cl
+
+mlflow = pytest.importorskip("mlflow")
+
+
+def test_logging_bootstrap_creates_loggers(tmp_path, monkeypatch):
+    cfg = {
+        "tensorboard": {"enable": True, "logdir": str(tmp_path / "tb")},
+        "wandb": {"enable": True, "project": "codex-test"},
+        "mlflow": {
+            "enable": True,
+            "tracking_uri": str(tmp_path / "mlruns"),
+            "experiment": "exp",
+        },
+    }
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    loggers = cl._codex_logging_bootstrap(Namespace(hydra_cfg=cfg))
+    assert loggers.tb is not None
+    assert loggers.wb is not None
+    assert loggers.mlflow_active
+    loggers.tb.close()
+    loggers.wb.finish()
+    mlflow.end_run()

--- a/tests/test_checkpoint_integrity_corruption.py
+++ b/tests/test_checkpoint_integrity_corruption.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from codex_ml.utils.checkpointing import load_checkpoint, save_checkpoint
+
+
+class DummyModel:
+    def __init__(self):
+        self.weights = {"w": torch.tensor([1.0, 2.0])}
+
+    def state_dict(self):
+        return self.weights
+
+    def load_state_dict(self, state):
+        self.weights.update(state)
+
+
+class DummyOpt:
+    def __init__(self):
+        self.state = {"lr": 0.1}
+
+    def state_dict(self):
+        return self.state
+
+    def load_state_dict(self, state):
+        self.state.update(state)
+
+
+def test_load_checkpoint_detects_corruption(tmp_path):
+    path = tmp_path / "model.pt"
+    model = DummyModel()
+    opt = DummyOpt()
+
+    save_checkpoint(str(path), model, opt, scheduler=None, epoch=1, extra={})
+    original = path.read_bytes()
+    path.write_bytes(b"corrupted")
+
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        load_checkpoint(str(path), model, opt)
+
+    path.write_bytes(original)

--- a/tests/test_metrics_correctness.py
+++ b/tests/test_metrics_correctness.py
@@ -1,0 +1,32 @@
+import math
+
+import pytest
+
+from codex_ml.eval import metrics as M
+
+
+def test_perplexity_known_value():
+    nll = [math.log(4), math.log(4)]
+    targets = [0, 1]
+    ppl = M.perplexity(nll, targets, from_logits=False)
+    assert ppl == pytest.approx(4.0)
+
+
+def test_token_accuracy_known_value():
+    preds = [1, 2, 3, 4]
+    targs = [1, 2, 0, 9]
+    acc = M.token_accuracy(preds, targs, ignore_index=0)
+    assert acc == pytest.approx(2 / 3)
+
+
+def test_bleu_known_value():
+    pytest.importorskip("nltk")
+    score = M.bleu(["the cat sat"], ["the cat sat"])
+    assert score == pytest.approx(1.0)
+
+
+def test_rouge_l_known_value():
+    pytest.importorskip("rouge_score")
+    r = M.rouge_l(["a b c"], ["a b c"])
+    assert r is not None
+    assert r["rougeL_f"] == pytest.approx(1.0)

--- a/tests/test_repro_seed_consistency.py
+++ b/tests/test_repro_seed_consistency.py
@@ -1,0 +1,22 @@
+import random
+
+import numpy as np
+import torch
+
+from codex_ml.utils.repro import set_reproducible
+
+
+def test_set_reproducible_repeatable():
+    set_reproducible(7)
+    py1 = random.random()
+    np1 = np.random.rand()
+    t1 = torch.rand(1)
+
+    set_reproducible(7)
+    py2 = random.random()
+    np2 = np.random.rand()
+    t2 = torch.rand(1)
+
+    assert py1 == py2
+    assert np1 == np2
+    assert torch.allclose(t1, t2)


### PR DESCRIPTION
## Summary
- add corruption test to ensure checkpoint loading fails on checksum mismatch
- cover perplexity/token accuracy/BLEU/ROUGE metrics with known values
- check reproducible seeding and logging bootstrap/integration loader behaviour

## Testing
- `pre-commit run --files tests/interfaces/test_loader_tokenizer_env.py tests/test_checkpoint_integrity_corruption.py tests/test_metrics_correctness.py tests/test_repro_seed_consistency.py tests/monitoring/test_logging_bootstrap_real.py`
- `nox -s tests` *(fails: ConfigCompositionException: Could not override 'training.epochs')*

------
https://chatgpt.com/codex/tasks/task_e_68bef44e0ed08331b1a46e335c635d2c