### PR TITLE
Add matrix-driven CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,130 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  tests:
+    name: "${{ matrix.profile }} / py${{ matrix.python }} / ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Quick "smoke" run: lean deps, cpu only
+          - profile: smoke
+            os: ubuntu-latest
+            python: "3.12"
+            codex_groups: "base,dev,cpu"
+            run_net: "0"
+            run_gpu: "0"
+          # Full run on CPU: installs test extras
+          - profile: full
+            os: ubuntu-latest
+            python: "3.12"
+            codex_groups: "base,dev,cpu,test"
+            run_net: "0"
+            run_gpu: "0"
+          # Network tests (opt-in): guarded by secret NET_ALLOWED
+          - profile: net
+            os: ubuntu-latest
+            python: "3.12"
+            codex_groups: "base,dev,cpu,test"
+            run_net: "1"
+            run_gpu: "0"
+
+    # Gate the "net" profile with a secret; other profiles always run.
+    if: >
+      ${{
+        matrix.profile != 'net' ||
+        (matrix.profile == 'net' && secrets.NET_ALLOWED != '')
+      }}
+
+    env:
+      # Propagate to pytest gates in tests/conftest.py
+      RUN_NET_TESTS: ${{ matrix.run_net }}
+      RUN_GPU_TESTS: ${{ matrix.run_gpu }}
+      # Let the repo's setup script choose extras/groups
+      CODEX_SYNC_GROUPS: ${{ matrix.codex_groups }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install uv
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "uv>=0.7"
+          uv --version
+
+      - name: Bootstrap env (groups=${{ matrix.codex_groups }})
+        run: |
+          set -euxo pipefail
+          # Use the repo's bootstrap script so CPU torch is pinned correctly
+          # and dev/test extras install via groups.
+          bash .codex/scripts/setup.sh
+
+      - name: Show environment
+        run: |
+          . .venv/bin/activate || true
+          python -V
+          python -c "import torch, platform; print('torch', torch.__version__, 'cuda?', torch.cuda.is_available(), 'on', platform.platform())" || true
+
+      - name: Run tests
+        run: |
+          . .venv/bin/activate
+          pytest -q
+
+  # Optional GPU job. Runs only on self-hosted runners that advertise a 'gpu' label,
+  # and only if a secret ENABLE_GPU_TESTS is present. Assumes the runner has CUDA + a matching PyTorch.
+  tests-gpu:
+    name: "gpu / py3.12 / self-hosted"
+    # Requires a self-hosted runner with labels: self-hosted, linux, gpu
+    runs-on: [self-hosted, linux, gpu]
+    if: ${{ contains(runner.labels, 'gpu') && secrets.ENABLE_GPU_TESTS != '' }}
+    env:
+      RUN_GPU_TESTS: "1"
+      RUN_NET_TESTS: "0"
+      CODEX_SYNC_GROUPS: "base,dev,gpu,test"
+      # If you manage your own CUDA wheel index, set TORCH_CUDA_INDEX as a secret and uncomment:
+      # TORCH_CUDA_INDEX: ${{ secrets.TORCH_CUDA_INDEX }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "uv>=0.7"
+          uv --version
+      - name: Bootstrap env (gpu)
+        run: |
+          set -euxo pipefail
+          # Option A: let setup.sh handle groups (GPU group is a no-op on non-GPU runners)
+          bash .codex/scripts/setup.sh
+          # Option B (uncomment if you need a specific CUDA wheel index passed via secret):
+          # if [ -n "${TORCH_CUDA_INDEX:-}" ]; then
+          #   uv pip install --index-url "${TORCH_CUDA_INDEX}" torch
+          # fi
+      - name: Verify CUDA and torch
+        run: |
+          python - <<'PY'
+          import torch
+          print("torch:", torch.__version__, "cuda available:", torch.cuda.is_available())
+          assert torch.cuda.is_available(), "CUDA not available on this runner"
+          PY
+      - name: Run GPU-marked tests
+        run: |
+          pytest -q -m gpu


### PR DESCRIPTION
## Summary
- add matrix-driven CI workflow for smoke, full, net, and GPU tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'zstandard')*


------
https://chatgpt.com/codex/tasks/task_e_68c450e7a96883318e3949e12b03c19b