### PR TITLE
test: restore torch load and add plugin entry point helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       RUN_NET_TESTS: ${{ matrix.run_net }}
       RUN_GPU_TESTS: ${{ matrix.run_gpu }}
       CODEX_SYNC_GROUPS: ${{ matrix.codex_groups }}
+      TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD: "1"
+      HF_HUB_DISABLE_TELEMETRY: "1"
 
     steps:
       - name: Checkout
@@ -84,6 +86,8 @@ jobs:
       RUN_GPU_TESTS: "1"
       RUN_NET_TESTS: "0"
       CODEX_SYNC_GROUPS: "base,dev,gpu,test"
+      TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD: "1"
+      HF_HUB_DISABLE_TELEMETRY: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/conftest.py
+++ b/conftest.py
@@ -1,14 +1,19 @@
 # conftest.py
-import os
-import sys
-import typing
+# Make PyTorch 2.6+ behave like pre-2.6 for our test suite:
+# https://pytorch.org/docs/stable/serialization.html#troubleshooting
+import os as _os
+
+_os.environ.setdefault("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
+
 
 def _gpu_available() -> bool:
     try:
         import torch  # type: ignore
+
         return bool(getattr(torch, "cuda", None) and torch.cuda.is_available())
     except Exception:
         return False
+
 
 def pytest_report_header(config):
     # If the user *forces* GPU tests (e.g., -m "gpu" or -m "gpu and ..."),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ test = [
   "sentencepiece>=0.1.99",
   "zstandard>=0.22",
   "h5py>=3.10",
+  "nox>=2023.4.22",
 ]
 
 # CPU group: safe for Codex. In Codex we still explicitly pin the CPU index in scripts


### PR DESCRIPTION
## Summary
- force legacy torch.load behavior in tests and CI
- expose a cross-version `entry_points` helper for plugin discovery
- add nox to optional test dependencies

## Testing
- `pre-commit run ruff --files conftest.py .github/workflows/ci.yml src/codex_ml/plugins/registry.py pyproject.toml`
- `pre-commit run black --files conftest.py .github/workflows/ci.yml src/codex_ml/plugins/registry.py pyproject.toml`
- `pre-commit run isort --files conftest.py .github/workflows/ci.yml src/codex_ml/plugins/registry.py pyproject.toml`
- `pre-commit run end-of-file-fixer --files conftest.py .github/workflows/ci.yml src/codex_ml/plugins/registry.py pyproject.toml`
- `pre-commit run trailing-whitespace --files conftest.py .github/workflows/ci.yml src/codex_ml/plugins/registry.py pyproject.toml`
- `pre-commit run detect-secrets --files conftest.py .github/workflows/ci.yml src/codex_ml/plugins/registry.py pyproject.toml`
- `bandit -c bandit.yaml conftest.py .github/workflows/ci.yml src/codex_ml/plugins/registry.py pyproject.toml`
- `pytest tests/plugins/test_registry_basic.py tests/plugins/test_entry_point_discovery.py tests/test_nox_tests_delegation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47ce714ac8331acf90a402670dd9d