### PR TITLE
Implement codex AST upgrade automation

### DIFF
--- a/codex_ast_upgrade.py
+++ b/codex_ast_upgrade.py
@@ -22,20 +22,31 @@ Design anchors:
 
 STRICTLY LOCAL: Do NOT activate any online CI/CD or remote services.
 """
-import argparse, os, sys, zipfile, shutil, json, re, textwrap, datetime
+import argparse
+import datetime
+import json
+import re
+import tempfile
+import textwrap
+import zipfile
 from pathlib import Path
 
-TS = lambda: datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+def TS() -> str:
+    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
 
 # --------- utils ----------
 def w(p: Path, s: str):
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(s, encoding="utf-8")
 
+
 def a(p: Path, s: str):
     p.parent.mkdir(parents=True, exist_ok=True)
     with p.open("a", encoding="utf-8") as f:
         f.write(s)
+
 
 def r(p: Path) -> str:
     if not p.exists():
@@ -45,6 +56,7 @@ def r(p: Path) -> str:
     except Exception:
         try:
             from charset_normalizer import from_bytes
+
             data = p.read_bytes()
             best = from_bytes(data).best()
             enc = best.encoding if best else "utf-8"
@@ -52,8 +64,10 @@ def r(p: Path) -> str:
         except Exception:
             return p.read_text(errors="ignore")
 
+
 def udiff(before: str, after: str, a_label: str, b_label: str) -> str:
     import difflib
+
     return "".join(
         difflib.unified_diff(
             before.splitlines(True),
@@ -63,6 +77,7 @@ def udiff(before: str, after: str, a_label: str, b_label: str) -> str:
             lineterm="",
         )
     )
+
 
 def err_block(step_no: str, desc: str, msg: str, ctx: str) -> str:
     return f"""
@@ -74,17 +89,24 @@ What are the possible causes, and how can this be resolved while preserving inte
 
 """
 
+
 # --------- repo handling ----------
 def unzip_repo(zip_path: Path, out_dir: Path):
     with zipfile.ZipFile(zip_path) as z:
         z.extractall(out_dir)
 
+
 def detect_root(base: Path) -> Path:
     cands = [d for d in base.iterdir() if d.is_dir()]
     for d in cands:
-        if (d / "src").exists() or (d / "functional_training.py").exists() or (d / "training").exists():
+        if (
+            (d / "src").exists()
+            or (d / "functional_training.py").exists()
+            or (d / "training").exists()
+        ):
             return d
     return base
+
 
 # --------- additions (code blocks) ----------
 PARSERS_PY = """\
@@ -410,3 +432,545 @@ if __name__ == "__main__":
     main()
 """
 
+
+FALLBACK_SECTION = textwrap.dedent(
+    """
+    ## Fallback Modes & Feature Flags
+
+    The audit pipeline runs in offline-friendly stages. Parsing begins with the
+    stdlib ``ast`` module and gracefully degrades through LibCST, Parso, and a
+    final regex-based extractor so that reports are still emitted even for
+    partially-invalid code.
+
+    | Flag / Env | Purpose | Default |
+    | --- | --- | --- |
+    | `--external-search` / `--no-external-search` | Toggle the optional web search provider used for design-time evidence gathering. | Disabled |
+    | `--external-search-endpoint` | Override the provider endpoint. Accepts HTTP URLs or `file://` paths for offline indexes. | DuckDuckGo API |
+    | `--external-search-timeout` | Custom timeout in seconds when the external provider is enabled. | 5.0 |
+    | `CODEX_ANALYSIS_SEARCH_ENABLED` | Environment flag mirroring the CLI toggle. | `0` |
+    | `CODEX_ANALYSIS_SEARCH_ENDPOINT` | Environment override for the search endpoint. Supports absolute paths. | unset |
+    | `CODEX_ANALYSIS_SEARCH_TIMEOUT` | Environment override for timeout configuration. | unset |
+
+    When all parsing tiers fail, the degraded extractor still approximates
+    imports, function names, and class names so that metrics such as
+    ``mccabe_minimal`` remain available in generated reports.
+    """
+).strip()
+
+GUIDE_DOC = textwrap.dedent(
+    """
+    # Static Analysis Upgrade Overview
+
+    This guide documents the offline upgrade pipeline delivered by
+    ``codex_ast_upgrade.py``. The utility prepares repositories for resilient
+    static analysis by layering multiple parsing adapters, extraction helpers,
+    and safety-conscious defaults.
+
+    ## Goals
+
+    - Preserve formatting by preferring LibCST when ``ast`` parsing fails.
+    - Remain tolerant of broken files via Parso and degraded regex extraction.
+    - Provide simple complexity metrics without requiring heavy dependencies.
+    - Keep research evidence gathering offline by default while allowing
+      explicit opt-in.
+
+    ## Upgrade Outputs
+
+    Running the script results in:
+
+    1. Tiered parsing and extraction modules under ``src/codex_ml/analysis``.
+    2. A CLI pipeline at ``codex_ml.cli.audit_pipeline`` that walks Python
+       sources and emits JSON reports.
+    3. Patch files under ``patches/`` capturing all applied modifications.
+    4. NDJSON metrics describing the upgrade actions for reproducibility.
+
+    ## Fallback Strategy
+
+    1. **AST** – primary parsing using ``ast.parse``.
+    2. **LibCST** – formatting-preserving fallback for valid code that fails
+       ``ast``.
+    3. **Parso** – tolerant parsing for partially invalid code.
+    4. **Degraded Mode** – regex-based heuristics that still extract function,
+       class, and import names when all structured parsers fail.
+
+    The Research → Integrate → Validate → Measure → Iterate (RIVMI) loop is
+    embedded in the CLI through internal search providers so upgrades remain
+    auditable and extensible.
+    """
+).strip()
+
+TEST_TEMPLATE = textwrap.dedent(
+    """
+    from codex_ml.analysis.extractors import extract_degraded
+    from codex_ml.analysis.parsers import parse_tiered
+
+
+    def test_parse_tiered_handles_invalid_code():
+        code = "def broken(:\n    pass"
+        result = parse_tiered(code)
+        assert result.mode in {"cst", "parso", "degraded"}
+        if result.mode == "degraded":
+            extracted = extract_degraded(code)
+            assert extracted.functions, "degraded mode should approximate functions"
+    """
+).strip()
+
+README_FALLBACK_HEADER = re.compile(
+    r"^##\s+Fallback Modes?\s+&\s+(Feature\s+)?Flags", re.IGNORECASE | re.MULTILINE
+)
+PLACEHOLDER_IMAGE_RE = re.compile(
+    r"!\[[^\]]*(?:placeholder|todo|sample|badge)[^\]]*\]\([^)]+\)", re.IGNORECASE
+)
+PLACEHOLDER_LINK_RE = re.compile(
+    r"\[[^\]]*(?:placeholder|todo|sample)[^\]]*\]\([^)]+\)", re.IGNORECASE
+)
+PLACEHOLDER_HTML_IMG_RE = re.compile(r"<img[^>]*placeholder[^>]*>", re.IGNORECASE)
+PLACEHOLDER_HTML_LINK_RE = re.compile(r"<a[^>]*placeholder[^>]*>.*?</a>", re.IGNORECASE | re.DOTALL)
+
+SKIP_DIR_PARTS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".venv",
+    "venv",
+    "build",
+    "dist",
+    "node_modules",
+    "__pycache__",
+    ".eggs",
+}
+
+MODULE_SPECS = (
+    ("src/codex_ml/analysis/parsers.py", PARSERS_PY, ("class ParseResult", "def parse_tiered")),
+    (
+        "src/codex_ml/analysis/extractors.py",
+        EXTRACTORS_PY,
+        ("class Extraction", "def extract_ast", "def extract_degraded"),
+    ),
+    ("src/codex_ml/analysis/registry.py", REGISTRY_PY, ("class Registry", "def register_parser")),
+    (
+        "src/codex_ml/analysis/providers.py",
+        PROVIDERS_PY,
+        ("class InternalRepoSearch", "class ExternalWebSearch"),
+    ),
+    (
+        "src/codex_ml/analysis/metrics.py",
+        METRICS_PY,
+        ("def mccabe_minimal", "def perplexity_from_mean_nll"),
+    ),
+    (
+        "src/codex_ml/cli/audit_pipeline.py",
+        CLI_PY,
+        ("def audit_file", "def audit_repo"),
+    ),
+)
+
+
+def _ensure_trailing_newline(text: str) -> str:
+    if not text.endswith("\n"):
+        return f"{text}\n"
+    return text
+
+
+def _normalise_rel(root: Path, candidate: Path) -> Path:
+    if candidate.is_absolute():
+        try:
+            return candidate.relative_to(root)
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise ValueError(f"Path {candidate} is outside of repository root {root}") from exc
+    return candidate
+
+
+def _clean_placeholders(line: str) -> tuple[str, int]:
+    count = 0
+
+    def repl(_match: re.Match[str]) -> str:
+        nonlocal count
+        count += 1
+        return ""
+
+    cleaned = PLACEHOLDER_IMAGE_RE.sub(repl, line)
+    cleaned = PLACEHOLDER_LINK_RE.sub(repl, cleaned)
+    cleaned = PLACEHOLDER_HTML_IMG_RE.sub(repl, cleaned)
+    cleaned = PLACEHOLDER_HTML_LINK_RE.sub(repl, cleaned)
+    return cleaned, count
+
+
+def transform_readme(content: str) -> tuple[str, int, bool]:
+    placeholder_removed = 0
+    lines: list[str] = []
+    for raw_line in content.splitlines():
+        new_line, delta = _clean_placeholders(raw_line)
+        placeholder_removed += delta
+        if not new_line.strip() and delta and raw_line.strip():
+            continue
+        lines.append(new_line.rstrip())
+    text = "\n".join(lines)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    text = text.strip("\n")
+
+    if README_FALLBACK_HEADER.search(text):
+        has_section = True
+        updated_text = text
+    else:
+        has_section = False
+        addition = FALLBACK_SECTION
+        updated_text = f"{text}\n\n{addition}" if text else addition
+
+    return _ensure_trailing_newline(updated_text.strip("\n")), placeholder_removed, not has_section
+
+
+def iter_readmes(root: Path) -> list[Path]:
+    candidates: list[Path] = []
+    for readme in root.rglob("README.md"):
+        if any(part in SKIP_DIR_PARTS for part in readme.parts):
+            continue
+        candidates.append(readme)
+    return sorted(candidates)
+
+
+class UpgradeSession:
+    def __init__(self, root: Path, patch_dir: Path, metrics_path: Path) -> None:
+        self.root = root
+        self.patch_dir = patch_dir if patch_dir.is_absolute() else root / patch_dir
+        self.patch_dir.mkdir(parents=True, exist_ok=True)
+
+        metrics_rel = _normalise_rel(root, metrics_path)
+        self.metrics_rel = metrics_rel
+
+        self.diffs: list[str] = []
+        self.change_log: list[dict[str, object]] = []
+        self.pending_metrics: list[dict[str, object]] = []
+        self.latest_patch: Path | None = None
+        self.metrics_written: bool = False
+
+    def apply_text(
+        self,
+        rel_path: Path | str,
+        content: str,
+        *,
+        description: str,
+        metadata: dict[str, object] | None = None,
+        record_metric: bool = True,
+    ) -> bool:
+        rel = _normalise_rel(self.root, Path(rel_path))
+        target = self.root / rel
+        existed = target.exists()
+        before = r(target) if existed else ""
+        after = _ensure_trailing_newline(content.rstrip("\n"))
+        if before == after:
+            return False
+
+        w(target, after)
+        diff = udiff(before, after, f"a/{rel.as_posix()}", f"b/{rel.as_posix()}")
+        if diff and not diff.endswith("\n"):
+            diff = f"{diff}\n"
+        if diff:
+            self.diffs.append(diff)
+
+        ts = TS()
+        change_type = "updated" if existed else "created"
+        entry: dict[str, object] = {
+            "timestamp": ts,
+            "file": rel.as_posix(),
+            "change": change_type,
+            "description": description,
+        }
+        if metadata:
+            entry.update(metadata)
+        self.change_log.append(entry)
+
+        if record_metric:
+            metric_entry = dict(entry)
+            self.pending_metrics.append(metric_entry)
+        return True
+
+    def add_metric(self, event: str, metadata: dict[str, object] | None = None) -> None:
+        entry: dict[str, object] = {"timestamp": TS(), "event": event}
+        if metadata:
+            entry.update(metadata)
+        self.pending_metrics.append(entry)
+
+    def flush_metrics(self) -> dict[str, object]:
+        metrics_path = self.root / self.metrics_rel
+        prior = r(metrics_path)
+        existing_lines = [line for line in prior.splitlines() if line.strip()]
+        if not self.pending_metrics:
+            return {
+                "path": self.metrics_rel.as_posix(),
+                "entries_written": 0,
+                "changed": False,
+            }
+
+        serialised = [json.dumps(entry, sort_keys=True) for entry in self.pending_metrics]
+        merged_lines = existing_lines + serialised
+        new_content = "\n".join(merged_lines)
+        if new_content:
+            new_content = _ensure_trailing_newline(new_content)
+        changed = self.apply_text(
+            self.metrics_rel,
+            new_content,
+            description="append codex_ast_upgrade metrics",
+            metadata={"entries_appended": len(self.pending_metrics)},
+            record_metric=False,
+        )
+        self.pending_metrics.clear()
+        self.metrics_written = self.metrics_written or bool(changed)
+        return {
+            "path": self.metrics_rel.as_posix(),
+            "entries_written": len(serialised),
+            "changed": bool(changed),
+        }
+
+    def emit_patch(self) -> Path | None:
+        if not self.diffs:
+            return None
+        stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        patch_path = self.patch_dir / f"codex_ast_upgrade_{stamp}.patch"
+        patch_text = "".join(self.diffs)
+        if patch_text and not patch_text.endswith("\n"):
+            patch_text = f"{patch_text}\n"
+        w(patch_path, patch_text)
+        self.latest_patch = patch_path
+        return patch_path
+
+
+def upgrade_readmes(session: UpgradeSession) -> dict[str, object]:
+    updates: list[dict[str, object]] = []
+    for readme_path in iter_readmes(session.root):
+        original = r(readme_path)
+        if not original.strip():
+            continue
+        transformed, removed, added = transform_readme(original)
+        if transformed == _ensure_trailing_newline(original.rstrip("\n")):
+            continue
+        metadata = {
+            "placeholders_removed": removed,
+            "fallback_section_added": added,
+            "kind": "readme",
+        }
+        session.apply_text(
+            readme_path.relative_to(session.root),
+            transformed,
+            description="normalize README fallback guidance",
+            metadata=metadata,
+        )
+        updates.append(
+            {
+                "file": readme_path.relative_to(session.root).as_posix(),
+                "placeholders_removed": removed,
+                "fallback_section_added": added,
+            }
+        )
+    return {"updated": len(updates), "files": updates}
+
+
+def ensure_modules(session: UpgradeSession) -> dict[str, object]:
+    applied: list[dict[str, object]] = []
+    for rel_path, template, markers in MODULE_SPECS:
+        path = session.root / rel_path
+        existing = r(path)
+        if existing and all(marker in existing for marker in markers):
+            continue
+        text = textwrap.dedent(template).strip("\n")
+        session.apply_text(
+            Path(rel_path),
+            text,
+            description="ensure analysis module",
+            metadata={"markers": markers, "kind": "module"},
+        )
+        applied.append({"file": rel_path, "markers": markers})
+    return {"created_or_updated": len(applied), "files": applied}
+
+
+def ensure_docs_and_tests(
+    session: UpgradeSession,
+    doc_path: Path,
+    doc_content: str,
+    test_path: Path,
+    test_content: str,
+) -> dict[str, object]:
+    results: list[dict[str, object]] = []
+
+    doc_rel = _normalise_rel(session.root, doc_path)
+    doc_abs = session.root / doc_rel
+    existing_doc = r(doc_abs)
+    if not existing_doc.strip():
+        session.apply_text(
+            doc_rel,
+            textwrap.dedent(doc_content).strip("\n"),
+            description="add static analysis upgrade guide",
+            metadata={"kind": "doc"},
+        )
+        results.append({"file": doc_rel.as_posix(), "type": "doc"})
+
+    test_rel = _normalise_rel(session.root, test_path)
+    test_abs = session.root / test_rel
+    if not test_abs.exists():
+        session.apply_text(
+            test_rel,
+            textwrap.dedent(test_content).strip("\n"),
+            description="add parser fallback test",
+            metadata={"kind": "test"},
+        )
+        results.append({"file": test_rel.as_posix(), "type": "test"})
+
+    return {"created": len(results), "files": results}
+
+
+def perform_upgrade(
+    root: Path,
+    *,
+    patch_dir: Path,
+    metrics_path: Path,
+    doc_path: Path,
+    doc_template: str,
+    test_path: Path,
+    test_template: str,
+) -> dict[str, object]:
+    session = UpgradeSession(root, patch_dir, metrics_path)
+    steps: list[dict[str, object]] = []
+
+    def run_step(step_no: int, desc: str, fn, *args) -> None:
+        try:
+            details = fn(session, *args)
+        except Exception as exc:  # pragma: no cover - defensive best-effort
+            message = repr(exc)
+            ctx = {"step": step_no, "description": desc}
+            error_path = root / "ERROR_LOG.md"
+            try:
+                a(error_path, err_block(str(step_no), desc, message, json.dumps(ctx)))
+            except Exception:
+                pass
+            steps.append(
+                {"step": step_no, "description": desc, "status": "error", "error": message}
+            )
+        else:
+            steps.append({"step": step_no, "description": desc, "status": "ok", "details": details})
+
+    run_step(1, "normalize READMEs", upgrade_readmes)
+    run_step(2, "ensure analysis modules", ensure_modules)
+    run_step(
+        3,
+        "ensure docs/tests",
+        ensure_docs_and_tests,
+        doc_path,
+        doc_template,
+        test_path,
+        test_template,
+    )
+
+    session.add_metric("upgrade_run", {"files_changed": len(session.change_log)})
+    run_step(4, "flush metrics", lambda sess: sess.flush_metrics())
+
+    patch_path = session.emit_patch()
+
+    summary: dict[str, object] = {
+        "root": str(root),
+        "steps": steps,
+        "changes": session.change_log,
+        "metrics_file": (root / session.metrics_rel).as_posix(),
+        "patch": str(patch_path) if patch_path else None,
+    }
+    return summary
+
+
+def prepare_workspace(archive: Path | None, workspace: Path | None) -> Path:
+    if archive is None:
+        return (workspace or Path.cwd()).resolve()
+
+    archive = archive.resolve()
+    if workspace is None:
+        dest = Path(tempfile.mkdtemp(prefix="codex_ast_upgrade_"))
+    else:
+        dest = workspace.resolve()
+        dest.mkdir(parents=True, exist_ok=True)
+        if any(dest.iterdir()):
+            suffix = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            dest = dest / f"codex_ast_upgrade_{suffix}"
+    dest.mkdir(parents=True, exist_ok=True)
+    unzip_repo(archive, dest)
+    return dest
+
+
+def resolve_root(base: Path, explicit_root: str | None) -> Path:
+    if explicit_root:
+        candidate = Path(explicit_root)
+        if not candidate.is_absolute():
+            candidate = (base / candidate).resolve()
+        return candidate
+    return detect_root(base)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Codex AST upgrade utility")
+    parser.add_argument("archive", nargs="?", help="Optional zip archive of the repository")
+    parser.add_argument(
+        "--workspace",
+        type=str,
+        default=None,
+        help="Directory to extract the archive into. Defaults to a temporary directory when omitted.",
+    )
+    parser.add_argument(
+        "--root",
+        type=str,
+        default=None,
+        help="Repository root when operating on an unpacked directory.",
+    )
+    parser.add_argument(
+        "--patch-dir",
+        type=str,
+        default="patches",
+        help="Directory (relative to root) for generated unified diff patches.",
+    )
+    parser.add_argument(
+        "--metrics-out",
+        type=str,
+        default="artifacts/codex_ast_upgrade_metrics.ndjson",
+        help="NDJSON metrics output path relative to the repository root.",
+    )
+    parser.add_argument(
+        "--doc-out",
+        type=str,
+        default="docs/guides/static_analysis_upgrade.md",
+        help="Documentation path for the generated upgrade overview.",
+    )
+    parser.add_argument(
+        "--test-out",
+        type=str,
+        default="tests/analysis/test_parsers_tiered_fallback.py",
+        help="Test path for the parser fallback regression test.",
+    )
+    args = parser.parse_args(argv)
+
+    archive_path = Path(args.archive).expanduser() if args.archive else None
+    workspace_path = Path(args.workspace).expanduser() if args.workspace else None
+
+    base = prepare_workspace(archive_path, workspace_path)
+    root = resolve_root(base, args.root)
+
+    patch_dir = Path(args.patch_dir)
+    metrics_path = Path(args.metrics_out)
+    doc_path = Path(args.doc_out)
+    test_path = Path(args.test_out)
+
+    summary = perform_upgrade(
+        root.resolve(),
+        patch_dir=patch_dir,
+        metrics_path=metrics_path,
+        doc_path=doc_path,
+        doc_template=GUIDE_DOC,
+        test_path=test_path,
+        test_template=TEST_TEMPLATE,
+    )
+    summary.update(
+        {
+            "workspace": str(base.resolve()),
+            "archive": str(archive_path.resolve()) if archive_path else None,
+        }
+    )
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add fallback guidance templates plus README sanitisation helpers for the upgrade workflow
- implement an UpgradeSession orchestrator that writes analysis modules, docs, tests and NDJSON metrics while emitting patches
- expose a CLI that handles archives or local roots with configurable outputs for patches, reports and optional assets

## Testing
- ruff (lint)
- black (check)
- mypy (types)
- pytest (quick)


------
https://chatgpt.com/codex/tasks/task_e_68d0d16b758c8331b4d309d364273709