### PR TITLE
Codex/implement seeding utility with baseline tests 2025 09 16

### DIFF
--- a/src/codex_ml/utils/seeding.py
+++ b/src/codex_ml/utils/seeding.py
@@ -19,6 +19,7 @@ except Exception:  # pragma: no cover - torch missing
 
 
 _PYTHONHASHSEED: Final[str] = "PYTHONHASHSEED"
+_CUBLAS_WORKSPACE_CONFIG: Final[str] = "CUBLAS_WORKSPACE_CONFIG"
 
 
 def _set_pythonhashseed(seed: int) -> None:
@@ -37,6 +38,7 @@ def _seed_torch(seed: int) -> None:
 
     torch.manual_seed(seed)
     if hasattr(torch.cuda, "is_available") and torch.cuda.is_available():
+        os.environ.setdefault(_CUBLAS_WORKSPACE_CONFIG, ":16:8")
         torch.cuda.manual_seed_all(seed)
 
     try:


### PR DESCRIPTION
This pull request makes a minor update to the seeding utility in `src/codex_ml/utils/seeding.py` to improve reproducibility when using CUDA. The main change is the addition of a new environment variable setting in the torch seeding function.

* Reproducibility improvement:
  * In `_seed_torch`, sets the `CUBLAS_WORKSPACE_CONFIG` environment variable to `:16:8` when CUDA is available, which helps ensure deterministic behavior for cuBLAS operations.
  * Adds the `_CUBLAS_WORKSPACE_CONFIG` constant for the environment variable name.