### PR TITLE
Codex/implement policy driven safety filters 2025 09 16

### DIFF
--- a/src/codex_ml/safety/filters.py
+++ b/src/codex_ml/safety/filters.py
@@ -110,8 +110,19 @@ class SafetyPolicy:
         for candidate in candidates:
             if candidate.exists():
                 data = _load_policy_file(candidate)
-                if data is not None:
+                if data is None:
+                    continue
+                if not isinstance(data, dict):
+                    logger.warning(
+                        "Ignoring safety policy at %s: expected mapping but got %s",
+                        candidate,
+                        type(data).__name__,
+                    )
+                    continue
+                try:
                     return cls.from_dict(data)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.warning("Failed to parse safety policy from %s: %s", candidate, exc)
 
         return cls.from_dict(DEFAULT_POLICY_DATA)
 
@@ -363,7 +374,7 @@ FLAG_LOOKUP = {
 }
 
 
-def _load_policy_file(path: Path) -> Optional[dict[str, Any]]:
+def _load_policy_file(path: Path) -> Optional[Any]:
     if yaml is None:
         logger.debug("PyYAML not available; skipping policy file: %s", path)
         return None


### PR DESCRIPTION
This pull request improves the robustness of loading safety policy files in `src/codex_ml/safety/filters.py` by adding better error handling and logging. The changes ensure that invalid or malformed policy files are safely ignored, and more informative warnings are provided when issues are encountered.

Error handling and logging improvements:

* When loading a safety policy file, the code now checks if the loaded data is a dictionary. If not, it logs a warning and ignores the file.
* If parsing the policy data fails, a warning is logged with the exception details, and the process continues to try other candidates or falls back to the default policy.

Type annotation update:

* The return type of `_load_policy_file` was changed from `Optional[dict[str, Any]]` to `Optional[Any]` to reflect that the function may return data of any type, improving type safety.