### PR TITLE
Handle psutil fallback and gate GPU sampling

### DIFF
--- a/tests/monitoring/test_system_metrics.py
+++ b/tests/monitoring/test_system_metrics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import time
+from typing import Optional
 
 import pytest
 
@@ -43,3 +44,115 @@ def test_sample_system_metrics_without_psutil(monkeypatch) -> None:
     proc = payload.get("process")
     if proc is not None:
         assert "cpu_percent" in proc or "memory_info" in proc
+
+
+def test_system_metrics_logger_warns_and_writes_stub(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, caplog
+) -> None:
+    monkeypatch.setattr(system_metrics, "psutil", None)
+    monkeypatch.setattr(system_metrics, "HAS_PSUTIL", False)
+    monkeypatch.setattr(
+        system_metrics,
+        "_CONFIG",
+        system_metrics.SystemMetricsConfig(use_psutil=True, poll_gpu=False, use_nvml=False),
+    )
+    monkeypatch.setattr(system_metrics, "_NVML_DISABLED", True)
+    monkeypatch.setattr(system_metrics, "_PSUTIL_WARNING_CONTEXTS", set())
+
+    caplog.set_level("WARNING")
+    path = tmp_path / "logger-metrics.jsonl"
+
+    logger = system_metrics.SystemMetricsLogger(path, interval=0.05)
+
+    warning_records = [
+        rec
+        for rec in caplog.records
+        if getattr(rec, "event", None) == "system_metrics.psutil_missing"
+    ]
+    assert warning_records, "expected psutil fallback warning"
+    first_warning = warning_records[0]
+    assert getattr(first_warning, "component", None) == "SystemMetricsLogger"
+    assert getattr(first_warning, "sampler", None) == "minimal"
+
+    logger.start()
+    try:
+        time.sleep(0.2)
+    finally:
+        logger.stop()
+
+    raw = path.read_text(encoding="utf-8").strip().splitlines()
+    assert raw, "expected fallback sampler to write records"
+    record = json.loads(raw[0])
+    assert record.get("memory") is None
+    assert "cpu_count" in record
+    assert "ts" in record
+
+
+def test_log_system_metrics_warns_and_writes_stub(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, caplog
+) -> None:
+    monkeypatch.setattr(system_metrics, "psutil", None)
+    monkeypatch.setattr(system_metrics, "HAS_PSUTIL", False)
+    monkeypatch.setattr(
+        system_metrics,
+        "_CONFIG",
+        system_metrics.SystemMetricsConfig(use_psutil=True, poll_gpu=False, use_nvml=False),
+    )
+    monkeypatch.setattr(system_metrics, "_NVML_DISABLED", True)
+    monkeypatch.setattr(system_metrics, "_PSUTIL_WARNING_CONTEXTS", set())
+
+    caplog.set_level("WARNING")
+    path = tmp_path / "loop-metrics.jsonl"
+
+    class DummyEvent:
+        def __init__(self) -> None:
+            self._flag = False
+
+        def set(self) -> None:
+            self._flag = True
+
+        def is_set(self) -> bool:
+            return self._flag
+
+        def wait(self, timeout: Optional[float] = None) -> bool:
+            self._flag = True
+            return True
+
+    class DummyThread:
+        def __init__(self, *args, **kwargs) -> None:
+            self._target = kwargs.get("target") or (args[0] if args else None)
+            self._alive = False
+
+        def start(self) -> None:
+            self._alive = True
+            try:
+                if self._target:
+                    self._target()
+            finally:
+                self._alive = False
+
+        def is_alive(self) -> bool:
+            return self._alive
+
+        def join(self, timeout: Optional[float] = None) -> None:
+            self._alive = False
+
+    monkeypatch.setattr(system_metrics.threading, "Event", DummyEvent)
+    monkeypatch.setattr(system_metrics.threading, "Thread", DummyThread)
+
+    system_metrics.log_system_metrics(path, interval=0.01)
+
+    warning_records = [
+        rec
+        for rec in caplog.records
+        if getattr(rec, "event", None) == "system_metrics.psutil_missing"
+    ]
+    assert any(
+        getattr(record, "component", None) == "log_system_metrics" for record in warning_records
+    ), "expected warning from log_system_metrics fallback"
+
+    raw = path.read_text(encoding="utf-8").strip().splitlines()
+    assert raw, "expected fallback sampler to write records"
+    payload = json.loads(raw[0])
+    assert payload.get("memory") is None
+    assert "cpu_count" in payload


### PR DESCRIPTION
## Summary
- add explicit GPU opt-in flag and psutil availability guard so samplers degrade to the minimal collector when psutil is missing
- update background/system metrics loop helpers to emit structured warnings and skip psutil-dependent paths when unavailable
- extend regression tests and monitoring guide to cover the fallback behaviour and new configuration flag

## Testing
- pytest tests/monitoring/test_system_metrics.py tests/test_monitoring.py

------
https://chatgpt.com/codex/tasks/task_e_68d109f1d7748331a0c6d1a748ff9b51