### PR TITLE
Add Codex↔Copilot bridge documentation and align ITA contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository is intended to help developers customize environments in Codex b
 * [Quickstart: tokenizer → training → evaluation](docs/quickstart.md)
 * [Architecture overview diagram](docs/diagrams/architecture.svg)
 * [Registry & plugin guide](docs/dev/plugins.md)
+* [Codex ↔ Copilot bridge documentation](docs/bridge/README.md)
 
 > **Policy:** No GitHub-hosted Actions. Run `make codex-gates` locally or on a self-hosted runner (ephemeral runners recommended).
 

--- a/docs/bridge/README.md
+++ b/docs/bridge/README.md
@@ -18,6 +18,14 @@ auditable backend.
 
 > Non-goals: There is no public Copilot inference API; neither Codex nor the ITA call Copilot. Both agents call this API.
 
+## Documentation map
+
+- [Bridge overview](overview.md) – architecture, request flow, and component summary.
+- [Governance and guardrails](governance.md) – access controls, logging expectations, and threat-model ties.
+- [Ubuntu CLI integration](ubuntu_cli.md) – how to set up the service, Codex client, and Copilot shim on Ubuntu.
+- [GitHub App permissions](../../copilot/app/README.md) – minimal scopes for write operations.
+- [Threat model snapshot](../../ops/threat_model/STRIDE.md) – STRIDE matrix for the shared bridge.
+
 ## Quickstart
 
 ### 1. Run the ITA (Internal Tools API)

--- a/docs/bridge/governance.md
+++ b/docs/bridge/governance.md
@@ -1,0 +1,49 @@
+# Bridge Governance & Guardrails
+
+Codex and Copilot share responsibility for safe execution. The bridge centralises policy so that
+clients can remain thin and predictable. Use this guide when configuring production or Ubuntu-based
+development environments.
+
+## Access control
+
+- **API keys** are short-lived. Generate them with `python services/ita/scripts/issue_api_key.py`.
+  Hashes are stored in `services/ita/runtime/api_keys.json`, which is ignored by git.
+- **Environment overrides**: set `ITA_API_KEYS_PATH` to relocate the key store or
+  `ITA_ADDITIONAL_API_KEYS` when you must honour pre-provisioned credentials (comma separated).
+- **GitHub App credentials** live outside the repository. Export `GITHUB_APP_ID`,
+  `GITHUB_INSTALLATION_ID`, and `GITHUB_PRIVATE_KEY_PEM` in the shell that runs Codex or Copilot.
+
+## Operational semantics
+
+All write-like endpoints share the same safety semantics:
+
+| Concept | Behaviour |
+| --- | --- |
+| `dry_run=true` | Simulates side effects. Default for `/git/create-pr`. Responses include a `simulated` flag. |
+| `confirm=true` | Required when `dry_run=false`. Prevents accidental writes. Requests without it return **412 Precondition Failed**. |
+| `X-Request-Id` | Mandatory header propagated to responses for correlation. Useful for Ubuntu systemd or journald logs. |
+| Idempotency | Clients should reuse the same `X-Request-Id` when retrying to ease log inspection. |
+
+## Logging & observability
+
+- The ITA issues structured logs that include the hashed API key, request identifier, and endpoint
+  metadata. Forward them to your preferred aggregator on Ubuntu (e.g. `journalctl`, `fluent-bit`).
+- Clients should log the `X-Request-Id` they generated so cross-system tracing is trivial.
+- Enable `morgan` logging inside the Copilot Express shim (already configured) to audit inbound
+  extension calls.
+
+## Threat model touchpoints
+
+The STRIDE snapshot under `ops/threat_model/STRIDE.md` captures the baseline controls. A quick
+translation for operators:
+
+- **Spoofing** → Pair short-lived API keys with GitHub App JWTs exchanged for installation tokens.
+- **Tampering** → Idempotent write flows plus `confirm` gating keep destructive actions deliberate.
+- **Repudiation** → Persist correlation IDs and hashed API keys in audit logs.
+- **Information Disclosure** → Keep scopes minimal and redact tokens in logs or telemetry.
+- **Denial of Service** → Clients implement exponential backoff; the ITA is ready for rate limiting.
+- **Elevation of Privilege** → Hard-code repository/org allowlists before enabling write operations.
+
+For deeper architectural context, read the [bridge overview](overview.md) and keep the knowledge base
+entries up to date so Codex can surface the latest operational expectations.
+

--- a/docs/bridge/overview.md
+++ b/docs/bridge/overview.md
@@ -1,0 +1,60 @@
+# Internal Tools API Bridge Overview
+
+The **Codex ↔ Copilot bridge** gives every automation surface—ChatGPT-Codex, GitHub Copilot, and
+future MCP agents—a single, auditable backend. The Internal Tools API (ITA) concentrates every
+privileged action behind a contract-first FastAPI service so that new clients only need to bring
+authentication and request routing.
+
+## Why a bridge?
+
+| Challenge | Bridge answer |
+| --- | --- |
+| Codex and Copilot historically called independent scripts with diverging guardrails. | Ship one API that owns the safety gates and operational semantics. |
+| Platform parity was difficult: new tools had to be re-implemented twice. | Clients talk to ITA, so features land once and become available everywhere. |
+| Governance required manual reviews of bespoke scripts. | The contract, tests, and docs in this repository provide a repeatable baseline. |
+
+## Core components
+
+The bridge is split into small, purpose-built packages. Each client can be deployed on Ubuntu
+workstations or CI runners without bespoke setup beyond the documented dependencies.
+
+| Path | Purpose |
+| --- | --- |
+| `services/ita` | FastAPI application that implements the OpenAPI contract. Includes an API key store, request tracing, idempotent write flows, and contract tests. |
+| `agents/codex_client` | Python client consumed by Codex CLI tooling. Handles retries, validation, and streaming-friendly JSON payloads. |
+| `copilot/extension` | Express shim for GitHub Copilot extensions. It forwards `/ext/*` calls to ITA with the correct headers and logging. |
+| `copilot/app` | Documentation for the GitHub App scopes and environment variables required for write access. |
+| `mcp/server` | Placeholder Model Context Protocol server that will expose the same tools to IDE-integrated Copilot agents. |
+| `ops/threat_model` | STRIDE snapshot that enumerates the shared trust assumptions and mitigations. |
+| `tools/codex_safety` | Optional hooks that keep large binaries and oversized diffs from slipping into pull requests. |
+
+## Request flow
+
+1. A client (Codex CLI, Copilot extension, or MCP server) issues a call with `X-API-Key` and
+   `X-Request-Id` headers.
+2. The ITA middleware authenticates the API key, stores the hashed key in the request context, and
+   injects the correlation ID into the response headers.
+3. Router functions fan out to purpose-specific helpers:
+   - `/kb/search` → in-memory knowledge snippets that reference onboarding docs.
+   - `/repo/hygiene` → static lint/format/secret heuristics.
+   - `/tests/run` → synthetic execution harness simulating deterministic and flaky runs.
+   - `/git/create-pr` → guarded pull-request simulation that honours `confirm`/`dry_run` semantics.
+4. Clients present the responses back to users or upstream automations.
+
+The end-to-end interaction works the same on Ubuntu developer machines, self-hosted runners, and
+CI containers because every component only requires standard tooling (`python`, `node`, `uvicorn`,
+`npm`).
+
+## Getting started
+
+1. Follow the [Ubuntu CLI integration guide](ubuntu_cli.md) to install Python and Node tooling and
+   export the required environment variables.
+2. Launch the ITA locally with `uvicorn app.main:app --reload` from `services/ita`.
+3. Run the Codex demo client (`python -m codex_client.demo_plan_and_call`) to see a complete plan.
+4. Start the Copilot extension shim (`npm start` inside `copilot/extension`) to expose `/ext/*`
+   routes.
+
+Every change to the contract should be reflected in `services/ita/openapi.yaml` and validated by the
+contract tests under `services/ita/tests`. Clients intentionally depend on the generated schema so
+that breaking changes surface quickly during development.
+

--- a/docs/bridge/ubuntu_cli.md
+++ b/docs/bridge/ubuntu_cli.md
@@ -1,0 +1,80 @@
+# Ubuntu CLI Integration Guide
+
+This quickstart targets Ubuntu 24.04 LTS (the Codex universal base). It walks through preparing a
+developer workstation or self-hosted runner so Codex and Copilot automations can reach the Internal
+Tools API (ITA) bridge.
+
+## Prerequisites
+
+- Python 3.12+ (`sudo apt install python3 python3-venv python3-pip`)
+- Node.js 20+ (`curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -` then
+  `sudo apt install nodejs`)
+- GitHub App credentials for Copilot write operations (optional until you enable `/git/create-pr`).
+
+## 1. Launch the ITA service
+
+```bash
+cd /workspace/_codex_/services/ita
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install -e .[dev]
+export ITA_API_KEY=$(python scripts/issue_api_key.py)
+uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
+```
+
+`uvicorn` logs the request ID for every call. On Ubuntu you can background the process with
+`systemd --user` units or `tmux` depending on operator preference.
+
+## 2. Configure the Codex client
+
+```bash
+cd /workspace/_codex_/agents/codex_client
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install -e .
+export ITA_URL=http://localhost:8080
+export ITA_API_KEY=$ITA_API_KEY
+# Optional when using the OpenAI Responses API demo
+export OPENAI_API_KEY=sk-...
+python -m codex_client.demo_plan_and_call --query "bridge quickstart" --run-tests tests/unit
+```
+
+The demo prints the knowledge base snippets, hygiene scan, optional test run, and PR simulation. All
+network requests stay inside the Ubuntu host unless you point `ITA_URL` elsewhere.
+
+## 3. Run the Copilot extension shim
+
+```bash
+cd /workspace/_codex_/copilot/extension
+npm install
+export ITA_URL=http://localhost:8080
+export ITA_API_KEY=$ITA_API_KEY
+npm start
+```
+
+The Express server listens on port `3978`. Configure your Copilot extension manifest or testing tool
+to POST to `http://localhost:3978/ext/repo/hygiene` (and `/ext/tests/run`). Requests inherit the ITA
+guardrails because the shim copies the headers and never stores credentials on disk.
+
+## 4. Optional GitHub App wiring
+
+When you are ready to perform write operations set the following variables in every shell that calls
+the bridge:
+
+```bash
+export GITHUB_APP_ID=12345
+export GITHUB_INSTALLATION_ID=67890
+export GITHUB_PRIVATE_KEY_PEM="$(cat ~/keys/copilot-app.pem)"
+```
+
+The ITA will validate the configuration before attempting `/git/create-pr` with `confirm=true`.
+
+## 5. Keep tooling aligned
+
+- Pin dependencies using the provided lock files or `uv` workflow in the repository root.
+- Re-run `pytest services/ita/tests` and `npm run lint --prefix copilot/extension` after upgrades.
+- Read the [governance guide](governance.md) for policies that apply once you promote beyond a local
+  Ubuntu sandbox.
+

--- a/services/ita/app/knowledge_base.py
+++ b/services/ita/app/knowledge_base.py
@@ -34,6 +34,11 @@ _DEFAULT_ENTRIES: List[KnowledgeBaseEntry] = [
         keywords=("confirm", "dry_run", "github", "ita"),
     ),
     KnowledgeBaseEntry(
+        snippet="Follow the Ubuntu CLI guide to wire Codex and Copilot tooling into the shared bridge scripts.",
+        source="docs/bridge/ubuntu_cli.md",
+        keywords=("ubuntu", "cli", "setup", "codex", "copilot"),
+    ),
+    KnowledgeBaseEntry(
         snippet="Register the GitHub App with read contents and write pull_requests scopes before enabling mutation flows.",
         source="copilot/app/README.md",
         keywords=("github app", "permissions", "pull requests"),

--- a/services/ita/app/main.py
+++ b/services/ita/app/main.py
@@ -76,13 +76,18 @@ async def inject_request_context(request: Request, call_next):
     return response
 
 
-@app.get("/healthz", response_model=HealthResponse, tags=["system"])
+@app.get("/healthz", response_model=HealthResponse, tags=["system"], operation_id="healthz")
 async def healthz(context: RequestContext = Depends(get_request_context)) -> HealthResponse:
     _ = context  # context is validated by middleware, nothing else to do
     return HealthResponse()
 
 
-@app.post("/kb/search", response_model=KnowledgeSearchResponse, tags=["knowledge"])
+@app.post(
+    "/kb/search",
+    response_model=KnowledgeSearchResponse,
+    tags=["knowledge"],
+    operation_id="kbSearch",
+)
 async def kb_search(
     payload: KnowledgeSearchRequest,
     context: RequestContext = Depends(get_request_context),
@@ -92,7 +97,12 @@ async def kb_search(
     return KnowledgeSearchResponse(results=results)
 
 
-@app.post("/repo/hygiene", response_model=RepoHygieneResponse, tags=["repo"])
+@app.post(
+    "/repo/hygiene",
+    response_model=RepoHygieneResponse,
+    tags=["repo"],
+    operation_id="repoHygiene",
+)
 async def repo_hygiene(
     payload: RepoHygieneRequest,
     context: RequestContext = Depends(get_request_context),
@@ -105,7 +115,12 @@ async def repo_hygiene(
     return RepoHygieneResponse(issues=issues)
 
 
-@app.post("/tests/run", response_model=TestsRunResponse, tags=["tests"])
+@app.post(
+    "/tests/run",
+    response_model=TestsRunResponse,
+    tags=["tests"],
+    operation_id="testsRun",
+)
 async def tests_run(
     payload: TestsRunRequest,
     context: RequestContext = Depends(get_request_context),
@@ -114,7 +129,12 @@ async def tests_run(
     return simulate_test_execution(payload)
 
 
-@app.post("/git/create-pr", response_model=GitCreatePullRequestResponse, tags=["git"])
+@app.post(
+    "/git/create-pr",
+    response_model=GitCreatePullRequestResponse,
+    tags=["git"],
+    operation_id="gitCreatePr",
+)
 async def git_create_pr(
     payload: GitCreatePullRequestBody,
     confirm: bool = False,

--- a/services/ita/tests/test_contract.py
+++ b/services/ita/tests/test_contract.py
@@ -42,10 +42,14 @@ def test_openapi_matches_fastapi_schema(auth_headers: dict[str, str]) -> None:
         response = client.get("/openapi.json", headers=auth_headers)
         assert response.status_code == 200
         live_schema = response.json()
+    http_methods = {"get", "put", "post", "delete", "patch", "options", "head"}
     for path, methods in contract["paths"].items():
         assert path in live_schema["paths"], f"Path {path} missing from generated schema"
-        for method in methods:
+        for method, definition in methods.items():
+            if method not in http_methods:
+                continue
             assert method in live_schema["paths"][path], f"Method {method} missing for {path}"
+            assert definition["operationId"] == live_schema["paths"][path][method]["operationId"]
 
 
 # Placeholder: in CI, use schemathesis to fuzz test against openapi.yaml


### PR DESCRIPTION
## Summary
- add dedicated bridge documentation covering architecture, governance, and Ubuntu CLI setup
- link the new docs from the top-level README and from the in-app knowledge base
- align FastAPI operation IDs with the OpenAPI contract and tighten the schema regression test

## Testing
- pytest services/ita/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68cdd3e1a68483318e8d67e72958c85f