### PR TITLE
Restore torch stub version attribute

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -138,6 +138,9 @@ else:
         "cat",
     ]
 
+    __version__ = "0.0"
+    __all__.append("__version__")
+
     class Tensor:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             self._args = args


### PR DESCRIPTION
## Summary
- add a fallback `__version__` attribute to the offline torch stub so code accessing `torch.__version__` succeeds when PyTorch is unavailable

## Testing
- `black torch/__init__.py`
- `ruff check torch/__init__.py --fix`


------
https://chatgpt.com/codex/tasks/task_e_68d0e5c886748331b1cf3fa793b3577d