### PR TITLE
feat(cli): expose lora dropout

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,6 +32,12 @@ python -m training.engine_hf_trainer \
 
 `--lora_r` enables LoRA when >0. Adjust `--lora_alpha` and `--lora_dropout` to tune adapter capacity and regularisation. Use `--precision fp16` or `bf16` for half/mixed precision.
 
+Typical ranges:
+
+- `lora_r`: 4–64
+- `lora_alpha`: roughly 2×`lora_r`
+- `lora_dropout`: 0.0–0.3 for regularisation
+
 ## Checkpointing
 
 Periodic checkpoints can be enabled via:

--- a/docs/modules/training_engine.md
+++ b/docs/modules/training_engine.md
@@ -12,5 +12,6 @@ The training engine abstracts model optimization.
 - `--checkpoint-dir` directory for periodic checkpoints
 - `--resume-from` resume training from a checkpoint
 - `--lora-r`, `--lora-alpha`, `--lora-dropout` configure optional LoRA adapters
+  - typical `lora_r` values are 4–64 with `lora_alpha` around 2×`lora_r` and dropout 0.0–0.3
 
 Both modes log metrics to TensorBoard when `--tensorboard true` is supplied.

--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -127,8 +127,15 @@ def train_cmd(engine: str, engine_args: tuple[str, ...]) -> None:
         parser.add_argument("--val-texts", nargs="*", default=None)
         parser.add_argument("--gradient-accumulation-steps", type=int, default=1)
         parser.add_argument("--precision", choices=["fp32", "fp16", "bf16"], default=None)
-        parser.add_argument("--lora-r", type=int, default=None)
-        parser.add_argument("--lora-alpha", type=int, default=None)
+        parser.add_argument(
+            "--lora-r", type=int, default=0, help="LoRA rank; set >0 to enable"
+        )
+        parser.add_argument(
+            "--lora-alpha", type=int, default=16, help="LoRA alpha scaling"
+        )
+        parser.add_argument(
+            "--lora-dropout", type=float, default=0.0, help="LoRA dropout probability"
+        )
         parser.add_argument("--seed", type=int, default=0)
 
         args = parser.parse_args(list(engine_args))
@@ -138,6 +145,7 @@ def train_cmd(engine: str, engine_args: tuple[str, ...]) -> None:
             "precision": args.precision,
             "lora_r": args.lora_r,
             "lora_alpha": args.lora_alpha,
+            "lora_dropout": args.lora_dropout,
             "seed": args.seed,
             "device": args.device,
             "dtype": args.dtype,

--- a/tests/test_cli_train_engine.py
+++ b/tests/test_cli_train_engine.py
@@ -43,6 +43,12 @@ def test_cli_train_hf_engine_parses_args(monkeypatch, tmp_path):
             "hi",
             "--output-dir",
             str(tmp_path),
+            "--lora-r",
+            "4",
+            "--lora-alpha",
+            "32",
+            "--lora-dropout",
+            "0.1",
             "--seed",
             "123",
             "--device",
@@ -54,6 +60,9 @@ def test_cli_train_hf_engine_parses_args(monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert captured["texts"] == ["hi"]
     assert captured["output_dir"] == tmp_path
+    assert captured["kw"]["lora_r"] == 4
+    assert captured["kw"]["lora_alpha"] == 32
+    assert captured["kw"]["lora_dropout"] == 0.1
     assert captured["kw"]["seed"] == 123
     assert captured["kw"]["device"] == "cuda"
     assert captured["kw"]["dtype"] == "bf16"


### PR DESCRIPTION
## Summary
- add `--lora-dropout` flag with defaults and help text to training CLI
- document typical LoRA hyperparameter ranges in docs
- cover LoRA argument forwarding with tests

## Testing
- `pre-commit run --files src/codex/cli.py tests/test_cli_train_engine.py docs/getting-started.md docs/modules/training_engine.md`
- `nox -s tests` *(fails: Could not override 'training.epochs')*


------
https://chatgpt.com/codex/tasks/task_e_68bef26ac5b883319ef950906e314daa