### PR TITLE
Add source checksum to dataset manifests

### DIFF
--- a/docs/modules/data_handling.md
+++ b/docs/modules/data_handling.md
@@ -31,3 +31,17 @@ Setting `cache_dataset=true` enables on-disk caching, while
 
 Datasets may optionally include a `language` column.  Use the `language` key in
 `configs/data/base.yaml` to filter examples when loading.
+
+## Dataset Manifests
+
+Line-oriented datasets loaded through `codex_ml.data.registry.load_line_dataset`
+can emit a manifest alongside the shuffled cache. The manifest captures the
+resolved source path, record count, seed, shuffle flag, and two checksum
+fields:
+
+- `source_checksum` – SHA256 of the original file bytes before shuffling.
+- `shuffled_checksum` – SHA256 of the shuffled record order written to cache.
+
+Both checksums remain stable for identical inputs, allowing consumers to
+differentiate data changes from shuffle differences. A compatibility field
+named `checksum` mirrors `shuffled_checksum` for older tooling.


### PR DESCRIPTION
## Summary
- compute a source SHA256 checksum before shuffling line datasets
- persist both source and shuffled checksums when emitting manifests and keep a compatibility checksum field
- extend loader tests for checksum stability and document the new manifest fields

## Testing
- pytest tests/test_data_loaders.py tests/test_splits.py
- pytest tests/test_data_loaders.py tests/test_data_splits.py tests/test_splits.py *(fails: ModuleNotFoundError for optional dependency `omegaconf`)*

------
https://chatgpt.com/codex/tasks/task_e_68cccbc41b388331a803db6f246e6514