### PR TITLE
feat: improve reproducibility metadata

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -3648,7 +3652,7 @@
         "filename": "src/codex_ml/train_loop.py",
         "hashed_secret": "a9b28e1982d338dbc4df2e04031a9e304065c6d3",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 118
       }
     ],
     "tests/test_git_tag.py": [
@@ -3670,5 +3674,5 @@
       }
     ]
   },
-  "generated_at": "2025-09-07T12:23:36Z"
+  "generated_at": "2025-09-08T15:31:10Z"
 }

--- a/scripts/env/print_env_info.py
+++ b/scripts/env/print_env_info.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
-import platform
+"""Print environment details for reproducibility."""
+
+from __future__ import annotations
+
+import json
 import sys
 
-print(f"OS: {platform.platform()}")
-print(f"Python: {sys.version.split()[0]}")
-try:
-    import torch
+from codex_ml.utils.env import environment_summary
 
-    print(
-        f"CUDA: {getattr(torch.version, 'cuda', 'unknown')} (available: {torch.cuda.is_available()})"
-    )
-except Exception:
-    print("CUDA: not installed")
+
+def main() -> None:
+    info = environment_summary()
+    json.dump(info, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/codex_ml/train_loop.py
+++ b/src/codex_ml/train_loop.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, List
 
 from codex_ml.eval.metrics import perplexity, token_accuracy
 from codex_ml.monitoring.codex_logging import write_ndjson
+from codex_ml.utils.env import environment_summary
 from codex_ml.utils.repro import set_reproducible
 
 ART_DIR = Path("artifacts/metrics")
@@ -53,6 +54,7 @@ def record_metrics(
         "metrics": metrics,
         "cfg_hash": cfg_hash,
         "notes": notes,
+        "git_commit": environment_summary().get("git_commit"),
     }
     # write list for back-compat
     out_list = ART_DIR / "metrics.json"

--- a/src/codex_ml/utils/__init__.py
+++ b/src/codex_ml/utils/__init__.py
@@ -1,7 +1,13 @@
 """Utility modules for :mod:`codex_ml`."""
 
 from .checkpointing import CheckpointManager
+from .env import environment_summary
 from .repro import set_reproducible
 from .seed import deterministic_shuffle
 
-__all__ = ["CheckpointManager", "deterministic_shuffle", "set_reproducible"]
+__all__ = [
+    "CheckpointManager",
+    "deterministic_shuffle",
+    "set_reproducible",
+    "environment_summary",
+]

--- a/src/codex_ml/utils/checkpointing.py
+++ b/src/codex_ml/utils/checkpointing.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from codex_ml.monitoring.codex_logging import _codex_sample_system
+from codex_ml.utils.env import environment_summary
 
 try:  # pragma: no cover - optional torch dependency
     import torch
@@ -321,9 +322,14 @@ class CheckpointManager:
         ep_dir = self.root / f"epoch-{epoch}"
         ep_dir.mkdir(parents=True, exist_ok=True)
 
-        _write_json(ep_dir / "meta.json", {"epoch": epoch, "metrics": metrics or {}})
+        env = environment_summary()
+        _write_json(
+            ep_dir / "meta.json",
+            {"epoch": epoch, "metrics": metrics or {}, "git_commit": env.get("git_commit")},
+        )
         _write_json(ep_dir / "rng.json", _rng_dump())
         _write_json(ep_dir / "system.json", _codex_sample_system())
+        _write_json(ep_dir / "env.json", env)
         if config is not None:
             try:  # prefer YAML
                 import yaml

--- a/src/codex_ml/utils/env.py
+++ b/src/codex_ml/utils/env.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - optional torch dependency
+    import torch
+except Exception:  # pragma: no cover
+    torch = None  # type: ignore
+
+
+def _git_commit(root: Optional[Path] = None) -> Optional[str]:
+    """Return current Git commit hash if available."""
+    root = root or Path(__file__).resolve().parent.parent.parent.parent
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True)
+            .strip()
+        )
+    except Exception:
+        return None
+
+
+def environment_summary() -> Dict[str, Any]:
+    """Collect basic environment information for reproducibility."""
+    info: Dict[str, Any] = {
+        "os": platform.platform(),
+        "python": platform.python_version(),
+        "processor": platform.processor() or None,
+        "cpu_count": os.cpu_count(),
+    }
+    git_sha = _git_commit()
+    if git_sha is not None:
+        info["git_commit"] = git_sha
+    if torch is not None:
+        info["cuda_version"] = getattr(torch.version, "cuda", None)
+        try:
+            info["gpu"] = torch.cuda.get_device_name(0) if torch.cuda.is_available() else None
+        except Exception:  # pragma: no cover - torch but CUDA unavailable
+            info["gpu"] = None
+    return info
+
+
+__all__ = ["environment_summary"]

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -17,11 +17,10 @@ def test_split_dataset_cache(tmp_path: Path):
     texts = [f"sample-{i}" for i in range(6)]
     cache = tmp_path / "split.json"
     train1, val1 = split_dataset(texts, train_ratio=0.5, seed=1, cache_path=cache)
-    # Alter input; cached result should still be returned
+    # Alter input; cache should be invalidated due to data hash mismatch
     texts[0] = "changed"
     train2, val2 = split_dataset(texts, train_ratio=0.5, seed=1, cache_path=cache)
-    assert train1 == train2
-    assert val1 == val2
+    assert (train1, val1) != (train2, val2)
     assert cache.exists()
 
 

--- a/tools/bootstrap_dev_env.sh
+++ b/tools/bootstrap_dev_env.sh
@@ -11,11 +11,14 @@ PY="${PYTHON:-python3}"
 if [[ ! -d "$VENV" ]]; then "$PY" -m venv "$VENV"; fi
 source "$VENV/bin/activate"
 python -m pip install --upgrade pip setuptools wheel
-# Project + dev requirements
-pip install -r requirements.txt -r requirements-dev.txt
+# Project + dev requirements via lockfile
+if command -v uv >/dev/null 2>&1; then
+  uv pip install --locked -r requirements.txt -r requirements-dev.txt
+else
+  pip install -r requirements.lock
+fi
 # Gate CLIs used by hooks / logs: pre-commit, yamllint, shellcheck, semgrep, pip-audit
 pip install pre-commit yamllint shellcheck-py semgrep pip-audit
 # Pre-install hook envs so first run is deterministic
 pre-commit install --install-hooks --overwrite
 echo "[bootstrap] Ready. Run: pre-commit run --all-files && pytest"
-

--- a/training/data_utils.py
+++ b/training/data_utils.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, List, Mapping, Sequence, Tuple, TypeVar
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Sequence,
+    Tuple,
+    TypeVar,
+)
 
 import numpy as np
 import torch
@@ -59,6 +70,10 @@ def split_dataset(
     if n == 0:
         return [], []
 
+    data_hash = hashlib.sha256(
+        "".join(map(lambda x: repr(x), seq)).encode("utf-8")
+    ).hexdigest()
+
     # Try to reuse cached indices when compatible
     cached_train_idx: List[int] | None = None
     cached_val_idx: List[int] | None = None
@@ -72,6 +87,7 @@ def split_dataset(
                     and data.get("length") == n
                     and abs(float(data.get("train_ratio", train_ratio)) - float(train_ratio)) < 1e-12
                     and int(data.get("seed", seed)) == int(seed)
+                    and data.get("data_hash") == data_hash
                     and isinstance(data.get("train_idx"), list)
                     and isinstance(data.get("val_idx"), list)
                 ):
@@ -103,6 +119,7 @@ def split_dataset(
                         "length": n,
                         "seed": int(seed),
                         "train_ratio": float(train_ratio),
+                        "data_hash": data_hash,
                         "train_idx": train_idx,
                         "val_idx": val_idx,
                     },
@@ -145,12 +162,14 @@ def split_texts(
         Train and validation text lists.
     """
     items = list(texts)
+    data_hash = hashlib.sha256("".join(items).encode("utf-8")).hexdigest()
     if cache_path is not None:
         p = Path(cache_path)
         if p.exists():
             try:
                 data = json.loads(p.read_text(encoding="utf-8"))
-                return list(data["train"]), list(data["val"])
+                if data.get("data_hash") == data_hash:
+                    return list(data["train"]), list(data["val"])
             except Exception:
                 # fall through to recompute
                 pass
@@ -161,7 +180,8 @@ def split_texts(
         try:
             Path(cache_path).parent.mkdir(parents=True, exist_ok=True)
             Path(cache_path).write_text(
-                json.dumps({"train": train, "val": val}, indent=2), encoding="utf-8"
+                json.dumps({"train": train, "val": val, "data_hash": data_hash}, indent=2),
+                encoding="utf-8",
             )
         except Exception:
             pass


### PR DESCRIPTION
## Summary
- capture git commit and runtime environment in checkpoints and metrics
- add dataset hash validation for cached splits
- enforce dependency lockfile usage in dev bootstrap script

## Testing
- `pre-commit run --files scripts/env/print_env_info.py src/codex_ml/data_utils.py src/codex_ml/train_loop.py src/codex_ml/utils/__init__.py src/codex_ml/utils/checkpointing.py src/codex_ml/utils/env.py tests/test_data_utils.py tools/bootstrap_dev_env.sh training/data_utils.py`
- `mypy src/codex_ml/utils/env.py src/codex_ml/utils/checkpointing.py src/codex_ml/data_utils.py src/codex_ml/train_loop.py training/data_utils.py scripts/env/print_env_info.py` *(fails: Incompatible return value type, Need type annotation for "sample", invalid index type, etc.)*
- `nox -s tests` *(fails: hydra.errors.ConfigCompositionException: Could not override 'training.epochs')*

------
https://chatgpt.com/codex/tasks/task_e_68bef45d10608331839ecb2a3d452f07