### PR TITLE
fix: enforce local gate failures and tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint tests test build type setup venv env-info codex-gates wheelhouse fast-tests sys-tests ssp-tests sec-scan sec-audit lock-refresh ci-local coverage gates lint-policy lint-ruff lint-hybrid lint-auto quality fix-shebangs hooks integrity
+		.PHONY: format lint tests test build type setup venv env-info codex-gates wheelhouse fast-tests sys-tests ssp-tests sec-scan sec-audit lock-refresh ci-local coverage gates lint-policy lint-ruff lint-hybrid lint-auto quality fix-shebangs hooks integrity
 
 format:
 	pre-commit run --all-files
@@ -62,12 +62,12 @@ sbom:
 	@python scripts/sbom_cyclonedx.py
 
 lock-refresh:
-        @bash tools/uv_lock_refresh.sh
+	@bash tools/uv_lock_refresh.sh
 
 # Legacy CI target removed; use codex-gates for full local checks
 
 coverage:
-        @nox -s ci_local
+	@nox -s ci_local
 
 gates:
 	@bash tools/run_quality_gates.sh

--- a/scripts/codex_local_gates.sh
+++ b/scripts/codex_local_gates.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 echo "[Codex] Running local offline gates..."
 if command -v pre-commit >/dev/null 2>&1; then
-  pre-commit run --all-files || true
+  pre-commit run --all-files
 fi
 if command -v pytest >/dev/null 2>&1; then
-  pytest -q || true
-  pytest --cov=src/codex_ml --cov-fail-under=70 || true
+  pytest -q
+  pytest --cov=src/codex_ml --cov-fail-under=70
 fi
 echo "[Codex] Gates complete (offline)."

--- a/tools/codex_execute_audit.py
+++ b/tools/codex_execute_audit.py
@@ -265,11 +265,11 @@ def suggest_tests_and_gates():
         set -euo pipefail
         echo "[Codex] Running local offline gates..."
         if command -v pre-commit >/dev/null 2>&1; then
-          pre-commit run --all-files || true
+          pre-commit run --all-files
         fi
         if command -v pytest >/dev/null 2>&1; then
-          pytest -q || true
-          pytest --cov=src/codex_ml --cov-fail-under=70 || true
+          pytest -q
+          pytest --cov=src/codex_ml --cov-fail-under=70
         fi
         echo "[Codex] Gates complete (offline)."
         """

--- a/tools/codex_workflow_executor.py
+++ b/tools/codex_workflow_executor.py
@@ -88,11 +88,11 @@ def ensure_local_gates_present():
         set -euo pipefail
         echo "[Codex] Running local offline gates..."
         if command -v pre-commit >/dev/null 2>&1; then
-          pre-commit run --all-files || true
+          pre-commit run --all-files
         fi
         if command -v pytest >/dev/null 2>&1; then
-          pytest -q || true
-          pytest --cov=src/codex_ml --cov-fail-under=70 || true
+          pytest -q
+          pytest --cov=src/codex_ml --cov-fail-under=70
         fi
         echo "[Codex] Gates complete (offline)."
         """


### PR DESCRIPTION
## Summary
- ensure local gate script and generators propagate failures instead of masking them
- fix Makefile `lock-refresh` and `coverage` targets to use proper recipe tabs

## Testing
- `pre-commit run --files Makefile scripts/codex_local_gates.sh tools/codex_execute_audit.py tools/codex_workflow_executor.py` *(command not found: pre-commit)*
- `pytest -q` *(15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e08379a48331be4056c86c35bbad