### PR TITLE
Handle system metrics fallback without psutil

### DIFF
--- a/docs/ops/monitoring.md
+++ b/docs/ops/monitoring.md
@@ -31,7 +31,7 @@ All executions run locally via CLI. Do NOT activate any GitHub Actions online fi
 
 ## System metrics logging
 
-- `codex_ml.monitoring.system_metrics.SystemMetricsLogger` uses `psutil` to capture CPU utilisation, memory statistics, load averages, and per-process usage. When `psutil` is missing or disabled the module emits a structured `system_metrics.psutil_missing` warning (and `system_metrics.dependency_missing` during import failures) and falls back to a minimal CPU-only sampler (load averages, heuristic CPU %, and process RSS where available). Requested GPU telemetry is gated behind NVIDIA's NVML bindings; when NVML is absent or fails to initialise the logger records `system_metrics.nvml_missing` and continues streaming CPU-only payloads.
+- `codex_ml.monitoring.system_metrics.SystemMetricsLogger` uses `psutil` to capture CPU utilisation, memory statistics, load averages, and per-process usage. When `psutil` is missing or disabled the module emits structured `system_metrics.psutil_missing` and `system_metrics.logger_disabled` warnings (alongside `system_metrics.dependency_missing` during import failures) and the background logger becomes a no-op. Callers can still invoke `sample_system_metrics()` to retrieve a lightweight pure-Python snapshot (load averages, heuristic CPU %, and process RSS where available) and inspect the `SYSTEM_METRICS_DEGRADED` flag to detect the reduced capability. Requested GPU telemetry is gated behind NVIDIA's NVML bindings; when NVML is absent or fails to initialise the sampler records `system_metrics.nvml_missing` and continues streaming CPU-only payloads.
 - Enable the logger via training CLI flag `--system-metrics`. Passing `AUTO` (or omitting a value) writes to `<checkpoint_dir>/system_metrics.jsonl`; provide a relative or absolute path to redirect output.
 - Control sampling cadence with `--system-metrics-interval <seconds>` (minimum 0.1 s). Records are newline-delimited JSON objects.
 - Feature flags: set `CODEX_MONITORING_ENABLE_PSUTIL=0` to skip psutil entirely. GPU telemetry is opt-in via `CODEX_MONITORING_ENABLE_GPU=1` (optionally `CODEX_MONITORING_ENABLE_NVML=1` for NVML-backed metrics); force-disable it with `CODEX_MONITORING_DISABLE_GPU=1` or `configure_system_metrics(poll_gpu=False)`. Set `CODEX_DISABLE_NVML=1` to skip NVML imports altogether—`system_metrics.nvml_disabled` is logged at INFO level and the sampler remains CPU-only.
@@ -67,4 +67,6 @@ initialise NVML, or `CODEX_MONITORING_DISABLE_GPU=1`/`configure_system_metrics(p
 to keep sampling CPU-only environments quiet. Administrators can also set
 `CODEX_DISABLE_NVML=1` to short-circuit NVML probing. When dependencies are missing the sampler
 degrades gracefully with structured warnings (`system_metrics.psutil_missing`,
-`system_metrics.nvml_missing`/`system_metrics.nvml_disabled`) and minimal telemetry.
+`system_metrics.logger_disabled`, `system_metrics.nvml_missing`/`system_metrics.nvml_disabled`)
+and minimal telemetry is still available via `sample_system_metrics()`. The module exposes
+`SYSTEM_METRICS_DEGRADED` so callers can detect when psutil-backed sampling is unavailable.

--- a/tests/monitoring/test_system_metrics.py
+++ b/tests/monitoring/test_system_metrics.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Optional
 
 import pytest
 
@@ -46,7 +45,7 @@ def test_sample_system_metrics_without_psutil(monkeypatch) -> None:
         assert "cpu_percent" in proc or "memory_info" in proc
 
 
-def test_system_metrics_logger_warns_and_writes_stub(
+def test_system_metrics_logger_warns_and_noops(
     monkeypatch: pytest.MonkeyPatch, tmp_path, caplog
 ) -> None:
     monkeypatch.setattr(system_metrics, "psutil", None)
@@ -58,37 +57,43 @@ def test_system_metrics_logger_warns_and_writes_stub(
     )
     monkeypatch.setattr(system_metrics, "_NVML_DISABLED", True)
     monkeypatch.setattr(system_metrics, "_PSUTIL_WARNING_CONTEXTS", set())
+    monkeypatch.setattr(system_metrics, "_LOGGER_WARNING_CONTEXTS", set())
+    monkeypatch.setattr(system_metrics, "SYSTEM_METRICS_DEGRADED", False)
 
     caplog.set_level("WARNING")
     path = tmp_path / "logger-metrics.jsonl"
 
     logger = system_metrics.SystemMetricsLogger(path, interval=0.05)
+    assert system_metrics.SYSTEM_METRICS_DEGRADED is True
 
-    warning_records = [
+    logger.start()
+    logger.stop()
+
+    assert getattr(logger, "_noop", False) is True
+    assert not path.exists(), "no-op logger should not emit files"
+
+    missing_psutil = [
         rec
         for rec in caplog.records
         if getattr(rec, "event", None) == "system_metrics.psutil_missing"
     ]
-    assert warning_records, "expected psutil fallback warning"
-    first_warning = warning_records[0]
+    assert missing_psutil, "expected psutil fallback warning"
+    first_warning = missing_psutil[0]
     assert getattr(first_warning, "component", None) == "SystemMetricsLogger"
     assert getattr(first_warning, "sampler", None) == "minimal"
 
-    logger.start()
-    try:
-        time.sleep(0.2)
-    finally:
-        logger.stop()
-
-    raw = path.read_text(encoding="utf-8").strip().splitlines()
-    assert raw, "expected fallback sampler to write records"
-    record = json.loads(raw[0])
-    assert record.get("memory") is None
-    assert "cpu_count" in record
-    assert "ts" in record
+    noop_records = [
+        rec
+        for rec in caplog.records
+        if getattr(rec, "event", None) == "system_metrics.logger_disabled"
+    ]
+    assert noop_records, "expected no-op logger warning"
+    first_noop = noop_records[0]
+    assert getattr(first_noop, "component", None) == "SystemMetricsLogger"
+    assert "psutil" in getattr(first_noop, "missing", [])
 
 
-def test_log_system_metrics_warns_and_writes_stub(
+def test_log_system_metrics_warns_and_noops(
     monkeypatch: pytest.MonkeyPatch, tmp_path, caplog
 ) -> None:
     monkeypatch.setattr(system_metrics, "psutil", None)
@@ -100,59 +105,31 @@ def test_log_system_metrics_warns_and_writes_stub(
     )
     monkeypatch.setattr(system_metrics, "_NVML_DISABLED", True)
     monkeypatch.setattr(system_metrics, "_PSUTIL_WARNING_CONTEXTS", set())
+    monkeypatch.setattr(system_metrics, "_LOGGER_WARNING_CONTEXTS", set())
+    monkeypatch.setattr(system_metrics, "SYSTEM_METRICS_DEGRADED", False)
 
     caplog.set_level("WARNING")
     path = tmp_path / "loop-metrics.jsonl"
 
-    class DummyEvent:
-        def __init__(self) -> None:
-            self._flag = False
-
-        def set(self) -> None:
-            self._flag = True
-
-        def is_set(self) -> bool:
-            return self._flag
-
-        def wait(self, timeout: Optional[float] = None) -> bool:
-            self._flag = True
-            return True
-
-    class DummyThread:
-        def __init__(self, *args, **kwargs) -> None:
-            self._target = kwargs.get("target") or (args[0] if args else None)
-            self._alive = False
-
-        def start(self) -> None:
-            self._alive = True
-            try:
-                if self._target:
-                    self._target()
-            finally:
-                self._alive = False
-
-        def is_alive(self) -> bool:
-            return self._alive
-
-        def join(self, timeout: Optional[float] = None) -> None:
-            self._alive = False
-
-    monkeypatch.setattr(system_metrics.threading, "Event", DummyEvent)
-    monkeypatch.setattr(system_metrics.threading, "Thread", DummyThread)
-
     system_metrics.log_system_metrics(path, interval=0.01)
 
-    warning_records = [
+    missing_psutil = [
         rec
         for rec in caplog.records
         if getattr(rec, "event", None) == "system_metrics.psutil_missing"
     ]
     assert any(
-        getattr(record, "component", None) == "log_system_metrics" for record in warning_records
+        getattr(record, "component", None) == "log_system_metrics" for record in missing_psutil
     ), "expected warning from log_system_metrics fallback"
 
-    raw = path.read_text(encoding="utf-8").strip().splitlines()
-    assert raw, "expected fallback sampler to write records"
-    payload = json.loads(raw[0])
-    assert payload.get("memory") is None
-    assert "cpu_count" in payload
+    noop_records = [
+        rec
+        for rec in caplog.records
+        if getattr(rec, "event", None) == "system_metrics.logger_disabled"
+    ]
+    assert noop_records, "expected log_system_metrics to issue no-op warning"
+    noop = noop_records[0]
+    assert getattr(noop, "component", None) == "log_system_metrics"
+    assert "psutil" in getattr(noop, "missing", [])
+    assert system_metrics.SYSTEM_METRICS_DEGRADED is True
+    assert not path.exists(), "no-op log_system_metrics should not write output"


### PR DESCRIPTION
## Summary
- add a degraded-mode flag and structured no-op warnings when system metrics logging is unavailable
- allow the background logger to short-circuit when psutil/NVML are absent while keeping minimal sampling via `sample_system_metrics`
- document the fallback behaviour and extend tests to cover the no-op path when psutil is unavailable

## Testing
- pytest tests/monitoring/test_system_metrics.py
- pre-commit run --files src/codex_ml/monitoring/system_metrics.py docs/ops/monitoring.md tests/monitoring/test_system_metrics.py


------
https://chatgpt.com/codex/tasks/task_e_68d112b3616c8331bfb67007e48c730d