### PR TITLE
Implement minimal RLHF helpers and tests

### DIFF
--- a/src/codex_ml/interfaces/__init__.py
+++ b/src/codex_ml/interfaces/__init__.py
@@ -1,9 +1,4 @@
 # BEGIN: CODEX_IFACE_INIT
-from .registry import apply_config, get, get_component, load_component, register
-from .reward_model import RewardModel
-from .rl import RLAgent
-from .tokenizer import HFTokenizer, TokenizerAdapter
-
 __all__ = [
     "TokenizerAdapter",
     "HFTokenizer",
@@ -15,4 +10,38 @@ __all__ = [
     "get_component",
     "apply_config",
 ]
+
+
+def __getattr__(name: str):  # pragma: no cover - shim for optional deps
+    if name in {"TokenizerAdapter", "HFTokenizer"}:
+        from .tokenizer import HFTokenizer, TokenizerAdapter
+
+        return {"TokenizerAdapter": TokenizerAdapter, "HFTokenizer": HFTokenizer}[name]
+    if name in {"RewardModel"}:
+        from .reward_model import RewardModel
+
+        return RewardModel
+    if name in {"RLAgent"}:
+        from .rl import RLAgent
+
+        return RLAgent
+    if name in {"register", "get", "load_component", "get_component", "apply_config"}:
+        from . import registry
+
+        mapping = {
+            "register": registry.register,
+            "get": registry.get,
+            "load_component": registry.load_component,
+            "get_component": registry.get_component,
+            "apply_config": registry.apply_config,
+        }
+
+        return mapping[name]
+    raise AttributeError(name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - introspection helper
+    return sorted(__all__)
+
+
 # END: CODEX_IFACE_INIT

--- a/src/codex_ml/reward_models/__init__.py
+++ b/src/codex_ml/reward_models/__init__.py
@@ -1,5 +1,11 @@
 """Built-in reward model implementations."""
 
-from .simple import LengthRewardModel
-
 __all__ = ["LengthRewardModel"]
+
+
+def __getattr__(name: str):  # pragma: no cover - thin shim
+    if name == "LengthRewardModel":
+        from .simple import LengthRewardModel as _LengthRewardModel
+
+        return _LengthRewardModel
+    raise AttributeError(name)

--- a/src/codex_ml/reward_models/rlhf.py
+++ b/src/codex_ml/reward_models/rlhf.py
@@ -1,26 +1,256 @@
-"""Interfaces for future RLHF integration.
+"""Light‑weight RLHF helpers used in tests and examples.
 
-These minimal stubs document the expected APIs for reward modelling and
-reinforcement learning trainers.  Concrete implementations will be added in a
-future iteration.
+The real project will eventually plug in large reward models and policy
+optimisers.  For the purposes of offline tests we provide a deterministic
+reward model calibrator and a tiny trainer that coordinates a reward model with
+an :class:`~codex_ml.interfaces.rl.RLAgent` implementation.  The goal is to
+offer a concrete implementation that exercises the surrounding plumbing without
+pulling in heavyweight dependencies.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, MutableMapping, Optional, Sequence
+
+from codex_ml.interfaces.reward_model import RewardModel as RewardModelBase
+from codex_ml.interfaces.rl import RLAgent
+
+LOGGER = logging.getLogger(__name__)
 
 
-class RewardModel:
-    """Abstract reward model used during RLHF training."""
+def _coerce_triples(data: Iterable[Any]) -> list[tuple[str, str, float]]:
+    """Normalise preference data into ``(prompt, completion, reward)`` tuples."""
 
-    def score(self, *args: Any, **kwargs: Any) -> float:  # pragma: no cover - stub
-        """Return a scalar reward for the provided inputs."""
-        raise NotImplementedError
+    triples: list[tuple[str, str, float]] = []
+    for item in data:
+        prompt: Optional[str]
+        completion: Optional[str]
+        reward_value: Optional[float]
+
+        if isinstance(item, Mapping):
+            prompt = item.get("prompt")
+            completion = item.get("completion")
+            reward_value_raw = item.get("reward")
+        elif isinstance(item, (tuple, list)) and len(item) >= 3:
+            prompt = item[0]  # type: ignore[index]
+            completion = item[1]  # type: ignore[index]
+            reward_value_raw = item[2]  # type: ignore[index]
+        else:  # pragma: no cover - defensive branch
+            LOGGER.debug("Skipping unsupported preference entry: %r", item)
+            continue
+
+        if prompt is None or completion is None:
+            LOGGER.debug("Skipping preference entry missing text: %r", item)
+            continue
+
+        try:
+            reward_value = float(reward_value_raw) if reward_value_raw is not None else None
+        except (TypeError, ValueError):
+            LOGGER.debug("Skipping preference entry with non-numeric reward: %r", item)
+            continue
+
+        if reward_value is None:
+            LOGGER.debug("Skipping preference entry without reward: %r", item)
+            continue
+
+        triples.append((str(prompt), str(completion), reward_value))
+
+    return triples
+
+
+@dataclass
+class RewardModel(RewardModelBase):
+    """Tiny reward model that calibrates a base implementation.
+
+    The model wraps another :class:`RewardModelBase` instance (``LengthRewardModel``
+    by default) and learns a linear transformation ``reward = scale * base + bias``
+    from labelled preferences.  The helper is intentionally small but proves out
+    the reward-model API for downstream tooling.
+    """
+
+    base_model: RewardModelBase | None = None
+    scale: float = 1.0
+    bias: float = 0.0
+    _last_metrics: dict[str, float] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.base_model is None:
+            from .simple import LengthRewardModel
+
+            self.base_model = LengthRewardModel()
+
+    # ``RewardModelBase`` already defines ``batch_evaluate``; we override
+    # ``evaluate`` to apply the learnt calibration.
+    def evaluate(
+        self,
+        prompt: str,
+        completion: str,
+        *,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> float:
+        assert self.base_model is not None  # for type-checkers
+        base = self.base_model.evaluate(prompt, completion, metadata=metadata)
+        return self.scale * float(base) + self.bias
+
+    def score(
+        self,
+        prompt: str,
+        completion: str,
+        *,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> float:
+        """Compatibility alias matching the historical stub method name."""
+
+        return self.evaluate(prompt, completion, metadata=metadata)
+
+    def learn(self, data: Iterable[Any]) -> dict[str, float]:  # noqa: D401 - interface method
+        # Materialise the iterable so that we can feed it both to the wrapped
+        # model and to the calibration logic without exhausting generators.
+        materialised = list(data)
+        triples = _coerce_triples(materialised)
+
+        assert self.base_model is not None
+        base_metrics: dict[str, float] = {}
+        try:
+            maybe_metrics = self.base_model.learn(materialised)
+        except Exception as exc:  # pragma: no cover - defensive
+            LOGGER.debug("Base reward model learn() failed: %s", exc)
+        else:
+            if isinstance(maybe_metrics, Mapping):
+                base_metrics = {
+                    f"base_{k}": float(v)
+                    for k, v in maybe_metrics.items()
+                    if isinstance(v, (int, float))
+                }
+
+        if not triples:
+            metrics = {"examples": 0.0, "scale": self.scale, "bias": self.bias}
+            metrics.update(base_metrics)
+            self._last_metrics = metrics
+            return metrics
+
+        xs = [self.base_model.evaluate(p, c) for p, c, _ in triples]
+        ys = [reward for _, _, reward in triples]
+        n = len(xs)
+
+        mean_x = sum(xs) / n
+        mean_y = sum(ys) / n
+        denom = sum((x - mean_x) ** 2 for x in xs)
+        if denom <= 1e-12:
+            scale = 0.0
+        else:
+            scale = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys)) / denom
+        bias = mean_y - scale * mean_x
+
+        self.scale = float(scale)
+        self.bias = float(bias)
+
+        mse = sum((self.scale * x + self.bias - y) ** 2 for x, y in zip(xs, ys)) / n
+
+        metrics = {
+            "examples": float(n),
+            "scale": self.scale,
+            "bias": self.bias,
+            "mse": float(mse),
+        }
+        metrics.update(base_metrics)
+        self._last_metrics = metrics
+        return metrics
 
 
 class RLTrainer:
-    """Placeholder RL trainer for future integration."""
+    """Minimal trainer orchestrating an agent and a reward model."""
 
-    def train(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - stub
-        """Run the RLHF training loop."""
-        raise NotImplementedError
+    def __init__(
+        self,
+        agent: RLAgent,
+        reward_model: RewardModel,
+        *,
+        discount: float = 1.0,
+    ) -> None:
+        self.agent = agent
+        self.reward_model = reward_model
+        self.discount = discount
+
+    def _prepare_rewards(self, trajectory: Mapping[str, Any]) -> list[float]:
+        rewards: list[float] = []
+        existing = trajectory.get("rewards")
+        if isinstance(existing, Sequence):
+            for value in existing:
+                try:
+                    rewards.append(float(value))
+                except (TypeError, ValueError):  # pragma: no cover - defensive
+                    LOGGER.debug("Ignoring non-numeric reward value: %r", value)
+
+        explicit = trajectory.get("reward")
+        prompt = trajectory.get("prompt")
+        completion = trajectory.get("completion")
+        computed: Optional[float]
+        if explicit is not None:
+            try:
+                computed = float(explicit)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                computed = None
+        elif prompt is not None and completion is not None:
+            computed = self.reward_model.score(str(prompt), str(completion))
+        else:
+            computed = None
+
+        if computed is not None:
+            rewards.append(float(computed))
+
+        return rewards
+
+    def train(
+        self,
+        trajectories: Iterable[Mapping[str, Any]],
+        *,
+        reward_dataset: Iterable[Any] | None = None,
+    ) -> dict[str, float]:
+        reward_metrics: Optional[Mapping[str, float]] = None
+        if reward_dataset is not None:
+            dataset_list = list(reward_dataset)
+            reward_metrics = self.reward_model.learn(dataset_list)
+
+        episodes = 0
+        total_reward = 0.0
+        discounted_reward = 0.0
+        metric_totals: dict[str, float] = defaultdict(float)
+        metric_counts: dict[str, int] = defaultdict(int)
+
+        for trajectory in trajectories:
+            episodes += 1
+            traj_dict: MutableMapping[str, Any] = dict(trajectory)
+            rewards = self._prepare_rewards(traj_dict)
+            if rewards:
+                traj_dict["rewards"] = rewards
+                total_reward += sum(rewards)
+                discounted_reward += sum((self.discount**i) * r for i, r in enumerate(rewards))
+
+            agent_metrics = self.agent.update(traj_dict)
+            for key, value in agent_metrics.items():
+                try:
+                    metric_totals[key] += float(value)
+                    metric_counts[key] += 1
+                except (TypeError, ValueError):  # pragma: no cover - defensive
+                    LOGGER.debug("Ignoring non-numeric agent metric %s=%r", key, value)
+
+        result: dict[str, float] = {
+            "episodes": float(episodes),
+            "total_reward": float(total_reward),
+            "discounted_reward": float(discounted_reward),
+        }
+        for key, value in metric_totals.items():
+            count = metric_counts[key]
+            if count:
+                result[f"agent_{key}"] = value / count
+
+        if reward_metrics is not None:
+            for key, value in reward_metrics.items():
+                if isinstance(value, (int, float)):
+                    result[f"reward_{key}"] = float(value)
+
+        return result

--- a/tests/test_reward_models_rlhf.py
+++ b/tests/test_reward_models_rlhf.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+from codex_ml.reward_models.rlhf import RewardModel, RLTrainer
+from codex_ml.rl.simple_agent import RandomAgent
+
+
+def test_reward_model_learn_calibrates_scale_and_bias():
+    model = RewardModel()
+    dataset = [
+        ("p1", "a", 1.0),
+        ("p2", "abcd", 2.5),
+        ("p3", "abc", 2.0),
+    ]
+
+    metrics = model.learn(dataset)
+
+    assert metrics["examples"] == pytest.approx(3.0)
+    assert metrics["scale"] == pytest.approx(0.5)
+    assert metrics["bias"] == pytest.approx(0.5)
+    assert "base_loss" in metrics
+
+    # After calibration, scoring a new completion should use the fitted line.
+    score = model.score("prompt", "aa")
+    assert score == pytest.approx(1.5)
+
+
+def test_rl_trainer_updates_agent_and_reports_metrics():
+    model = RewardModel()
+    agent = RandomAgent()
+    reward_dataset = [
+        ("p1", "aa", 1.5),
+        ("p2", "aaaa", 2.7),
+    ]
+    trainer = RLTrainer(agent, model, discount=0.9)
+
+    trajectories = [
+        {"prompt": "p1", "completion": "aa"},
+        {"prompt": "p2", "completion": "aaaa", "rewards": [0.1]},
+    ]
+
+    result = trainer.train(trajectories, reward_dataset=reward_dataset)
+
+    assert result["episodes"] == pytest.approx(2.0)
+    assert result["total_reward"] > 0
+    assert result["discounted_reward"] > 0
+    assert "agent_loss" in result
+    assert result["agent_loss"] == pytest.approx(0.0)
+    assert result["reward_examples"] == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- add a light-weight RLHF reward model implementation that calibrates a base reward signal and expose a tiny trainer helper
- make the interfaces and reward-model packages lazily import heavy modules to avoid optional dependency failures during import
- add unit tests covering the new RLHF reward model calibration and trainer metrics aggregation

## Testing
- `pytest tests/test_reward_models_rlhf.py`


------
https://chatgpt.com/codex/tasks/task_e_68c848a7c6a883319f678c7ae9ad12f6