### PR TITLE
Restore functional training integration

### DIFF
--- a/src/codex_ml/training/__init__.py
+++ b/src/codex_ml/training/__init__.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import json
-import random
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
-from codex_ml.utils.checkpointing import CheckpointManager
 from codex_ml.utils.error_log import log_error
 
 try:  # pragma: no cover - optional dependency in tests
@@ -18,38 +17,10 @@ except Exception:  # pragma: no cover - OmegaConf optional
 __all__ = ["TrainingRunConfig", "run_functional_training"]
 
 
-class _SimpleModel:
-    def __init__(self) -> None:
-        self.step = 0
-
-    def state_dict(self) -> Dict[str, Any]:
-        return {"step": self.step}
-
-    def load_state_dict(self, state: Mapping[str, Any]) -> None:
-        self.step = int(state.get("step", 0))
-
-
-class _SimpleOptimizer:
-    def __init__(self) -> None:
-        self.state: Dict[str, Any] = {}
-
-    def state_dict(self) -> Dict[str, Any]:
-        return {"state": dict(self.state)}
-
-    def load_state_dict(self, state: Mapping[str, Any]) -> None:
-        self.state = dict(state.get("state", {}))
-
-
-class _SimpleScheduler(_SimpleOptimizer):
-    """Scheduler stub sharing persistence helpers."""
-
-    pass
-
-
 @dataclass
 class TrainingRunConfig:
     seed: int = 42
-    model: str = "minilm"
+    model: Any = "minilm"
     learning_rate: float = 0.0003
     batch_size: int = 32
     max_epochs: int = 5
@@ -138,6 +109,77 @@ def _merge_dataset_config(dataset: Dict[str, Any], mapping: Mapping[str, Any]) -
         dataset["eval_texts"] = _listify_texts(mapping["eval_texts"])
 
 
+def _maybe_resolve_container(value: Any) -> Any:
+    """Resolve DictConfig objects into plain Python containers when possible."""
+
+    if DictConfig is not None and isinstance(value, DictConfig):  # type: ignore[arg-type]
+        resolved = OmegaConf.to_container(value, resolve=True)  # type: ignore[union-attr]
+        return resolved
+    return value
+
+
+def _coerce_model_entry(value: Any, default: Any) -> Any:
+    entry = value if value is not None else default
+    entry = _maybe_resolve_container(entry)
+    if isinstance(entry, Mapping):
+        return dict(entry)
+    if isinstance(entry, str):
+        return entry
+    return str(entry)
+
+
+def _model_name_from_value(value: Any, default: str = "MiniLM") -> str:
+    entry = _maybe_resolve_container(value)
+    if isinstance(entry, Mapping):
+        candidate = entry.get("name")
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    if isinstance(entry, str) and entry:
+        return entry
+    return default
+
+
+def _normalize_model_config(value: Any, fallback_name: str = "MiniLM") -> Dict[str, Any]:
+    entry = _maybe_resolve_container(value)
+    if isinstance(entry, Mapping):
+        cfg = dict(entry)
+    elif isinstance(entry, str) and entry:
+        cfg = {"name": entry}
+    else:
+        cfg = {}
+    name = cfg.get("name")
+    if not isinstance(name, str) or not name:
+        cfg["name"] = fallback_name or "MiniLM"
+    return cfg
+
+
+def _find_latest_checkpoint(directory: Path) -> Optional[Path]:
+    """Return the most recent checkpoint file within ``directory`` if present."""
+
+    if not directory.exists():
+        return None
+
+    marker = directory / "last"
+    with contextlib.suppress(Exception):
+        text = marker.read_text(encoding="utf-8").strip()
+        if text:
+            target = Path(text)
+            if not target.is_absolute():
+                target = directory / text
+            if target.exists():
+                return target
+
+    step_candidates = sorted(p for p in directory.glob("step*.pt") if p.is_file())
+    if step_candidates:
+        return step_candidates[-1]
+
+    generic = sorted(p for p in directory.glob("*.pt") if p.is_file())
+    if generic:
+        return generic[-1]
+
+    return None
+
+
 def _coerce_config(raw: Mapping[str, Any]) -> TrainingRunConfig:
     mapping = _normalize_config(raw)
     base = TrainingRunConfig()
@@ -176,9 +218,11 @@ def _coerce_config(raw: Mapping[str, Any]) -> TrainingRunConfig:
     tensorboard_value = _scalar(base.tensorboard, "tensorboard")
     mlflow_value = _scalar(base.mlflow_enable, "mlflow_enable")
 
+    model_value = _coerce_model_entry(_scalar(base.model, "model"), base.model)
+
     return TrainingRunConfig(
         seed=int(_scalar(base.seed, "seed")),
-        model=str(_scalar(base.model, "model")),
+        model=model_value,
         learning_rate=float(_scalar(base.learning_rate, "learning_rate", "lr")),
         batch_size=int(_scalar(base.batch_size, "batch_size")),
         max_epochs=int(_scalar(base.max_epochs, "max_epochs", "epochs")),
@@ -203,14 +247,18 @@ def _coerce_config(raw: Mapping[str, Any]) -> TrainingRunConfig:
 def run_functional_training(
     config: Mapping[str, Any] | TrainingRunConfig, *, resume: bool = False
 ) -> Dict[str, Any]:
-    """Run a lightweight training loop with checkpointing support."""
+    """Run the Codex functional training loop with optional resume support."""
 
+    normalized_mapping: Dict[str, Any] | None = None
+    training_mapping: Mapping[str, Any] | None = None
     if isinstance(config, TrainingRunConfig):
         cfg = config
     else:
-        cfg = _coerce_config(config)
-
-    random.seed(cfg.seed)
+        normalized_mapping = _normalize_config(config)
+        cfg = _coerce_config(normalized_mapping)
+        maybe_training = normalized_mapping.get("training") if normalized_mapping else None
+        if isinstance(maybe_training, Mapping):
+            training_mapping = maybe_training
 
     dataset_cfg = cfg.dataset or {}
     dataset_format = str(dataset_cfg.get("format", "text"))
@@ -235,62 +283,124 @@ def run_functional_training(
     output_dir = Path(cfg.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    checkpoint_root = Path(cfg.checkpoint_dir) if cfg.checkpoint_dir else output_dir / "checkpoints"
-    checkpoint_root.mkdir(parents=True, exist_ok=True)
+    checkpoint_candidate = (
+        Path(cfg.checkpoint_dir) if cfg.checkpoint_dir else output_dir / "checkpoints"
+    )
+    if checkpoint_candidate.suffix:
+        checkpoint_dir = checkpoint_candidate.parent
+    else:
+        checkpoint_dir = checkpoint_candidate
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
-    model = _SimpleModel()
-    optimizer = _SimpleOptimizer()
-    scheduler = _SimpleScheduler()
+    try:
+        from datasets import Dataset  # type: ignore
+        from transformers import AutoTokenizer  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependencies
+        raise RuntimeError("datasets and transformers are required for training") from exc
 
-    manager = CheckpointManager(checkpoint_root, keep_last=max(cfg.max_epochs, 1), keep_best=1)
+    import numpy as np  # type: ignore
 
-    start_epoch = 0
-    resumed_from: Optional[Path] = None
+    from codex_ml.models.registry import get_model
+    from codex_ml.utils.checkpointing import load_training_checkpoint
+    from training.functional_training import TrainCfg, run_custom_trainer
+
+    def _lookup(*keys: str, default: Any = None) -> Any:
+        for key in keys:
+            if (
+                isinstance(training_mapping, Mapping)
+                and key in training_mapping
+                and training_mapping[key] is not None
+            ):
+                return _maybe_resolve_container(training_mapping[key])
+            if (
+                normalized_mapping is not None
+                and key in normalized_mapping
+                and normalized_mapping[key] is not None
+            ):
+                return _maybe_resolve_container(normalized_mapping[key])
+        return default
+
+    model_entry = _lookup("model", default=cfg.model)
+    fallback_name = _model_name_from_value(cfg.model)
+    model_cfg = _normalize_model_config(model_entry, fallback_name)
+
+    tokenizer_name = str(
+        model_cfg.get("pretrained_model_name_or_path")
+        or model_cfg.get("tokenizer_name")
+        or model_cfg.get("name")
+        or "sshleifer/tiny-gpt2"
+    )
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+    if getattr(tokenizer, "pad_token", None) is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    def _to_numpy(value: Any) -> Any:
+        return value.numpy() if hasattr(value, "numpy") else np.array(value)
+
+    tokenized = tokenizer(list(train_texts), padding=True, return_tensors="pt")
+    tokenized["labels"] = tokenized["input_ids"].clone()
+    tokenized["labels"][tokenized["attention_mask"] == 0] = -100
+    train_ds = Dataset.from_dict({k: _to_numpy(v) for k, v in tokenized.items()})
+
+    val_ds = None
+    if val_texts:
+        val_tok = tokenizer(list(val_texts), padding=True, return_tensors="pt")
+        val_tok["labels"] = val_tok["input_ids"].clone()
+        val_tok["labels"][val_tok["attention_mask"] == 0] = -100
+        val_ds = Dataset.from_dict({k: _to_numpy(v) for k, v in val_tok.items()})
+
+    model = get_model(model_cfg.get("name", fallback_name), model_cfg)
+
+    train_kwargs: Dict[str, Any] = {}
+    for field_name in TrainCfg.__dataclass_fields__:
+        value = _lookup(field_name)
+        if value is not None:
+            train_kwargs[field_name] = value
+
+    train_kwargs.setdefault("lr", cfg.learning_rate)
+    train_kwargs.setdefault("batch_size", cfg.batch_size)
+    train_kwargs.setdefault("epochs", cfg.max_epochs)
+    train_kwargs.setdefault("grad_accum", cfg.gradient_accumulation)
+    train_kwargs.setdefault("save_every", cfg.checkpoint_every_n_steps)
+    train_kwargs.setdefault("warmup_steps", cfg.warmup_steps)
+    train_kwargs.setdefault("seed", cfg.seed)
+
+    train_kwargs["lr"] = float(train_kwargs["lr"])
+    train_kwargs["batch_size"] = int(train_kwargs["batch_size"])
+    train_kwargs["epochs"] = int(train_kwargs["epochs"])
+    train_kwargs["grad_accum"] = int(train_kwargs["grad_accum"])
+    train_kwargs["save_every"] = int(train_kwargs["save_every"])
+    train_kwargs["warmup_steps"] = int(train_kwargs["warmup_steps"])
+    train_kwargs["seed"] = int(train_kwargs["seed"])
+
+    train_kwargs["checkpoint_dir"] = str(checkpoint_dir)
+
+    lora_cfg = _lookup("lora")
+    if isinstance(lora_cfg, Mapping):
+        if "enable" in lora_cfg:
+            train_kwargs["use_lora"] = bool(lora_cfg["enable"])
+        if lora_cfg.get("r") is not None:
+            train_kwargs["lora_r"] = int(lora_cfg["r"])
+        if lora_cfg.get("alpha") is not None:
+            train_kwargs["lora_alpha"] = int(lora_cfg["alpha"])
+        if lora_cfg.get("dropout") is not None:
+            train_kwargs["lora_dropout"] = float(lora_cfg["dropout"])
+
+    resume_path: Optional[Path] = None
     if resume:
-        marker = checkpoint_root / "last"
-        if marker.exists():
-            try:
-                resume_path = Path(marker.read_text(encoding="utf-8").strip())
-                if resume_path.exists():
-                    manager.resume_from(
-                        resume_path, model=model, optimizer=optimizer, scheduler=scheduler
-                    )
-                    resumed_from = resume_path
-                    try:
-                        start_epoch = int(resume_path.name.split("-")[-1]) + 1
-                    except ValueError:
-                        start_epoch = 0
-            except Exception as exc:
-                log_error(
-                    "train.resume",
-                    f"{exc.__class__.__name__}: {exc}",
-                    json.dumps({"path": str(locals().get("resume_path", ""))}),
-                )
+        resume_value = train_kwargs.get("resume_from")
+        if resume_value:
+            candidate = Path(str(resume_value))
+            if candidate.is_dir():
+                resume_path = _find_latest_checkpoint(candidate)
+            elif candidate.exists():
+                resume_path = candidate
+        if resume_path is None:
+            resume_path = _find_latest_checkpoint(checkpoint_dir)
+        if resume_path is not None:
+            train_kwargs["resume_from"] = str(resume_path)
+            with contextlib.suppress(Exception):
+                load_training_checkpoint(str(resume_path))
 
-    metrics: List[Dict[str, Any]] = []
-    last_checkpoint: Optional[Path] = None
-    total_tokens = sum(len(text.split()) for text in train_texts)
-
-    for epoch in range(start_epoch, cfg.max_epochs):
-        model.step += len(train_texts)
-        metric = {"epoch": epoch, "tokens": total_tokens, "loss": round(1.0 / (epoch + 1), 4)}
-        metrics.append(metric)
-        last_checkpoint = manager.save(
-            epoch,
-            model=model,
-            optimizer=optimizer,
-            scheduler=scheduler,
-            config={
-                "seed": cfg.seed,
-                "model": cfg.model,
-                "learning_rate": cfg.learning_rate,
-                "batch_size": cfg.batch_size,
-            },
-            metrics=metric,
-        )
-
-    return {
-        "metrics": metrics,
-        "checkpoint_dir": str(last_checkpoint) if last_checkpoint else None,
-        "resumed_from": str(resumed_from) if resumed_from else None,
-    }
+    train_cfg = TrainCfg(**train_kwargs)
+    return run_custom_trainer(model, tokenizer, train_ds, val_ds, train_cfg)


### PR DESCRIPTION
## Summary
- restore `run_functional_training` to instantiate registry models, HuggingFace tokenizers, build datasets, and dispatch to `training.functional_training.run_custom_trainer`
- add helpers to normalize model configs, resolve DictConfig containers, and locate the latest checkpoint when resuming
- allow `TrainingRunConfig` to carry structured model entries while continuing to merge dataset settings from multiple sections

## Testing
- `pytest tests/training/test_run_functional_training_resume.py tests/test_run_functional_training_tokenizer.py` *(fails: missing numpy / omegaconf dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c97a994c288331b0be1b7a39f69e88