### PR TITLE
fix: pass hydra overrides through CLI

### DIFF
--- a/training/functional_training.py
+++ b/training/functional_training.py
@@ -197,7 +197,7 @@ def run_custom_trainer(model, tokenizer, train_ds, val_ds, cfg: TrainCfg) -> Dic
     device = torch.device(cfg.device or ("cuda" if torch.cuda.is_available() else "cpu"))
     model.to(device)
     set_seed(cfg.seed)
-    if torch.cuda.is_available() and cfg.dtype in {"fp32", "fp16", "bf16"}:
+    if device.type == "cuda" and cfg.dtype in {"fp32", "fp16", "bf16"}:
         assert (
             torch.backends.cudnn.deterministic
         ), "cuDNN must be deterministic; call set_reproducible()"


### PR DESCRIPTION
## Summary
- forward `--override-file`/`--set` entries to Hydra instead of manual merging
- ensure cuDNN determinism is only required when training on CUDA devices

## Testing
- `pre-commit run --files src/codex_ml/cli/main.py training/functional_training.py`
- `mypy --ignore-missing-imports --follow-imports=skip src/codex_ml/cli/main.py training/functional_training.py`
- `nox -s tests` *(fails: KeyError: 'gradient_accumulation_steps')*

------
https://chatgpt.com/codex/tasks/task_e_68bf5344444c83319100fffe9e4aece6