### PR TITLE
codex: restore real package delegation in offline stubs

### DIFF
--- a/hydra/__init__.py
+++ b/hydra/__init__.py
@@ -1,19 +1,90 @@
-"""Hydra stub for offline execution."""
+"""Expose the real Hydra package when available, otherwise provide a stub."""
 
 from __future__ import annotations
 
+import os
+import sys
 from functools import wraps
+from importlib.machinery import PathFinder
+from importlib.util import module_from_spec
+from pathlib import Path
+from types import ModuleType
 from typing import Any, Callable
 
-__all__ = ["main"]
+
+def _load_real_hydra() -> ModuleType | None:
+    """Attempt to load Hydra from outside the repository checkout."""
+
+    stub_package_dir = Path(__file__).resolve().parent
+    package_name = __name__.split(".", 1)[0]
+
+    search_paths: list[str] = []
+    for entry in sys.path:
+        try:
+            resolved = Path(entry).resolve()
+        except OSError:
+            # Some entries (e.g. namespace packages) may not resolve to a path.
+            search_paths.append(entry)
+            continue
+
+        if resolved == stub_package_dir:
+            continue
+
+        try:
+            candidate = resolved / package_name
+        except TypeError:
+            # Non-path entries such as import hooks may not support division.
+            search_paths.append(entry)
+            continue
+
+        if candidate == stub_package_dir:
+            continue
+        search_paths.append(entry)
+
+    spec = PathFinder.find_spec(__name__, search_paths)
+    if spec is None or spec.loader is None:
+        return None
+
+    module = module_from_spec(spec)
+    sys.modules[__name__] = module
+    spec.loader.exec_module(module)
+    return module
 
 
-def main(*args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        @wraps(func)
-        def wrapper(*f_args: Any, **f_kwargs: Any) -> Any:
-            return func(*f_args, **f_kwargs)
+_should_force_stub = bool(os.environ.get("CODEX_FORCE_HYDRA_STUB"))
+_real_hydra = None if _should_force_stub else _load_real_hydra()
 
-        return wrapper
+if _real_hydra is not None:
+    __doc__ = _real_hydra.__doc__
+    __all__ = getattr(_real_hydra, "__all__", None)
+    __spec__ = _real_hydra.__spec__
+    __loader__ = _real_hydra.__loader__
+    __package__ = _real_hydra.__package__
+    __path__ = getattr(_real_hydra, "__path__", None)
+    __file__ = getattr(_real_hydra, "__file__", None)
 
-    return decorator
+    for name, value in _real_hydra.__dict__.items():
+        if name in {
+            "__doc__",
+            "__all__",
+            "__spec__",
+            "__loader__",
+            "__package__",
+            "__path__",
+            "__file__",
+        }:
+            continue
+        globals()[name] = value
+else:
+
+    __all__ = ["main"]
+
+    def main(*args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            @wraps(func)
+            def wrapper(*f_args: Any, **f_kwargs: Any) -> Any:
+                return func(*f_args, **f_kwargs)
+
+            return wrapper
+
+        return decorator

--- a/omegaconf/__init__.py
+++ b/omegaconf/__init__.py
@@ -1,81 +1,154 @@
-"""Minimal OmegaConf stub for offline testing."""
+"""Expose the real OmegaConf package when available, otherwise provide a stub."""
 
 from __future__ import annotations
 
+import os
+import sys
+from importlib.machinery import PathFinder
+from importlib.util import module_from_spec
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Iterable, Mapping
 
-from yaml import safe_dump, safe_load  # type: ignore
 
-__all__ = ["DictConfig", "OmegaConf"]
+def _load_real_omegaconf() -> ModuleType | None:
+    """Attempt to load OmegaConf from outside the repository checkout."""
 
+    stub_package_dir = Path(__file__).resolve().parent
+    package_name = __name__.split(".", 1)[0]
+    search_paths: list[str] = []
+    for entry in sys.path:
+        try:
+            resolved = Path(entry).resolve()
+        except OSError:
+            # Some entries (e.g. namespace packages) may not resolve to a path.
+            search_paths.append(entry)
+            continue
 
-class DictConfig(dict):
-    """Simple dictionary-backed stand-in for OmegaConf's DictConfig."""
+        if resolved == stub_package_dir:
+            continue
 
+        try:
+            candidate = resolved / package_name
+        except TypeError:
+            # Non-path entries such as import hooks may not support division.
+            search_paths.append(entry)
+            continue
 
-def _merge_dicts(base: dict[str, Any], other: Mapping[str, Any]) -> dict[str, Any]:
-    result = dict(base)
-    for key, value in other.items():
-        if isinstance(value, Mapping) and isinstance(result.get(key), Mapping):
-            result[key] = _merge_dicts(result[key], value)  # type: ignore[arg-type]
-        else:
-            result[key] = value
-    return result
+        if candidate == stub_package_dir:
+            continue
+        search_paths.append(entry)
 
-
-class OmegaConf:
-    @staticmethod
-    def to_container(cfg: Any, *, resolve: bool = False) -> Any:  # noqa: D401 - compatibility
-        if isinstance(cfg, DictConfig):
-            return dict(cfg)
-        return cfg
-
-    @staticmethod
-    def to_object(cfg: Any) -> Any:
-        return OmegaConf.to_container(cfg)
-
-    @staticmethod
-    def create(initial: Mapping[str, Any] | None = None) -> DictConfig:
-        return DictConfig(dict(initial or {}))
-
-    @staticmethod
-    def from_dotlist(overrides: Iterable[str]) -> DictConfig:
-        data: dict[str, Any] = {}
-        for item in overrides:
-            if "=" not in item:
-                continue
-            key, value = item.split("=", 1)
-            data[key.strip()] = value.strip()
-        return DictConfig(data)
-
-    @staticmethod
-    def structured(obj: Any) -> Any:
-        return obj
-
-    @staticmethod
-    def set_struct(cfg: Any, flag: bool) -> None:  # pragma: no cover - compatibility no-op
+    spec = PathFinder.find_spec(__name__, search_paths)
+    if spec is None or spec.loader is None:
         return None
 
-    @staticmethod
-    def load(path: str | Path) -> DictConfig:
-        content = Path(path).read_text(encoding="utf-8")
-        data = safe_load(content) or {}
-        if not isinstance(data, Mapping):
-            raise TypeError("OmegaConf.load expected mapping")
-        return DictConfig(dict(data))
+    module = module_from_spec(spec)
+    sys.modules[__name__] = module
+    spec.loader.exec_module(module)
+    return module
 
-    @staticmethod
-    def save(config: Mapping[str, Any], path: str | Path) -> None:
-        Path(path).write_text(safe_dump(dict(config)), encoding="utf-8")
 
-    @staticmethod
-    def merge(*configs: Mapping[str, Any]) -> DictConfig:
-        merged: dict[str, Any] = {}
-        for cfg in configs:
-            if cfg is None:
-                continue
-            if not isinstance(cfg, Mapping):
-                raise TypeError("OmegaConf.merge expects mapping inputs")
-            merged = _merge_dicts(merged, cfg)
-        return DictConfig(merged)
+_should_force_stub = bool(os.environ.get("CODEX_FORCE_OMEGACONF_STUB"))
+_real_omegaconf = None if _should_force_stub else _load_real_omegaconf()
+
+if _real_omegaconf is not None:
+    __doc__ = _real_omegaconf.__doc__
+    __all__ = getattr(_real_omegaconf, "__all__", None)
+    __spec__ = _real_omegaconf.__spec__
+    __loader__ = _real_omegaconf.__loader__
+    __package__ = _real_omegaconf.__package__
+    __path__ = getattr(_real_omegaconf, "__path__", None)
+    __file__ = getattr(_real_omegaconf, "__file__", None)
+
+    for name, value in _real_omegaconf.__dict__.items():
+        if name in {
+            "__doc__",
+            "__all__",
+            "__spec__",
+            "__loader__",
+            "__package__",
+            "__path__",
+            "__file__",
+        }:
+            continue
+        globals()[name] = value
+else:
+
+    from yaml import safe_dump, safe_load  # type: ignore
+
+    __all__ = ["DictConfig", "OmegaConf", "MISSING"]
+
+    class DictConfig(dict):
+        """Simple dictionary-backed stand-in for OmegaConf's DictConfig."""
+
+    class _MissingType:
+        def __repr__(self) -> str:  # pragma: no cover - trivial
+            return "MISSING"
+
+    MISSING: Any = _MissingType()
+
+    def _merge_dicts(base: dict[str, Any], other: Mapping[str, Any]) -> dict[str, Any]:
+        result = dict(base)
+        for key, value in other.items():
+            if isinstance(value, Mapping) and isinstance(result.get(key), Mapping):
+                result[key] = _merge_dicts(result[key], value)  # type: ignore[arg-type]
+            else:
+                result[key] = value
+        return result
+
+    class OmegaConf:
+        @staticmethod
+        def to_container(cfg: Any, *, resolve: bool = False) -> Any:  # noqa: D401 - compat
+            if isinstance(cfg, DictConfig):
+                return dict(cfg)
+            return cfg
+
+        @staticmethod
+        def to_object(cfg: Any) -> Any:
+            return OmegaConf.to_container(cfg)
+
+        @staticmethod
+        def create(initial: Mapping[str, Any] | None = None) -> DictConfig:
+            return DictConfig(dict(initial or {}))
+
+        @staticmethod
+        def from_dotlist(overrides: Iterable[str]) -> DictConfig:
+            data: dict[str, Any] = {}
+            for item in overrides:
+                if "=" not in item:
+                    continue
+                key, value = item.split("=", 1)
+                data[key.strip()] = value.strip()
+            return DictConfig(data)
+
+        @staticmethod
+        def structured(obj: Any) -> Any:
+            return obj
+
+        @staticmethod
+        def set_struct(cfg: Any, flag: bool) -> None:  # pragma: no cover - compatibility
+            return None
+
+        @staticmethod
+        def load(path: str | Path) -> DictConfig:
+            content = Path(path).read_text(encoding="utf-8")
+            data = safe_load(content) or {}
+            if not isinstance(data, Mapping):
+                raise TypeError("OmegaConf.load expected mapping")
+            return DictConfig(dict(data))
+
+        @staticmethod
+        def save(config: Mapping[str, Any], path: str | Path) -> None:
+            Path(path).write_text(safe_dump(dict(config)), encoding="utf-8")
+
+        @staticmethod
+        def merge(*configs: Mapping[str, Any]) -> DictConfig:
+            merged: dict[str, Any] = {}
+            for cfg in configs:
+                if cfg is None:
+                    continue
+                if not isinstance(cfg, Mapping):
+                    raise TypeError("OmegaConf.merge expects mapping inputs")
+                merged = _merge_dicts(merged, cfg)
+            return DictConfig(merged)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -1,107 +1,131 @@
-"""Minimal torch stub for offline testing."""
+"""Compatibility shim that defers to real PyTorch when available.
+
+This module exposes a lightweight stub only when the real dependency cannot be
+imported. When PyTorch is installed we temporarily remove the repository root
+from ``sys.path`` and re-import the actual package so production code continues
+to work as expected.
+"""
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from typing import Any, Tuple
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import List
 
-__all__ = [
-    "Tensor",
-    "tensor",
-    "manual_seed",
-    "cuda",
-    "topk",
-    "where",
-    "zeros_like",
-    "full_like",
-    "full",
-    "multinomial",
-    "sort",
-    "cumsum",
-    "softmax",
-    "cat",
-]
+_repo_root = Path(__file__).resolve().parent.parent
 
+_original_sys_path: List[str] = list(sys.path)
+_filtered_sys_path: List[str] = []
+for entry in _original_sys_path:
+    resolved = Path(entry or ".").resolve()
+    if resolved == _repo_root:
+        continue
+    _filtered_sys_path.append(entry)
 
-class Tensor:
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._args = args
-        self._kwargs = kwargs
+_stub_module = sys.modules.get(__name__)
 
-    def clone(self) -> "Tensor":  # pragma: no cover - simple stub
-        return Tensor(*self._args, **self._kwargs)
+_real_torch: ModuleType | None = None
+try:
+    if _stub_module is not None:
+        del sys.modules[__name__]
+    sys.path = _filtered_sys_path
+    _real_torch = importlib.import_module("torch")
+except ImportError:
+    _real_torch = None
+finally:
+    sys.path = _original_sys_path
 
-    def size(self, dim: int | None = None):  # pragma: no cover - simple stub
-        if dim is None:
-            return (len(self._args),)
-        return 1
+if _real_torch is not None:
+    sys.modules[__name__] = _real_torch
+else:
+    if _stub_module is not None:
+        sys.modules[__name__] = _stub_module
 
-    def to(self, *_args: Any, **_kwargs: Any) -> "Tensor":
-        return self
+    from types import SimpleNamespace
+    from typing import Any, Tuple
 
-    @property
-    def device(self) -> str:  # pragma: no cover - simple stub
-        return "cpu"
+    __version__ = "0.0"
 
+    __all__ = [
+        "Tensor",
+        "tensor",
+        "manual_seed",
+        "cuda",
+        "topk",
+        "where",
+        "zeros_like",
+        "full_like",
+        "full",
+        "multinomial",
+        "sort",
+        "cumsum",
+        "softmax",
+        "cat",
+    ]
 
-def tensor(*args: Any, **kwargs: Any) -> Tensor:
-    return Tensor(*args, **kwargs)
+    class Tensor:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self._args = args
+            self._kwargs = kwargs
 
+        def clone(self) -> "Tensor":  # pragma: no cover - simple stub
+            return Tensor(*self._args, **self._kwargs)
 
-def manual_seed(_seed: int) -> None:  # pragma: no cover - deterministic stub
-    return None
+        def size(self, dim: int | None = None):  # pragma: no cover - simple stub
+            if dim is None:
+                return (len(self._args),)
+            return 1
 
+        def to(self, *_args: Any, **_kwargs: Any) -> "Tensor":
+            return self
 
-def _not_impl(*_args: Any, **_kwargs: Any) -> Tensor:  # pragma: no cover - guard
-    raise NotImplementedError("torch operations not available in offline stub")
+        @property
+        def device(self) -> str:  # pragma: no cover - simple stub
+            return "cpu"
 
+    def tensor(*args: Any, **kwargs: Any) -> Tensor:
+        return Tensor(*args, **kwargs)
 
-def topk(*args: Any, **kwargs: Any) -> Tuple[Tensor, Tensor]:
-    return Tensor(*args, **kwargs), Tensor(*args, **kwargs)
-
-
-def where(*args: Any, **kwargs: Any) -> Tensor:
-    return Tensor(*args, **kwargs)
-
-
-def zeros_like(*_args: Any, **_kwargs: Any) -> Tensor:
-    return Tensor()
-
-
-def full_like(*_args: Any, **_kwargs: Any) -> Tensor:
-    return Tensor()
-
-
-def full(shape: Tuple[int, ...], value: float, device: str | None = None) -> Tensor:
-    return Tensor(shape, value, device=device)
-
-
-def multinomial(*_args: Any, **_kwargs: Any) -> Tensor:
-    return Tensor()
-
-
-def sort(*_args: Any, **_kwargs: Any) -> Tuple[Tensor, Tensor]:
-    return Tensor(), Tensor()
-
-
-def cumsum(*_args: Any, **_kwargs: Any) -> Tensor:
-    return Tensor()
-
-
-def softmax(tensor_in: Tensor, dim: int = -1) -> Tensor:
-    return tensor_in
-
-
-def cat(tensors: Any, dim: int = 0) -> Tensor:
-    return Tensor(tensors, dim)
-
-
-class _CudaModule(SimpleNamespace):
-    def is_available(self) -> bool:  # pragma: no cover - offline stub
-        return False
-
-    def manual_seed_all(self, _seed: int) -> None:  # pragma: no cover
+    def manual_seed(_seed: int) -> None:  # pragma: no cover - deterministic stub
         return None
 
+    def topk(*args: Any, **kwargs: Any) -> Tuple[Tensor, Tensor]:
+        return Tensor(*args, **kwargs), Tensor(*args, **kwargs)
 
-cuda = _CudaModule()
+    def where(*args: Any, **kwargs: Any) -> Tensor:
+        return Tensor(*args, **kwargs)
+
+    def zeros_like(*_args: Any, **_kwargs: Any) -> Tensor:
+        return Tensor()
+
+    def full_like(*_args: Any, **_kwargs: Any) -> Tensor:
+        return Tensor()
+
+    def full(shape: Tuple[int, ...], value: float, device: str | None = None) -> Tensor:
+        return Tensor(shape, value, device=device)
+
+    def multinomial(*_args: Any, **_kwargs: Any) -> Tensor:
+        return Tensor()
+
+    def sort(*_args: Any, **_kwargs: Any) -> Tuple[Tensor, Tensor]:
+        return Tensor(), Tensor()
+
+    def cumsum(*_args: Any, **_kwargs: Any) -> Tensor:
+        return Tensor()
+
+    def softmax(tensor_in: Tensor, dim: int = -1) -> Tensor:
+        return tensor_in
+
+    def cat(tensors: Any, dim: int = 0) -> Tensor:
+        return Tensor(tensors, dim)
+
+    class _CudaModule(SimpleNamespace):
+        def is_available(self) -> bool:  # pragma: no cover - offline stub
+            return False
+
+        def manual_seed_all(self, _seed: int) -> None:  # pragma: no cover
+            return None
+
+    cuda = _CudaModule()


### PR DESCRIPTION
## Summary
- restore the Hydra shim so it imports the real package when present while keeping the fallback decorator wrapper
- reinstate OmegaConf delegation and expose the richer fallback stub (including MISSING) only when the real library is absent
- restore the torch shim to load the real module when installed and otherwise provide the lightweight tensor helpers

## Testing
- `ruff check hydra/__init__.py omegaconf/__init__.py torch/__init__.py --fix`
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68d0d521aa0c83319e164a7a023d6457