### PR TITLE
Improve codex CLI group defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Verified pending September patches already integrated for eval loop, Hydra entrypoint, deterministic loader, and telemetry defaults.
 - Disabled GitHub Actions workflows locally to enforce offline execution policy.
 - Ran targeted pytest suite (`tests/codex_ml`) to confirm evaluation logic and data loader wiring.
+- Clarified `codex` CLI group behaviour: invoking groups with no subcommand now prints contextual help and `codex run` with no task emits the whitelist banner.
 
 ## Mapping
 - Identified tokenization adapters in `src/codex_ml/tokenization/hf_tokenizer.py`.

--- a/docs/modules/cli.md
+++ b/docs/modules/cli.md
@@ -31,6 +31,11 @@ The repository also provides a lightweight maintenance CLI at
 python -m codex.cli tasks
 ```
 
+Running the bare group (`codex`, `codex logs`, `codex tokenizer`, or
+`codex repro`) prints contextual help explaining when to stay in this
+maintenance CLI versus jumping to the richer console scripts (for
+example `codex_ml.cli`).
+
 One useful utility is `pool-fix`, which resets the global tokenization
 thread pool and enables SQLite connection pooling for session logs. It
 accepts an optional `--max-workers` argument to limit the number of
@@ -39,6 +44,10 @@ threads and warm connections:
 ```bash
 python -m codex.cli run pool-fix
 ```
+
+Calling `codex run` without a task now prints the whitelisted task list
+along with a reminder to use `codex run <task>` to execute one of the
+entries.
 
 This can resolve hangs caused by runaway threads in tokenizers on some
 platforms.

--- a/tests/cli/test_repo_cli.py
+++ b/tests/cli/test_repo_cli.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from codex import cli as repo_cli
+
+
+def _runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_run_without_task_lists_whitelist():
+    runner = _runner()
+    result = runner.invoke(repo_cli.cli, ["run"])
+    assert result.exit_code == 0
+    output = result.output.strip()
+    assert output
+    assert "Whitelisted maintenance tasks" in output
+
+
+def test_run_with_invalid_task_errors():
+    runner = _runner()
+    result = runner.invoke(repo_cli.cli, ["run", "does-not-exist"])
+    assert result.exit_code != 0
+    assert "not allowed" in result.output
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        [],
+        ["logs"],
+        ["tokenizer"],
+        ["repro"],
+    ],
+)
+def test_groups_emit_help_when_no_subcommand(args):
+    runner = _runner()
+    result = runner.invoke(repo_cli.cli, args)
+    assert result.exit_code == 0
+    assert result.output.strip()
+    assert "Usage:" in result.output
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["bogus"],
+        ["logs", "bogus"],
+        ["tokenizer", "bogus"],
+        ["repro", "bogus"],
+    ],
+)
+def test_invalid_subcommands_exit_non_zero(args):
+    runner = _runner()
+    result = runner.invoke(repo_cli.cli, args)
+    assert result.exit_code != 0
+    assert "No such command" in result.output


### PR DESCRIPTION
## Summary
- ensure the `codex`, `logs`, `tokenizer`, and `repro` groups print contextual help when run without a subcommand and highlight the direct console scripts
- show the whitelisted task banner when `codex run` receives no task
- document the new behaviour and add CLI smoke tests to guard it

## Testing
- pytest tests/cli/test_repo_cli.py


------
https://chatgpt.com/codex/tasks/task_e_68d108e650f08331ac52e21605991a90