### PR TITLE
Harden tokenization CLI and streaming tests for stubbed environments

### DIFF
--- a/src/tokenization/__init__.py
+++ b/src/tokenization/__init__.py
@@ -1,5 +1,17 @@
 """Tokenization utilities."""
 
-from . import sentencepiece_adapter, train_tokenizer
+__all__: list[str] = []
 
-__all__ = ["sentencepiece_adapter", "train_tokenizer"]
+try:
+    from . import sentencepiece_adapter  # type: ignore # noqa: F401
+except ModuleNotFoundError:
+    sentencepiece_adapter = None  # type: ignore[assignment]
+else:  # pragma: no cover - import succeeded
+    __all__.append("sentencepiece_adapter")
+
+try:
+    from . import train_tokenizer  # type: ignore # noqa: F401
+except ModuleNotFoundError:
+    train_tokenizer = None  # type: ignore[assignment]
+else:  # pragma: no cover - import succeeded
+    __all__.append("train_tokenizer")

--- a/src/tokenization/cli.py
+++ b/src/tokenization/cli.py
@@ -1,11 +1,96 @@
 from __future__ import annotations
 
+import inspect as inspect_module
 import json
 import shutil
+import sys
+import types
 from pathlib import Path
+from typing import Callable
 
-import typer
-from tokenizers import Tokenizer
+try:  # pragma: no cover - optional dependency
+    import typer  # type: ignore
+except Exception:  # pragma: no cover - fallback CLI when typer missing
+
+    class _FallbackTyper:
+        def __init__(self, **_: object) -> None:
+            self._commands: dict[str, tuple[Callable[..., object], inspect_module.Signature]] = {}
+
+        def command(self, name: str | None = None):
+            def _register(func):
+                cmd_name = name or func.__name__.replace("_", "-")
+                self._commands[cmd_name] = (func, inspect_module.signature(func))
+                return func
+
+            return _register
+
+        def __call__(self) -> None:
+            argv = sys.argv[1:]
+            if not argv:
+                raise SystemExit(0)
+            cmd_name, *rest = argv
+            entry = self._commands.get(cmd_name)
+            if entry is None:
+                raise SystemExit(1)
+            func, signature = entry
+            params = list(signature.parameters.values())
+            converted: list[object] = []
+            for arg, param in zip(rest, params):
+                annotation = param.annotation
+                if annotation is Path or annotation == "Path":
+                    converted.append(Path(arg))
+                else:
+                    converted.append(arg)
+            func(*converted)
+
+    def _fallback_echo(message: object) -> None:
+        print(message)
+
+    def _fallback_option(default=None, *_: object, **__: object):
+        return default
+
+    typer = types.SimpleNamespace(
+        Typer=_FallbackTyper, echo=_fallback_echo, Option=_fallback_option
+    )
+
+try:  # pragma: no cover - optional dependency
+    from tokenizers import Tokenizer  # type: ignore
+except Exception:  # pragma: no cover - fallback when tokenizers missing
+
+    class Tokenizer:  # type: ignore[no-redef]
+        def __init__(self, data: dict, path: Path) -> None:
+            self._data = data
+            self._path = path
+
+        @classmethod
+        def from_file(cls, path: str) -> "Tokenizer":
+            file_path = Path(path)
+            data = json.loads(file_path.read_text())
+            return cls(data, file_path)
+
+        def get_vocab_size(self) -> int:
+            vocab = self._data.get("model", {}).get("vocab")
+            if isinstance(vocab, list):
+                return len(vocab)
+            vocab_list = self._data.get("vocab", [])
+            if isinstance(vocab_list, list):
+                return len(vocab_list)
+            value = self._data.get("vocab_size")
+            return int(value) if isinstance(value, (int, float, str)) else 0
+
+        def get_special_tokens(self) -> list[str]:
+            added_tokens = self._data.get("added_tokens", [])
+            if not isinstance(added_tokens, list):
+                return []
+            return [
+                item.get("content")
+                for item in added_tokens
+                if isinstance(item, dict) and item.get("special")
+            ]
+
+        def encode(self, text: str):  # pragma: no cover - encode requires optional dependency
+            raise RuntimeError("The 'tokenizers' package is required for encode operations")
+
 
 app = typer.Typer(help="Tokenizer utilities")
 
@@ -20,10 +105,25 @@ def inspect(path: Path) -> None:
     manifest_path = path / "manifest.json"
     manifest = json.loads(manifest_path.read_text()) if manifest_path.exists() else {}
     tokenizer_config = json.loads((path / "tokenizer.json").read_text())
-    added_tokens = tokenizer_config.get("added_tokens", [])
-    special_tokens = [item.get("content") for item in added_tokens if item.get("special")]
+    special_tokens: object | None = None
+    try:
+        getter = getattr(tk, "get_special_tokens", None)
+        if callable(getter):
+            special_tokens = getter()
+    except Exception:
+        special_tokens = None
+    if special_tokens is None:
+        added_tokens = tokenizer_config.get("added_tokens", [])
+        special_tokens = [item.get("content") for item in added_tokens if item.get("special")]
+        if not special_tokens:
+            cfg = manifest.get("config", {})
+            special_tokens = {
+                "pad": cfg.get("padding"),
+                "truncation": cfg.get("truncation"),
+                "max_length": cfg.get("max_length"),
+            }
     typer.echo(f"vocab_size: {tk.get_vocab_size()}")
-    typer.echo(f"special_tokens: {special_tokens}")
+    typer.echo(f"special_tokens_or_cfg: {special_tokens}")
     cfg = manifest.get("config", {})
     pad = cfg.get("padding")
     trunc = cfg.get("truncation")

--- a/tests/tokenization/conftest.py
+++ b/tests/tokenization/conftest.py
@@ -1,4 +1,83 @@
+import os
+import sys
+import types
+from pathlib import Path
+
 import pytest
+
+_TRANSFORMERS_STUB = os.getenv("CODEX_TEST_TRANSFORMERS_STUB", "").strip() == "1"
+_SPM_STUB_FLAG = os.getenv("CODEX_TEST_SPM_STUB", "").strip() == "1"
+_TOKENIZERS_STUB_FLAG = os.getenv("CODEX_TEST_TOKENIZERS_STUB", "").strip() == "1"
+
+if _TRANSFORMERS_STUB:
+    sys.modules.setdefault("transformers", types.SimpleNamespace(__version__="0.0"))
+
+if _TOKENIZERS_STUB_FLAG:
+
+    class _StubSentencePieceUnigramTokenizer:
+        pass
+
+    class _StubTokenizer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        @classmethod
+        def from_file(cls, path: str):  # pragma: no cover - stub
+            raise RuntimeError("tokenizers stub active; real package required")
+
+        def get_vocab_size(self) -> int:  # pragma: no cover - stub
+            return 0
+
+        def get_special_tokens(self) -> list[str]:  # pragma: no cover - stub
+            return []
+
+    class _StubBPE:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+    fake_tokenizers = types.SimpleNamespace(
+        __version__="0.0",
+        SentencePieceUnigramTokenizer=_StubSentencePieceUnigramTokenizer,
+        Tokenizer=_StubTokenizer,
+        models=types.SimpleNamespace(BPE=_StubBPE),
+        normalizers=types.SimpleNamespace(NFKC=lambda: None),
+        pre_tokenizers=types.SimpleNamespace(ByteLevel=lambda: None),
+        trainers=types.SimpleNamespace(BpeTrainer=lambda **_: None),
+    )
+    sys.modules.setdefault("tokenizers", fake_tokenizers)
+
+_SPM_STUB: types.SimpleNamespace | None = None
+if _SPM_STUB_FLAG:
+
+    def _fake_train(**kwargs):
+        model_prefix = Path(kwargs["model_prefix"])
+        model_prefix.with_suffix(".model").write_text("model", encoding="utf-8")
+        model_prefix.with_suffix(".vocab").write_text("vocab", encoding="utf-8")
+
+    _SPM_STUB = types.SimpleNamespace(
+        SentencePieceTrainer=types.SimpleNamespace(Train=_fake_train),
+        SentencePieceProcessor=lambda: types.SimpleNamespace(Load=lambda _path: None),
+    )
+    sys.modules.setdefault("sentencepiece", _SPM_STUB)
 
 pytest.importorskip("transformers")
 pytest.importorskip("sentencepiece")
+
+
+if _SPM_STUB_FLAG and _SPM_STUB is not None:
+
+    @pytest.fixture(autouse=True)
+    def _stub_sentencepiece(monkeypatch, tmp_path):
+        """Stub SentencePiece training for deterministic unit tests."""
+        try:
+            from tokenization import train_tokenizer as train_module
+        except ModuleNotFoundError:
+            yield
+            return
+
+        if train_module is None:
+            yield
+            return
+
+        monkeypatch.setattr(train_module, "spm", _SPM_STUB, raising=False)
+        yield

--- a/tests/tokenization/test_streaming_ingest.py
+++ b/tests/tokenization/test_streaming_ingest.py
@@ -89,4 +89,4 @@ def test_iter_text_streams_progressively(monkeypatch):
 def test_iter_text_rejects_non_positive_chunk_size():
     cfg = module.TrainTokenizerConfig(corpus_glob=[], stream_chunk_size=0)
     with pytest.raises(ValueError):
-        list(module._iter_text(["foo.txt"], cfg))
+        module._resolve_streaming_options(cfg)

--- a/tests/tokenization/test_train_tokenizer_streaming.py
+++ b/tests/tokenization/test_train_tokenizer_streaming.py
@@ -76,11 +76,10 @@ def test_sentencepiece_streaming_iterator(monkeypatch, tmp_path):
     )
 
     out_dir = train_tokenizer.train(cfg)
-    shard_input = captured.get("input")
-    assert shard_input is not None
-    shards = [Path(part) for part in str(shard_input).split(",")]
-    assert shards
-    assert all("shard-" in shard.name for shard in shards)
+    iterator = captured.get("sentence_iterator")
+    assert iterator is not None
+    sentences = list(iterator)
+    assert sentences == ["alpha", "beta"]
 
     manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["config"]["stream_chunk_size"] == 3

--- a/tests/utils/cli_runner.py
+++ b/tests/utils/cli_runner.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def run_module(module: str, *args, extra_env: dict | None = None, check: bool = True):
+    """Run a Python module as a subprocess with a controlled environment.
+
+    Ensures PYTHONPATH includes the repo 'src' directory so in-repo packages are importable.
+    Uses the current Python interpreter (sys.executable).
+    Captures stdout/stderr for assertions in tests.
+    """
+    env = dict(os.environ)
+    env.update(extra_env or {})
+    env.setdefault("PYTHONPATH", str(PROJECT_ROOT / "src"))
+    cmd = [sys.executable, "-m", module, *map(str, args)]
+    return subprocess.run(cmd, capture_output=True, text=True, env=env, check=check)

--- a/tokenization/__init__.py
+++ b/tokenization/__init__.py
@@ -18,6 +18,18 @@ if _pkg_src.exists():
     if pkg_src_str not in __path__:
         __path__.append(pkg_src_str)
 
-from . import sentencepiece_adapter, train_tokenizer  # noqa: E402
+__all__: list[str] = []
 
-__all__ = ["sentencepiece_adapter", "train_tokenizer"]
+try:  # noqa: WPS229 - optional dependency shim
+    from . import sentencepiece_adapter  # type: ignore # noqa: E402,F401
+except ModuleNotFoundError:
+    sentencepiece_adapter = None  # type: ignore[assignment]
+else:  # pragma: no cover - import succeeded
+    __all__.append("sentencepiece_adapter")
+
+try:  # noqa: WPS229 - optional dependency shim
+    from . import train_tokenizer  # type: ignore # noqa: E402,F401
+except ModuleNotFoundError:
+    train_tokenizer = None  # type: ignore[assignment]
+else:  # pragma: no cover - import succeeded
+    __all__.append("train_tokenizer")


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the tokenization package, primarily focused on making the codebase more robust to missing optional dependencies, improving streaming support in tokenizer training, and enhancing testability and CLI usability. The most important changes are grouped below by theme.

**Optional Dependency Handling and Import Robustness**

* Refactored `src/tokenization/__init__.py` and `tokenization/__init__.py` to conditionally import `sentencepiece_adapter` and `train_tokenizer`, gracefully handling `ModuleNotFoundError` and maintaining the `__all__` list only for successfully imported modules. This makes the package more resilient when optional dependencies are missing. [[1]](diffhunk://#diff-c235c73190522b4702ef58155632e64cf1abbd6456adea9bfba8320fb06a11e6L3-R17) [[2]](diffhunk://#diff-7bc8f4084df0551040cd8eed4ca5c71f4284c941295fd2fbd68bde15425fe32eL21-R35)
* Updated `src/tokenization/cli.py` to provide fallback implementations for the CLI and tokenizer classes when `typer` or `tokenizers` are not installed, ensuring the CLI remains usable and testable even if these dependencies are unavailable.

**Streaming and SentencePiece Training Refactor**

* Replaced the temporary file-based sharding approach in `train_tokenizer.py` with a streaming sentence iterator (`_spm_sentence_iterator`), allowing direct streaming of text data into SentencePiece training and improving efficiency and testability. [[1]](diffhunk://#diff-d38d3cc64ab025552a9a0459fc041bdd0fd7d7954f735855eb153f4fd03dc9c5L104-R121) [[2]](diffhunk://#diff-d38d3cc64ab025552a9a0459fc041bdd0fd7d7954f735855eb153f4fd03dc9c5L166-R171) [[3]](diffhunk://#diff-d38d3cc64ab025552a9a0459fc041bdd0fd7d7954f735855eb153f4fd03dc9c5L188-R180)
* Updated the training logic to use the new iterator and improved error handling for SentencePiece training, including more informative warnings and fallback behavior. [[1]](diffhunk://#diff-d38d3cc64ab025552a9a0459fc041bdd0fd7d7954f735855eb153f4fd03dc9c5L166-R171) [[2]](diffhunk://#diff-d38d3cc64ab025552a9a0459fc041bdd0fd7d7954f735855eb153f4fd03dc9c5L188-R180) [[3]](diffhunk://#diff-d38d3cc64ab025552a9a0459fc041bdd0fd7d7954f735855eb153f4fd03dc9c5R193-R195)

**CLI and Testing Enhancements**

* Improved the CLI inspect command to better handle special tokens: it now tries to use the tokenizer’s method, falls back to config data, and displays either special tokens or config values.
* Added a utility function `run_module` in `tests/utils/cli_runner.py` to reliably run CLI commands in tests with a controlled environment, simplifying and stabilizing CLI-related tests.
* Refactored tests to use the new CLI runner and direct JSON file creation for deterministic and dependency-independent testing.
* Added comprehensive stubs and fixtures in `tests/tokenization/conftest.py` to simulate missing dependencies and provide deterministic test environments for SentencePiece and Tokenizers.

**Minor Improvements and Cleanups**

* Improved error handling and test assertions for streaming ingest and tokenizer training, ensuring edge cases (such as invalid chunk sizes) are properly tested and handled. [[1]](diffhunk://#diff-9e4c72ed8c081f3fd308c369a9c2672e592079a8a05513e6fcca84ce4c2e8684L92-R92) [[2]](diffhunk://#diff-0e6e80235e5440978b1307de460e169e8f6f1d28b06e05389a7d22b9b6f97f91L79-R82)
* Removed unused imports and cleaned up code in `train_tokenizer.py` for clarity.

These changes collectively make the tokenization package more robust, flexible, and easier to test and maintain, especially in environments with missing optional dependencies.

------
## Summary
- add a reusable CLI subprocess runner helper for tests so the active interpreter and PYTHONPATH are respected
- make the tokenization CLI resilient when `typer` or `tokenizers` are missing by providing lightweight fallbacks and using manifest data for inspection
- adjust the trainer to stream SentencePiece data via an iterator, allow safe `from_spm` loading, and expose opt-in stubs for SentencePiece/tokenizers in tests
- tidy tokenization package imports so optional dependencies are loaded lazily and update tests to use the new helpers

## Testing
- `CODEX_TEST_TRANSFORMERS_STUB=1 CODEX_TEST_SPM_STUB=1 pytest -q tests/tokenization/test_cli_inspect_export.py`
- `CODEX_TEST_TRANSFORMERS_STUB=1 CODEX_TEST_SPM_STUB=1 CODEX_TEST_TOKENIZERS_STUB=1 pytest -q tests/tokenization/test_train_tokenizer_streaming.py::test_sentencepiece_streaming_iterator`
- `CODEX_TEST_TRANSFORMERS_STUB=1 CODEX_TEST_SPM_STUB=1 CODEX_TEST_TOKENIZERS_STUB=1 pytest -q tests/tokenization -k "not integration"` *(fails: extensive suite requires real `tokenizers`/`transformers`; stub module lacks full API)*

------
https://chatgpt.com/codex/tasks/task_e_68cd72998bfc8331a77196c6c189b290