### PR TITLE
Fix SentencePieceAdapter truncation to preserve prefixes

### DIFF
--- a/docs/guides/tokenization.md
+++ b/docs/guides/tokenization.md
@@ -1,0 +1,73 @@
+# Tokenization Adapters
+
+Codex ships with several tokenizer adapters that present a common interface to
+training and evaluation pipelines. This guide focuses on the
+`SentencePieceTokenizer`, which wraps the optional [`sentencepiece`][spm]
+package and integrates with the `TokenizerAdapter` factory.
+
+> **Optional dependency** — install SentencePiece support with:
+>
+> ```bash
+> pip install sentencepiece
+> ```
+>
+> Alternatively, install the dedicated extra: `pip install .[sentencepiece]`.
+
+## Loading from configuration
+
+`TokenizerAdapter.from_config` recognises configurations with
+`{"type": "sentencepiece", "model_path": "path/to/model.model"}` and
+returns a ready-to-use `SentencePieceTokenizer`.
+
+```python
+from codex_ml.tokenization.adapter import TokenizerAdapter
+
+config = {
+    "type": "sentencepiece",
+    "model_path": "artifacts/spm.model",
+    "special_tokens": ["<extra_pad>"]
+}
+
+tokenizer = TokenizerAdapter.from_config(config)
+```
+
+## Direct usage
+
+The adapter can also be instantiated directly from a `.model` file (or an
+existing `SentencePieceProcessor`). The encode/decode methods mirror the
+behaviour of the lightweight adapter under `tokenization/` and support
+single-sequence truncation modes (`only_first` and `longest_first`) that retain
+leading tokens.
+
+```python
+from codex_ml.tokenization.adapter import SentencePieceTokenizer
+
+tokenizer = SentencePieceTokenizer("artifacts/spm.model")
+ids = tokenizer.encode("hello world", truncation="only_first", max_length=4)
+text = tokenizer.decode(ids)
+```
+
+For batches, call `batch_encode` with shared truncation/padding arguments:
+
+```python
+encoded_batch = tokenizer.batch_encode(
+    ["alpha beta", "gamma delta"],
+    truncation="only_first",
+    max_length=3,
+)
+```
+
+## Saving and reloading
+
+Call `save_pretrained(path)` to persist the SentencePiece model and associated
+special tokens. The resulting directory can be reloaded with
+`SentencePieceTokenizer.from_pretrained(path)`.
+
+```python
+save_dir = "artifacts/tokenizer"
+tokenizer.save_pretrained(save_dir)
+reloaded = SentencePieceTokenizer.from_pretrained(save_dir)
+assert reloaded.encode("hello world") == tokenizer.encode("hello world")
+```
+
+[spm]: https://github.com/google/sentencepiece

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 cli = ["typer>=0.9", "rich>=13"]
 tracking = ["mlflow>=2"]
 peft = ["peft>=0.10.0"]
+sentencepiece = ["sentencepiece>=0.1.99"]
 
 # Dev tools live here so Codex can opt-in explicitly (or use them locally/CI).
 dev = [

--- a/src/tokenization/sentencepiece_adapter.py
+++ b/src/tokenization/sentencepiece_adapter.py
@@ -30,8 +30,14 @@ class SentencePieceAdapter:
         max_length: Optional[int] = None,
     ) -> List[int]:
         ids = self.sp.EncodeAsIds(text)
-        if truncation in ("longest_first", "only_first", "only_second") and max_length:
-            ids = ids[-max_length:] if truncation == "only_first" else ids[:max_length]
+        if truncation in ("only_first", "longest_first") and max_length:
+            if len(ids) > max_length:
+                # NOTE: this preserves the leading tokens for single sequence inputs.
+                # Pair-handling logic should be added alongside two-sequence support.
+                ids = ids[:max_length]
+        elif truncation == "only_second" and max_length:
+            if len(ids) > max_length:
+                ids = ids[-max_length:]
         if padding in (True, "longest", "max_length") and max_length:
             # pad_id is defined at model training; if absent, fall back to 0
             pad_id = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,4 +137,5 @@ def no_sentencepiece(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
     monkeypatch.delitem(sys.modules, "sentencepiece", raising=False)
+    monkeypatch.delitem(sys.modules, "codex_ml.tokenization.sentencepiece_adapter", raising=False)
     yield

--- a/tests/tokenization/test_sentencepiece_adapter_edges.py
+++ b/tests/tokenization/test_sentencepiece_adapter_edges.py
@@ -11,16 +11,38 @@ from src.tokenization.sentencepiece_adapter import SentencePieceAdapter
 spm = pytest.importorskip("sentencepiece")
 
 
-def test_padding_truncation_roundtrip() -> None:
-    """Verify encoding/decoding with vendored tiny model."""
-    # tiny toy model vendored in tests/assets
+def _load_tiny_adapter() -> SentencePieceAdapter:
     model = Path(__file__).resolve().parents[1] / "assets" / "spm_tiny.model"
     if not model.exists():
         pytest.skip("Missing spm_tiny.model; run tools/gen_tiny_spm.py to create artifacts.")
     assert model.exists(), "Missing spm_tiny.model; run tools/gen_tiny_spm.py to create artifacts."
+    return SentencePieceAdapter(model_path=model)
 
-    tok = SentencePieceAdapter(model_path=model)
+
+def test_padding_truncation_roundtrip() -> None:
+    """Verify encoding/decoding with vendored tiny model."""
+    tok = _load_tiny_adapter()
     ids = tok.encode("hello world", padding="max_length", truncation="only_first", max_length=8)
     assert len(ids) == 8  # noqa: PLR2004,S101
     text = tok.decode(ids)
     assert isinstance(text, str)  # noqa: S101
+
+
+@pytest.mark.parametrize("truncation", ["only_first", "longest_first"])
+def test_single_sequence_truncation_preserves_prefix(truncation: str) -> None:
+    tok = _load_tiny_adapter()
+    text = "hello world again"
+    full_ids = tok.encode(text)
+    ids = tok.encode(text, truncation=truncation, max_length=2)
+    assert len(ids) == 2  # noqa: PLR2004,S101
+    assert ids == full_ids[:2]
+
+
+def test_only_first_truncation_matches_prefix_roundtrip() -> None:
+    tok = _load_tiny_adapter()
+    text = "hello world again"
+    full_ids = tok.encode(text)
+    ids = tok.encode(text, truncation="only_first", max_length=3)
+    expected = tok.decode(full_ids[:3])
+    decoded = tok.decode(ids)
+    assert decoded == expected

--- a/tests/tokenization/test_sentencepiece_tokenizer.py
+++ b/tests/tokenization/test_sentencepiece_tokenizer.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Tests for the SentencePieceTokenizer adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_ml.tokenization.adapter import SentencePieceTokenizer, TokenizerAdapter
+
+spm = pytest.importorskip("sentencepiece")
+
+
+def _train_sentencepiece_model(tmp_path: Path) -> Path:
+    corpus = tmp_path / "corpus.txt"
+    corpus.write_text(
+        "\n".join(
+            [
+                "hello world",
+                "hello there",
+                "general kenobi",
+                "tokenization adapter",
+                "sentence piece tokenizer",
+                "batch encode decode",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    model_prefix = tmp_path / "spm_test"
+    spm.SentencePieceTrainer.train(
+        input=str(corpus),
+        model_prefix=str(model_prefix),
+        vocab_size=32,
+        character_coverage=1.0,
+        model_type="unigram",
+        pad_id=0,
+        unk_id=1,
+        bos_id=2,
+        eos_id=3,
+        hard_vocab_limit=False,
+    )
+    return model_prefix.with_suffix(".model")
+
+
+def test_sentencepiece_tokenizer_roundtrip(tmp_path: Path) -> None:
+    model_file = _train_sentencepiece_model(tmp_path)
+    tokenizer = SentencePieceTokenizer(model_file)
+    text = "hello world"
+    ids = tokenizer.encode(text)
+    assert isinstance(ids, list) and ids  # noqa: S101
+    decoded = tokenizer.decode(ids)
+    assert decoded.replace(" ", "").lower().startswith("hello")
+
+
+def test_sentencepiece_tokenizer_batch_and_truncation(tmp_path: Path) -> None:
+    model_file = _train_sentencepiece_model(tmp_path)
+    tokenizer = SentencePieceTokenizer(model_file)
+    text = "alpha beta gamma delta"
+    full_ids = tokenizer.encode(text)
+    truncated = tokenizer.encode(text, truncation="only_first", max_length=3)
+    assert len(truncated) == 3
+    assert tokenizer.decode(truncated) == tokenizer.decode(full_ids[:3])
+    batch = tokenizer.batch_encode(
+        ["alpha beta", "gamma delta"], truncation="only_first", max_length=2
+    )
+    assert all(len(seq) <= 2 for seq in batch)
+
+
+def test_sentencepiece_tokenizer_save_and_reload(tmp_path: Path) -> None:
+    model_file = _train_sentencepiece_model(tmp_path)
+    tokenizer = SentencePieceTokenizer(model_file, special_tokens=["<extra>"])
+    save_dir = tmp_path / "saved"
+    tokenizer.save_pretrained(str(save_dir))
+    reloaded = SentencePieceTokenizer.from_pretrained(save_dir)
+    text = "general kenobi"
+    original = tokenizer.encode(text)
+    restored = reloaded.encode(text)
+    assert original == restored
+    assert reloaded.special_tokens == ["<extra>"]
+
+
+def test_tokenizer_adapter_from_config(tmp_path: Path) -> None:
+    model_file = _train_sentencepiece_model(tmp_path)
+    cfg = {"type": "sentencepiece", "model_path": str(model_file)}
+    tokenizer = TokenizerAdapter.from_config(cfg)
+    assert isinstance(tokenizer, SentencePieceTokenizer)
+    text = "adapter config"
+    ids = tokenizer.encode(text, truncation="longest_first", max_length=4)
+    assert ids == tokenizer.encode(text)[:4]


### PR DESCRIPTION
## Summary
- ensure single-sequence truncation modes keep the leading tokens in `SentencePieceAdapter`
- extend edge tests to assert prefix preservation for `only_first` and `longest_first`

## Testing
- pytest -q tests/tokenization/test_sentencepiece_adapter_edges.py

------
https://chatgpt.com/codex/tasks/task_e_68cc8de560a88331aeca723a28739162