### PR TITLE
fix: align automation scripts with relocated AGENTS guide

### DIFF
--- a/tools/codex_agents_workflow.py
+++ b/tools/codex_agents_workflow.py
@@ -35,7 +35,7 @@ ERRORS_NDJSON = CODEx_DIR / "errors.ndjson"
 RESULTS = CODEx_DIR / "results.md"
 
 README = ROOT / "README.md"
-AGENTS = ROOT / "AGENTS.md"
+AGENTS = ROOT / "docs" / "guides" / "AGENTS.md"
 CONTRIB = ROOT / "CONTRIBUTING.md"
 PRECOMMIT = ROOT / ".pre-commit-config.yaml"
 PYTEST_INI = ROOT / "pytest.ini"
@@ -232,7 +232,7 @@ def ensure_readme_refs() -> bool:
                 """
 # codex-universal
 
-See [AGENTS.md](./AGENTS.md) for environment variables, logging roles, testing expectations, and tool usage.
+See [docs/guides/AGENTS.md](docs/guides/AGENTS.md) for environment variables, logging roles, testing expectations, and tool usage.
 **DO NOT ACTIVATE ANY GitHub Actions files.**
 
 ## Continuous Integration (local parity)
@@ -255,10 +255,10 @@ See the read-only workflow reference at `.github/workflows/ci.yml` (not activate
         )
 
     changed = False
-    if "AGENTS.md" not in txt:
+    if "docs/guides/AGENTS.md" not in txt:
         txt = (
             txt.rstrip()
-            + "\n\nFor environment variables, logging roles, testing expectations, and tool usage, see [AGENTS.md](./AGENTS.md).\n"
+            + "\n\nFor environment variables, logging roles, testing expectations, and tool usage, see [docs/guides/AGENTS.md](docs/guides/AGENTS.md).\n"
         )
         write_if_changed(README, txt, "Add discoverability link to AGENTS.md.")
         changed = True

--- a/tools/codex_supplied_task_runner.py
+++ b/tools/codex_supplied_task_runner.py
@@ -33,7 +33,7 @@ TARGETS = [
     "src/codex/logging/export.py",
 ]
 README = ROOT / "README.md"
-AGENTS = ROOT / "AGENTS.md"
+AGENTS = ROOT / "docs" / "guides" / "AGENTS.md"
 PRE_COMMIT = ROOT / ".pre-commit-config.yaml"
 
 DOCSTRINGS = {


### PR DESCRIPTION
## Summary
- point codex_supplied_task_runner and codex_agents_workflow to docs/guides/AGENTS.md
- update README link logic in codex_agents_workflow to new AGENTS path

## Testing
- `python -m py_compile tools/codex_supplied_task_runner.py tools/codex_agents_workflow.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'zstandard')*

------
https://chatgpt.com/codex/tasks/task_e_68c280c8fec88331bf82cb467a0312e0