### PR TITLE
Address review feedback in noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,4 @@
+# Access environment defaults for coverage thresholds and lock refresh commands.
 import os
 import shutil
 from contextlib import suppress


### PR DESCRIPTION
## Summary
- document why the noxfile relies on `os.environ` for coverage and lock defaults

## Testing
- SKIP=pytest git commit (pre-commit quick tests skipped via SKIP=pytest)


------
https://chatgpt.com/codex/tasks/task_e_68c9b72cfb8083319857a8d696204d8c