### PR TITLE
fix: correct training import paths

### DIFF
--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -172,7 +172,7 @@ def train_cmd(engine: str, engine_args: tuple[str, ...]) -> None:
             raise
     else:
         try:
-            from training.codex.training import main as run_custom_train
+            from codex.training import main as run_custom_train
         except Exception as exc:  # pragma: no cover - fallback path
             click.echo(f"[warn] custom engine unavailable, falling back to hf_trainer: {exc}")
             from training.engine_hf_trainer import run_hf_trainer

--- a/src/codex/training.py
+++ b/src/codex/training.py
@@ -42,6 +42,28 @@ from codex_ml.tokenization import TokenizerAdapter, load_tokenizer
 from codex_ml.utils.checkpointing import CheckpointManager, set_seed
 from codex_utils.repro import log_env_info
 
+try:  # re-export functional training helpers
+    from training.functional_training import (  # type: ignore
+        TrainCfg,
+        run_custom_trainer,
+    )
+except Exception:  # pragma: no cover - training optional
+
+    class TrainCfg:  # type: ignore[misc]
+        pass
+
+    def run_custom_trainer(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("training.functional_training is unavailable")
+
+
+try:  # optional HF trainer
+    from training.engine_hf_trainer import run_hf_trainer  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+
+    def run_hf_trainer(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("HuggingFace trainer is unavailable")
+
+
 try:  # Optional TensorBoard integration
     from tools.monitoring_integrate import SummaryWriter  # type: ignore
 except Exception:  # pragma: no cover - optional dep

--- a/src/codex_ml/cli/codex_cli.py
+++ b/src/codex_ml/cli/codex_cli.py
@@ -19,7 +19,7 @@ def train(text: list[str]):
     model = "sshleifer/tiny-gpt2"
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
-    from training.codex.training import TrainCfg, run_custom_trainer
+    from codex.training import TrainCfg, run_custom_trainer
 
     tokenizer = AutoTokenizer.from_pretrained(model)
     model = AutoModelForCausalLM.from_pretrained(model)

--- a/src/codex_ml/cli/main.py
+++ b/src/codex_ml/cli/main.py
@@ -26,7 +26,7 @@ except Exception:  # pragma: no cover
 
 
 try:  # connect to training entry point if available
-    from training.codex.training import main as _functional_training_main
+    from codex.training import main as _functional_training_main
 except Exception:  # pragma: no cover - training optional
     _functional_training_main = None
 
@@ -42,7 +42,7 @@ def run_training(cfg: DictConfig | None, output_dir: str | None = None) -> None:
         Fallback path for training artifacts if not specified in ``cfg``.
     """
     if _functional_training_main is None:  # pragma: no cover - safety fallback
-        raise RuntimeError("training.codex.training.main is unavailable")
+        raise RuntimeError("codex.training.main is unavailable")
 
     try:
         from hydra.core.global_hydra import GlobalHydra

--- a/tests/privacy/test_dp_training.py
+++ b/tests/privacy/test_dp_training.py
@@ -1,7 +1,7 @@
 import torch
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
-from training.codex.training import TrainCfg, run_custom_trainer
+from codex.training import TrainCfg, run_custom_trainer
 
 
 def test_dp_training_runs(tmp_path):

--- a/tests/test_cli_train_engine.py
+++ b/tests/test_cli_train_engine.py
@@ -18,7 +18,7 @@ def test_cli_train_custom_engine_forwards_args(monkeypatch):
     def fake_main(argv=None):
         captured["argv"] = argv
 
-    monkeypatch.setattr("training.codex.training.main", fake_main)
+    monkeypatch.setattr("codex.training.main", fake_main)
     result = runner.invoke(cli, ["train", "--engine", "custom", "--output-dir", "out"])
     assert result.exit_code == 0
     assert captured["argv"] == ["--engine", "custom", "--output-dir", "out"]

--- a/tests/training/test_checkpoint_resume.py
+++ b/tests/training/test_checkpoint_resume.py
@@ -1,7 +1,7 @@
 import torch
 
+from codex.training import TrainCfg, run_custom_trainer
 from codex_ml.models import MiniLM, MiniLMConfig
-from training.codex.training import TrainCfg, run_custom_trainer
 from training.data_utils import TextDataset, split_texts
 
 

--- a/tests/training/test_custom_loop_overfit.py
+++ b/tests/training/test_custom_loop_overfit.py
@@ -1,5 +1,5 @@
+from codex.training import TrainCfg, run_custom_trainer
 from codex_ml.models import MiniLM, MiniLMConfig
-from training.codex.training import TrainCfg, run_custom_trainer
 from training.data_utils import TextDataset, split_texts
 
 

--- a/tests/training/test_functional_training_main.py
+++ b/tests/training/test_functional_training_main.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from omegaconf import OmegaConf
 
-import training.codex.training as ft
+import codex.training as ft
 
 
 def test_main_invokes_run_hf_trainer(monkeypatch, tmp_path: Path):

--- a/tests/training/test_lora_optional.py
+++ b/tests/training/test_lora_optional.py
@@ -1,7 +1,7 @@
 import pytest
 
+from codex.training import TrainCfg, run_custom_trainer
 from codex_ml.models import MiniLM, MiniLMConfig
-from training.codex.training import TrainCfg, run_custom_trainer
 from training.data_utils import TextDataset, split_texts
 
 

--- a/tests/training/test_strict_determinism.py
+++ b/tests/training/test_strict_determinism.py
@@ -3,8 +3,8 @@ import types
 import pytest
 import torch
 
+from codex.training import TrainCfg, run_custom_trainer
 from codex_ml.models import MiniLM, MiniLMConfig
-from training.codex.training import TrainCfg, run_custom_trainer
 from training.data_utils import TextDataset
 from training.engine_hf_trainer import run_hf_trainer
 


### PR DESCRIPTION
## Summary
- fix training import paths to codex.training
- expose functional training helpers

## Testing
- `pre-commit run --files src/codex_ml/cli/main.py src/codex_ml/cli/codex_cli.py src/codex/cli.py src/codex/training.py tests/test_cli_train_engine.py tests/privacy/test_dp_training.py tests/training/test_checkpoint_resume.py tests/training/test_lora_optional.py tests/training/test_functional_training_main.py tests/training/test_custom_loop_overfit.py tests/training/test_strict_determinism.py`
- `pytest tests/test_cli_train_engine.py tests/privacy/test_dp_training.py tests/training/test_checkpoint_resume.py tests/training/test_lora_optional.py tests/training/test_functional_training_main.py tests/training/test_custom_loop_overfit.py tests/training/test_strict_determinism.py` *(fails: MiniLM forward keyword errors and coverage <70%)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c64364508331b07a4c9c5a493826