### PR TITLE
fix: declare zstandard and parquet tooling dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,7 @@ pre-commit
 yamllint
 shellcheck-py
 pip-audit
+pandas
+pyarrow
+zstandard
 # END: CODEX_DEV_REQUIREMENTS

--- a/requirements.lock
+++ b/requirements.lock
@@ -138,3 +138,4 @@ webencodings==0.5.1
 websockets==15.0.1
 xxhash==3.5.0
 yarl==1.20.1
+zstandard==0.24.0


### PR DESCRIPTION
## Summary
- add pandas, pyarrow, and zstandard to dev requirements for bundling and ledger tooling
- lock zstandard for reproducible environments

## Testing
- `python -m pre_commit run --files requirements-dev.txt requirements.lock`
- `pytest tests/breadcrumbs -q`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c25700a3e08331a6f57fda66a01ad4