### PR TITLE
Add tests for metrics, reproducibility, and logging bootstrap

### DIFF
--- a/tests/interfaces/test_tokenizer_loader_env.py
+++ b/tests/interfaces/test_tokenizer_loader_env.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+from codex_ml.interfaces import get_component
+
+
+def test_get_component_tokenizer_env(tmp_path):
+    module = tmp_path / "dummy_tok.py"
+    module.write_text("class Tok:\n    def __init__(self):\n        self.ok = True\n")
+    sys.path.insert(0, str(tmp_path))
+    try:
+        os.environ["CODEX_TOKENIZER_PATH"] = "dummy_tok:Tok"
+        inst = get_component("CODEX_TOKENIZER_PATH", "dummy_tok:Tok")
+        assert inst.ok
+    finally:
+        sys.path.remove(str(tmp_path))
+        os.environ.pop("CODEX_TOKENIZER_PATH", None)

--- a/tests/monitoring/test_logging_bootstrap_initialization.py
+++ b/tests/monitoring/test_logging_bootstrap_initialization.py
@@ -1,0 +1,43 @@
+import argparse
+import types
+
+from codex_ml.monitoring import codex_logging as cl
+
+
+def test_logging_bootstrap_initialization(monkeypatch, tmp_path):
+    calls = {}
+
+    class DummyWriter:
+        def __init__(self, logdir):
+            calls["tb"] = logdir
+
+        def add_scalar(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(cl, "SummaryWriter", DummyWriter)
+
+    def fake_wandb_init(**kw):
+        calls["wb"] = kw
+        return object()
+
+    monkeypatch.setattr(cl, "wandb", types.SimpleNamespace(init=fake_wandb_init))
+
+    dummy_mlflow = types.SimpleNamespace(
+        set_tracking_uri=lambda uri: calls.setdefault("ml_uri", uri),
+        set_experiment=lambda exp: calls.setdefault("ml_exp", exp),
+        start_run=lambda: calls.setdefault("ml_run", True),
+    )
+    monkeypatch.setattr(cl, "mlflow", dummy_mlflow)
+
+    cfg = {
+        "tensorboard": {"enable": True, "logdir": str(tmp_path)},
+        "wandb": {"enable": True, "project": "proj"},
+        "mlflow": {"enable": True, "tracking_uri": "uri", "experiment": "exp"},
+    }
+
+    loggers = cl._codex_logging_bootstrap(argparse.Namespace(hydra_cfg=cfg))
+
+    assert isinstance(loggers.tb, DummyWriter)
+    assert loggers.wb is not None
+    assert calls["wb"]["mode"] == "offline" and calls["wb"]["project"] == "proj"
+    assert loggers.mlflow_active and calls["ml_uri"] == "uri" and calls["ml_exp"] == "exp"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,6 @@
 # BEGIN: CODEX_TEST_METRICS
+import math
+
 import pytest
 
 from codex_ml.eval import metrics as M
@@ -37,6 +39,30 @@ def test_bleu_and_rouge_optional():
     r = M.rouge_l(["a b"], ["a b"])
     assert (score is None) or (0.0 <= score <= 1.0)
     assert (r is None) or ("rougeL_f" in r)
+
+
+def test_token_accuracy_perfect_match():
+    pred = [1, 2, 3]
+    targ = [1, 2, 3]
+    assert M.token_accuracy(pred, targ) == pytest.approx(1.0)
+
+
+def test_perplexity_known_value():
+    nll = [0.0, math.log(4)]
+    targets = [0, 0]
+    assert M.perplexity(nll, targets, from_logits=False) == pytest.approx(2.0)
+
+
+def test_bleu_known_value():
+    pytest.importorskip("nltk")
+    score = M.bleu(["the cat"], ["the cat"])
+    assert score == pytest.approx(1.0)
+
+
+def test_rouge_l_known_value():
+    pytest.importorskip("rouge_score")
+    res = M.rouge_l(["hello world"], ["hello world"])
+    assert res and res["rougeL_f"] == pytest.approx(1.0)
 
 
 # END: CODEX_TEST_METRICS

--- a/tests/test_repro_helper.py
+++ b/tests/test_repro_helper.py
@@ -1,26 +1,21 @@
 import random
 
 import numpy as np
-
-try:
-    import torch
-except Exception:  # pragma: no cover - torch missing
-    torch = None
+import pytest
 
 from codex_ml.utils import set_reproducible
 
 
-def test_set_reproducible_cpu():
+def test_set_reproducible_consistency():
+    torch = pytest.importorskip("torch")
     set_reproducible(123)
-    a1 = random.random()
-    n1 = np.random.rand()
-    t1 = torch.rand(1) if torch is not None else None
+    py1 = random.random()
+    np1 = np.random.rand()
+    t1 = torch.rand(1)
 
     set_reproducible(123)
-    a2 = random.random()
-    n2 = np.random.rand()
-    t2 = torch.rand(1) if torch is not None else None
+    py2 = random.random()
+    np2 = np.random.rand()
+    t2 = torch.rand(1)
 
-    assert a1 == a2 and n1 == n2
-    if torch is not None:
-        assert torch.allclose(t1, t2)
+    assert py1 == py2 and np1 == np2 and torch.allclose(t1, t2)


### PR DESCRIPTION
## Summary
- verify load_checkpoint detects corrupted checkpoints
- cover perplexity/token_accuracy/BLEU/ROUGE-L metric correctness
- ensure set_reproducible yields consistent random numbers
- test logging bootstrap creates tensorboard, wandb, and mlflow loggers
- validate get_component loads tokenizers via CODEX_TOKENIZER_PATH

## Testing
- `pre-commit run --files tests/test_checkpoint_checksum.py tests/test_metrics.py tests/test_repro_helper.py tests/interfaces/test_tokenizer_loader_env.py tests/monitoring/test_logging_bootstrap_initialization.py`
- `nox -s tests` *(failed: ConfigCompositionException: Could not override 'training.epochs')*

------
https://chatgpt.com/codex/tasks/task_e_68bef44e0ed08331b1a46e335c635d2c