### PR TITLE
Codex/prepare for root reorg with error capture 2025 09 10 dptljl

### DIFF
--- a/tests/breadcrumbs/test_catalog_db.py
+++ b/tests/breadcrumbs/test_catalog_db.py
@@ -6,11 +6,26 @@ from tools import catalog_db
 
 
 def test_catalog_ingest(tmp_path: Path) -> None:
-    os.environ['CODEX_CATALOG_DB'] = str(tmp_path / 'cat.sqlite')
-    report = tmp_path / 'compare.json'
-    report.write_text(json.dumps({'summary': {'unexpected_added': 1, 'unexpected_removed': 0, 'changed': 2, 'moves': 3}}))
-    catalog_db.record_run({'run_id': 'r1', 'started_at': 's', 'finished_at': 'f', 'status': 'ok', 'git_head': 'h', 'branch': 'main'})
-    catalog_db.ingest_compare_report('r1', str(report))
-    catalog_db.upsert_artifact('r1', 'manifest', str(report))
-    rows = catalog_db.query('SELECT unexpected_added FROM diffs')
+    db_file = tmp_path / "cat.sqlite"
+    os.environ["CODEX_CATALOG_DB"] = str(db_file)
+    report = tmp_path / "compare.json"
+    report.write_text(
+        json.dumps(
+            {"summary": {"unexpected_added": 1, "unexpected_removed": 0, "changed": 2, "moves": 3}}
+        )
+    )
+    catalog_db.record_run(
+        {
+            "run_id": "r1",
+            "started_at": "s",
+            "finished_at": "f",
+            "status": "ok",
+            "git_head": "h",
+            "branch": "main",
+        }
+    )
+    catalog_db.ingest_compare_report("r1", str(report))
+    catalog_db.upsert_artifact("r1", "manifest", str(report))
+    rows = catalog_db.query("SELECT unexpected_added FROM diffs")
     assert rows[0][0] == 1
+    assert db_file.exists()

--- a/tests/breadcrumbs/test_compaction.py
+++ b/tests/breadcrumbs/test_compaction.py
@@ -5,7 +5,8 @@ from tools import ledger
 
 
 def test_parquet_roundtrip(tmp_path: Path) -> None:
-    ledger_path = tmp_path / 'ledger.jsonl'
-    ledger.append_event({'event': 'start', 'status': 'ok', 'run_id': 'r1'}, ledger_path)
-    out = clp.compact(ledger_path)
-    assert out.exists()
+    ledger_path = tmp_path / "ledger.jsonl"
+    ledger.append_event({"event": "start", "status": "ok", "run_id": "r1"}, ledger_path)
+    outs = clp.compact(ledger_path)
+    assert len(outs) == 1
+    assert outs[0].exists()

--- a/tools/compact_ledger_to_parquet.py
+++ b/tools/compact_ledger_to_parquet.py
@@ -1,30 +1,41 @@
 """Compact the JSON ledger into monthly Parquet files."""
+
 from __future__ import annotations
 
 import argparse
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import List
 
 import pandas as pd
 
 from . import ledger
 
 
-def compact(path: Path = Path(".codex/ledger.jsonl")) -> Path:
-    """Validate the ledger and write a monthly Parquet file."""
+def compact(path: Path = Path(".codex/ledger.jsonl")) -> List[Path]:
+    """Validate the ledger and write monthly Parquet files.
+
+    Returns a list of written Parquet paths.
+    """
     ledger.verify_chain(path)
     rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
     if not rows:
         raise ValueError("ledger is empty")
-    for r in rows:
-        r["ts"] = datetime.fromisoformat(r["ts"].replace("Z", ""))
-    month = rows[0]["ts"].strftime("%Y%m")
     out_dir = Path(".codex/warehouse")
     out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"ledger-{month}.parquet"
-    pd.DataFrame(rows).to_parquet(out_path, index=False)
-    return out_path
+    buckets: dict[str, list[dict]] = {}
+    for r in rows:
+        ts = datetime.fromisoformat(r["ts"].replace("Z", ""))
+        r["ts"] = ts
+        month = ts.strftime("%Y%m")
+        buckets.setdefault(month, []).append(r)
+    out_paths: List[Path] = []
+    for month, entries in buckets.items():
+        out_path = out_dir / f"ledger-{month}.parquet"
+        pd.DataFrame(entries).to_parquet(out_path, index=False)
+        out_paths.append(out_path)
+    return out_paths
 
 
 def _main() -> int:

--- a/tools/file_integrity_audit.py
+++ b/tools/file_integrity_audit.py
@@ -9,111 +9,124 @@ import pathlib
 from typing import Dict, List
 
 DEFAULT_EXCLUDES = [
-    "__pycache__/",
-    ".pytest_cache/",
-    "site/",
-    ".ruff_cache/",
-    ".codex/warehouse/",
-    ".codex/bundles/",
+    "*__pycache__/*",
+    ".pytest_cache/*",
+    "site/*",
+    ".ruff_cache/*",
+    ".codex/warehouse/*",
+    ".codex/bundles/*",
 ]
 
 
 def sha256(p: pathlib.Path) -> str:
     h = hashlib.sha256()
-    with p.open('rb') as f:
-        for chunk in iter(lambda: f.read(65536), b''):
+    with p.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
             h.update(chunk)
     return h.hexdigest()
 
-def walk_manifest(root: pathlib.Path, excludes: List[str] | None = None) -> Dict[str, Dict[str, int]]:
+
+def walk_manifest(
+    root: pathlib.Path, excludes: List[str] | None = None
+) -> Dict[str, Dict[str, int]]:
     out: Dict[str, Dict[str, int]] = {}
     excludes = excludes or []
-    for p in root.rglob('*'):
-        if p.is_file() and '.git' not in p.parts:
+    for p in root.rglob("*"):
+        if p.is_file() and ".git" not in p.parts:
             rel = str(p.relative_to(root))
             if match_any(rel, DEFAULT_EXCLUDES + excludes):
                 continue
-            out[rel] = {'sha256': sha256(p), 'size': p.stat().st_size}
+            out[rel] = {"sha256": sha256(p), "size": p.stat().st_size}
     return out
 
+
 def save(path: str, obj: Dict[str, Dict[str, int]]) -> None:
-    pathlib.Path(path).write_text(json.dumps(obj, indent=2), encoding='utf-8')
+    pathlib.Path(path).write_text(json.dumps(obj, indent=2), encoding="utf-8")
+
 
 def load(path: str) -> Dict[str, Dict[str, int]]:
-    return json.loads(pathlib.Path(path).read_text(encoding='utf-8'))
+    return json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+
 
 def match_any(path: str, patterns: List[str]) -> bool:
     return any(fnmatch.fnmatch(path, pat) for pat in patterns)
 
-def compare(pre: str, post: str, allow_removed: List[str], allow_added: List[str], allow_changed: List[str]) -> bool:
+
+def compare(
+    pre: str, post: str, allow_removed: List[str], allow_added: List[str], allow_changed: List[str]
+) -> bool:
     pre_map = load(pre)
     post_map = load(post)
     pre_hash_to_paths: Dict[str, set] = {}
     post_hash_to_paths: Dict[str, set] = {}
     for p, meta in pre_map.items():
-        pre_hash_to_paths.setdefault(meta['sha256'], set()).add(p)
+        pre_hash_to_paths.setdefault(meta["sha256"], set()).add(p)
     for p, meta in post_map.items():
-        post_hash_to_paths.setdefault(meta['sha256'], set()).add(p)
+        post_hash_to_paths.setdefault(meta["sha256"], set()).add(p)
     removed = [p for p in pre_map if p not in post_map]
     added = [p for p in post_map if p not in pre_map]
-    changed = [p for p in pre_map if p in post_map and pre_map[p]['sha256'] != post_map[p]['sha256']]
-    moves: List[Dict[str,str]] = []
+    changed = [
+        p for p in pre_map if p in post_map and pre_map[p]["sha256"] != post_map[p]["sha256"]
+    ]
+    moves: List[Dict[str, str]] = []
     rem_left = []
     for p in removed:
-        targets = sorted(post_hash_to_paths.get(pre_map[p]['sha256'], set()))
+        targets = sorted(post_hash_to_paths.get(pre_map[p]["sha256"], set()))
         if targets:
-            moves.append({'from': p, 'to': targets[0]})
+            moves.append({"from": p, "to": targets[0]})
         else:
             rem_left.append(p)
     add_left = set(added)
     for m in moves:
-        if m['to'] in add_left:
-            add_left.remove(m['to'])
+        if m["to"] in add_left:
+            add_left.remove(m["to"])
     unexpected_removed = [p for p in rem_left if not match_any(p, allow_removed)]
     unexpected_added = [p for p in add_left if not match_any(p, allow_added)]
     unexpected_changed = [p for p in changed if not match_any(p, allow_changed)]
     result = {
-        'summary': {
-            'removed': len(removed),
-            'added': len(added),
-            'changed': len(changed),
-            'moves': len(moves),
-            'unexpected_removed': len(unexpected_removed),
-            'unexpected_added': len(unexpected_added),
-            'unexpected_changed': len(unexpected_changed),
+        "summary": {
+            "removed": len(removed),
+            "added": len(added),
+            "changed": len(changed),
+            "moves": len(moves),
+            "unexpected_removed": len(unexpected_removed),
+            "unexpected_added": len(unexpected_added),
+            "unexpected_changed": len(unexpected_changed),
         },
-        'details': {
-            'removed': removed,
-            'added': added,
-            'changed': changed,
-            'moves': moves,
-            'unexpected_removed': unexpected_removed,
-            'unexpected_added': list(unexpected_added),
-            'unexpected_changed': unexpected_changed,
+        "details": {
+            "removed": removed,
+            "added": added,
+            "changed": changed,
+            "moves": moves,
+            "unexpected_removed": unexpected_removed,
+            "unexpected_added": list(unexpected_added),
+            "unexpected_changed": unexpected_changed,
         },
     }
     print(json.dumps(result, indent=2))
     return not (unexpected_removed or unexpected_added or unexpected_changed)
 
+
 def main() -> int:
     ap = argparse.ArgumentParser()
-    sub = ap.add_subparsers(dest='cmd', required=True)
-    s1 = sub.add_parser('snapshot')
-    s1.add_argument('out')
-    s2 = sub.add_parser('compare')
-    s2.add_argument('pre')
-    s2.add_argument('post')
-    s2.add_argument('--allow-removed', action='append', default=[])
-    s2.add_argument('--allow-added', action='append', default=[])
-    s2.add_argument('--allow-changed', action='append', default=[])
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    s1 = sub.add_parser("snapshot")
+    s1.add_argument("out")
+    s2 = sub.add_parser("compare")
+    s2.add_argument("pre")
+    s2.add_argument("post")
+    s2.add_argument("--allow-removed", action="append", default=[])
+    s2.add_argument("--allow-added", action="append", default=[])
+    s2.add_argument("--allow-changed", action="append", default=[])
     args = ap.parse_args()
-    root = pathlib.Path('.').resolve()
-    if args.cmd == 'snapshot':
+    root = pathlib.Path(".").resolve()
+    if args.cmd == "snapshot":
         save(args.out, walk_manifest(root))
         print(f"[integrity] snapshot -> {args.out}")
         return 0
     ok = compare(args.pre, args.post, args.allow_removed, args.allow_added, args.allow_changed)
     return 0 if ok else 1
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
## Summary
- defer catalog database path resolution to runtime environment variables
- expand integrity audit exclusions and emit monthly ledger Parquet files

## Testing
- `pre-commit run --files tools/catalog_db.py tools/file_integrity_audit.py tools/compact_ledger_to_parquet.py tests/breadcrumbs/test_catalog_db.py tests/breadcrumbs/test_compaction.py`
- `pytest tests/test_cli_train_engine.py tests/breadcrumbs/test_bundle_and_integrity.py tests/breadcrumbs/test_catalog_db.py tests/breadcrumbs/test_compaction.py -q`
- `pytest tests/training/test_checkpoint_resume.py::test_checkpoint_resume -q` *(fails: MiniLM.forward() got an unexpected keyword argument 'labels')*
- `pytest tests/training/test_strict_determinism.py::test_hf_trainer_passes_when_deterministic -q` *(fails: ModuleNotFoundError: No module named 'omegaconf')*

------
https://chatgpt.com/codex/tasks/task_e_68c269c4f03883319d3d63283c7a698f