### PR TITLE
Implement thread pool reset and document CLI pool-fix task

### DIFF
--- a/docs/modules/cli.md
+++ b/docs/modules/cli.md
@@ -8,3 +8,24 @@ python -m codex_ml.cli.codex_cli metrics-server --port 9000
 ```
 
 Subcommands: `train`, `evaluate`, `tokenize`, `repo-map`, `metrics-server`.
+
+## Maintenance tasks
+
+The repository also provides a lightweight maintenance CLI at
+`codex.cli`. Tasks are listed via:
+
+```bash
+python -m codex.cli tasks
+```
+
+One useful utility is `pool-fix`, which resets the global tokenization
+thread pool and enables SQLite connection pooling for session logs. It
+accepts an optional `--max-workers` argument to limit the number of
+threads and warm connections:
+
+```bash
+python -m codex.cli run pool-fix
+```
+
+This can resolve hangs caused by runaway threads in tokenizers on some
+platforms.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,3 +79,20 @@ def test_fix_pool_executor_created() -> None:
         if executor is not None:
             executor.shutdown(wait=True)
             cf._executor = None
+
+
+def test_fix_pool_missing_cf(monkeypatch) -> None:
+    import builtins
+
+    from codex.cli import _fix_pool
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):  # type: ignore[override]
+        if name == "concurrent.futures":
+            raise ImportError("no concurrent.futures")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    # Should not raise even if concurrent.futures is unavailable
+    _fix_pool(max_workers=1)


### PR DESCRIPTION
## Summary
- configure `_fix_pool` to reset global thread pool and enable SQLite pooling
- document `pool-fix` maintenance task in CLI docs
- add tests covering thread pool setup and missing `concurrent.futures`

## Testing
- `pytest tests/test_cli.py tests/test_cli_pool.py -q`
- `pre-commit run --files docs/modules/cli.md src/codex/cli.py tests/test_cli.py` *(fails: Interrupted (^C))*


------
https://chatgpt.com/codex/tasks/task_e_68c774687ed48331b0bf1ae67e88ebf7