### PR TITLE
feat(seed): add reproducible seeding helper scaffolding

### DIFF
--- a/src/codex_ml/utils/seeding.py
+++ b/src/codex_ml/utils/seeding.py
@@ -19,6 +19,7 @@ except Exception:  # pragma: no cover - torch missing
 
 
 _PYTHONHASHSEED: Final[str] = "PYTHONHASHSEED"
+_CUBLAS_WORKSPACE_CONFIG: Final[str] = "CUBLAS_WORKSPACE_CONFIG"
 
 
 def _set_pythonhashseed(seed: int) -> None:
@@ -37,6 +38,7 @@ def _seed_torch(seed: int) -> None:
 
     torch.manual_seed(seed)
     if hasattr(torch.cuda, "is_available") and torch.cuda.is_available():
+        os.environ.setdefault(_CUBLAS_WORKSPACE_CONFIG, ":16:8")
         torch.cuda.manual_seed_all(seed)
 
     try:


### PR DESCRIPTION
## Summary
- add deterministic seeding helper that seeds python, numpy, and torch with cudnn safeguards
- add skipped reproducibility tests covering python, numpy, and torch RNGs plus PYTHONHASHSEED assertions
- extend nox coverage helper to include codex_ml modules
- ensure the seeding helper configures the cuBLAS workspace for deterministic CUDA operations

## Testing
- .venv/bin/pre-commit run -a *(fails: offline environment prevents hook bootstrapping)*
- nox -s tests *(fails: nox not installed in base interpreter)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c8ef75488331821e9e0f90cd27cc