### PR TITLE
Codex/expand zip file contents instead of zipping 2025 09 22 (follow-up: delay workflow disable)

### DIFF
--- a/codex_patch_runner.py
+++ b/codex_patch_runner.py
@@ -186,7 +186,6 @@ def gather_targets() -> List[Path]:
 
 
 def run_sequence(dry_run: bool = False) -> Dict[str, object]:
-    hard_disable_github_actions()
     applied: List[str] = []
     failed: List[str] = []
     if PATCHES_DIR.exists():
@@ -198,6 +197,8 @@ def run_sequence(dry_run: bool = False) -> Dict[str, object]:
                 applied.append(patch.name)
             else:
                 failed.append(patch.name)
+    if not dry_run:
+        hard_disable_github_actions()
     compile_code, out, err = run(
         [
             "python",


### PR DESCRIPTION
## Summary
- Updated the status emission to distinguish between empty patch directories and failed applications, and to list any failed patch names for audit logs.
- Tracked patch application failures in `run_sequence`, surfaced them in the JSON payload, and ensured the CLI exits non-zero whenever any patch fails to apply.
- Captured the `compileall` return code in `run_sequence`, included it in the emitted results, and ensured the CLI exits non-zero whenever the syntax check fails.
- Delayed disabling GitHub workflows until after pending patches are applied so workflow patches continue to apply cleanly.

## Testing
- python -m compileall codex_patch_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68d0de35f76c8331871fa857707a5e12