### PR TITLE
Add Codex safety harness

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,7 @@
-# Text stays normalized and diffable
+# Normalize text; keep LF in the repository
+* text=auto eol=lf
+
+# Explicit text patterns (prevents accidental platform-specific endings)
 *.md text eol=lf
 *.txt text eol=lf
 *.json text eol=lf
@@ -10,22 +13,46 @@
 *.sha256 text eol=lf
 SHA256SUMS text eol=lf
 
-# Treat these as binary for diffs (no EOL munging), but DO NOT LFS-track by default
-*.model   -text
-*.bin     -text
-*.safetensors -text
-*.zip     -text
-*.7z      -text
-*.tar     -text
-*.tar.*   -text
-*.png     -text
-*.jpg     -text
-*.jpeg    -text
-*.gif     -text
-*.pdf     -text
+# Binary artifacts (no normalization or diff noise)
+*.model binary
+*.bin binary
+*.safetensors binary
+*.zip binary
+*.7z binary
+*.tar binary
+*.tar.* binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary
+*.mp4 binary
+*.mov binary
+*.mp3 binary
+*.wav binary
+*.ttf binary
+*.otf binary
+*.woff binary
+*.woff2 binary
+*.dll binary
+*.so binary
+*.dylib binary
 
-# Global safety: do not normalize unknown binaries
-* -text
+# Generated/minified assets should not produce giant text diffs
+*.min.js   -diff
+*.min.css  -diff
+*.map      -diff
+dist/**    -diff
+build/**   -diff
+out/**     -diff
+public/**  -diff
 
-# NOTE: If you later decide to use LFS (and accept possible overage costs),
-#       explicitly 'git lfs track' per path in a follow-up, instead of blanket rules.
+# Opt notebooks out of diffs by default
+*.ipynb    -diff
+
+# Flag common lockfiles as generated so GitHub collapses them
+package-lock.json linguist-generated=true
+yarn.lock         linguist-generated=true
+pnpm-lock.yaml    linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,52 @@ report.xml
 coverage.xml
 validation_summary.json
 *-validation.json
+
+# Windows Explorer metadata
+Thumbs.db
+
+# Editor and IDE settings
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+.idea/
+*.swp
+
+# Python packaging/build artifacts
+*.py[cod]
+*.pyo
+*.pyd
+*.egg-info/
+.eggs/
+venv/
+
+# Node.js artifacts
+node_modules/
+npm-debug.log*
+yarn-error.log
+.pnpm-store/
+
+# Build/coverage/output directories
+dist/
+build/
+out/
+coverage/
+htmlcov/
+.next/
+.nuxt/
+.cache/
+.storybook-static/
+.cypress/
+cypress/videos/
+cypress/screenshots/
+
+# Archives
+*.zip
+*.tar
+*.tar.gz
+*.7z
+
+# Logs and databases
+*.db
+*.log
+logs/

--- a/tools/codex-safety-hooks/install.sh
+++ b/tools/codex-safety-hooks/install.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+HOOK_DIR="$ROOT/.git/hooks"
+SRC_DIR="$ROOT/tools/codex-safety-hooks"
+
+mkdir -p "$HOOK_DIR"
+
+install_hook() {
+  local name="$1"
+  local target="$HOOK_DIR/$name"
+  if [ -f "$target" ] && [ ! -f "$target.backup" ]; then
+    mv "$target" "$target.backup"
+  fi
+  cp "$SRC_DIR/$name" "$target"
+  chmod +x "$target"
+  echo "Installed $name hook."
+}
+
+install_hook "pre-commit"
+install_hook "pre-push"
+
+echo "Codex Safety Hooks installed."

--- a/tools/codex-safety-hooks/pre-commit
+++ b/tools/codex-safety-hooks/pre-commit
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Blocks oversized diffs, huge/binary blobs, minified bundles, and ensures LFS for large files.
+set -euo pipefail
+
+if [ "${BYPASS_SAFETY:-}" = "1" ]; then
+  echo "[codex-safety] BYPASS_SAFETY=1 set. Skipping pre-commit safeguards."
+  exit 0
+fi
+
+# Tunables (aligned to GitHub UI/API diff & size behaviors)
+MAX_FILES="${MAX_FILES:-300}"
+MAX_DIFF_LINES="${MAX_DIFF_LINES:-20000}"
+MAX_RAW_DIFF_BYTES="${MAX_RAW_DIFF_BYTES:-1048576}" # 1 MiB raw diff content
+HARD_FILE_BLOCK_BYTES="${HARD_FILE_BLOCK_BYTES:-104857600}" # 100 MiB Git hard block (use LFS)
+LFS_RECOMMEND_BYTES="${LFS_RECOMMEND_BYTES:-52428800}" # 50 MiB recommend LFS
+
+# 1) Gather staged paths
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+[ -z "$STAGED" ] && exit 0
+
+# 2) Diff size guards (files/lines/bytes) on the staged index
+FILE_COUNT=$(echo "$STAGED" | wc -l | tr -d ' ')
+LINES_TOTAL=$(git diff --cached --numstat | awk '{add+=$1; del+=$2} END {print add+del+0}')
+RAW_BYTES=$(git diff --cached | wc -c | tr -d ' ')
+
+if [ "$FILE_COUNT" -gt "$MAX_FILES" ] || [ "$LINES_TOTAL" -gt "$MAX_DIFF_LINES" ] || [ "$RAW_BYTES" -gt "$MAX_RAW_DIFF_BYTES" ]; then
+  echo "[codex-safety:pre-commit] Diff too large for GitHub to render sanely."
+  echo "  Files: $FILE_COUNT (limit $MAX_FILES)"
+  echo "  Lines: $LINES_TOTAL (limit $MAX_DIFF_LINES)"
+  echo "  Raw bytes: $RAW_BYTES (limit $MAX_RAW_DIFF_BYTES)"
+  echo "Action: split this commit into smaller, topic-focused commits (avoid giant refactors/minified assets)."
+  exit 1
+fi
+
+# 3) Block common noisy/generated artifacts unless explicitly allowed
+BLOCK_DIRS_REGEX='^(dist|build|out|coverage|\\.next|\\.nuxt|\\.cache|target|bin|obj|site|public)/'
+BLOCK_FILES_REGEX='(\\.min\\.(js|css)|\\.map|package-lock\\.json|yarn\\.lock|pnpm-lock\\.yaml|Cargo\\.lock)$'
+
+while IFS= read -r f; do
+  if [[ "$f" =~ $BLOCK_DIRS_REGEX ]] || [[ "$f" =~ $BLOCK_FILES_REGEX ]]; then
+    if git check-attr -a -- "$f" | grep -Eq '(^|[[:space:]])(-diff|binary)'; then
+      continue
+    fi
+    echo "[codex-safety:pre-commit] Generated/minified/lock file staged: $f"
+    echo "Action: add to .gitignore OR mark '-diff' or 'binary' in .gitattributes if it must be versioned."
+    echo "Tip: '*.min.js -diff' in .gitattributes prevents huge text diffs for bundles."
+    exit 1
+  fi
+done <<< "$STAGED"
+
+# 4) Large file & LFS enforcement
+# Helper: size of staged blob for a path
+blob_size() {
+  local path="$1"
+  local oid
+  oid=$(git ls-files -s -- "$path" | awk '{print $2}')
+  if [ -z "$oid" ]; then
+    echo 0
+    return
+  fi
+  git cat-file -s "$oid"
+}
+
+# Helper: detect LFS pointer in working tree (good enough for pre-commit)
+is_lfs_pointer() {
+  local path="$1"
+  head -n 1 -- "$path" 2>/dev/null | grep -q 'version https://git-lfs.github.com/spec/v1'
+}
+
+while IFS= read -r f; do
+  size=$(blob_size "$f")
+  if [ "$size" -ge "$HARD_FILE_BLOCK_BYTES" ]; then
+    echo "[codex-safety:pre-commit] File ≥ 100 MiB: $f ($size bytes). Git blocks these without LFS."
+    echo "Action: 'git lfs track \"$f\"' and recommit, or store externally."
+    exit 1
+  fi
+  if [ "$size" -ge "$LFS_RECOMMEND_BYTES" ] && ! is_lfs_pointer "$f"; then
+    echo "[codex-safety:pre-commit] Large file (>50 MiB) not tracked via LFS: $f ($size bytes)."
+    echo "Action: 'git lfs track \"$f\"' then re-add."
+    exit 1
+  fi
+done <<< "$STAGED"
+
+exit 0

--- a/tools/codex-safety-hooks/pre-push
+++ b/tools/codex-safety-hooks/pre-push
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Re-checks diff scale against upstream and prevents pushing PRs that will blow UI/API diff limits.
+set -euo pipefail
+
+if [ "${BYPASS_SAFETY:-}" = "1" ]; then
+  echo "[codex-safety] BYPASS_SAFETY=1 set. Skipping pre-push safeguards."
+  exit 0
+fi
+
+REMOTE="$1"; REMOTE_URL="${2:-}" || true
+
+MAX_FILES="${MAX_FILES:-300}"
+MAX_DIFF_LINES="${MAX_DIFF_LINES:-20000}"
+MAX_RAW_DIFF_BYTES="${MAX_RAW_DIFF_BYTES:-1048576}"
+HARD_FILE_BLOCK_BYTES="${HARD_FILE_BLOCK_BYTES:-104857600}"   # 100 MiB
+LFS_RECOMMEND_BYTES="${LFS_RECOMMEND_BYTES:-52428800}"        # 50 MiB
+
+# Determine upstream range (fallback to repo root if none)
+if git rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1; then
+  UPSTREAM="$(git rev-parse --abbrev-ref --symbolic-full-name @{u})"
+  RANGE="$UPSTREAM..HEAD"
+else
+  ROOT_COMMIT="$(git rev-list --max-parents=0 HEAD | tail -1)"
+  RANGE="$ROOT_COMMIT..HEAD"
+fi
+
+# Skip if nothing to push
+if git diff --quiet $RANGE; then
+  exit 0
+fi
+
+FILE_COUNT=$(git diff --name-only $RANGE | wc -l | tr -d ' ')
+LINES_TOTAL=$(git diff --numstat $RANGE | awk '{add+=$1; del+=$2} END {print add+del+0}')
+RAW_BYTES=$(git diff $RANGE | wc -c | tr -d ' ')
+
+if [ "$FILE_COUNT" -gt "$MAX_FILES" ] || [ "$LINES_TOTAL" -gt "$MAX_DIFF_LINES" ] || [ "$RAW_BYTES" -gt "$MAX_RAW_DIFF_BYTES" ]; then
+  echo "[codex-safety:pre-push] Push would exceed GitHub diff limits."
+  echo "  Files: $FILE_COUNT (limit $MAX_FILES)"
+  echo "  Lines: $LINES_TOTAL (limit $MAX_DIFF_LINES)"
+  echo "  Raw bytes: $RAW_BYTES (limit $MAX_RAW_DIFF_BYTES)"
+  echo "Split the change into smaller PRs/commits (avoid bundling minified or generated outputs)."
+  exit 1
+fi
+
+# Large file check across new/modified paths in the push range
+NEW_OR_MOD=$(git diff --name-only --diff-filter=AM $RANGE)
+for f in $NEW_OR_MOD; do
+  oid=$(git ls-files -s -- "$f" | awk '{print $2}') || true
+  [ -z "${oid:-}" ] && continue
+  size=$(git cat-file -s "$oid")
+  if [ "$size" -ge "$HARD_FILE_BLOCK_BYTES" ]; then
+    echo "[codex-safety:pre-push] '$f' is ≥ 100 MiB ($size). Push will be rejected by Git unless tracked via LFS."
+    exit 1
+  fi
+done
+
+exit 0

--- a/tools/codex_safety/__init__.py
+++ b/tools/codex_safety/__init__.py
@@ -1,0 +1,8 @@
+"""
+Codex Safety package.
+
+Provides:
+- openai_wrapper: streaming + backoff + sane defaults
+"""
+
+__all__ = ["openai_wrapper"]

--- a/tools/codex_safety/openai_wrapper.py
+++ b/tools/codex_safety/openai_wrapper.py
@@ -1,0 +1,91 @@
+"""Utility helpers for resilient OpenAI API usage."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+from typing import Any, AsyncIterator, Dict, Optional
+
+from openai import OpenAI
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+# Tunables (sane defaults for Codex Safety usage)
+MODEL = os.getenv("CODEX_MODEL", "gpt-4.1-mini")
+MAX_OUTPUT_TOKENS = int(os.getenv("MAX_OUTPUT_TOKENS", "8192"))
+CLIENT_TIMEOUT_S = int(os.getenv("OPENAI_CLIENT_TIMEOUT_S", "120"))
+MAX_RETRIES = int(os.getenv("OPENAI_MAX_RETRIES", "6"))
+BASE_BACKOFF_S = float(os.getenv("OPENAI_BASE_BACKOFF_S", "0.5"))
+MAX_CONCURRENCY = int(os.getenv("OPENAI_MAX_CONCURRENCY", "8"))
+
+_sema = asyncio.Semaphore(MAX_CONCURRENCY)
+
+
+def _jitter_delay(attempt: int) -> float:
+    """Return an exponential backoff delay with full jitter."""
+    return min(30.0, BASE_BACKOFF_S * (2**attempt)) * random.random()
+
+
+async def call_openai_stream(
+    prompt_messages: list[dict[str, Any]],
+    extra: Optional[Dict[str, Any]] = None,
+) -> AsyncIterator[str]:
+    """Stream a response with retries and jittered backoff."""
+    extra = extra or {}
+    attempt = 0
+    while True:
+        try:
+            async with _sema:
+                with client.responses.stream(
+                    model=extra.get("model", MODEL),
+                    input=prompt_messages,
+                    max_output_tokens=extra.get("max_output_tokens", MAX_OUTPUT_TOKENS),
+                    temperature=extra.get("temperature", 0.2),
+                    timeout=CLIENT_TIMEOUT_S,
+                ) as stream:
+                    for event in stream:
+                        if event.type == "response.output_text.delta":
+                            yield event.delta
+                        elif event.type == "response.completed":
+                            return
+                    raise RuntimeError("stream ended without completion")
+        except Exception:
+            if attempt >= MAX_RETRIES:
+                raise
+            delay = _jitter_delay(attempt)
+            await asyncio.sleep(delay)
+            attempt += 1
+
+
+async def call_openai_json(
+    prompt_messages: list[dict[str, Any]],
+    extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Non-streaming request with retries; returns the JSON response."""
+    extra = extra or {}
+    attempt = 0
+    while True:
+        try:
+            async with _sema:
+                resp = client.responses.create(
+                    model=extra.get("model", MODEL),
+                    input=prompt_messages,
+                    max_output_tokens=extra.get("max_output_tokens", MAX_OUTPUT_TOKENS),
+                    temperature=extra.get("temperature", 0.2),
+                    timeout=CLIENT_TIMEOUT_S,
+                )
+                return resp.to_dict()
+        except Exception:
+            if attempt >= MAX_RETRIES:
+                raise
+            delay = _jitter_delay(attempt)
+            await asyncio.sleep(delay)
+            attempt += 1
+
+
+def chunk_text(content: str, max_chars: int = 12_000) -> list[str]:
+    """Split text into chunks small enough for single API calls."""
+    if max_chars <= 0:
+        raise ValueError("max_chars must be positive")
+    return [content[i : i + max_chars] for i in range(0, len(content), max_chars)]


### PR DESCRIPTION
## Summary
- add Codex safety hook installer along with pre-commit and pre-push safeguards for diff scale and LFS enforcement
- tighten repository hygiene via updated .gitignore/.gitattributes to cut noisy diffs and flag binaries
- introduce a codex_safety OpenAI wrapper that provides streaming responses with retry/backoff defaults

## Testing
- `bash tools/codex-safety-hooks/install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68cd80ba3060833197945ec1ce2cadda