### PR TITLE
Codex/prepare for root reorg with error capture 2025 09 10 dptljl - ensure src/codex coverage

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,7 @@
 import os
 from contextlib import suppress
 from pathlib import Path
+from typing import Sequence
 
 import nox
 
@@ -64,12 +65,14 @@ def _coverage_args(
     fail_under: str | None = None,
     branch: bool = False,
     external: bool = False,
+    paths: Sequence[str] | None = ("src/codex",),
 ) -> list[str]:
     """Return pytest coverage flags if pytest-cov is available."""
     if _module_available(session, "pytest_cov", external=external):
-        args = ["--cov", "--cov-report=term-missing"]
+        args = [f"--cov={p}" for p in (paths or [])] or ["--cov"]
         if branch:
-            args.insert(1, "--cov-branch")
+            args.append("--cov-branch")
+        args.append("--cov-report=term-missing")
         if fail_under is not None:
             args.append(f"--cov-fail-under={fail_under}")
         return args


### PR DESCRIPTION
## Summary
- reinstate `src/codex` coverage in helper so quality sessions measure core package

## Testing
- `python -m pre_commit run ruff --files noxfile.py`
- `python -m pre_commit run black --files noxfile.py`
- `python -m pre_commit run isort --files noxfile.py`
- `python -m pre_commit run end-of-file-fixer --files noxfile.py`
- `python -m pre_commit run trailing-whitespace --files noxfile.py`
- `CODEX_ALLOW_CI=1 python -m pre_commit run ci-guard --files noxfile.py`
- `pytest tests/test_cli_train_engine.py tests/breadcrumbs/test_bundle_and_integrity.py tests/breadcrumbs/test_catalog_db.py tests/breadcrumbs/test_compaction.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2713b41148331b56813d59123ed27