### PR TITLE
Add validation pipeline tooling

### DIFF
--- a/.github/Copilot.md
+++ b/.github/Copilot.md
@@ -1,0 +1,114 @@
+# Validation Pipeline
+
+This repository ships a lightweight validation harness that mirrors the checks
+run in CI so that contributors can iterate quickly while still producing the
+artifacts needed by automation. The tooling is intentionally split into three
+layers so you can pick the right entry point for the job:
+
+1. `scripts/run_validation.sh` – bash wrapper for local usage and ad-hoc CI jobs.
+2. `tools/validate.py` – Python orchestrator that produces machine-readable
+   summaries and supports richer workflows (re-run failures, pass pytest args).
+3. `.github/workflows/validate.yml` – GitHub Actions workflow that wires the
+   harness into PR validation and scheduled full test runs.
+
+## Quick start
+
+Run the fast smoke-test bundle (no heavy dependencies) from the repository root:
+
+```bash
+./scripts/run_validation.sh --fast
+```
+
+Run the full suite (installs `requirements-dev.txt` inside an isolated virtual
+environment and executes all tests):
+
+```bash
+./scripts/run_validation.sh --full
+```
+
+For programmatic use or when you need JSON output, call the Python orchestrator:
+
+```bash
+python tools/validate.py --mode fast --verbose
+```
+
+The orchestrator writes its summary to `validation_summary.json` by default and
+mirrors it to any custom `--output` path you provide.
+
+## What the runner does
+
+1. Creates/uses a cached virtual environment at `.venv_validation`.
+2. Installs minimal dependencies in `--fast` mode (`pytest`, `pre-commit`,
+   `ruff`) or the full `requirements-dev.txt` in `--full` mode.
+3. Runs pre-commit hooks (set `VALIDATE_SKIP_PRECOMMIT=1` to skip locally).
+4. Executes optional repository hooks from `.github/validate-hooks.d/` (drop an
+   executable shell script here to add custom steps; skip with
+   `VALIDATE_SKIP_HOOKS=1`).
+5. Runs pytest with either the curated fast set or the entire `tests/`
+   directory, emitting `report.xml` (JUnit) and, when `coverage` is available,
+   `coverage.xml`.
+6. Stores a human-readable log in `validation.log`.
+
+Environment knobs that the runner understands:
+
+| Variable | Purpose |
+|----------|---------|
+| `VALIDATE_MODE` | Propagated into the log/summary for debugging |
+| `PYTEST_EXTRA` | Extra arguments passed through to pytest |
+| `VALIDATE_SKIP_PRECOMMIT` | Set to `1` to skip pre-commit hooks |
+| `VALIDATE_SKIP_HOOKS` | Set to `1` to disable `.github/validate-hooks.d/` scripts |
+
+## Python orchestrator features
+
+`tools/validate.py` wraps the shell runner and adds:
+
+- `--files` to target a comma-separated list of test files.
+- `--pytest-args "-k expr"` to pass arbitrary pytest flags (stored in the
+  summary and handed to coverage runs too).
+- `--last-failed` (`pytest --lf`) for quick re-runs of only the failing tests.
+- `--no-run` to convert existing artifacts into JSON without executing tests
+  again (useful if the shell runner was triggered separately).
+- Automatic parsing of `report.xml` and `coverage.xml` into summary statistics
+  (`tests`, `failures`, line coverage percent, etc.).
+- Tail output from `validation.log` embedded in the JSON for quick triage.
+
+The JSON schema is stable and designed to be consumed by dashboard tooling or
+other automation. If you specify a custom `--output` the tool also keeps the
+canonical `validation_summary.json` in sync for downstream consumers.
+
+## GitHub Actions workflow
+
+`.github/workflows/validate.yml` wires the orchestrator into CI:
+
+- **fast-check** (pull requests): runs on `ubuntu-latest`, uses Python 3.12,
+  executes `python tools/validate.py --mode fast`, and uploads the log, JUnit
+  XML, coverage report (if generated), and JSON summary as artifacts.
+- **full-suite** (scheduled/nightly or manual dispatch): reuses the same steps
+  but runs in `--full` mode to exercise the heavier dependency stack.
+
+Both jobs cache `~/.cache/pip` for speed. Because the orchestrator writes
+`validation_summary.json`, downstream automation can read that artifact to make
+policy decisions (e.g., gating on coverage).
+
+## Extending the pipeline
+
+- Add repository-specific hooks by dropping executable scripts into
+  `.github/validate-hooks.d/`. Each script receives the current mode (`fast` or
+  `full`) as the first argument and should exit non-zero on failure.
+- Adjust the fast test selection directly inside `scripts/run_validation.sh` or
+  use `PYTEST_EXTRA="-k <expr>"` while iterating locally.
+- Update `requirements-dev.txt` with any new tooling dependencies; the runner
+  will pick them up automatically in `--full` mode.
+- If you need to install optional heavy dependencies for fast mode, add a hook
+  script or pre-install them in the virtual environment before running the
+  validation script.
+
+## Troubleshooting tips
+
+- Missing optional dependencies? Start with `--fast` while coding and rely on
+  the scheduled `--full` job (or a local `--full` run) for full coverage.
+- Want to rerun only the last failures? Use `python tools/validate.py --last-failed`.
+- Need to skip linting temporarily? Run with `VALIDATE_SKIP_PRECOMMIT=1` but be
+  sure to re-enable before committing.
+- Stale artifacts bothering you? Remove `.venv_validation/`, `validation.log`,
+  and `report.xml`; everything will be regenerated on the next run.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,78 @@
+name: Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions: read-all
+
+jobs:
+  fast-check:
+    name: fast / py3.12
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
+
+      - name: Run validation (fast)
+        run: python tools/validate.py --mode fast --output fast-validation.json --verbose
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fast-validation
+          path: |
+            validation.log
+            report.xml
+            coverage.xml
+            fast-validation.json
+            validation_summary.json
+
+  full-suite:
+    if: github.event_name != 'pull_request'
+    name: full / py3.12
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-full-${{ hashFiles('requirements-dev.txt') }}
+
+      - name: Run validation (full)
+        run: python tools/validate.py --mode full --output full-validation.json --verbose
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: full-validation
+          path: |
+            validation.log
+            report.xml
+            coverage.xml
+            full-validation.json
+            validation_summary.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Test artifacts
 .tox/
 .venv/
+.venv_validation/
 
 # Coverage and cache artifacts
 .coverage
@@ -30,3 +31,8 @@ reports/*
 artifacts/*
 logs/*
 .codex/validation/
+validation.log
+report.xml
+coverage.xml
+validation_summary.json
+*-validation.json

--- a/scripts/run_validation.sh
+++ b/scripts/run_validation.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Lightweight validation runner for local dev and CI
+# Usage:
+#   ./scripts/run_validation.sh --fast            # quick checks only
+#   ./scripts/run_validation.sh --full            # install dev deps & run full suite
+#   ./scripts/run_validation.sh --files f1,f2     # run only given test files (comma-separated)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VENV_DIR="${ROOT}/.venv_validation"
+REQ_DEV="${ROOT}/requirements-dev.txt"
+LOG="${ROOT}/validation.log"
+HOOK_DIR="${ROOT}/.github/validate-hooks.d"
+
+MODE="fast"
+FILES=""
+PYTEST_EXTRA_ENV=${PYTEST_EXTRA:-""}
+PASSTHROUGH=()
+SKIP_PRECOMMIT=${VALIDATE_SKIP_PRECOMMIT:-"0"}
+SKIP_HOOKS=${VALIDATE_SKIP_HOOKS:-"0"}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fast)
+      MODE="fast"
+      shift
+      ;;
+    --full)
+      MODE="full"
+      shift
+      ;;
+    --files)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo "Missing value for --files" >&2
+        exit 1
+      fi
+      FILES="$1"
+      shift
+      ;;
+    --files=*)
+      FILES="${1#*=}"
+      shift
+      ;;
+    --)
+      shift
+      PASSTHROUGH+=("$@")
+      break
+      ;;
+    *)
+      PASSTHROUGH+=("$1")
+      shift
+      ;;
+  esac
+done
+
+{
+  echo "Validation started at $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo "Mode: $MODE"
+} > "$LOG"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  python -m venv "$VENV_DIR"
+fi
+# shellcheck source=/dev/null
+source "$VENV_DIR/bin/activate"
+
+pip install -U pip setuptools wheel >> "$LOG" 2>&1
+
+if [[ -f "$REQ_DEV" && "$MODE" == "full" ]]; then
+  echo "Installing dev requirements..." | tee -a "$LOG"
+  pip install -r "$REQ_DEV" >> "$LOG" 2>&1
+else
+  echo "Installing fast-mode requirements..." | tee -a "$LOG"
+  if ! pip install pytest pre-commit ruff >> "$LOG" 2>&1; then
+    pip install pytest >> "$LOG" 2>&1
+  fi
+fi
+
+if [[ "$SKIP_PRECOMMIT" == "1" ]]; then
+  echo "VALIDATE_SKIP_PRECOMMIT=1 -> skipping pre-commit" | tee -a "$LOG"
+elif command -v pre-commit >/dev/null 2>&1; then
+  echo "Running pre-commit hooks..." | tee -a "$LOG"
+  PRECOMMIT_STATUS=0
+
+  # Collect local modifications (tracked + staged + untracked)
+  declare -A _seen_files
+  LOCAL_FILES=()
+  while IFS= read -r file; do
+    [[ -n "$file" ]] || continue
+    [[ -n "${_seen_files[$file]:-}" ]] && continue
+    _seen_files[$file]=1
+    LOCAL_FILES+=("$file")
+  done < <(git diff --name-only && git diff --cached --name-only && git ls-files --others --exclude-standard)
+
+  if [[ ${#LOCAL_FILES[@]} -gt 0 ]]; then
+    echo "  • linting local modifications (${#LOCAL_FILES[@]})" | tee -a "$LOG"
+    if ! pre-commit run --show-diff-on-failure --files "${LOCAL_FILES[@]}" >> "$LOG" 2>&1; then
+      PRECOMMIT_STATUS=2
+    fi
+  fi
+
+  BASE_CANDIDATES=()
+  [[ -n "${VALIDATE_BASE_REF:-}" ]] && BASE_CANDIDATES+=("$VALIDATE_BASE_REF")
+  if UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null); then
+    BASE_CANDIDATES+=("$UPSTREAM")
+  fi
+  [[ -n "${GITHUB_BASE_REF:-}" ]] && BASE_CANDIDATES+=("origin/${GITHUB_BASE_REF}")
+  BASE_CANDIDATES+=("origin/HEAD" "origin/main" "origin/master" "HEAD^")
+
+  HEAD_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "")
+  BASE_COMMIT=""
+  for candidate in "${BASE_CANDIDATES[@]}"; do
+    [[ -n "$candidate" ]] || continue
+    if git rev-parse --verify "$candidate" >/dev/null 2>&1; then
+      candidate_commit=$(git rev-parse "$candidate")
+      if [[ -n "$candidate_commit" && "$candidate_commit" != "$HEAD_COMMIT" ]]; then
+        BASE_COMMIT="$candidate_commit"
+        break
+      fi
+    fi
+  done
+
+  if [[ -n "$BASE_COMMIT" ]]; then
+    echo "  • linting diff $BASE_COMMIT..$HEAD_COMMIT" | tee -a "$LOG"
+    if ! pre-commit run --show-diff-on-failure --from-ref "$BASE_COMMIT" --to-ref "$HEAD_COMMIT" >> "$LOG" 2>&1; then
+      PRECOMMIT_STATUS=2
+    fi
+  elif [[ $PRECOMMIT_STATUS -eq 0 ]]; then
+    echo "  • no base ref detected; linting all tracked files once" | tee -a "$LOG"
+    if ! pre-commit run --show-diff-on-failure --all-files >> "$LOG" 2>&1; then
+      PRECOMMIT_STATUS=2
+    fi
+  fi
+
+  if [[ $PRECOMMIT_STATUS -ne 0 ]]; then
+    echo "pre-commit checks failed -- see $LOG" | tee -a "$LOG"
+    deactivate
+    exit $PRECOMMIT_STATUS
+  fi
+else
+  echo "pre-commit not installed; skipping hooks" | tee -a "$LOG"
+fi
+
+if [[ "$SKIP_HOOKS" != "1" && -d "$HOOK_DIR" ]]; then
+  shopt -s nullglob
+  HOOKS=("$HOOK_DIR"/*)
+  shopt -u nullglob
+  for hook in "${HOOKS[@]}"; do
+    [[ -f "$hook" && -x "$hook" ]] || continue
+    echo "Running validation hook $(basename "$hook")" | tee -a "$LOG"
+    if ! "$hook" "$MODE" >> "$LOG" 2>&1; then
+      echo "Hook $(basename "$hook") failed -- see $LOG" | tee -a "$LOG"
+      deactivate
+      exit 3
+    fi
+  done
+fi
+
+PYTEST_ARGS=("--junitxml=report.xml" "--maxfail=1" "-q")
+if [[ -n "$FILES" ]]; then
+  IFS=',' read -ra FARR <<< "$FILES"
+  PYTEST_ARGS+=("${FARR[@]}")
+elif [[ "$MODE" == "fast" ]]; then
+  PYTEST_ARGS+=(
+    "tests/test_ingestion_split_cache.py"
+    "tests/test_query_logs_build_query.py"
+    "tests/test_query_logs_tail.py"
+    "tests/test_session_logger_log_adapters.py"
+    "tests/security/test_log_redaction.py"
+    "tests/test_session_query_cli.py"
+    "tests/test_chat_session_exit.py"
+    "tests/test_chat_session.py"
+  )
+else
+  PYTEST_ARGS+=("tests")
+fi
+
+PYTEST_ENV_ARGS=()
+if [[ -n "$PYTEST_EXTRA_ENV" ]]; then
+  # shellcheck disable=SC2206  # we intentionally rely on word-splitting here
+  PYTEST_ENV_ARGS=($PYTEST_EXTRA_ENV)
+fi
+
+unset CODEX_SESSION_ID
+
+ALL_ARGS=("${PYTEST_ARGS[@]}" "${PYTEST_ENV_ARGS[@]}" "${PASSTHROUGH[@]}")
+
+echo "Running pytest ${ALL_ARGS[*]}" | tee -a "$LOG"
+set +e
+pytest "${PYTEST_ARGS[@]}" "${PYTEST_ENV_ARGS[@]}" "${PASSTHROUGH[@]}" 2>&1 | tee -a "$LOG"
+RET=${PIPESTATUS[0]}
+set -e
+
+if [[ $RET -ne 0 ]]; then
+  echo "pytest failed (exit $RET). See $LOG and report.xml" | tee -a "$LOG"
+  deactivate
+  exit $RET
+fi
+
+if python -c "import coverage" >/dev/null 2>&1; then
+  echo "Generating coverage..." | tee -a "$LOG"
+  pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=xml:coverage.xml "${PYTEST_ENV_ARGS[@]}" "${PASSTHROUGH[@]}" >> "$LOG" 2>&1 || true
+fi
+
+{
+  echo "Artifacts:"
+  echo "  junit: report.xml"
+  [[ -f coverage.xml ]] && echo "  coverage: coverage.xml"
+  echo "Log: validation.log"
+} >> "$LOG"
+
+echo "Validation successful" | tee -a "$LOG"
+deactivate
+exit 0

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Validation orchestration CLI.
+
+This helper wraps :mod:`scripts.run_validation` to provide richer CLI ergonomics
+for developers as well as a machine-readable JSON summary that can be consumed
+by CI systems or local tooling.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from xml.etree import ElementTree as ET
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "scripts" / "run_validation.sh"
+DEFAULT_OUTPUT = ROOT / "validation_summary.json"
+LOG_PATH = ROOT / "validation.log"
+REPORT_PATH = ROOT / "report.xml"
+COVERAGE_PATH = ROOT / "coverage.xml"
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Codex validation orchestrator")
+    parser.add_argument(
+        "--mode",
+        choices=["fast", "full"],
+        default="fast",
+        help="Validation mode to run (fast skips heavy deps)",
+    )
+    parser.add_argument("--files", help="Comma-separated test files to run", default=None)
+    parser.add_argument("--pytest-args", help="Additional pytest arguments", default=None)
+    parser.add_argument(
+        "--last-failed",
+        action="store_true",
+        help="Re-run only the tests that failed in the previous session",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Path to write the JSON summary (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--no-run",
+        action="store_true",
+        help="Only gather existing artifacts without executing the runner",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Echo the JSON summary to stdout")
+    return parser.parse_args(argv)
+
+
+def run_validation(
+    mode: str, files: Optional[str], pytest_args: Optional[str], last_failed: bool
+) -> int:
+    if not RUNNER.exists():
+        raise FileNotFoundError(f"Validation runner missing at {RUNNER}")
+
+    cmd = [str(RUNNER), f"--{mode}"]
+    if files:
+        cmd.append(f"--files={files}")
+
+    passthrough: List[str] = []
+    if pytest_args:
+        passthrough.extend(shlex.split(pytest_args))
+    if last_failed:
+        passthrough.append("--lf")
+
+    env = os.environ.copy()
+    env["VALIDATE_MODE"] = mode
+    existing_extra = env.get("PYTEST_EXTRA", "").strip()
+    if passthrough:
+        combined = " ".join(passthrough)
+        env["PYTEST_EXTRA"] = f"{existing_extra} {combined}".strip()
+    elif existing_extra:
+        env["PYTEST_EXTRA"] = existing_extra
+
+    print("Running:", " ".join(cmd + passthrough))
+    result = subprocess.run(cmd + passthrough, env=env)
+    return result.returncode
+
+
+def safe_float(value: Optional[str]) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_junit(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists():
+        return None
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError as exc:  # pragma: no cover - defensive
+        return {"error": f"Unable to parse JUnit XML: {exc}"}
+
+    root = tree.getroot()
+    suites = []
+    if root.tag == "testsuite":
+        suites = [root]
+    else:
+        suites = list(root.findall(".//testsuite"))
+
+    summary = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0, "time": 0.0}
+    for suite in suites:
+        summary["tests"] += int(suite.attrib.get("tests", 0))
+        summary["failures"] += int(suite.attrib.get("failures", 0))
+        summary["errors"] += int(suite.attrib.get("errors", 0))
+        summary["skipped"] += int(suite.attrib.get("skipped", 0))
+        summary["time"] += float(suite.attrib.get("time", 0.0))
+    return summary
+
+
+def parse_coverage(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists():
+        return None
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError as exc:  # pragma: no cover - defensive
+        return {"error": f"Unable to parse coverage XML: {exc}"}
+
+    root = tree.getroot()
+    summary: Dict[str, Any] = {
+        "line_rate": safe_float(root.attrib.get("line-rate")),
+        "branch_rate": safe_float(root.attrib.get("branch-rate")),
+        "timestamp": root.attrib.get("timestamp"),
+        "version": root.attrib.get("version"),
+    }
+    if summary["line_rate"] is not None:
+        summary["line_percent"] = round(summary["line_rate"] * 100, 2)
+    if summary["branch_rate"] is not None:
+        summary["branch_percent"] = round(summary["branch_rate"] * 100, 2)
+    return summary
+
+
+def gather_summary(
+    mode: str, files: Optional[str], rc: int, pytest_args: Optional[str], last_failed: bool
+) -> Dict[str, Any]:
+    summary: Dict[str, Any] = {
+        "mode": mode,
+        "files": files.split(",") if files else [],
+        "return_code": rc,
+        "status": "passed" if rc == 0 else "failed",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "artifacts": {
+            "log": str(LOG_PATH) if LOG_PATH.exists() else None,
+            "junit": str(REPORT_PATH) if REPORT_PATH.exists() else None,
+            "coverage": str(COVERAGE_PATH) if COVERAGE_PATH.exists() else None,
+        },
+        "pytest": {
+            "extra_args": pytest_args,
+            "last_failed": last_failed,
+        },
+    }
+
+    junit_stats = parse_junit(REPORT_PATH)
+    if junit_stats:
+        summary["junit_stats"] = junit_stats
+
+    coverage_stats = parse_coverage(COVERAGE_PATH)
+    if coverage_stats:
+        summary["coverage_stats"] = coverage_stats
+
+    if LOG_PATH.exists():
+        try:
+            summary["log_tail"] = LOG_PATH.read_text().splitlines()[-20:]
+        except OSError:
+            summary["log_tail"] = None
+
+    return summary
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+
+    rc = 0
+    if not args.no_run:
+        rc = run_validation(args.mode, args.files, args.pytest_args, args.last_failed)
+
+    summary = gather_summary(args.mode, args.files, rc, args.pytest_args, args.last_failed)
+    output_path = Path(args.output)
+    payload = json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    try:
+        output_path.write_text(payload)
+        if output_path.resolve() != DEFAULT_OUTPUT:
+            DEFAULT_OUTPUT.write_text(payload)
+    except OSError as exc:
+        print(f"Unable to write summary to {output_path}: {exc}", file=sys.stderr)
+        return rc or 1
+
+    if args.verbose:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+
+    if rc != 0:
+        print(f"Validation failed with exit code {rc}. See {output_path}")
+    else:
+        print(f"Validation succeeded. Summary written to {output_path}")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a reusable validation shell runner with pre-commit integration, hook support, and curated fast tests
- provide a Python orchestration CLI that emits JSON summaries and parses junit/coverage artifacts
- wire the pipeline into CI via a new validation workflow and document usage in `.github/Copilot.md`, while ignoring generated artifacts

## Testing
- python tools/validate.py --mode fast --output fast-validation.json --verbose

------
https://chatgpt.com/codex/tasks/task_e_68cc5530fbf8833198c8260678f44c7a