### PR TITLE
Handle malformed safety policy data gracefully

### DIFF
--- a/src/codex_ml/safety/filters.py
+++ b/src/codex_ml/safety/filters.py
@@ -110,8 +110,19 @@ class SafetyPolicy:
         for candidate in candidates:
             if candidate.exists():
                 data = _load_policy_file(candidate)
-                if data is not None:
+                if data is None:
+                    continue
+                if not isinstance(data, dict):
+                    logger.warning(
+                        "Ignoring safety policy at %s: expected mapping but got %s",
+                        candidate,
+                        type(data).__name__,
+                    )
+                    continue
+                try:
                     return cls.from_dict(data)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.warning("Failed to parse safety policy from %s: %s", candidate, exc)
 
         return cls.from_dict(DEFAULT_POLICY_DATA)
 
@@ -363,7 +374,7 @@ FLAG_LOOKUP = {
 }
 
 
-def _load_policy_file(path: Path) -> Optional[dict[str, Any]]:
+def _load_policy_file(path: Path) -> Optional[Any]:
     if yaml is None:
         logger.debug("PyYAML not available; skipping policy file: %s", path)
         return None


### PR DESCRIPTION
## Summary
- log and skip malformed safety policy files instead of crashing when they decode to non-mapping objects
- treat `_load_policy_file` as returning arbitrary YAML content so callers can validate before building the policy

## Testing
- pytest tests/safety/test_filters.py tests/safety/test_filters_regressions.py

------
https://chatgpt.com/codex/tasks/task_e_68c8f83a5aa88331a53e9848fde99304