### PR TITLE
fix: deduplicate conversation logger connection helper

### DIFF
--- a/src/codex/logging/conversation_logger.py
+++ b/src/codex/logging/conversation_logger.py
@@ -17,7 +17,8 @@ from . import session_logger
 from .session_logger import _default_db_path
 
 
-def _connect(path: str):
+def _connect(path: str) -> sqlite3.Connection:
+    """Return a SQLite connection with WAL mode enabled."""
     cx = sqlite3.connect(path, check_same_thread=False)
     # Enable WAL for one-writer/many-readers (creates a '-wal' sidecar file).
     try:
@@ -28,40 +29,12 @@ def _connect(path: str):
 
 
 def _ensure_wal(db_path: Optional[str]) -> str:
+    """Ensure the database at ``db_path`` is initialized with WAL enabled."""
     path = db_path or str(_default_db_path())
+    # Opening a connection toggles the WAL pragma via ``_connect`` above.
     with _connect(path):
         pass
     return path
-
-
-def _connect(path: str) -> sqlite3.Connection:
-    cx = sqlite3.connect(path, check_same_thread=False)
-    # Enable WAL for one-writer/many-readers (creates a '-wal' sidecar file).
-    try:
-        cx.execute("PRAGMA journal_mode=WAL;")
-    except Exception:
-        pass
-    return cx
-
-
-def _connect(path: str) -> sqlite3.Connection:
-    cx = sqlite3.connect(path, check_same_thread=False)
-    # Enable WAL for one-writer/many-readers (creates a '-wal' sidecar file).
-    try:
-        cx.execute("PRAGMA journal_mode=WAL;")
-    except Exception:
-        pass
-    return cx
-
-
-def _connect(path: str) -> sqlite3.Connection:
-    cx = sqlite3.connect(path, check_same_thread=False)
-    # Enable WAL for one-writer/many-readers (creates a '-wal' sidecar file).
-    try:
-        cx.execute("PRAGMA journal_mode=WAL;")
-    except Exception:
-        pass
-    return cx
 
 
 def start_session(session_id: str, db_path: Optional[str] = None) -> None:


### PR DESCRIPTION
## Summary
This pull request refactors the database connection logic in `conversation_logger.py` to improve code clarity and remove duplicate function definitions. The changes ensure that the SQLite connection is consistently initialized with WAL (Write-Ahead Logging) mode enabled.

Refactoring and code cleanup:

* Added a docstring to the `_connect` function and clarified its purpose, specifying that it returns a SQLite connection with WAL mode enabled.
* Removed multiple duplicate definitions of the `_connect` function, consolidating the logic into a single implementation.
* Improved the `_ensure_wal` function by adding a docstring and clarifying that opening a connection toggles the WAL pragma.