### PR TITLE
feat(tokenizer): add base config and cli skeleton

### DIFF
--- a/configs/tokenization/base.yaml
+++ b/configs/tokenization/base.yaml
@@ -1,5 +1,43 @@
-# Tokenizer training and loading defaults
-corpus_glob: corpus.txt
+# Tokenizer pipeline defaults for Codex ML.
+# Provides dataset sources, cache locations, normalization behavior, and training hyperparameters.
+datasets:
+  train:
+    id: train
+    path: data/tokenizer/train.txt
+    checksum: null
+  validation:
+    id: validation
+    path: data/tokenizer/validation.txt
+    checksum: null
+cache:
+  dir: artifacts/tokenizers
+  manifest_name: manifest.json
+normalizer:
+  lowercase: true
+  unicode_form: nfkc
+  strip_accents: false
+special_tokens:
+  pad: "<pad>"
+  unk: "<unk>"
+  bos: "<s>"
+  eos: "</s>"
+  mask: "<mask>"
+training:
+  model_type: unigram
+  vocab_size: 32000
+  character_coverage: 0.9995
+  min_frequency: 2
+  seed: 42
+  workers: 4
+  max_length: null
+  padding_strategy: max_length
+  pad_to_multiple_of: null
+  normalization_rule: null
+  dry_run: false
+  shuffle_corpus: false
+  cache_overwrite: false
+# Legacy compatibility keys used by existing tooling; kept until full migration to the new schema.
+corpus_glob: data/tokenizer/train.txt
 model_type: unigram
 vocab_size: 32000
 character_coverage: 0.9995
@@ -9,6 +47,6 @@ workers: 4
 out_dir: artifacts/tokenizers
 name: default
 padding: max_length
-truncation: True
+truncation: true
 max_length: null
 dry_run: false

--- a/src/codex_ml/cli/codex_cli.py
+++ b/src/codex_ml/cli/codex_cli.py
@@ -12,6 +12,77 @@ def codex() -> None:
     """Codex command line interface."""
 
 
+@codex.group()
+def tokenizer() -> None:
+    """Tokenizer pipeline commands."""
+
+
+@tokenizer.command(name="train")
+@click.option(
+    "--config",
+    default="configs/tokenization/base.yaml",
+    show_default=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=str),
+    help="Path to the tokenizer YAML configuration.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Retrain even if dataset checksums match the cached manifest.",
+)
+def tokenizer_train(config: str, force: bool) -> None:
+    """Train or refresh the tokenizer cache (stub)."""
+    raise click.ClickException("tokenizer train not yet implemented; coming in EPIC 1 PR-2.")
+
+
+@tokenizer.command(name="validate")
+@click.option(
+    "--config",
+    default="configs/tokenization/base.yaml",
+    show_default=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=str),
+    help="Configuration file to validate against the tokenizer manifest.",
+)
+def tokenizer_validate(config: str) -> None:
+    """Validate tokenizer cache manifests (stub)."""
+    raise click.ClickException("tokenizer validate not yet implemented; coming in EPIC 1 PR-2.")
+
+
+@tokenizer.command(name="encode")
+@click.argument("text", nargs=-1)
+@click.option(
+    "--tokenizer-path",
+    default="artifacts/tokenizers/default/tokenizer.json",
+    show_default=True,
+    type=click.Path(exists=False, dir_okay=False, path_type=str),
+    help="Tokenizer model JSON to load for encoding.",
+)
+@click.option(
+    "--no-add-special-tokens",
+    is_flag=True,
+    help="Disable automatic inclusion of special tokens during encoding.",
+)
+def tokenizer_encode(
+    text: tuple[str, ...], tokenizer_path: str, no_add_special_tokens: bool
+) -> None:
+    """Encode text to token IDs using the configured tokenizer (stub)."""
+    raise click.ClickException("tokenizer encode not yet implemented; coming in EPIC 1 PR-2.")
+
+
+@tokenizer.command(name="decode")
+@click.argument("ids", nargs=-1, type=int)
+@click.option(
+    "--tokenizer-path",
+    default="artifacts/tokenizers/default/tokenizer.json",
+    show_default=True,
+    type=click.Path(exists=False, dir_okay=False, path_type=str),
+    help="Tokenizer model JSON to load for decoding.",
+)
+def tokenizer_decode(ids: tuple[int, ...], tokenizer_path: str) -> None:
+    """Decode token IDs to text using the configured tokenizer (stub)."""
+    raise click.ClickException("tokenizer decode not yet implemented; coming in EPIC 1 PR-2.")
+
+
 @codex.command()
 @click.option(
     "--config",

--- a/tests/tokenization/test_tokenizer.py
+++ b/tests/tokenization/test_tokenizer.py
@@ -1,0 +1,23 @@
+import pytest
+
+pytestmark = pytest.mark.skip(reason="Tokenizer pipeline CLI pending implementation (EPIC 1 PR-2).")
+
+
+def test_tokenizer_encode_decode_roundtrip() -> None:
+    """Placeholder for encode/decode symmetry validation."""
+    pass
+
+
+def test_tokenizer_special_token_behavior() -> None:
+    """Placeholder for verifying reserved token handling."""
+    pass
+
+
+def test_tokenizer_padding_invariants() -> None:
+    """Placeholder for padding invariants during batch encoding."""
+    pass
+
+
+def test_tokenizer_manifest_presence() -> None:
+    """Placeholder for manifest generation checks."""
+    pass


### PR DESCRIPTION
This pull request introduces a new tokenizer pipeline for Codex ML, laying the groundwork for future tokenizer training, validation, and encoding/decoding operations. The changes include a comprehensive configuration schema, new CLI commands for tokenizer management, and placeholder tests for key tokenizer behaviors. These updates are currently stubs and will be fully implemented in a future PR.

**Tokenizer pipeline configuration:**

* Expanded `configs/tokenization/base.yaml` to include dataset sources, cache settings, normalization options, special tokens, and detailed training hyperparameters, replacing the previous minimal configuration.
* Updated YAML boolean values for consistency (e.g., `truncation: True` to `truncation: true`).

**CLI integration:**

* Added a new `tokenizer` command group to `src/codex_ml/cli/codex_cli.py` with stub commands for `train`, `validate`, `encode`, and `decode`, each with relevant options and help text. These commands currently raise a "not yet implemented" exception.

**Testing scaffolding:**

* Introduced `tests/tokenization/test_tokenizer.py` with placeholder tests for encode/decode roundtrip, special token handling, padding invariants, and manifest generation. All tests are marked as skipped pending implementation.