### PR TITLE
docs: detail deferred items and error capture blocks

### DIFF
--- a/CODEBASE_AUDIT.md
+++ b/CODEBASE_AUDIT.md
@@ -176,16 +176,23 @@
 
 ## 7. Deferred Items
 
-- **chatgpt-codex CLI** – missing; building local wrapper deemed out-of-scope.
-- **Full Hydra sweep support** – complex to maintain; consider only if experiments require large search.
-- **Comprehensive security review** – requires dedicated owner; current filters provide baseline only.
+The following features are intentionally postponed for a later cycle, with minimal plans noted for future work:
+
+- **Advanced RL support:** Implementing RL agents and reward models is complex and not required for initial production. Defer until a clear use case arises. Minimal plan: finish scaffolding and implement a trivial reward model for testing.
+- **Full multi-node distributed training:** While single-node multi-GPU support is important, adding multi-node support requires significant engineering and may not be necessary for the current scale. Defer until model sizes demand it.
+- **Comprehensive secret scanning integration:** Adding third-party secret scanning tools requires careful tuning to avoid false positives. Schedule for a later security audit.
+- **Notebook auto-generation:** Automatically generating interactive notebooks (e.g., quick start) can be helpful but is not critical. Provide manual examples first.
 
 ## 8. Error Capture Blocks
 
-:::
-Question for ChatGPT-5 2024-10-07T00:00:00Z:
-While performing \[STEP_RUN_CLI: invoking `chatgpt-codex`\], encountered the following error:
-`bash: command not found: chatgpt-codex`
-Context: preparing automatic audit generation.
+Automation scripts should capture unexpected errors and format them as research questions for ChatGPT-5 using a standard template:
+
+```text
+Question for ChatGPT @codex {timestamp}:
+While performing [STEP_NUMBER:STEP_DESCRIPTION], encountered the following error:
+[ERROR_MESSAGE]
+Context: [BRIEF_CONTEXT]
 What are the possible causes, and how can this be resolved while preserving intended functionality?
-:::
+```
+
+`tools/apply_interfaces.py` appends these blocks to `.codex/errors.ndjson`; new automation should adopt the same pattern.

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -1,2 +1,8 @@
-RLHF and full reward-model stack deferred.
-Deepspeed/FSDP integration deferred.
+# Deferred Items
+
+Some features remain out of scope for the immediate patch cycle. These are noted with a rationale and suggested future plans:
+
+* **Advanced RL support:** Implementing RL agents and reward models is complex and not required for initial production. Defer until a clear use case arises. Minimal plan: finish scaffolding and implement a trivial reward model for testing.
+* **Full multi-node distributed training:** While single-node multi-GPU support is important, adding multi-node support requires significant engineering and may not be necessary for the current scale. Defer until model sizes demand it.
+* **Comprehensive secret scanning integration:** Adding third-party secret scanning tools requires careful tuning to avoid false positives. Schedule for a later security audit.
+* **Notebook auto-generation:** Automatically generating interactive notebooks (e.g., quick start) can be helpful but is not critical. Provide manual examples first.

--- a/ERROR_CAPTURE_BLOCKS.md
+++ b/ERROR_CAPTURE_BLOCKS.md
@@ -1,5 +1,17 @@
 # Error Capture Blocks
 
+Automation scripts should log unexpected errors as research questions for ChatGPT-5 using a consistent template. These blocks are typically appended to `.codex/errors.ndjson`; `tools/apply_interfaces.py` demonstrates the pattern.
+
+```text
+Question for ChatGPT @codex {timestamp}:
+While performing [STEP_NUMBER:STEP_DESCRIPTION], encountered the following error:
+[ERROR_MESSAGE]
+Context: [BRIEF_CONTEXT]
+What are the possible causes, and how can this be resolved while preserving intended functionality?
+```
+
+## Examples
+
 ```
 Question for ChatGPT-5 2025-08-28T04:45Z:
 While performing STEP 1: run `chatgpt-codex --prompt-file AUDIT_PROMPT.md`, encountered the following error:
@@ -53,8 +65,11 @@ B) Verify plugin availability: `pytest --version` (plugins listed).
 C) Re-run coverage: `pytest --cov=src/codex_ml --cov-report=term --cov-fail-under=70`.
 D) If coverage is temporarily blocking, run tests without coverage, then re-enable after adding the plugin.
 ```
+
+```
 Question for ChatGPT @codex 2025-09-02T03:08Z:
 While performing step "nox -s tests", encountered the following error:
 RuntimeError: Failed to import transformers.trainer because it cannot import name 'clear_device_cache' from 'accelerate.utils.memory'.
 Context: running test suite in isolated nox environment after installing dependencies.
 What are the possible causes, and how can this be resolved while preserving intended functionality?
+```


### PR DESCRIPTION
## Summary
- align audit deferred items with project DEFERRED doc
- describe standard ChatGPT-5 error capture block template

## Testing
- `pre-commit run --files CODEBASE_AUDIT.md ERROR_CAPTURE_BLOCKS.md DEFERRED.md`
- `nox -s tests` *(fails: ConfigCompositionException: Could not override 'training.epochs')*

------
https://chatgpt.com/codex/tasks/task_e_68bef468d42083319f44e9288c92a875