### PR TITLE
feat(tokenizer): scaffold tokenizer pipeline CLI and config

### DIFF
--- a/src/codex_ml/cli/codex_cli.py
+++ b/src/codex_ml/cli/codex_cli.py
@@ -6,6 +6,9 @@ import click
 
 from codex_ml.telemetry import start_metrics_server
 
+DEFAULT_TOKENIZER_CONFIG = "configs/tokenization/base.yaml"
+DEFAULT_TOKENIZER_JSON = "artifacts/tokenizers/default/tokenizer.json"
+
 
 @click.group()
 def codex() -> None:
@@ -20,7 +23,7 @@ def tokenizer() -> None:
 @tokenizer.command("train")
 @click.option(
     "--config",
-    default="configs/tokenization/base.yaml",
+    default=DEFAULT_TOKENIZER_CONFIG,
     show_default=True,
     type=click.Path(exists=True, dir_okay=False, path_type=str),
     help="Path to the tokenizer pipeline configuration file.",
@@ -36,7 +39,7 @@ def tokenizer_train(config: str) -> None:
 @tokenizer.command("validate")
 @click.option(
     "--config",
-    default="configs/tokenization/base.yaml",
+    default=DEFAULT_TOKENIZER_CONFIG,
     show_default=True,
     type=click.Path(exists=True, dir_okay=False, path_type=str),
     help="Path to the tokenizer pipeline configuration file.",
@@ -53,7 +56,7 @@ def tokenizer_validate(config: str) -> None:
 @click.argument("text", required=False)
 @click.option(
     "--tokenizer-path",
-    default="artifacts/tokenizers/default/tokenizer.json",
+    default=DEFAULT_TOKENIZER_JSON,
     show_default=True,
     type=click.Path(dir_okay=False, path_type=str),
     help="Path to the serialized tokenizer JSON file to use for encoding.",
@@ -70,7 +73,7 @@ def tokenizer_encode(text: Optional[str], tokenizer_path: str) -> None:
 @click.argument("token_ids", nargs=-1, type=int)
 @click.option(
     "--tokenizer-path",
-    default="artifacts/tokenizers/default/tokenizer.json",
+    default=DEFAULT_TOKENIZER_JSON,
     show_default=True,
     type=click.Path(dir_okay=False, path_type=str),
     help="Path to the serialized tokenizer JSON file to use for decoding.",


### PR DESCRIPTION
This pull request refactors the way default configuration paths are handled for the tokenizer CLI commands in `src/codex_ml/cli/codex_cli.py`. The main improvement is the introduction of constants for default paths, which reduces duplication and makes future updates easier.

Refactoring for maintainability:

* Introduced `DEFAULT_TOKENIZER_CONFIG` and `DEFAULT_TOKENIZER_JSON` constants to centralize the default file paths for tokenizer configuration and JSON artifacts.
* Updated all relevant CLI options (`--config` and `--tokenizer-path`) in the tokenizer commands to use these new constants instead of hardcoded strings. [[1]](diffhunk://#diff-3d72bde037276b79e8a2056925f972c2b4a22a3cce7d13f55d860dadcd39b6c7L23-R26) [[2]](diffhunk://#diff-3d72bde037276b79e8a2056925f972c2b4a22a3cce7d13f55d860dadcd39b6c7L39-R42) [[3]](diffhunk://#diff-3d72bde037276b79e8a2056925f972c2b4a22a3cce7d13f55d860dadcd39b6c7L56-R59) [[4]](diffhunk://#diff-3d72bde037276b79e8a2056925f972c2b4a22a3cce7d13f55d860dadcd39b6c7L73-R76)

------
## Summary
- replace the legacy tokenizer configuration with a dataset- and cache-aware pipeline layout
- add a `codex tokenizer` CLI group with stubbed train/validate/encode/decode commands for the upcoming pipeline work
- introduce skipped regression tests that will be enabled when the tokenizer pipeline lands
- centralize default tokenizer config and artifact paths so the CLI options stay consistent

## Testing
- python -m pytest tests/tokenization/test_tokenizer.py

------
https://chatgpt.com/codex/tasks/task_e_68c8d132576c8331be05a0bcd27952b3