### PR TITLE
Fix tokenizer train stub registration in CLI

### DIFF
--- a/src/codex_ml/cli/codex_cli.py
+++ b/src/codex_ml/cli/codex_cli.py
@@ -29,76 +29,10 @@ def tokenizer() -> None:
     """Tokenizer pipeline utilities."""
 
 
-@tokenizer.command("train")
+@tokenizer.command(name="train")
 @click.option(
     "--config",
     default=DEFAULT_TOKENIZER_CONFIG,
-    show_default=True,
-    type=click.Path(exists=True, dir_okay=False, path_type=str),
-    help="Path to the tokenizer pipeline configuration file.",
-)
-def tokenizer_train(config: str) -> None:
-    """Train a tokenizer according to the provided configuration."""
-    del config
-    raise click.ClickException(
-        "tokenizer train pipeline not yet implemented; will land in a follow-up."
-    )
-
-
-@tokenizer.command("validate")
-@click.option(
-    "--config",
-    default=DEFAULT_TOKENIZER_CONFIG,
-    show_default=True,
-    type=click.Path(exists=True, dir_okay=False, path_type=str),
-    help="Path to the tokenizer pipeline configuration file.",
-)
-def tokenizer_validate(config: str) -> None:
-    """Validate dataset manifests and cached tokenizer artifacts."""
-    del config
-    raise click.ClickException(
-        "tokenizer validate pipeline not yet implemented; will land in a follow-up."
-    )
-
-
-@tokenizer.command("encode")
-@click.argument("text", required=False)
-@click.option(
-    "--tokenizer-path",
-    default=DEFAULT_TOKENIZER_JSON,
-    show_default=True,
-    type=click.Path(dir_okay=False, path_type=str),
-    help="Path to the serialized tokenizer JSON file to use for encoding.",
-)
-def tokenizer_encode(text: Optional[str], tokenizer_path: str) -> None:
-    """Encode text with a trained tokenizer."""
-    del text, tokenizer_path
-    raise click.ClickException(
-        "tokenizer encode pipeline not yet implemented; will land in a follow-up."
-    )
-
-
-@tokenizer.command("decode")
-@click.argument("token_ids", nargs=-1, type=int)
-@click.option(
-    "--tokenizer-path",
-    default=DEFAULT_TOKENIZER_JSON,
-    show_default=True,
-    type=click.Path(dir_okay=False, path_type=str),
-    help="Path to the serialized tokenizer JSON file to use for decoding.",
-)
-def tokenizer_decode(token_ids: tuple[int, ...], tokenizer_path: str) -> None:
-    """Decode token IDs with a trained tokenizer."""
-    del token_ids, tokenizer_path
-    raise click.ClickException(
-        "tokenizer decode pipeline not yet implemented; will land in a follow-up."
-    )
-
-
-@codex.command()
-@click.option(
-    "--config",
-    default="configs/tokenization/base.yaml",
     show_default=True,
     type=click.Path(exists=True, dir_okay=False, path_type=str),
     help="Path to the tokenizer YAML configuration.",
@@ -108,7 +42,7 @@ def tokenizer_decode(token_ids: tuple[int, ...], tokenizer_path: str) -> None:
     is_flag=True,
     help="Retrain even if dataset checksums match the cached manifest.",
 )
-def tokenizer_train(config: str, force: bool) -> None:  # noqa: F811
+def tokenizer_train(config: str, force: bool) -> None:
     """Train or refresh the tokenizer cache (stub)."""
     _tokenizer_stub("train")
 
@@ -116,12 +50,12 @@ def tokenizer_train(config: str, force: bool) -> None:  # noqa: F811
 @tokenizer.command(name="validate")
 @click.option(
     "--config",
-    default="configs/tokenization/base.yaml",
+    default=DEFAULT_TOKENIZER_CONFIG,
     show_default=True,
     type=click.Path(exists=True, dir_okay=False, path_type=str),
     help="Configuration file to validate against the tokenizer manifest.",
 )
-def tokenizer_validate(config: str) -> None:  # noqa: F811
+def tokenizer_validate(config: str) -> None:
     """Validate tokenizer cache manifests (stub)."""
     _tokenizer_stub("validate")
 
@@ -130,7 +64,7 @@ def tokenizer_validate(config: str) -> None:  # noqa: F811
 @click.argument("text", nargs=-1)
 @click.option(
     "--tokenizer-path",
-    default="artifacts/tokenizers/default/tokenizer.json",
+    default=DEFAULT_TOKENIZER_JSON,
     show_default=True,
     type=click.Path(exists=False, dir_okay=False, path_type=str),
     help="Tokenizer model JSON to load for encoding.",
@@ -140,7 +74,7 @@ def tokenizer_validate(config: str) -> None:  # noqa: F811
     is_flag=True,
     help="Disable automatic inclusion of special tokens during encoding.",
 )
-def tokenizer_encode(  # noqa: F811
+def tokenizer_encode(
     text: tuple[str, ...], tokenizer_path: str, no_add_special_tokens: bool
 ) -> None:
     """Encode text to token IDs using the configured tokenizer (stub)."""
@@ -151,12 +85,12 @@ def tokenizer_encode(  # noqa: F811
 @click.argument("ids", nargs=-1, type=int)
 @click.option(
     "--tokenizer-path",
-    default="artifacts/tokenizers/default/tokenizer.json",
+    default=DEFAULT_TOKENIZER_JSON,
     show_default=True,
     type=click.Path(exists=False, dir_okay=False, path_type=str),
     help="Tokenizer model JSON to load for decoding.",
 )
-def tokenizer_decode(ids: tuple[int, ...], tokenizer_path: str) -> None:  # noqa: F811
+def tokenizer_decode(ids: tuple[int, ...], tokenizer_path: str) -> None:
     """Decode token IDs to text using the configured tokenizer (stub)."""
     _tokenizer_stub("decode")
 


### PR DESCRIPTION
## Summary
- remove the legacy tokenizer command stubs that shadowed the new implementations
- register the updated tokenizer train stub on the tokenizer click group and reuse the shared defaults

## Testing
- python -m compileall src/codex_ml/cli/codex_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68c9138505dc8331909c9b59e57c28eb