### PR TITLE
Fix _fix_pool imports and add pooling test

### DIFF
--- a/.codex/change_log.md
+++ b/.codex/change_log.md
@@ -15828,3 +15828,9 @@ This repository includes CPU-friendly smoke tests for HF Trainer and end-to-end 
 - Moves standardized; integrity audit (v2) ready.
 - Pytest/pre-commit/MkDocs/nox repairs applied.
 - GH Actions gated (manual + self-hosted).
+## 2025-09-15T04:03:56Z — src/codex/cli.py
+- **Action:** edit
+- **Rationale:** add missing imports for SQLite pooling helper
+## 2025-09-15T04:03:56Z — tests/test_cli_pool.py
+- **Action:** edit
+- **Rationale:** verify `_fix_pool` sets pooling environment variable

--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path

--- a/tests/test_cli_pool.py
+++ b/tests/test_cli_pool.py
@@ -1,8 +1,10 @@
 """Tests for the ``_fix_pool`` helper in :mod:`codex.cli`."""
 
 import concurrent.futures as cf
+import os
 
 from codex.cli import _fix_pool
+from codex.db import sqlite_patch
 
 
 def test_fix_pool_executor_created() -> None:
@@ -19,3 +21,17 @@ def test_fix_pool_executor_created() -> None:
         if executor is not None:
             executor.shutdown(wait=True)
             cf._executor = None
+
+
+def test_fix_pool_sets_env(monkeypatch) -> None:
+    """Calling ``_fix_pool`` enables SQLite pooling via env var."""
+    monkeypatch.delenv("CODEX_SQLITE_POOL", raising=False)
+    try:
+        _fix_pool(max_workers=0)
+        assert os.environ.get("CODEX_SQLITE_POOL") == "1"
+    finally:
+        executor = getattr(cf, "_executor", None)
+        if executor is not None:
+            executor.shutdown(wait=True)
+            cf._executor = None
+        sqlite_patch.disable_pooling()


### PR DESCRIPTION
## Summary
- import os and sqlite3 in `_fix_pool`
- test SQLite pool env var initialization
- document changes in `.codex/change_log.md`

## Testing
- `pre-commit run --files src/codex/cli.py tests/test_cli_pool.py .codex/change_log.md` *(bandit interrupted)*
- `nox -s tests` *(fails: tests/checkpointing/test_corrupt_checkpoint_load.py::test_load_checkpoint_detects_corruption)*
- `pytest tests/test_cli_pool.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c78f92b34c83318b4a0b6b897a6d49