### PR TITLE
fix: run bootstrap activation in current shell

### DIFF
--- a/tools/bootstrap_dev_env.sh
+++ b/tools/bootstrap_dev_env.sh
@@ -27,10 +27,15 @@ PY
 
 run_step() {
   local step="$1" desc="$2"; shift 2
-  local output
-  output=$("$@" 2>&1)
-  local status=$?
-  if [ $status -ne 0 ]; then
+  local output_file
+  output_file=$(mktemp)
+  if "$@" >"$output_file" 2>&1; then
+    rm -f "$output_file"
+  else
+    local status=$?
+    local output
+    output=$(cat "$output_file")
+    rm -f "$output_file"
     log_error "$step" "$desc" "$output"
     printf '%s\n' "$output" >&2
     exit $status


### PR DESCRIPTION
## Summary
- avoid subshell in `run_step` to allow `source` to mutate parent shell

## Testing
- `pre-commit run --files tools/bootstrap_dev_env.sh`
- `nox -s tests` *(fails: ConfigCompositionException: Could not override 'training.epochs')*

------
https://chatgpt.com/codex/tasks/task_e_68bf22bce1a08331b1395f2cb8a8593c