### PR TITLE
Add smoke tests for plugin and monitoring CLI commands

### DIFF
--- a/tests/test_monitoring_cli.py
+++ b/tests/test_monitoring_cli.py
@@ -1,0 +1,113 @@
+"""Smoke tests for the codex_ml.monitoring CLI utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("typer")
+
+from typer.testing import CliRunner
+
+from codex_ml.monitoring import cli as monitoring_cli
+
+
+@pytest.fixture()
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_inspect_reports_line_count(cli_runner: CliRunner, tmp_path: Path) -> None:
+    log_path = tmp_path / "events.ndjson"
+    log_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": 123.0,
+                        "run_id": "run-1",
+                        "phase": "train",
+                        "step": 1,
+                        "metric": "loss",
+                        "value": 0.5,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": 124.0,
+                        "run_id": "run-1",
+                        "phase": "eval",
+                        "step": 2,
+                        "metric": "accuracy",
+                        "value": 0.8,
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+
+    result = cli_runner.invoke(monitoring_cli.app, ["inspect", str(log_path)])
+
+    assert result.exit_code == 0
+    assert "'lines': 2" in result.stdout
+    assert str(log_path) in result.stdout
+
+
+def test_export_generates_csv(cli_runner: CliRunner, tmp_path: Path) -> None:
+    src = tmp_path / "telemetry.ndjson"
+    src.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": 1.0,
+                        "run_id": "run-A",
+                        "phase": "train",
+                        "step": 1,
+                        "split": "train",
+                        "metric": "loss",
+                        "value": 0.4,
+                        "dataset": "dummy",
+                        "meta": {"source": "unit-test"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": 2.0,
+                        "run_id": "run-A",
+                        "phase": "eval",
+                        "step": 2,
+                        "metric": "accuracy",
+                        "value": 0.9,
+                        "meta": {},
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    dst = tmp_path / "telemetry.csv"
+
+    result = cli_runner.invoke(monitoring_cli.app, ["export", str(src), str(dst)])
+
+    assert result.exit_code == 0
+    output_lines = dst.read_text().splitlines()
+    assert output_lines[0].startswith(
+        "version,ts,run_id,phase,step,split,dataset,metric,value,meta"
+    )
+    assert "unit-test" in output_lines[1]
+    assert "accuracy" in "".join(output_lines[1:])
+
+
+def test_export_rejects_unknown_format(cli_runner: CliRunner, tmp_path: Path) -> None:
+    src = tmp_path / "telemetry.ndjson"
+    src.write_text("{}\n")
+    dst = tmp_path / "telemetry.json"
+
+    result = cli_runner.invoke(monitoring_cli.app, ["export", str(src), str(dst), "--fmt", "json"])
+
+    assert result.exit_code != 0
+    assert "unsupported format" in result.stdout or "unsupported format" in result.stderr

--- a/tests/test_plugins_cli.py
+++ b/tests/test_plugins_cli.py
@@ -1,0 +1,86 @@
+"""Smoke tests for the codex_ml.plugins CLI commands."""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+
+import pytest
+
+pytest.importorskip("typer")
+
+from typer.testing import CliRunner
+
+from codex_ml.cli import plugins_cli
+from codex_ml.plugins import registries
+
+
+@pytest.fixture()
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def isolate_plugin_registries() -> Iterator[None]:
+    """Reset plugin registries so tests can freely register temporary plugins."""
+
+    groups = dict(plugins_cli._GROUPS)
+    snapshots = {name: reg._items.copy() for name, reg in groups.items()}
+    try:
+        yield
+    finally:
+        for name, reg in groups.items():
+            reg._items = snapshots[name]
+
+
+@pytest.fixture()
+def temporary_model_plugin(isolate_plugin_registries: None) -> Iterator[str]:
+    """Register a simple model plugin for exercising CLI commands."""
+
+    @registries.models.register("Example_Model", description="example")
+    def _model_plugin(multiplier: int = 2) -> int:
+        """Return a predictable integer so diagnostics can inspect it."""
+
+        return multiplier * 2
+
+    yield "example_model"
+
+    # Ensure the registry is cleaned up even if a test fails early.
+    with contextlib.suppress(KeyError):
+        del registries.models._items["example_model"]
+
+
+def test_list_command_shows_registered_plugin(
+    cli_runner: CliRunner, temporary_model_plugin: str
+) -> None:
+    result = cli_runner.invoke(plugins_cli.app, ["list", "models"])
+
+    assert result.exit_code == 0
+    assert temporary_model_plugin in result.stdout
+
+
+def test_diagnose_reports_registered_count(
+    cli_runner: CliRunner, temporary_model_plugin: str
+) -> None:
+    result = cli_runner.invoke(plugins_cli.app, ["diagnose", "models"])
+
+    assert result.exit_code == 0
+    assert "registered=1" in result.stdout
+
+
+def test_explain_outputs_module_and_docstring(
+    cli_runner: CliRunner, temporary_model_plugin: str
+) -> None:
+    result = cli_runner.invoke(plugins_cli.app, ["explain", "models", temporary_model_plugin])
+
+    assert result.exit_code == 0
+    assert "module: tests.test_plugins_cli" in result.stdout
+    assert "Return a predictable integer" in result.stdout
+    assert "(multiplier: int = 2) -> int" in result.stdout
+
+
+def test_unknown_group_exits_with_error(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(plugins_cli.app, ["list", "unknown"])
+
+    assert result.exit_code != 0
+    assert "unknown group" in result.stderr or "unknown group" in result.stdout


### PR DESCRIPTION
## Summary
- add smoke coverage for the plugins CLI, including listing, diagnostics, and explain output while using a temporary registry entry
- exercise the monitoring CLI inspect and export commands with lightweight NDJSON fixtures and unsupported-format handling

## Testing
- pytest tests/test_plugins_cli.py tests/test_monitoring_cli.py
- pre-commit run --files tests/test_plugins_cli.py tests/test_monitoring_cli.py src/codex_ml/plugins/registries.py

------
https://chatgpt.com/codex/tasks/task_e_68d105408d9c8331bc7f59338bf6b801