### PR TITLE
fix: use lockfile for uv bootstrap

### DIFF
--- a/tools/bootstrap_dev_env.sh
+++ b/tools/bootstrap_dev_env.sh
@@ -13,7 +13,7 @@ source "$VENV/bin/activate"
 python -m pip install --upgrade pip setuptools wheel
 # Project + dev requirements via lockfile
 if command -v uv >/dev/null 2>&1; then
-  uv pip install --locked -r requirements.txt -r requirements-dev.txt
+  uv pip install --locked -r requirements.lock
 else
   pip install -r requirements.lock
 fi


### PR DESCRIPTION
This pull request updates the way Python dependencies are installed in the development environment bootstrap script. Instead of installing from `requirements.txt` and `requirements-dev.txt`, it now installs exclusively from the `requirements.lock` file, ensuring a more consistent and reproducible environment setup.

Dependency installation update:

* Changed the `tools/bootstrap_dev_env.sh` script to use only `requirements.lock` for installing project and development dependencies, replacing the previous use of `requirements.txt` and `requirements-dev.txt`.