### PR TITLE
Add Codex↔Copilot bridge skeleton and docs

### DIFF
--- a/docs/integrations/bridge_pattern_integration.md
+++ b/docs/integrations/bridge_pattern_integration.md
@@ -1,0 +1,117 @@
+Got it—here’s a clean, **bridge-pattern blueprint** that lets **Codex** and **Copilot** “co-op” by hitting the **same internal tools** (HTTP services), plus a **drop-in Codex task prompt** you can paste into a Codex run. I’m grounding every design choice in current docs so it’s production-sane.
+
+---
+
+# Bridge Pattern: Codex ↔ (shared tools) ↔ Copilot
+
+## 1) High-level architecture
+
+* **Internal Tools API (ITA)**: your HTTP service(s) that expose org knowledge & actions (e.g., search KB, repo hygiene, test/lint, PR ops). This is the **single source of truth** both agents call.
+* **Codex side**: call ITA via **OpenAI tool calling** (Responses API / Agents SDK). Keep stable schemas; stream; backoff; rate-limit. ([OpenAI Platform][1])
+* **Copilot side** (two official paths):
+
+  1. **Copilot Extensions**: build a Copilot “agent” backed by a **GitHub App** + your hosted service; Copilot Chat users invoke tools that call your ITA. ([GitHub Docs][2])
+  2. **MCP (Model Context Protocol)**: ship an **MCP server** that exposes tools mapping 1:1 to your ITA. Register it in VS Code / Visual Studio so Copilot can call those tools. Note current constraints (e.g., Copilot coding agent supports **tools only**, not MCP “resources/prompts”; **no remote MCP servers that use OAuth**). Design auth accordingly (non-OAuth secrets or app-issued tokens). ([GitHub Docs][3])
+
+**Why GitHub App over OAuth?** Fine-grained permissions, repo-scoped access, short-lived tokens → least privilege by default. Use OAuth only where you truly need user-scoped access. ([GitHub Docs][4])
+
+---
+
+## 2) Internal Tools API (ITA): contract & guardrails
+
+* **Contract first**: publish an **OpenAPI** spec for endpoints like:
+
+  * `POST /kb/search` → RAG search over internal docs
+  * `POST /repo/hygiene` → lint/format/secret-scan a diff
+  * `POST /tests/run` → run focused tests; return JUnit summary
+  * `POST /git/create-pr` → create/update PR with labels/checklists
+  * `GET /catalog/tools` → tool discovery for agents
+* **Operational gates**:
+
+  * **Idempotency keys** and **dry-run** mode for destructive ops.
+  * **Safety confirmations** (e.g., “requires ‘confirm=true’” for `git/create-pr`).
+  * **Rate limits + backoff headers** (mirror OpenAI’s retry discipline).
+* **Auth**:
+
+  * Server-to-server: **GitHub App** installation tokens for repo actions. ([GitHub Docs][4])
+  * From Copilot (MCP): avoid OAuth (per constraint); issue **short-lived API keys** bound to org & repo. ([GitHub Docs][5])
+* **Observability**: correlation IDs, structured logs, per-tool metrics & audit events.
+
+---
+
+## 3) Codex → ITA: tool calling patterns
+
+* Use **OpenAI Responses API / Agents SDK tools** to describe each ITA endpoint (JSON Schema params; narrow, well-typed). Favor few, composable tools over mega-tools. ([OpenAI Platform][1])
+* **Streaming** + **exponential backoff with jitter**; cap concurrency with a semaphore; raise `max_output_tokens` only when needed. (Same wrapper you’re already using.)
+* **Structured outputs** (JSON Schema) for deterministic downstream handling when the model returns summaries/plans before calling tools. (Azure doc also frames structured outputs clearly.) ([Microsoft Learn][6])
+
+---
+
+## 4) Copilot → ITA, two supported routes
+
+### A) Copilot Extensions (GitHub-native)
+
+* **Create Extension & GitHub App**; host your agent service; map chat intents (slash commands or natural queries) to **the exact ITA endpoints** above. ([GitHub Docs][2])
+* **Permissions**: grant the App the minimum repo scopes required (e.g., `contents:read`, `pull_requests:write` if you open PRs).
+* **Dev loop**: GitHub provides an **extension debug CLI** to build/test from terminal. ([GitHub][7])
+
+### B) MCP server (VS Code / Visual Studio)
+
+* Implement tools mirroring ITA endpoints; **don’t rely on OAuth** (not supported for remote MCP). Use your short-lived API keys. ([GitHub Docs][5])
+* Register via `mcp.json` (workspace or user). VS Code & Visual Studio docs cover configuration. ([Visual Studio Code][8])
+* **Copilot coding agent limitations**: “tools only” (no MCP resources/prompts). Plan UI affordances accordingly. ([GitHub Docs][5])
+
+---
+
+## 5) Governance & safety
+
+* **Human-in-the-loop**: destructive endpoints require explicit confirmation tokens; Copilot Extension should summarize intent & show a diff before calling ITA “write” actions.
+* **Data boundaries**: ITA enforces repo/org allowlists; redact secrets from logs; attach user identity (from Copilot or IDE) to each call for audit.
+* **Network**: Copilot endpoints & IDEs must reach your ITA; if your org firewalls Copilot, follow allowlist guidance. ([GitHub Docs][9])
+
+---
+
+## 6) Acceptance tests (minimum)
+
+1. **Read-only flow** (both agents): `/kb/search` returns top-k with citations; latency < X ms P95.
+2. **Repo-write flow** (both agents): propose PR → human confirm → `git/create-pr` opens PR with labels; PR body includes provenance (“via Codex” / “via Copilot”).
+3. **Safety**: attempt disallowed repo; expect 403 + guidance.
+4. **Resilience**: kill ITA mid-call; both agents retry per policy; surface user-safe error.
+
+---
+
+# Drop-in **Codex Task Prompt** (paste into a Codex session)
+
+> Objective
+> Implement a **bridge-pattern “Codex & Copilot co-op”** so both agents call the **same Internal Tools API (ITA)**. Deliver a working skeleton with contracts, clients, configs, and tests.
+>
+> Constraints
+> 1) Use **Copilot Extensions** or **MCP** for Copilot; no direct Copilot inference API.  
+> 2) If using MCP: coding agent supports tools only; no remote OAuth; use short-lived keys.  
+> 3) Use a **GitHub App** for repo ops, not OAuth where possible.  
+> 4) Codex calls ITA via **OpenAI tool calling**.
+>
+> Deliverables
+> - `openapi.yaml`, ITA service with tests, Codex tool wrapper, either Copilot Extension or MCP server + `mcp.json`, and a README.
+>
+> Exit criteria
+> - Both agents can: (1) fetch KB answers; (2) dry-run a PR; (3) open a PR only with confirm=true; with auditable logs.
+
+References
+- OpenAI Agents/Responses (tool calling). ([OpenAI Platform][1])
+- Copilot Extensions. ([GitHub Docs][2])
+- MCP with Copilot. ([GitHub Docs][3])
+- GitHub App vs OAuth. ([GitHub Docs][4])
+- Structured outputs. ([Microsoft Learn][6])
+- MCP config in VS Code. ([VS Code][8])
+- Copilot network allowlist. ([GitHub Docs][9])
+
+[1]: https://platform.openai.com/docs/guides/agents-sdk?utm_source=chatgpt.com
+[2]: https://docs.github.com/en/copilot/how-tos/use-copilot-extensions?utm_source=chatgpt.com
+[3]: https://docs.github.com/en/copilot/concepts/about-mcp?utm_source=chatgpt.com
+[4]: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps?utm_source=chatgpt.com
+[5]: https://docs.github.com/en/copilot/concepts/coding-agent/mcp-and-coding-agent?utm_source=chatgpt.com
+[6]: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/structured-outputs?utm_source=chatgpt.com
+[7]: https://github.com/features/copilot/extensions?utm_source=chatgpt.com
+[8]: https://code.visualstudio.com/docs/copilot/customization/mcp-servers?utm_source=chatgpt.com
+[9]: https://docs.github.com/en/copilot/responsible-use/copilot-in-the-cli?utm_source=chatgpt.com

--- a/docs/integrations/github_copilot_cli.md
+++ b/docs/integrations/github_copilot_cli.md
@@ -1,0 +1,77 @@
+Yep — you can use **GitHub Copilot in the CLI** right in an Ubuntu 24.x terminal via the official `gh` (GitHub CLI) extension. Here’s the tight, copy-pasteable setup plus what it can do.
+
+## What you get
+
+* Natural-language help for shell/git/`gh` commands:
+
+  * Explain a command: `gh copilot explain "sudo apt-get"` ([GitHub Docs][1])
+  * Suggest a command (interactive): `gh copilot suggest "Undo the last commit"` ([GitHub Docs][1])
+* Optional aliases so it can **execute** chosen suggestions (`ghcs`) after confirmation. ([GitHub Docs][2])
+
+## Requirements (Ubuntu 24.x)
+
+* A GitHub account with **Copilot access** (Free/Pro/Business/Enterprise per your plan). Orgs can **disable Copilot in the CLI**; if so, it won’t work until enabled. ([GitHub Docs][3])
+* **GitHub CLI (`gh`)** installed and authenticated. ([GitHub Docs][4])
+* The **Copilot in the CLI** extension installed. ([GitHub Docs][5])
+* CLI currently supports **English** prompts. ([GitHub Docs][6])
+
+## Install & use (copy/paste)
+
+```bash
+# 1) Install GitHub CLI (Ubuntu 24 has "gh" in the archive)
+sudo apt update && sudo apt install -y gh  # or see cli.github.com for alternatives
+
+# 2) Authenticate GitHub CLI
+gh auth login  # follow the prompts (HTTPS, "Login with a web browser")
+
+# 3) Install Copilot in the CLI
+gh extension install github/gh-copilot
+
+# 4) Try it
+gh copilot explain "sudo apt-get"
+gh copilot suggest "find the 10 largest files under /var/log, human-readable"
+```
+
+References: “Install Copilot in the CLI” and usage docs. ([GitHub Docs][5])
+`gh` is packaged for Ubuntu 24 (“Noble”) and can also be installed from GitHub’s official sources. ([Launchpad][7])
+
+## Optional: one-liner aliases (lets Copilot run commands you approve)
+
+```bash
+# Bash (Ubuntu default)
+echo 'eval "$(gh copilot alias -- bash)"' >> ~/.bashrc && source ~/.bashrc
+
+# Zsh
+echo 'eval "$(gh copilot alias -- zsh)"' >> ~/.zshrc && source ~/.zshrc
+```
+
+Now you can use:
+
+```bash
+ghce "what does 'iptables -L' do?"   # explain
+ghcs "archive current dir to tar.gz excluding .git"  # suggest → choose Execute
+```
+
+You can also change the default execution confirmation or analytics via:
+
+```bash
+gh copilot config
+```
+
+(covers execution confirmation and optional usage analytics). ([GitHub Docs][2])
+
+## Troubleshooting quick hits
+
+* **“Feature disabled by org”** → your owner must enable “Copilot in the CLI.” ([GitHub Docs][1])
+* **Extension out of date** → `gh extension upgrade gh-copilot`. ([GitHub Docs][5])
+* **Auth problems** → re-run `gh auth login` and ensure the account has Copilot entitlements. ([GitHub Docs][4])
+
+If you want, I can bundle a tiny shell script that installs `gh`, logs in (browser step still required), adds the Copilot extension, and wires up the aliases for Bash/Zsh — so your lab VMs get Copilot-in-CLI in one go.
+
+[1]: https://docs.github.com/copilot/using-github-copilot/using-github-copilot-in-the-command-line "Using GitHub Copilot in the command line - GitHub Docs"
+[2]: https://docs.github.com/en/copilot/github-copilot-in-the-cli/configuring-github-copilot-in-the-cli "Customizing GitHub Copilot in the CLI - GitHub Docs"
+[3]: https://docs.github.com/en/copilot/get-started/plans?utm_source=chatgpt.com "Plans for GitHub Copilot"
+[4]: https://docs.github.com/en/github-cli/github-cli/quickstart?utm_source=chatgpt.com "GitHub CLI quickstart"
+[5]: https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-in-the-cli "Installing GitHub Copilot in the CLI - GitHub Docs"
+[6]: https://docs.github.com/en/copilot/responsible-use/copilot-in-the-cli?utm_source=chatgpt.com "Responsible use of GitHub Copilot in the CLI"
+[7]: https://launchpad.net/ubuntu/noble/%2Bpackage/gh?utm_source=chatgpt.com "gh : Noble (24.04) : Ubuntu - Launchpad"

--- a/docs/integrations/github_copilot_cli2.md
+++ b/docs/integrations/github_copilot_cli2.md
@@ -1,0 +1,251 @@
+You’re right to call out the apparent contradiction. Let’s nail it down precisely, then give you a **complete, validated implementation guide** you can drop into your internal runbooks so teams can use **GitHub Copilot in the CLI** on Ubuntu 24.x reliably—and understand exactly what it is (and is not).
+
+# Reconciling the discrepancy (one paragraph you can quote)
+
+* **True:** There is **no public programmatic inference API** to call GitHub Copilot (or Copilot Chat) from an external agent like Codex. You can’t fetch Copilot’s suggestions by HTTP API the way you do with OpenAI, nor can you legally scrape its IDE channel. Multiple official references and community threads confirm this. ([Stack Overflow][1])
+* **Also true:** GitHub ships an **official Copilot integration for terminals** as a **GitHub CLI extension**: `gh copilot`. It runs locally in a shell, relies on your GitHub account entitlements, and provides *interactive* commands—primarily `explain` and `suggest`—plus shell aliases. That’s not an API; it’s a **user-facing client** on top of your GitHub auth. ([GitHub Docs][2])
+
+The rest of this document is a full, implementation-grade guide for Ubuntu 24.x, written so an infra/enablement team can operate and support it at scale.
+
+---
+
+# 1) What “Copilot in the CLI” is (and isn’t)
+
+**What it is**
+
+* An official **GitHub CLI extension** (`github/gh-copilot`) that adds a chat-like Copilot experience in your terminal. The two core commands are:
+
+  * `gh copilot explain "<cmd>"` → explains a command.
+  * `gh copilot suggest "<task>"` → suggests a shell/git/gh command for your task, with an interactive flow to refine/execute. ([GitHub][3])
+* Optional **aliases** (`ghcs`, `ghce`) to speed up usage and allow (opt-in) execution of suggested commands. ([The GitHub Blog][4])
+
+**What it isn’t**
+
+* Not an API you can call “headless” for completions. It is primarily **interactive**. Some users request non-interactive/STDOUT modes, but they are not generally available as of now. ([GitHub][5])
+
+---
+
+# 2) Prerequisites & entitlements (Ubuntu 24.x)
+
+1. **GitHub account with Copilot access** (Free/Pro/Business/Enterprise per your plan; orgs can restrict CLI usage). ([GitHub Docs][6])
+2. **GitHub CLI `gh` installed and authenticated** with OAuth (PATs are not supported by the extension; clear `GH_TOKEN`/`GITHUB_TOKEN` if they interfere). On Ubuntu 24 (“Noble”), `gh` is in APT. ([GitHub][7])
+3. **Install the extension**: `gh extension install github/gh-copilot`. ([GitHub Docs][8])
+4. **Network**: if you’re behind a corporate firewall/proxy, allowlist Copilot endpoints per plan (Business: `*.business.githubcopilot.com`, Enterprise: `*.enterprise.githubcopilot.com`; generally `*.githubcopilot.com`). ([GitHub Docs][9])
+
+---
+
+# 3) Installation & first-run checklist (copy/paste for Ubuntu 24.x)
+
+```bash
+# Update packages & install gh
+sudo apt update && sudo apt install -y gh
+
+# Authenticate gh (choose HTTPS + “Login with a web browser”)
+gh auth login
+
+# Install Copilot in the CLI extension
+gh extension install github/gh-copilot
+
+# Smoke test: show help
+gh copilot --help
+```
+
+* The **install** and **usage** steps above are exactly what GitHub documents (and what the extension README states). ([GitHub Docs][8])
+
+**Org policy note.** If your organization restricts Copilot (or specifically “Copilot in the CLI”), owners must enable it in Copilot org settings/policies. ([GitHub Docs][6])
+
+---
+
+# 4) Daily usage (what users actually run)
+
+### 4.1 Explain a command
+
+```bash
+gh copilot explain "sudo apt-get"
+```
+
+Copilot returns a human-readable explanation of the command and flags. ([GitHub Docs][2])
+
+### 4.2 Suggest a command for a task
+
+```bash
+gh copilot suggest "Undo the last commit"
+```
+
+You’ll get an **interactive** flow where Copilot asks whether this should be a “generic shell”, `git`, or `gh` command, then proposes options (copy/execute/explain further). ([GitHub Docs][2])
+
+### 4.3 Optional: teach the shell the short aliases (Bash/Zsh)
+
+```bash
+# Bash
+echo 'eval "$(gh copilot alias -- bash)"' >> ~/.bashrc && source ~/.bashrc
+
+# Zsh
+echo 'eval "$(gh copilot alias -- zsh)"' >> ~/.zshrc && source ~/.zshrc
+```
+
+After this, you can use:
+
+* `ghce "what does 'iptables -L' do?"`  (explain)
+* `ghcs "find 10 largest files under /var/log, human-readable"` (suggest/execute)
+  Official docs describe these aliases and why you should use the generator (not hand-written shell aliases) if you want **execution** to work. ([GitHub Docs][10])
+
+### 4.4 Configure behavior (confirmation & analytics)
+
+```bash
+gh copilot config
+```
+
+From here, you can set the **default execution confirmation** (so `ghcs` won’t prompt every time) and opt in/out of **usage analytics**. GitHub documents those toggles and the sample telemetry payload. ([GitHub Docs][11])
+
+---
+
+# 5) Admin / enterprise setup: network & policy
+
+**Policy & access**
+
+* Owners enroll the org in Copilot (Business/Enterprise), set policies, and grant member access. This is where an org might also choose to **disable** Copilot in the CLI. ([GitHub Docs][6])
+
+**Firewalls & egress**
+
+* Allowlist Copilot service domains by subscription tier; GitHub has an explicit allowlist reference and documented change history for service endpoints. ([GitHub Docs][9])
+* If you enforce subscription-based routing (e.g., block Individual), GitHub’s changelog explains the policy and firewall story. ([The GitHub Blog][12])
+
+**Proxies & custom certificates**
+
+* Copilot supports HTTP proxy/custom certs (most docs discuss IDEs, but the same network endpoints matter for the CLI extension because it rides the same service). ([GitHub Docs][13])
+
+---
+
+# 6) Automation reality (for platform teams & agent builders)
+
+* **No programmatic Copilot inference API.** That’s unchanged. You cannot “wire Codex to call Copilot” via HTTP. ([Stack Overflow][1])
+* **The CLI is designed for humans**: interactive prompts (choose target: shell/git/gh; choose copy/execute/etc.). Users have requested **non-interactive/STDOUT** modes, but they’re not general features today. You’ll find open issues requesting just that. ([GitHub][5])
+* If you need a **bridge** so Codex and Copilot have *shared context*, do it the supported way: expose your retrieval/tools via HTTP, point **Codex** directly at them, and expose those same tools to **Copilot Chat** via **Copilot Extensions** or **MCP** (so **Copilot → your services**, not **Codex → Copilot**). ([Microsoft Learn][14])
+
+---
+
+# 7) Troubleshooting (field issues + fixes)
+
+| Symptom                                   | Likely cause                      | What to check / fix                                                                                                       |
+| ----------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `gh copilot` says feature disabled        | Org policy forbids CLI            | Ask org owner to enable Copilot in CLI / grant access. ([GitHub Docs][6])                                                 |
+| `gh copilot` installed but auth fails     | Using PAT env vars / not OAuth    | Clear `GH_TOKEN`/`GITHUB_TOKEN` and login with `gh auth login` OAuth. Extension docs note PATs unsupported. ([GitHub][3]) |
+| No suggestions / network errors           | Firewall/proxy blocking endpoints | Allowlist Copilot domains for your plan; confirm outbound TLS works. ([GitHub Docs][9])                                   |
+| Aliases `ghcs`/`ghce` don’t work          | Aliases not generated correctly   | Use `gh copilot alias -- bash | zsh | pwsh` per docs; don’t hand-craft if you want execution. ([GitHub Docs][11]) |
+| Want headless output to script            | CLI is interactive                | Not supported; see open feature requests. Consider alternative flows/tools. ([GitHub][5])                                 |
+| TUI copy-to-clipboard weird in automation | Interactive design                | Users try `expect`; it’s finicky because the TUI isn’t built for scripting. ([Stack Overflow][15])                        |
+| “What are the actual commands?”           | Command reference                 | Core verbs are `explain`, `suggest`, plus `config` and `alias`. ([DEV Community][16])                                     |
+
+---
+
+# 8) Security & privacy notes your compliance team will ask about
+
+* **Execution confirmation**: by default, Copilot CLI requires confirmation before executing a suggested command; you can change that default in `gh copilot config`. This is an intentional guardrail. ([GitHub Docs][11])
+* **Usage analytics**: you can **opt out/in** in the same config flow; GitHub documents the shape of telemetry (high-level, product-quality signals). ([GitHub Docs][10])
+* **Duplication detection / public code matches** & other Copilot controls exist, but they apply to IDE/Chat experiences. For enterprise compliance and data routing you should follow GitHub’s Copilot policy docs (Business/Enterprise) and network allowlists. ([GitHub Docs][9])
+
+---
+
+# 9) Full command cookbook (Ubuntu 24.x)
+
+### 9.1 Install and authenticate
+
+```bash
+sudo apt update && sudo apt install -y gh
+gh auth login  # browser OAuth
+gh extension install github/gh-copilot
+```
+
+([GitHub Docs][8])
+
+### 9.2 Quick explain & suggest
+
+```bash
+gh copilot explain "sudo sysctl -w net.ipv4.ip_forward=1"
+gh copilot suggest "kill process listening on port 3000"
+```
+
+([GitHub Docs][2])
+
+### 9.3 Speed with aliases (and allow execution)
+
+```bash
+# Bash
+echo 'eval "$(gh copilot alias -- bash)"' >> ~/.bashrc && source ~/.bashrc
+ghce "what does 'journalctl -u ssh' do?"
+ghcs "archive current dir to tar.gz excluding .git"  # choose Execute in the TUI
+```
+
+([GitHub Docs][10])
+
+### 9.4 Configure confirmation & analytics
+
+```bash
+gh copilot config    # set default execution confirmation; toggle analytics
+```
+
+([GitHub Docs][11])
+
+---
+
+# 10) Differences vs the older “Copilot CLI” (npm) people still mention
+
+* There was an earlier **npm** tool (`@githubnext/github-copilot-cli`). The official, supported path today is the **`gh` extension** (`github/gh-copilot`). The GitHub blog and docs highlight the extension’s **GA** and built-in alias support. If you previously used `??`, `?`, or `gh?` shortcuts from community scripts, migrate to `gh copilot` + `gh copilot alias`. ([npm][17])
+
+---
+
+# 11) Frequently asked (with precise answers)
+
+**Q:** Can I call Copilot from Codex (or any other agent) to get suggestions programmatically?  
+**A:** **No.** There is no public inference API. Use the `gh copilot` **interactive** client, or integrate Copilot **Chat** in supported IDEs, or build a bridge where *both* Copilot and Codex call **your** services (Extensions/MCP for Copilot; HTTP for Codex). ([Stack Overflow][1])
+
+**Q:** Can `gh copilot suggest` run non-interactively and print only the command to STDOUT?  
+**A:** Not today; there are open issues requesting this. The designed path is interactive selection and (optionally) execution via alias. ([GitHub][5])
+
+**Q:** What commands exist in the CLI?  
+**A:** `explain`, `suggest`, `config`, and `alias`. Examples are in GitHub’s docs and README. ([DEV Community][16])
+
+**Q:** Does this work on Ubuntu 24.x terminals?  
+**A:** Yes. Install `gh` from APT (or GitHub’s packages), auth, install the extension, and you’re good. ([GitHub][7])
+
+**Q:** Our enterprise blocks traffic. What exactly must be allowed?  
+**A:** Allow `*.githubcopilot.com` generically, and specifically **Business**: `*.business.githubcopilot.com`, **Enterprise**: `*.enterprise.githubcopilot.com`. See GitHub’s allowlist and network routing notes. ([GitHub Docs][18])
+
+---
+
+# 12) Source of truth (pin these in your runbook)
+
+* **Using Copilot in the command line** (official guide; commands & behavior). ([GitHub Docs][2])
+* **Install Copilot in the CLI** (official installer steps). ([GitHub Docs][8])
+* **Customize Copilot in the CLI** (aliases, execution confirmation, analytics). ([GitHub Docs][11])
+* **Extension repository** (`github/gh-copilot`, with quickstart and caveats re: OAuth, PATs). ([GitHub][3])
+* **No public inference API** (threads confirming limitation). ([Stack Overflow][1])
+* **Aliases GA & usage** (GitHub Changelog + blog examples). ([The GitHub Blog][4])
+* **Org setup & policies** (how to enable/disable and grant access). ([GitHub Docs][6])
+* **Network allowlist** (firewall/proxy). ([GitHub Docs][18])
+
+---
+
+## Bottom line
+
+There’s no inconsistency once you separate **“API access”** (not available) from **“official CLI client”** (available, interactive, policy-controlled). If your goal is “Codex and Copilot cooperate,” use the **bridge pattern** so both systems access the **same internal tools**, instead of trying to make one call the other. If your goal is simply “use Copilot in Ubuntu terminals,” the steps above are production-ready and policy-compliant.
+
+[1]: https://stackoverflow.com/questions/76741410/how-to-invoke-github-copilot-programmatically?utm_source=chatgpt.com "How to invoke Github Copilot programmatically?"
+[2]: https://docs.github.com/copilot/using-github-copilot/using-github-copilot-in-the-command-line?utm_source=chatgpt.com "Using GitHub Copilot in the command line"
+[3]: https://github.com/github/gh-copilot?utm_source=chatgpt.com "github/gh-copilot: Ask for assistance right in your terminal."
+[4]: https://github.blog/changelog/2024-03-21-github-copilot-general-availability-in-the-cli/?utm_source=chatgpt.com "GitHub Copilot General Availability in the CLI"
+[5]: https://github.com/github/gh-copilot/issues/37?utm_source=chatgpt.com "[FEAT]: For `gh copilot suggest`, add a flag to send only the ..."
+[6]: https://docs.github.com/en/copilot/how-tos/set-up/set-up-for-organization?utm_source=chatgpt.com "Setting up GitHub Copilot for your organization"
+[7]: https://github.com/cli/cli?utm_source=chatgpt.com "cli/cli: GitHub's official command line tool"
+[8]: https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-in-the-cli?utm_source=chatgpt.com "Installing GitHub Copilot in the CLI"
+[9]: https://docs.github.com/en/copilot/how-tos/administer/organizations/managing-access-to-github-copilot-in-your-organization/managing-github-copilot-access-to-your-organizations-network?utm_source=chatgpt.com "Managing GitHub Copilot access to your organization's ..."
+[10]: https://docs.github.com/es/copilot/how-tos/personal-settings/configuring-github-copilot-in-the-cli?utm_source=chatgpt.com "Configuring GitHub Copilot in the CLI"
+[11]: https://docs.github.com/en/copilot/how-tos/configure-personal-settings/customize-copilot-in-the-cli?utm_source=chatgpt.com "Customizing GitHub Copilot in the CLI"
+[12]: https://github.blog/changelog/2024-11-04-copilot-subscription-based-network-routing-is-now-enforced/?utm_source=chatgpt.com "Copilot subscription-based network routing is now enforced"
+[13]: https://docs.github.com/copilot/configuring-github-copilot/configuring-network-settings-for-github-copilot?utm_source=chatgpt.com "Configuring network settings for GitHub Copilot"
+[14]: https://learn.microsoft.com/en-us/visualstudio/ide/copilot-chat-context?view=vs-2022&utm_source=chatgpt.com "Customize chat responses - Visual Studio (Windows) | Microsoft Learn"
+[15]: https://stackoverflow.com/questions/79253147/how-to-automate-cli-interactions-with-gh-copilot-using-expect?utm_source=chatgpt.com "How to automate cli interactions with gh copilot using expect"
+[16]: https://dev.to/github/stop-struggling-with-terminal-commands-github-copilot-in-the-cli-is-here-to-help-4pnb?utm_source=chatgpt.com "Getting Started with GitHub Copilot in the CLI"
+[17]: https://www.npmjs.com/package/%40githubnext/github-copilot-cli?utm_source=chatgpt.com "githubnext/github-copilot-cli"
+[18]: https://docs.github.com/en/copilot/reference/allowlist-reference?utm_source=chatgpt.com "Allowlist reference - GitHub Copilot"

--- a/temp/bridge_codex_copilot_bridge/README.md
+++ b/temp/bridge_codex_copilot_bridge/README.md
@@ -1,51 +1,32 @@
+# Bridge Pattern Skeleton — Codex ↔ Copilot via Internal Tools API (ITA)
+> Scope: Minimal, non-invasive scaffold placed under temp/bridge_codex_copilot_bridge  
+> Constraints: no dep pin changes, no network in tests, reuse tools/codex_safety/openai_wrapper.py
 
-# Bridge: Codex ↔ Copilot Co-op (Shared Internal Tools API)
-
-This repository provides a production-ready **bridge pattern** so **ChatGPT-Codex** and **GitHub Copilot** both call the **same Internal Tools API (ITA)**. It includes:
-
-- **services/ita** — Minimal Internal Tools API (FastAPI) with contract-first `openapi.yaml`, idempotency, `dry_run`, and `confirm` gates.
-- **agents/codex_client** — Codex tool-calling client (OpenAI Responses API), streaming + backoff + concurrency guard.
-- **copilot/extension** — Starter for a GitHub Copilot **Extension** (GitHub App + service) that forwards chat intents to ITA.
-- **mcp/server** — A future-ready **MCP** server skeleton exposing the same tools (no OAuth), for VS Code/Visual Studio Copilot integration.
-- **ops/** — Policy/observability/threat-model stubs for governance.
-- **tools/codex_safety** — Optional: safety hooks, ignore/attributes patterns to avoid giant diffs.
-
-> Non-goals: There is **no public Copilot inference API**; neither Codex nor ITA call Copilot. Both agents call **this** API.
-
-## Quickstart
-
-### 1) Run the ITA (Internal Tools API)
-```bash
-cd services/ita
-python -m venv .venv && source .venv/bin/activate
-pip install -U pip
-pip install -e .
-export ITA_API_KEY=$(python scripts/issue_api_key.py)
-uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
-# health check: curl http://localhost:8080/healthz
+Layout
+```
+temp/bridge_codex_copilot_bridge/
+├─ services/ita/
+│  ├─ openapi.yaml
+│  └─ app/
+│     └─ main.py
+├─ agents/codex_client/
+│  ├─ toolspecs/
+│  │  ├─ kb_search.json
+│  │  ├─ repo_hygiene.json
+│  │  ├─ tests_run.json
+│  │  └─ git_create_pr.json
+│  └─ client/
+│     └─ openai_tools.py
+├─ mcp/
+│  ├─ server/
+│  │  └─ main.py
+│  └─ examples/
+│     └─ mcp.json
+└─ README.md (this file)
 ```
 
-### 2) Try the Codex client demo
-```bash
-cd agents/codex_client
-python -m venv .venv && source .venv/bin/activate
-pip install -U pip
-pip install -e .
-export OPENAI_API_KEY=YOUR_KEY
-export ITA_URL=http://localhost:8080
-export ITA_API_KEY=THE_KEY_YOU_GENERATED
-python -m codex_client.demo_plan_and_call
-```
-
-### 3) Run the Copilot Extension shim (forwards to ITA)
-```bash
-cd copilot/extension
-npm install
-export ITA_URL=http://localhost:8080
-export ITA_API_KEY=THE_KEY_YOU_GENERATED
-npm start
-# POST from Copilot Extension would hit /ext/* which forwards to ITA
-```
-
-### 4) MCP (future) — placeholder server
-See `mcp/server/README.md` and `mcp/mcp.json` for wiring.
+Notes
+- ITA is a stub FastAPI app exposing 4 endpoints with deterministic responses for local smoke tests.
+- Tool specs mirror the ITA contract (JSON Schema params) to be consumable by tool-calling LLMs.
+- MCP is optional and intentionally minimal here; wire-up can be done later in an IDE context.
+- Client calls should use tools/codex_safety/openai_wrapper.py for streaming/backoff if you build demos.

--- a/temp/bridge_codex_copilot_bridge/agents/codex_client/client/openai_tools.py
+++ b/temp/bridge_codex_copilot_bridge/agents/codex_client/client/openai_tools.py
@@ -1,0 +1,31 @@
+"""
+Thin helpers to keep tool specs aligned and demonstrate integration with our safety wrapper.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+# Reuse existing safety harness if/when calling LLMs
+# from tools.codex_safety.openai_wrapper import call_openai_stream, call_openai_json  # noqa: F401
+
+
+def load_toolspecs(directory: str | Path) -> List[Dict[str, Any]]:
+    """
+    Load all *.json tool spec files from a directory.
+    """
+    d = Path(directory)
+    specs: List[Dict[str, Any]] = []
+    for p in sorted(d.glob("*.json")):
+        with p.open("r", encoding="utf-8") as fh:
+            specs.append(json.load(fh))
+    return specs
+
+
+if __name__ == "__main__":
+    # Demo: list loaded specs
+    here = Path(__file__).resolve().parents[1] / "toolspecs"
+    for spec in load_toolspecs(here):
+        print(f"- {spec['name']}: {spec.get('description','')}")

--- a/temp/bridge_codex_copilot_bridge/agents/codex_client/toolspecs/git_create_pr.json
+++ b/temp/bridge_codex_copilot_bridge/agents/codex_client/toolspecs/git_create_pr.json
@@ -1,0 +1,15 @@
+{
+  "name": "git_create_pr",
+  "description": "Create a pull request (defaults to dry-run unless confirm=true).",
+  "parameters": {
+    "type": "object",
+    "required": ["title", "body", "head", "base"],
+    "properties": {
+      "title": { "type": "string" },
+      "body": { "type": "string" },
+      "head": { "type": "string" },
+      "base": { "type": "string" },
+      "confirm": { "type": "boolean" }
+    }
+  }
+}

--- a/temp/bridge_codex_copilot_bridge/agents/codex_client/toolspecs/kb_search.json
+++ b/temp/bridge_codex_copilot_bridge/agents/codex_client/toolspecs/kb_search.json
@@ -1,0 +1,12 @@
+{
+  "name": "kb_search",
+  "description": "Search internal knowledge base for a given query and return top_k results.",
+  "parameters": {
+    "type": "object",
+    "required": ["query", "top_k"],
+    "properties": {
+      "query": { "type": "string", "description": "search string" },
+      "top_k": { "type": "integer", "minimum": 1, "maximum": 20, "default": 5 }
+    }
+  }
+}

--- a/temp/bridge_codex_copilot_bridge/agents/codex_client/toolspecs/repo_hygiene.json
+++ b/temp/bridge_codex_copilot_bridge/agents/codex_client/toolspecs/repo_hygiene.json
@@ -1,0 +1,11 @@
+{
+  "name": "repo_hygiene",
+  "description": "Run hygiene checks (lint/format/scan) on a diff.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "diff": { "type": "string" },
+      "checks": { "type": "array", "items": { "type": "string" } }
+    }
+  }
+}

--- a/temp/bridge_codex_copilot_bridge/agents/codex_client/toolspecs/tests_run.json
+++ b/temp/bridge_codex_copilot_bridge/agents/codex_client/toolspecs/tests_run.json
@@ -1,0 +1,10 @@
+{
+  "name": "tests_run",
+  "description": "Run focused tests matching an optional pattern.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "pattern": { "type": "string" }
+    }
+  }
+}

--- a/temp/bridge_codex_copilot_bridge/mcp/examples/mcp.json
+++ b/temp/bridge_codex_copilot_bridge/mcp/examples/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "bridge-ita": {
+      "command": "python",
+      "args": ["-m", "temp.bridge_codex_copilot_bridge.mcp.server.main"],
+      "env": {}
+    }
+  }
+}

--- a/temp/bridge_codex_copilot_bridge/mcp/server/main.py
+++ b/temp/bridge_codex_copilot_bridge/mcp/server/main.py
@@ -1,0 +1,7 @@
+"""
+Minimal MCP server placeholder (no external deps).
+This file is intentionally a scaffold. Actual MCP server implementation can mirror ITA tools.
+"""
+
+if __name__ == "__main__":
+    print("MCP server placeholder. Implement tools mirroring ITA when ready.")

--- a/temp/bridge_codex_copilot_bridge/services/ita/app/main.py
+++ b/temp/bridge_codex_copilot_bridge/services/ita/app/main.py
@@ -1,17 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
 
 from fastapi import FastAPI
-from .routers import kb, repo, tests, gitops
-import os
+from pydantic import BaseModel
 
-app = FastAPI(title="Internal Tools API (ITA)")
+app = FastAPI(title="ITA Bridge Stub", version="0.1.0")
 
-app.include_router(kb.router)
-app.include_router(repo.router)
-app.include_router(tests.router)
-app.include_router(gitops.router)
 
-@app.get("/healthz")
-async def healthz():
-    return {"status": "ok", "env": {"GITHUB_APP_ID": bool(os.getenv("GITHUB_APP_ID"))}}
+class KBSearchReq(BaseModel):
+    query: str
+    top_k: int = 5
 
-# Run: uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
+
+class HygieneReq(BaseModel):
+    diff: str | None = None
+    checks: List[str] | None = None
+
+
+class TestsReq(BaseModel):
+    pattern: str | None = None
+
+
+class CreatePRReq(BaseModel):
+    title: str
+    body: str
+    head: str
+    base: str
+    confirm: bool | None = None
+
+
+@app.post("/kb/search")
+def kb_search(req: KBSearchReq) -> Dict[str, Any]:
+    # Deterministic stubbed results
+    results = [
+        {
+            "title": f"KB match for: {req.query}",
+            "url": "https://internal.example/kb/123",
+            "snippet": "This is a stubbed KB snippet.",
+        }
+        for _ in range(max(1, min(req.top_k, 5)))
+    ]
+    return {"results": results}
+
+
+@app.post("/repo/hygiene")
+def repo_hygiene(req: HygieneReq) -> Dict[str, Any]:
+    findings = []
+    if req.diff and "TODO" in req.diff:
+        findings.append({"type": "lint", "message": "Found TODO in diff"})
+    return {"ok": len(findings) == 0, "findings": findings}
+
+
+@app.post("/tests/run")
+def tests_run(req: TestsReq | None = None) -> Dict[str, Any]:
+    # Stubbed: always pass a small set
+    return {"passed": 12, "failed": 0, "duration_s": 1.23}
+
+
+@app.post("/git/create-pr")
+def git_create_pr(req: CreatePRReq) -> Dict[str, Any]:
+    dry = not bool(req.confirm)
+    if dry:
+        return {
+            "dry_run": True,
+            "message": f"[DRY RUN] Would create PR {req.head}->{req.base}: {req.title}",
+            "pr_url": None,
+        }
+    # In a real implementation: call GitHub App flow. Here: stub URL.
+    return {
+        "dry_run": False,
+        "message": "PR created",
+        "pr_url": "https://github.com/owner/repo/pull/123",
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/temp/bridge_codex_copilot_bridge/services/ita/openapi.yaml
+++ b/temp/bridge_codex_copilot_bridge/services/ita/openapi.yaml
@@ -1,31 +1,20 @@
-
 openapi: 3.0.3
 info:
-  title: Internal Tools API (ITA)
-  version: "0.1.0"
-  description: >
-    Contract-first API used by both Codex and Copilot. Destructive endpoints require
-    `confirm=true` and support `dry_run=true`. Every request must include
-    `X-API-Key` header (short-lived) and `X-Request-Id` for traceability.
-
+  title: Internal Tools API (ITA) — Bridge Skeleton
+  version: 0.1.0
 servers:
-  - url: http://localhost:8080
-
-security:
-  - ApiKeyAuth: []
-
+  - url: http://localhost:8000
 paths:
   /kb/search:
     post:
-      summary: Retrieve knowledge snippets with citations
-      operationId: kbSearch
+      summary: Search internal knowledge base
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required: [query]
+              required: [query, top_k]
               properties:
                 query:
                   type: string
@@ -36,7 +25,7 @@ paths:
                   default: 5
       responses:
         "200":
-          description: OK
+          description: Search results
           content:
             application/json:
               schema:
@@ -47,136 +36,87 @@ paths:
                     items:
                       type: object
                       properties:
+                        title: { type: string }
+                        url: { type: string }
                         snippet: { type: string }
-                        source: { type: string }
-                        score:  { type: number }
-        "401": { description: Unauthorized }
-        "429": { description: Rate limited }
-
   /repo/hygiene:
     post:
-      summary: Lint/format/scan an incoming diff
-      operationId: repoHygiene
+      summary: Lint/format/scan a diff (stub)
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required: [diff]
               properties:
-                diff:
-                  type: string
+                diff: { type: string }
                 checks:
                   type: array
-                  items:
-                    type: string
-                    enum: [lint, format, secrets, license]
+                  items: { type: string }
       responses:
         "200":
-          description: OK
+          description: Hygiene report
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  issues:
+                  ok: { type: boolean }
+                  findings:
                     type: array
                     items:
                       type: object
                       properties:
                         type: { type: string }
-                        path: { type: string }
                         message: { type: string }
-                        severity: { type: string, enum: [info, warn, error] }
-
   /tests/run:
     post:
-      summary: Run focused tests by package/file/pattern
-      operationId: testsRun
+      summary: Run focused tests (stub)
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
               type: object
-              required: [targets]
               properties:
-                targets:
-                  type: array
-                  items: { type: string }
-                timeout_s:
-                  type: integer
-                  default: 300
+                pattern: { type: string }
       responses:
         "200":
-          description: OK
+          description: Test summary
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  summary:
-                    type: object
-                    properties:
-                      total: { type: integer }
-                      passed: { type: integer }
-                      failed: { type: integer }
-                      duration_s: { type: number }
-                  failures:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name: { type: string }
-                        message: { type: string }
-
+                  passed: { type: integer }
+                  failed: { type: integer }
+                  duration_s: { type: number }
   /git/create-pr:
     post:
-      summary: Create or update a Pull Request (guarded by confirm/dry_run)
-      operationId: gitCreatePr
-      parameters:
-        - in: query
-          name: confirm
-          schema: { type: boolean, default: false }
-        - in: query
-          name: dry_run
-          schema: { type: boolean, default: true }
+      summary: Create a pull request (dry-run default)
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required: [repo, title, body, base, head]
+              required: [title, body, head, base]
               properties:
-                repo: { type: string, example: "org/repo" }
                 title: { type: string }
                 body: { type: string }
-                base: { type: string }
                 head: { type: string }
-                labels:
-                  type: array
-                  items: { type: string }
+                base: { type: string }
+                confirm:
+                  type: boolean
+                  description: Set true to actually proceed; default dry-run
       responses:
         "200":
-          description: Created/Simulated
+          description: PR creation result
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  simulated: { type: boolean }
-                  pr_url: { type: string, nullable: true }
+                  dry_run: { type: boolean }
                   message: { type: string }
-        "412":
-          description: Precondition required (confirm=true missing)
-        "401":
-          description: Unauthorized
-
-components:
-  securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
-      in: header
-      name: X-API-Key
+                  pr_url: { type: string, nullable: true }


### PR DESCRIPTION
## Summary
- add bridge skeleton README describing layout and constraints for Codex↔Copilot integration
- define an Internal Tools API OpenAPI contract with matching FastAPI stub service and tool specs plus loader helper
- provide MCP placeholder assets and publish Copilot CLI guidance with bridge integration blueprint documentation

## Testing
- `python -c "import importlib.util, sys, pathlib as p; m=str(p.Path('temp/bridge_codex_copilot_bridge/services/ita/app/main.py')); spec=importlib.util.spec_from_file_location('main', m); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); print('Imported OK')"`


------
https://chatgpt.com/codex/tasks/task_e_68cd9b112abc83318b1e8f94baa5affe