### PR TITLE
0 c base 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,14 @@
 # Environment configuration (tracked via template only)
 .env
 .env.*
+.envrc
 !.env.example
+# Additional secret-bearing dotfiles
+.env.local
+.envrc.local
+*.secret
+*.secrets
+*.vault
 
 # Test artifacts
 .tox/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,24 +54,32 @@ repos:
               echo "[git-secrets] skipping (git-secrets not installed)"
             fi
       - id: block-env-files
-        name: block committed .env files
+        name: block committed secret env files
         entry: bash
         language: system
-        pass_filenames: true
+        pass_filenames: false
+        always_run: true
         args:
           - -lc
           - |
-            for path in "$@"; do
+            while IFS= read -r path; do
+              if [ -z "$path" ]; then
+                continue
+              fi
+
               base="$(basename "$path")"
+              if [ "$base" = ".env.example" ]; then
+                continue
+              fi
+
               case "$base" in
-                .env|.env.*)
-                  if [ "$base" != ".env.example" ]; then
-                    echo "[secrets] refusing to commit $path"
-                    exit 1
-                  fi
+                .env|.env.*|.envrc|.envrc.*|*.secret|*.secrets|*.vault)
+                  echo "[secrets] refusing to commit $path"
+                  echo "Create a local copy from .env.example instead of committing secrets."
+                  exit 1
                   ;;
               esac
-            done
+            done < <(git diff --cached --name-only --diff-filter=ACM)
       - id: codex-block-large-generated
         name: Block large generated files in .codex
         entry: python tools/precommit_block_large.py

--- a/README.md
+++ b/README.md
@@ -16,16 +16,20 @@ For environment variables, logging roles, testing expectations, and tool usage, 
 
 ### Local environment configuration
 
-Secrets and machine-specific configuration live in `.env`, which is ignored by
-Git. Start from the committed template:
+Secrets and machine-specific configuration belong in a developer-local `.env`
+file. The repository tracks `.env.example` as the canonical template and
+explicitly ignores real `.env` files and similar secret dotfiles. Start your
+local configuration by copying the template:
 
 ```bash
 cp .env.example .env
 # edit .env with local tokens and overrides
 ```
 
-Never commit real `.env` files—pre-commit will block them, and they are excluded
-via `.gitignore`.
+`pre-commit` runs the `block-env-files` hook to prevent accidental commits of
+`.env`, `.envrc`, or other secret-bearing files. If you need to reset your
+environment, delete the local `.env` and copy the template again—Git will not
+track the personalised file.
 
 ### Quick setup for tools & tests
 

--- a/docs/safety/policy_guidance.md
+++ b/docs/safety/policy_guidance.md
@@ -64,8 +64,9 @@ Key points:
 * Training failures triggered by `SafetyViolation` are also recorded via `log_error("train.safety", …)`.
 * Rotate or archive `.codex/safety/*.ndjson` as appropriate for your environment.
 * Keep secrets in `.env` (generated from `.env.example`). The template is tracked,
-  but real `.env` files are ignored and pre-commit blocks them from entering the
-  repository.
+  but real `.env` files are ignored via `.gitignore`, and the
+  `block-env-files` pre-commit hook blocks them (and related dotfiles like
+  `.envrc`) from entering the repository.
 
 ## Testing changes
 

--- a/docs/security/remove-env-file.md
+++ b/docs/security/remove-env-file.md
@@ -1,0 +1,24 @@
+# Removing tracked `.env` files
+
+The repository no longer tracks a real `.env` file. Instead, secrets live in a
+local-only copy that every developer creates from the committed template:
+
+```bash
+cp .env.example .env
+```
+
+This protects credentials by keeping them out of Git history and CI mirrors.
+Only `.env.example` remains in the repo so we have a documented list of the
+expected keys.
+
+## Why `.env` stays untracked
+
+* `.gitignore` excludes `.env`, `.envrc`, and related secret-bearing files.
+* A `pre-commit` hook named `block-env-files` fails fast if someone tries to
+  add `.env`, `.envrc`, or other secret suffixes (`*.secret`, `*.secrets`,
+  `*.vault`).
+* Secret scanners (`git-secrets`, the `.secrets.baseline` detectors) still run
+  in CI as a defence-in-depth layer.
+
+If you need to reset credentials, delete your local `.env` and re-copy the
+template. Never commit real tokens.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
   - hydra_distributed_overrides: ops/hydra_distributed_overrides.md
   - monitoring: ops/monitoring.md
   - security: ops/security.md
+  - remove-env-file: security/remove-env-file.md
   - training_args: ops/training_args.md
   - ubuntu_setup: ops/ubuntu_setup.md
   - patch-troubleshooting: patch-troubleshooting.md


### PR DESCRIPTION
This pull request strengthens secret management practices by updating documentation and tooling to ensure that secret-bearing files like `.env`, `.envrc`, and related dotfiles are never committed to the repository. The `.env.example` template is now the only tracked environment file, and both `.gitignore` and an improved pre-commit hook enforce this policy. Several docs were updated to clarify the workflow and rationale, and a new guidance page was added.

**Secret file handling and tooling:**

* Updated the `block-env-files` pre-commit hook in `.pre-commit-config.yaml` to block `.env`, `.envrc`, and other secret-related files from being committed, regardless of filename, and improved messaging for developers. The hook now always runs and checks all staged files, not just those passed as arguments. (`[.pre-commit-config.yamlL57-R82](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L57-R82)`)
* `.gitignore` and pre-commit now explicitly ignore and block secret files, ensuring only `.env.example` is tracked and providing clear instructions for local setup. (`[README.mdL19-R32](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R32)`)

**Documentation updates:**

* Added a new page `docs/security/remove-env-file.md` explaining why `.env` and similar files are untracked, how to use `.env.example`, and the layered security approach. (`[docs/security/remove-env-file.mdR1-R24](diffhunk://#diff-4dc7d23e557d5cfab7cf4f22fe79dbaff78f21bb8646ec995fdfda54272af9eaR1-R24)`)
* Updated references in `README.md` and `docs/safety/policy_guidance.md` to clarify the secret management workflow and the role of the pre-commit hook. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R32)`, `[[2]](diffhunk://#diff-e9aeba470f1f41e0bbda1d42e415c46b679aaf3e7656632ed990529d12baad6cL67-R69)`)
* Registered the new guidance page in the documentation navigation via `mkdocs.yml`. (`[mkdocs.ymlR62](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R62)`)