### PR TITLE
Add Typer CLI tests for plugin and monitoring commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased - 2025-09-21
+- Added Typer-based CLI tests that cover plugin registry introspection and monitoring NDJSON export flows offline.
 - Added offline stub modules for yaml/omegaconf/hydra/torch to keep quick CLI tests running without external deps.
 - Verified pending September patches already integrated for eval loop, Hydra entrypoint, deterministic loader, and telemetry defaults.
 - Disabled GitHub Actions workflows locally to enforce offline execution policy.

--- a/docs/ops/monitoring.md
+++ b/docs/ops/monitoring.md
@@ -22,6 +22,11 @@ python -m codex_ml.cli.main --enable-wandb --mlflow-enable
 python -m codex_ml.cli train-model --config configs/training/base.yaml --system-metrics AUTO --system-metrics-interval 15
 ```
 
+### Test coverage
+
+- `tests/cli/test_monitoring_cli.py` exercises the Typer commands (`inspect` and `export`) against temporary NDJSON data to keep
+  the CLI working offline. Companion coverage in `tests/cli/test_plugins_cli.py` verifies plugin registry inspection commands.
+
 ### Viewing
 
 - TensorBoard: `tensorboard --logdir runs/demo/tensorboard`

--- a/tests/cli/test_monitoring_cli.py
+++ b/tests/cli/test_monitoring_cli.py
@@ -1,0 +1,116 @@
+"""Typer CLI coverage for monitoring NDJSON utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("typer")
+from typer.testing import CliRunner
+
+from codex_ml.monitoring import cli as monitoring_cli
+
+
+@pytest.fixture()
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
+def _write_ndjson(path: Path, records: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+def test_inspect_reports_line_count(cli_runner: CliRunner, tmp_path: Path) -> None:
+    log_path = tmp_path / "events.ndjson"
+    _write_ndjson(
+        log_path,
+        [
+            {
+                "ts": 1.0,
+                "run_id": "run-a",
+                "phase": "train",
+                "step": 1,
+                "metric": "loss",
+                "value": 0.5,
+            },
+            {
+                "ts": 2.0,
+                "run_id": "run-a",
+                "phase": "eval",
+                "step": 2,
+                "metric": "accuracy",
+                "value": 0.8,
+            },
+        ],
+    )
+
+    result = cli_runner.invoke(monitoring_cli.app, ["inspect", str(log_path)])
+
+    assert result.exit_code == 0
+    assert "'lines': 2" in result.stdout
+    assert str(log_path) in result.stdout
+
+
+def test_export_generates_csv(cli_runner: CliRunner, tmp_path: Path) -> None:
+    src = tmp_path / "telemetry.ndjson"
+    _write_ndjson(
+        src,
+        [
+            {
+                "ts": 3.0,
+                "run_id": "demo",
+                "phase": "train",
+                "step": 3,
+                "split": "train",
+                "dataset": "demo-set",
+                "metric": "loss",
+                "value": 0.4,
+                "meta": {"source": "unit-test"},
+            },
+            {
+                "ts": 4.0,
+                "run_id": "demo",
+                "phase": "eval",
+                "step": 4,
+                "metric": "accuracy",
+                "value": 0.9,
+                "meta": {},
+            },
+        ],
+    )
+    dst = tmp_path / "telemetry.csv"
+
+    result = cli_runner.invoke(monitoring_cli.app, ["export", str(src), str(dst)])
+
+    assert result.exit_code == 0
+    output_lines = dst.read_text().splitlines()
+    assert output_lines[0].startswith(
+        "version,ts,run_id,phase,step,split,dataset,metric,value,meta"
+    )
+    assert "unit-test" in output_lines[1]
+    assert any("accuracy" in line for line in output_lines[1:])
+
+
+def test_export_rejects_unknown_format(cli_runner: CliRunner, tmp_path: Path) -> None:
+    src = tmp_path / "telemetry.ndjson"
+    _write_ndjson(
+        src,
+        [
+            {
+                "ts": 1.0,
+                "run_id": "demo",
+                "phase": "train",
+                "step": 1,
+                "metric": "loss",
+                "value": 0.1,
+            }
+        ],
+    )
+    dst = tmp_path / "telemetry.json"
+
+    result = cli_runner.invoke(monitoring_cli.app, ["export", str(src), str(dst), "--fmt", "json"])
+
+    assert result.exit_code != 0
+    assert "unsupported format" in result.stdout or "unsupported format" in result.stderr

--- a/tests/cli/test_plugins_cli.py
+++ b/tests/cli/test_plugins_cli.py
@@ -1,0 +1,102 @@
+"""Typer CLI coverage for the codex_ml plugin registry helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import pytest
+
+pytest.importorskip("typer")
+from typer.testing import CliRunner
+
+from codex_ml.cli import plugins_cli
+
+
+@dataclass
+class _RegistryItem:
+    obj: Callable[..., object]
+
+
+class _DummyRegistry:
+    """Minimal stand-in for the Typer CLI registry helpers."""
+
+    def __init__(self, item: _RegistryItem) -> None:
+        self._item = item
+
+    def names(self) -> tuple[str, ...]:
+        return ("demo_plugin",)
+
+    def get(self, name: str) -> _RegistryItem | None:
+        if name == "demo_plugin":
+            return self._item
+        return None
+
+    def load_from_entry_points(
+        self, group: str, require_api: str | None = None
+    ) -> tuple[dict[str, _RegistryItem], dict[str, str]]:
+        return {"demo_plugin": self._item}, {}
+
+
+def demo_plugin(multiplier: int = 2) -> int:
+    """Return a predictable value so CLI explain output is stable."""
+
+    return multiplier * 2
+
+
+@pytest.fixture()
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def stubbed_registry(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
+    registry = _DummyRegistry(_RegistryItem(obj=demo_plugin))
+    monkeypatch.setattr(plugins_cli, "_GROUPS", {"demo": registry})
+    return "demo", "demo_plugin"
+
+
+def test_list_displays_stubbed_plugin(
+    cli_runner: CliRunner, stubbed_registry: tuple[str, str]
+) -> None:
+    group, plugin = stubbed_registry
+
+    result = cli_runner.invoke(plugins_cli.app, ["list", group])
+
+    assert result.exit_code == 0
+    assert plugin in result.stdout
+
+
+def test_diagnose_reports_registered_count(
+    cli_runner: CliRunner, stubbed_registry: tuple[str, str]
+) -> None:
+    group, _ = stubbed_registry
+
+    result = cli_runner.invoke(plugins_cli.app, ["diagnose", group])
+
+    assert result.exit_code == 0
+    assert "registered=1" in result.stdout
+
+
+def test_explain_emits_module_doc_and_signature(
+    cli_runner: CliRunner, stubbed_registry: tuple[str, str]
+) -> None:
+    group, plugin = stubbed_registry
+
+    result = cli_runner.invoke(plugins_cli.app, ["explain", group, plugin])
+
+    assert result.exit_code == 0
+    assert "module: tests.cli.test_plugins_cli" in result.stdout
+    assert "Return a predictable value" in result.stdout
+    assert "(multiplier: int = 2) -> int" in result.stdout
+
+
+def test_diagnose_entry_point_mode_uses_stub(
+    cli_runner: CliRunner, stubbed_registry: tuple[str, str]
+) -> None:
+    group, _ = stubbed_registry
+
+    result = cli_runner.invoke(plugins_cli.app, ["diagnose", group, "--use-entry-points"])
+
+    assert result.exit_code == 0
+    assert "registered=1" in result.stdout


### PR DESCRIPTION
## Summary
- add typer-based CLI coverage for plugin registry commands with a stubbed registry
- exercise monitoring CLI inspect/export commands against NDJSON fixtures and error paths
- document the new CLI test coverage in the monitoring ops guide and changelog

## Testing
- pytest tests/cli/test_plugins_cli.py tests/cli/test_monitoring_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d10a4483ac83319597a7658097cd06