### PR TITLE
fix: remove plus prefix from training overrides

### DIFF
--- a/src/codex_ml/cli/main.py
+++ b/src/codex_ml/cli/main.py
@@ -54,7 +54,7 @@ def run_training(cfg: DictConfig | None, output_dir: str | None = None) -> None:
     texts = cfg_dict.pop("texts", None)
     val_texts = cfg_dict.pop("val_texts", None)
     cfg_output = cfg_dict.pop("output_dir", None) or output_dir
-    overrides = [f"+training.{k}={v}" for k, v in cfg_dict.items()]
+    overrides = [f"training.{k}={v}" for k, v in cfg_dict.items()]
 
     argv: list[str] = []
     if cfg_output:

--- a/tests/test_codexml_cli.py
+++ b/tests/test_codexml_cli.py
@@ -69,5 +69,5 @@ def test_run_training_invokes_functional_entry(monkeypatch):
 
     assert captured["argv"][:4] == ["--output-dir", "my_runs", "--texts", "hi"]
     assert "--val-texts" in captured["argv"]
-    assert "+training.epochs=2" in captured["argv"]
-    assert "+training.lr=1e-05" in captured["argv"]
+    assert "training.epochs=2" in captured["argv"]
+    assert "training.lr=1e-05" in captured["argv"]


### PR DESCRIPTION
## Summary
- stop using `+training.*` overrides and replace with `training.*`
- update CLI test expectations accordingly

## Testing
- `pre-commit run --files src/codex_ml/cli/main.py tests/test_codexml_cli.py`
- `mypy src/codex_ml/cli/main.py` *(fails: command interrupted)*
- `nox -s tests` *(fails: session coverage interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7c0d67788331a476ad037ab046bb