### PR TITLE
Add batch padding/truncation test for HFTokenizerAdapter

### DIFF
--- a/tests/test_tokenizer_batch_encode.py
+++ b/tests/test_tokenizer_batch_encode.py
@@ -168,6 +168,17 @@ def test_batch_encode_consistency():
     assert enc1["attention_mask"].shape == enc2["attention_mask"].shape
 
 
+def test_batch_encode_padding_and_truncation(hf_tok):
+    """Ensure padding adds pad tokens while truncation cuts long inputs."""
+    adp = hf_tok
+    texts = ["hi", "this is a much longer sentence"]
+    enc = adp.batch_encode(texts, max_length=5, return_dict=False)
+    first, second = enc
+    assert len(first) == len(second) == 5
+    assert first[-1] == adp.pad_id
+    assert second[-1] != adp.pad_id
+
+
 __all__ = [
     "DummyTokenizer",
     "test_batch_encode_shapes",
@@ -179,4 +190,5 @@ __all__ = [
     "test_batch_encode_no_max_length",
     "test_batch_encode_parametrized_lengths",
     "test_batch_encode_consistency",
+    "test_batch_encode_padding_and_truncation",
 ]


### PR DESCRIPTION
## Summary
- add regression test ensuring `batch_encode` inserts pad tokens and truncates long inputs

## Testing
- `SKIP=bandit pre-commit run --files tests/test_tokenizer_batch_encode.py`
- `nox -s tests` *(fails: ConfigCompositionException: Could not override 'training.epochs')*

------
https://chatgpt.com/codex/tasks/task_e_68bef26ac5b883319ef950906e314daa