### PR TITLE
fix: restore torch shim helper imports

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -7,6 +7,79 @@ package, preventing the stub from shadowing it. If the import fails we expose a
 minimal subset of the API used by the lightweight tests.
 """
 
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any, Tuple
+
+__all__: list[str]
+
+
+def _load_real_module(name: str) -> ModuleType | None:
+    module_path = Path(__file__).resolve()
+    repo_root = module_path.parent.parent.resolve()
+    module_parts = Path(*name.split("."))
+    loader_name = f"_codex_real_{name.replace('.', '_')}"
+
+    candidate_roots: list[Path] = []
+    for entry in sys.path:
+        try:
+            path_obj = Path(entry).resolve()
+        except Exception:  # pragma: no cover - guard against non-path entries
+            continue
+        if path_obj == repo_root:
+            continue
+        candidate_roots.append(path_obj)
+
+    site_packages = [
+        repo_root
+        / ".venv"
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages",
+        repo_root
+        / "venv"
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages",
+    ]
+    candidate_roots.extend(site for site in site_packages if site.exists())
+
+    seen: set[str] = set()
+    unique_roots: list[Path] = []
+    for root in candidate_roots:
+        key = str(root)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_roots.append(root)
+
+    for root in unique_roots:
+        package_dir = root / module_parts
+        init_py = package_dir / "__init__.py"
+        if init_py.exists() and init_py.resolve() != module_path:
+            spec = importlib.util.spec_from_file_location(loader_name, init_py)
+        else:
+            module_py = package_dir.with_suffix(".py")
+            if not module_py.exists() or module_py.resolve() == module_path:
+                continue
+            spec = importlib.util.spec_from_file_location(loader_name, module_py)
+
+        if spec and spec.loader:
+            module = importlib.util.module_from_spec(spec)
+            sys.modules.setdefault(loader_name, module)
+            try:
+                spec.loader.exec_module(module)  # type: ignore[arg-type]
+            except Exception:  # pragma: no cover - fall back to stub on failure
+                sys.modules.pop(loader_name, None)
+                continue
+            return module
+    return None
+
+
 _real_module = _load_real_module("torch")
 
 if _real_module is not None:


### PR DESCRIPTION
## Summary
- add the standard module loader helper and required imports to the torch shim so it can delegate to a real installation when present
- preserve the lightweight offline fallback without raising NameError when PyTorch is absent

## Testing
- black torch/__init__.py
- ruff check torch/__init__.py --fix

------
https://chatgpt.com/codex/tasks/task_e_68d0ddb49644833192cda4cf9714aee0