### PR TITLE
Codex/implement safety filters and policy skeleton 2025 09 16 (trainer import fix)

### DIFF
--- a/src/codex_ml/registry/trainers.py
+++ b/src/codex_ml/registry/trainers.py
@@ -12,7 +12,7 @@ trainer_registry = Registry("trainer", entry_point_group="codex_ml.trainers")
 
 @trainer_registry.register("functional")
 def _load_functional_trainer() -> Callable[..., Any]:
-    from codex_ml.training.functional_training import run_custom_trainer
+    from training.functional_training import run_custom_trainer
 
     return run_custom_trainer
 


### PR DESCRIPTION

This pull request refactors the safety filters logic in `src/codex_ml/safety/filters.py` to improve clarity and correctness in the handling of text sanitization for block and allow rules. It also introduces a helper for loading policy files and adds a test to ensure redactions are properly retained when allow rules override block rules.

**Safety filters logic improvements:**

* Refactored the `_scan` method to clarify the handling of sanitized text for block and allow actions, replacing `sanitized_allowed` and `sanitized_blocked` with `sanitized_block` and `sanitized_allow`. This ensures that redactions are applied correctly depending on rule actions.
* Updated the `evaluate` method to use the new sanitized text variables and to correctly select which sanitized text to return based on the presence of block and allow rule matches. This fixes logic where allow rules should retain redactions for secrets even when overriding block rules. [[1]](diffhunk://#diff-ca4a665e0eb37dbfc7dfaf29992fed106d9bfb27ef4b2d519bf2236cea6c29abL180-R188) [[2]](diffhunk://#diff-ca4a665e0eb37dbfc7dfaf29992fed106d9bfb27ef4b2d519bf2236cea6c29abL199-R210)

**Policy file loading improvements:**

* Introduced the `_load_policy_file` helper function to handle optional PyYAML dependency and robust error handling when loading safety policy files. This improves reliability and clarity in policy loading. [[1]](diffhunk://#diff-ca4a665e0eb37dbfc7dfaf29992fed106d9bfb27ef4b2d519bf2236cea6c29abR16-R19) [[2]](diffhunk://#diff-ca4a665e0eb37dbfc7dfaf29992fed106d9bfb27ef4b2d519bf2236cea6c29abR366-R376)
* Refactored the `SafetyPolicy.load` method to use `_load_policy_file`, simplifying error handling and making the code easier to maintain.

**Testing improvements:**

* Added a new test, `test_allow_rule_retains_redactions_for_secret_matches`, to verify that allow rules retain redactions for secret matches, ensuring the correct behavior of the updated sanitization logic.

**Additional fixes:**

* Restored the functional trainer loader to import `run_custom_trainer` from the top-level `training.functional_training` module so `get_trainer("functional")` continues to resolve the bundled trainer.

**Testing**

* `python -m compileall src/codex_ml/registry/trainers.py`


------
https://chatgpt.com/codex/tasks/task_e_68c97cff5bc88331b0026e6af99d2677