### PR TITLE
Guard optional deps and add setup snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,34 @@ For more details on environment setup, see OpenAI Codex.
 
 For environment variables, logging roles, testing expectations, and tool usage, see [docs/guides/AGENTS.md](docs/guides/AGENTS.md).
 
+### Quick setup for tools & tests
+
+```bash
+# Base dev tools
+pip install -U pre-commit nox pytest
+
+# Optional (enables coverage)
+pip install -U pytest-cov
+
+# Optional ML deps (CPU-only wheels shown; pick the right index for your platform)
+pip install -U torch transformers datasets  \
+  --index-url https://download.pytorch.org/whl/cpu
+
+# Optional logging/telemetry
+pip install -U mlflow prometheus-client click
+
+# Run the basics
+pre-commit run --all-files          # if pre-commit is installed
+nox -s tests                        # or: pytest -m "not slow"
+```
+
+| Symptom                                     | Fix                                                                        |
+| ------------------------------------------- | -------------------------------------------------------------------------- |
+| `command not found: pre-commit`             | `pip install pre-commit`                                                   |
+| `command not found: nox`                    | `pip install nox`                                                          |
+| `pytest: unrecognized arguments: --cov=...` | `pip install pytest-cov` **or** run `pytest` without `--cov`               |
+| `ModuleNotFoundError: torch`                | `pip install torch [right wheel index]` or rely on `importorskip` in tests |
+
 ## Local CI (no GitHub-hosted Actions)
 
 Run the gates locally or on a self-hosted runner.

--- a/src/codex_ml/cli/generate.py
+++ b/src/codex_ml/cli/generate.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from transformers import AutoTokenizer
-
 from codex_ml.modeling.codex_model_loader import load_model_with_optional_lora
 from codex_ml.models.generate import generate
+from codex_ml.utils.optional import optional_import
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -22,11 +21,13 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--top-p", type=float, default=1.0)
     parser.add_argument("--lora-r", type=int, default=0, help="LoRA rank; 0 disables")
     parser.add_argument("--lora-alpha", type=int, default=16, help="LoRA alpha")
-    parser.add_argument(
-        "--lora-dropout", type=float, default=0.05, help="LoRA dropout probability"
-    )
+    parser.add_argument("--lora-dropout", type=float, default=0.05, help="LoRA dropout probability")
     args = parser.parse_args(argv)
 
+    transformers, has_tf = optional_import("transformers")
+    if not has_tf:
+        raise ImportError("transformers is required for generation")
+    AutoTokenizer = transformers.AutoTokenizer  # type: ignore[attr-defined]
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
     model_cfg: dict[str, Any] = {
         "vocab_size": tokenizer.vocab_size,

--- a/src/codex_ml/cli/infer.py
+++ b/src/codex_ml/cli/infer.py
@@ -10,10 +10,11 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
 
-import torch
-from transformers import AutoTokenizer
-
 from codex_ml.modeling.codex_model_loader import load_model_with_optional_lora
+from codex_ml.utils.optional import optional_import
+
+torch, _HAS_TORCH = optional_import("torch")
+transformers, _HAS_TRANSFORMERS = optional_import("transformers")
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -40,7 +41,9 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--lora-alpha", type=int, default=16, help="LoRA alpha")
     parser.add_argument("--lora-dropout", type=float, default=0.05, help="LoRA dropout probability")
     args = parser.parse_args(argv)
-
+    if not (_HAS_TORCH and _HAS_TRANSFORMERS):
+        raise ImportError("torch and transformers are required for inference")
+    AutoTokenizer = transformers.AutoTokenizer  # type: ignore[attr-defined]
     tok_name = args.tokenizer or args.checkpoint
     tokenizer = AutoTokenizer.from_pretrained(tok_name)
 

--- a/src/codex_ml/eval/evaluator.py
+++ b/src/codex_ml/eval/evaluator.py
@@ -2,14 +2,30 @@ from __future__ import annotations
 
 from typing import Dict, Iterable
 
-import torch
-from datasets import Dataset
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from codex_ml.utils.optional import optional_import
 
 from .metrics import perplexity, token_accuracy
 
+torch, _HAS_TORCH = optional_import("torch")
+datasets, _HAS_DATASETS = optional_import("datasets")
+transformers, _HAS_TRANSFORMERS = optional_import("transformers")
+
+if _HAS_DATASETS:
+    Dataset = datasets.Dataset  # type: ignore[attr-defined]
+else:  # pragma: no cover - optional dependency
+    Dataset = None  # type: ignore[assignment]
+
+if _HAS_TRANSFORMERS:
+    AutoModelForCausalLM = transformers.AutoModelForCausalLM  # type: ignore[attr-defined]
+    AutoTokenizer = transformers.AutoTokenizer  # type: ignore[attr-defined]
+else:  # pragma: no cover - optional dependency
+    AutoModelForCausalLM = None  # type: ignore[assignment]
+    AutoTokenizer = None  # type: ignore[assignment]
+
 
 def evaluate_model(model, tokenizer, texts: Iterable[str]) -> Dict[str, float]:
+    if not (_HAS_TORCH and _HAS_DATASETS):
+        raise ImportError("torch and datasets are required for evaluation")
     ds = Dataset.from_dict({"text": list(texts)})
     column = list(ds["text"])
     toks = tokenizer(column, return_tensors="pt", padding=True)
@@ -26,6 +42,8 @@ def evaluate_model(model, tokenizer, texts: Iterable[str]) -> Dict[str, float]:
 
 
 def run_evaluator(model_name: str, texts: Iterable[str]) -> Dict[str, float]:
+    if not _HAS_TRANSFORMERS:
+        raise ImportError("transformers is required for run_evaluator")
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token

--- a/src/codex_ml/modeling/codex_model_loader.py
+++ b/src/codex_ml/modeling/codex_model_loader.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Optional
 
-from transformers import AutoModelForCausalLM
+from codex_ml.utils.optional import optional_import
+
+transformers, _HAS_TRANSFORMERS = optional_import("transformers")
+if _HAS_TRANSFORMERS:
+    AutoModelForCausalLM = transformers.AutoModelForCausalLM  # type: ignore[attr-defined]
+else:  # pragma: no cover - optional dependency
+    AutoModelForCausalLM = None  # type: ignore[assignment]
 
 __all__ = ["load_model_with_optional_lora"]
 
@@ -31,6 +37,9 @@ def load_model_with_optional_lora(
     **kw: Any,
 ) -> Any:
     """Load a base model and optionally apply LoRA adapters."""
+
+    if AutoModelForCausalLM is None:
+        raise ImportError("transformers is required to load models")
 
     torch_dtype = None
     if dtype:

--- a/src/codex_ml/utils/modeling.py
+++ b/src/codex_ml/utils/modeling.py
@@ -1,7 +1,15 @@
 from typing import Any, Dict, Optional
 
-import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from codex_ml.utils.optional import optional_import
+
+torch, _HAS_TORCH = optional_import("torch")
+transformers, _HAS_TRANSFORMERS = optional_import("transformers")
+if _HAS_TRANSFORMERS:
+    AutoModelForCausalLM = transformers.AutoModelForCausalLM  # type: ignore[attr-defined]
+    AutoTokenizer = transformers.AutoTokenizer  # type: ignore[attr-defined]
+else:  # pragma: no cover - optional dependency
+    AutoModelForCausalLM = None  # type: ignore[assignment]
+    AutoTokenizer = None  # type: ignore[assignment]
 
 try:  # optional PEFT
     from peft import LoraConfig, PeftModel, get_peft_model
@@ -18,6 +26,8 @@ def load_model_and_tokenizer(
     device_map: str = "auto",
     lora: Optional[Dict[str, Any]] = None,
 ):
+    if not (_HAS_TORCH and _HAS_TRANSFORMERS):
+        raise ImportError("torch and transformers are required for model loading")
     torch_dtype = {
         "auto": None,
         "fp32": torch.float32,

--- a/src/codex_ml/utils/optional.py
+++ b/src/codex_ml/utils/optional.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import importlib
+import types
+
+
+def optional_import(name: str) -> tuple[types.ModuleType | None, bool]:
+    """Best-effort dynamic import.
+
+    Returns a tuple of (module, available) where ``module`` is the imported
+    module object or ``None`` if the import failed for any reason.
+    """
+    try:
+        return importlib.import_module(name), True
+    except Exception:
+        return None, False
+
+
+__all__ = ["optional_import"]

--- a/tests/test_minilm_forward.py
+++ b/tests/test_minilm_forward.py
@@ -1,7 +1,9 @@
-import torch
-import torch.nn.functional as F
+import pytest
 
-from codex_ml.models import MiniLM, MiniLMConfig
+torch = pytest.importorskip("torch", reason="torch not installed")
+import torch.nn.functional as F  # noqa: E402
+
+from codex_ml.models import MiniLM, MiniLMConfig  # noqa: E402
 
 
 def test_minilm_overfits_tiny_batch():

--- a/tests/test_model_forward.py
+++ b/tests/test_model_forward.py
@@ -1,9 +1,10 @@
 """MiniLM forward pass shape test."""
 
 import pytest
-import torch
 
-from codex_ml.models import MiniLM, MiniLMConfig
+torch = pytest.importorskip("torch", reason="torch not installed")
+
+from codex_ml.models import MiniLM, MiniLMConfig  # noqa: E402
 
 
 @pytest.mark.ml

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -2,9 +2,15 @@
 
 import pytest
 
-from codex_ml.interfaces.tokenizer import HFTokenizer
-from codex_ml.tokenization.hf_tokenizer import HFTokenizerAdapter
-from tokenization.train_tokenizer import TrainTokenizerConfig, train
+transformers = pytest.importorskip("transformers", reason="transformers not installed")
+# sentencepiece is optional for some tokenizers; guard it too, but don't hard-require.
+try:
+    import sentencepiece  # noqa: F401
+except Exception:
+    pass
+from codex_ml.interfaces.tokenizer import HFTokenizer  # noqa: E402
+from codex_ml.tokenization.hf_tokenizer import HFTokenizerAdapter  # noqa: E402
+from tokenization.train_tokenizer import TrainTokenizerConfig, train  # noqa: E402
 
 
 @pytest.mark.tokenizer


### PR DESCRIPTION
## Summary
- skip tokenizer and MiniLM tests when torch/transformers are missing
- lazy-import optional dependencies with helper for cli, training and evaluation
- document quick setup commands for tools and ML deps

## Testing
- `pre-commit run --files README.md src/codex_ml/cli/generate.py src/codex_ml/cli/infer.py src/codex_ml/cli/main.py src/codex_ml/eval/evaluator.py src/codex_ml/modeling/codex_model_loader.py src/codex_ml/training/functional_training.py src/codex_ml/utils/modeling.py src/codex_ml/utils/optional.py tests/test_minilm_forward.py tests/test_model_forward.py tests/test_tokenizer.py` (fails: bandit step interrupted)
- `pytest -vv tests/test_model_forward.py` (skipped: torch not installed)
- `pytest -vv tests/test_minilm_forward.py tests/test_tokenizer.py` (skipped: torch/transformers not installed)


------
https://chatgpt.com/codex/tasks/task_e_68c6361b76fc833191bea423ba54cda6