### PR TITLE
Seed tiny offline fixtures and registry tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,14 @@ runs/
 site/
 reports/*
 artifacts/*
+!artifacts/models/
+!artifacts/models/tiny_tokenizer/
+!artifacts/models/tiny_tokenizer/vocab.json
+!artifacts/models/tiny_sequence_model/
+!artifacts/models/tiny_sequence_model/model.json
+!artifacts/rl/
+!artifacts/rl/scripted_agent/
+!artifacts/rl/scripted_agent/policy.json
 logs/*
 .codex/validation/
 validation.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Populated offline model/data/metric registries with guarded GPT-2, TinyLLaMA, and tiny corpus fixtures plus Hydra config snippets and regression tests.
 - Seeded the plugin catalogues with offline-ready defaults (GPT-2, TinyLLaMA, tiny corpus, weighted accuracy) and extended docs/quickstart guidance on optional usage versus minimal setups.
 - Added offline functional trainer and heuristic reward-model shims, CLI discovery tests, and a composite `offline/catalogue` config for one-command baseline activation.
+- Introduced ultra-light offline fixtures (tiny vocabulary/model, scripted agent, length reward) with registry entries, Hydra preset (`offline/tiny_fixtures`), and integration tests for graceful error messages.
 
 ## Mapping
 - Identified tokenization adapters in `src/codex_ml/tokenization/hf_tokenizer.py`.

--- a/artifacts/models/tiny_sequence_model/model.json
+++ b/artifacts/models/tiny_sequence_model/model.json
@@ -1,0 +1,14 @@
+{
+  "description": "A scripted offline sequence generator for smoke tests.",
+  "responses": [
+    {
+      "prefix": "hello",
+      "completion": "offline world"
+    },
+    {
+      "prefix": "offline",
+      "completion": "catalogue ready"
+    }
+  ],
+  "default_completion": "tiny offline model"
+}

--- a/artifacts/models/tiny_tokenizer/vocab.json
+++ b/artifacts/models/tiny_tokenizer/vocab.json
@@ -1,0 +1,8 @@
+{
+  "<pad>": 0,
+  "<unk>": 1,
+  "hello": 2,
+  "offline": 3,
+  "world": 4,
+  "catalogue": 5
+}

--- a/artifacts/rl/scripted_agent/policy.json
+++ b/artifacts/rl/scripted_agent/policy.json
@@ -1,0 +1,7 @@
+{
+  "actions": [1, 0, 1, 1],
+  "loop": true,
+  "metadata": {
+    "description": "Deterministic offline policy for registry smoke tests."
+  }
+}

--- a/configs/model/offline/tiny_sequence.yaml
+++ b/configs/model/offline/tiny_sequence.yaml
@@ -1,0 +1,9 @@
+# Offline scripted sequence model configuration.
+# Uses the JSON payload stored in artifacts/models/tiny_sequence_model.
+defaults:
+  - override /model: base
+
+model:
+  name: offline:tiny-sequence
+  local_path: ${oc.env:CODEX_ML_TINY_SEQUENCE_PATH,${oc.env:CODEX_ML_OFFLINE_MODELS_DIR,${hydra:runtime.cwd}/artifacts/models/tiny_sequence_model}}
+  local_files_only: true

--- a/configs/offline/tiny_fixtures.yaml
+++ b/configs/offline/tiny_fixtures.yaml
@@ -1,0 +1,38 @@
+# Offline preset that exclusively relies on the seeded tiny fixtures.
+defaults:
+  - env: ubuntu
+  - model: offline/tiny_sequence
+  - data: offline/tiny_corpus
+  - logging: base
+  - training: offline/tiny_functional
+  - tokenizer: offline/tiny_vocab
+  - tracking: base
+  - pipeline_inputs: smoke
+  - interfaces: offline
+  - _self_
+
+tokenizer:
+  plugin: offline:tiny-vocab
+
+model:
+  plugin: offline:tiny-sequence
+
+trainer:
+  plugin: offline:functional
+  config_path: ${oc.env:CODEX_ML_FUNCTIONAL_TRAINER_CONFIG,${oc.env:CODEX_ML_OFFLINE_CONFIGS_DIR,${hydra:runtime.cwd}/data/offline/trainer_functional.json}}}
+
+reward_model:
+  plugin: offline:length
+  config_path: ${oc.env:CODEX_ML_LENGTH_REWARD_PATH,${oc.env:CODEX_ML_OFFLINE_METRICS_DIR,${hydra:runtime.cwd}/data/offline/length_reward.json}}}
+
+rl_agent:
+  plugin: offline:scripted
+  policy_path: ${oc.env:CODEX_ML_SCRIPTED_AGENT_PATH,${oc.env:CODEX_ML_OFFLINE_RL_DIR,${hydra:runtime.cwd}/artifacts/rl/scripted_agent/policy.json}}}
+
+eval:
+  datasets: []
+  metrics:
+    - offline:weighted-accuracy
+  metric_params:
+    offline:weighted-accuracy:
+      weights_path: ${oc.env:CODEX_ML_WEIGHTED_ACCURACY_PATH,${oc.env:CODEX_ML_OFFLINE_METRICS_DIR,${hydra:runtime.cwd}/data/offline/weighted_accuracy.json}}}

--- a/configs/tokenizer/offline/tiny_vocab.yaml
+++ b/configs/tokenizer/offline/tiny_vocab.yaml
@@ -1,0 +1,8 @@
+# Offline tiny vocabulary tokenizer configuration.
+# Points the tokenizer registry at the static vocab stored in artifacts/models/tiny_tokenizer.
+defaults:
+  - override /tokenizer: base
+
+tokenizer:
+  name: offline:tiny-vocab
+  name_or_path: ${oc.env:CODEX_ML_TINY_TOKENIZER_PATH,${oc.env:CODEX_ML_OFFLINE_MODELS_DIR,${hydra:runtime.cwd}/artifacts/models/tiny_tokenizer}}

--- a/configs/training/offline/tiny_functional.yaml
+++ b/configs/training/offline/tiny_functional.yaml
@@ -1,0 +1,20 @@
+# Offline-first training defaults that exclusively use the tiny fixtures.
+defaults:
+  - override /training: base
+
+training:
+  model:
+    name: offline:tiny-sequence
+    local_files_only: true
+    local_path: ${oc.env:CODEX_ML_TINY_SEQUENCE_PATH,${oc.env:CODEX_ML_OFFLINE_MODELS_DIR,${hydra:runtime.cwd}/artifacts/models/tiny_sequence_model}}
+  tokenizer:
+    name: offline:tiny-vocab
+    name_or_path: ${oc.env:CODEX_ML_TINY_TOKENIZER_PATH,${oc.env:CODEX_ML_OFFLINE_MODELS_DIR,${hydra:runtime.cwd}/artifacts/models/tiny_tokenizer}}
+  dataset:
+    train_path: ${oc.env:CODEX_ML_TINY_CORPUS_PATH,${oc.env:CODEX_ML_OFFLINE_DATASETS_DIR,${hydra:runtime.cwd}/data/offline/tiny_corpus.txt}}
+    eval_path: null
+    format: text
+    shuffle: false
+  trainer:
+    name: offline:functional
+    config_path: ${oc.env:CODEX_ML_FUNCTIONAL_TRAINER_CONFIG,${oc.env:CODEX_ML_OFFLINE_CONFIGS_DIR,${hydra:runtime.cwd}/data/offline/trainer_functional.json}}}

--- a/data/offline/length_reward.json
+++ b/data/offline/length_reward.json
@@ -1,0 +1,5 @@
+{
+  "scale": 0.25,
+  "offset": 1.0,
+  "notes": "Favour slightly longer completions while staying deterministic."
+}

--- a/data/offline/trainer_functional.json
+++ b/data/offline/trainer_functional.json
@@ -1,0 +1,6 @@
+{
+  "learning_rate": 0.001,
+  "gradient_accumulation_steps": 1,
+  "max_steps": 3,
+  "log_interval": 1
+}

--- a/docs/guides/offline_catalogue.md
+++ b/docs/guides/offline_catalogue.md
@@ -1,9 +1,9 @@
 # Offline default catalogue
 
 Codex ML now ships a small catalogue of offline-ready components spanning
-models, tokenizers, datasets and metrics.  This guide summarises the expected
-local file layout and shows how to activate each default without relying on
-network access.
+models, tokenizers, datasets, metrics, trainers, reward models and RL agents.
+This guide summarises the expected local file layout and shows how to activate
+each default without relying on network access.
 
 ## Directory layout
 
@@ -22,11 +22,20 @@ artifacts/
       pytorch_model.bin
       tokenizer.model
       tokenizer_config.json
+    tiny_sequence_model/
+      model.json
+    tiny_tokenizer/
+      vocab.json
+  rl/
+    scripted_agent/
+      policy.json
 
 data/
   offline/
     tiny_corpus.txt
     weighted_accuracy.json
+    length_reward.json
+    trainer_functional.json
 ```
 
 You may also point the loaders at bespoke directories via the following
@@ -39,6 +48,13 @@ environment variables:
 - `CODEX_ML_TINY_CORPUS_PATH`
 - `CODEX_ML_OFFLINE_METRICS_DIR`
 - `CODEX_ML_WEIGHTED_ACCURACY_PATH`
+- `CODEX_ML_TINY_TOKENIZER_PATH`
+- `CODEX_ML_TINY_SEQUENCE_PATH`
+- `CODEX_ML_FUNCTIONAL_TRAINER_CONFIG`
+- `CODEX_ML_OFFLINE_CONFIGS_DIR`
+- `CODEX_ML_LENGTH_REWARD_PATH`
+- `CODEX_ML_SCRIPTED_AGENT_PATH`
+- `CODEX_ML_OFFLINE_RL_DIR`
 
 ## Hydra overrides
 
@@ -72,19 +88,47 @@ python -m codex_ml.cli evaluate -cn config metrics/offline/weighted_accuracy
 The fragments live under `configs/{model,tokenizer,data,metrics}/offline/` and
 mirror the directory layout above.
 
+## Tiny fixtures preset
+
+For completely dependency-free smoke tests the repository now includes a "tiny"
+stack of fixtures: a six-token vocabulary, a scripted response model, a
+deterministic trainer configuration, a JSON-configurable length-based reward
+model and a scripted RL policy. Enable them with the dedicated preset:
+
+```bash
+python -m codex_ml.cli train -cn offline/tiny_fixtures
+```
+
+The preset wires in the following plugin entries:
+
+| Component      | Plugin name             | Fixture location |
+|----------------|-------------------------|------------------|
+| Tokenizer      | `offline:tiny-vocab`    | `artifacts/models/tiny_tokenizer/vocab.json` |
+| Model          | `offline:tiny-sequence` | `artifacts/models/tiny_sequence_model/model.json` |
+| Dataset        | `offline:tiny-corpus`   | `data/offline/tiny_corpus.txt` |
+| Metric         | `offline:weighted-accuracy` | `data/offline/weighted_accuracy.json` |
+| Trainer        | `offline:functional`    | `data/offline/trainer_functional.json` |
+| Reward model   | `offline:length`        | `data/offline/length_reward.json` |
+| RL agent       | `offline:scripted`      | `artifacts/rl/scripted_agent/policy.json` |
+
+Each fixture can be overridden with the environment variables listed above, so
+air-gapped deployments can swap in bespoke assets without editing the repo.
+
 ## Accessing the catalogue programmatically
 
 The plugin registries expose the same defaults so integration tests and user
 code can fetch components without importing the lower-level registries:
 
 ```python
-from codex_ml.plugins.registries import datasets, metrics, models, reward_models, trainers
+from codex_ml.plugins.registries import datasets, metrics, models, reward_models, rl_agents, tokenizers, trainers
 
-model = models.resolve_and_instantiate("gpt2-offline", {"local_path": "./artifacts/models/gpt2"})
-records = datasets.resolve_and_instantiate("offline:tiny-corpus", path="./data/offline/tiny_corpus.txt")
+tokenizer = tokenizers.resolve_and_instantiate("offline:tiny-vocab")
+model = models.resolve_and_instantiate("offline:tiny-sequence")
+records = datasets.resolve_and_instantiate("offline:tiny-corpus")
 weighted_acc = metrics.resolve_and_instantiate("offline:weighted-accuracy")
 trainer = trainers.resolve_and_instantiate("offline:functional")
-heuristic_rm = reward_models.resolve_and_instantiate("offline:heuristic")
+length_rm = reward_models.resolve_and_instantiate("offline:length")
+agent = rl_agents.resolve_and_instantiate("offline:scripted")
 ```
 
 Missing files raise `FileNotFoundError` with the list of searched locations,
@@ -116,6 +160,10 @@ with the tiny built-ins:
 - Use `tokenizer.name=hf` with `name_or_path` pointing to a minimal vocabulary.
 - Remove `data=offline/tiny_corpus` and supply your own `dataset_loader.path`.
 - Drop `metrics/offline/weighted_accuracy` to avoid shipping JSON weights.
+- Swap `reward_model.plugin=offline:length` for `offline:heuristic` when you
+  prefer fully in-memory behaviour.
+- Replace `rl_agent.plugin=offline:scripted` with your own policy loader if the
+  scripted agent is too opinionated.
 
 These choices keep the installation lightweight while leaving the offline
 catalogue available for teams that need reproducible baselines.

--- a/src/codex_ml/models/offline_tiny.py
+++ b/src/codex_ml/models/offline_tiny.py
@@ -1,0 +1,53 @@
+"""Minimal offline-friendly model used for registry smoke tests."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Sequence
+
+
+@dataclass
+class ResponseRule:
+    prefix: str
+    completion: str
+
+
+class TinySequenceModel:
+    """Return scripted completions using prefix matching."""
+
+    def __init__(self, rules: Sequence[ResponseRule], *, default_completion: str) -> None:
+        self.rules = list(rules)
+        self.default_completion = default_completion
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "TinySequenceModel":
+        responses = [
+            ResponseRule(prefix=str(entry["prefix"]), completion=str(entry["completion"]))
+            for entry in payload.get("responses", [])
+        ]
+        default = str(payload.get("default_completion", ""))
+        return cls(responses, default_completion=default)
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "TinySequenceModel":
+        candidate = Path(path)
+        if candidate.is_dir():
+            candidate = candidate / "model.json"
+        if not candidate.exists():
+            raise FileNotFoundError(f"Model fixture not found at {candidate}")
+        payload: Dict[str, Any] = json.loads(candidate.read_text(encoding="utf-8"))
+        return cls.from_payload(payload)
+
+    def generate(self, prompt: str) -> str:
+        for rule in self.rules:
+            if prompt.startswith(rule.prefix):
+                return rule.completion
+        return self.default_completion
+
+    def __call__(self, prompts: Iterable[str], **_: Any) -> list[str]:
+        return [self.generate(prompt) for prompt in prompts]
+
+
+__all__ = ["TinySequenceModel", "ResponseRule"]

--- a/src/codex_ml/reward_models/simple.py
+++ b/src/codex_ml/reward_models/simple.py
@@ -8,9 +8,21 @@ from codex_ml.interfaces.reward_model import RewardModel
 class LengthRewardModel(RewardModel):
     """Toy reward model that scores completions by length.
 
+    Parameters
+    ----------
+    scale:
+        Multiplicative factor applied to the completion length.
+    offset:
+        Constant added to the scaled length.
+
     This implementation is intentionally simple and is intended for tests and
-    examples. The reward is the number of characters in the completion.
+    examples. The reward defaults to the number of characters in the completion
+    but can be tuned via ``scale`` and ``offset``.
     """
+
+    def __init__(self, *, scale: float = 1.0, offset: float = 0.0) -> None:
+        self.scale = float(scale)
+        self.offset = float(offset)
 
     def evaluate(
         self,
@@ -19,8 +31,8 @@ class LengthRewardModel(RewardModel):
         *,
         metadata: Optional[Mapping[str, Any]] = None,
     ) -> float:
-        """Return the length of ``completion`` as the reward."""
-        return float(len(completion))
+        """Return ``offset + scale * len(completion)`` as the reward."""
+        return self.offset + self.scale * float(len(completion))
 
     def learn(self, data: Any) -> dict[str, float]:
         """Dummy learn method returning a placeholder metric."""

--- a/src/codex_ml/rl/__init__.py
+++ b/src/codex_ml/rl/__init__.py
@@ -1,5 +1,6 @@
 """Reinforcement learning agents for Codex."""
 
+from .scripted_agent import ScriptedAgent
 from .simple_agent import RandomAgent
 
-__all__ = ["RandomAgent"]
+__all__ = ["RandomAgent", "ScriptedAgent"]

--- a/src/codex_ml/rl/scripted_agent.py
+++ b/src/codex_ml/rl/scripted_agent.py
@@ -1,0 +1,64 @@
+"""Deterministic RL agent backed by a local JSON policy."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from codex_ml.interfaces.rl import RLAgent
+
+
+@dataclass
+class _PolicyState:
+    actions: Sequence[int]
+    loop: bool
+
+
+class ScriptedAgent(RLAgent):
+    """Replay a finite list of actions stored in an offline fixture."""
+
+    def __init__(self, policy: _PolicyState) -> None:
+        if not policy.actions:
+            raise ValueError("Policy must contain at least one action")
+        self._policy = policy
+        self._index = 0
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "ScriptedAgent":
+        candidate = Path(path)
+        if candidate.is_dir():
+            candidate = candidate / "policy.json"
+        if not candidate.exists():
+            raise FileNotFoundError(f"Policy file not found: {candidate}")
+        payload = json.loads(candidate.read_text(encoding="utf-8"))
+        actions = payload.get("actions", [])
+        if not isinstance(actions, list):  # pragma: no cover - defensive
+            raise TypeError("Policy JSON must include an 'actions' list")
+        parsed_actions = [int(value) for value in actions]
+        loop = bool(payload.get("loop", True))
+        return cls(_PolicyState(actions=parsed_actions, loop=loop))
+
+    def act(self, state: Any) -> Any:  # noqa: D401 - interface compliance
+        action = self._policy.actions[self._index]
+        self._index += 1
+        if self._index >= len(self._policy.actions):
+            self._index = 0 if self._policy.loop else len(self._policy.actions) - 1
+        return action
+
+    def update(self, trajectory: Mapping[str, Any]) -> dict[str, float]:  # noqa: D401
+        return {"loss": 0.0}
+
+    def save(self, path: str) -> None:  # noqa: D401
+        target = Path(path)
+        payload = {"actions": list(self._policy.actions), "loop": self._policy.loop}
+        target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    def load(self, path: str) -> None:  # noqa: D401
+        reloaded = self.from_file(path)
+        self._policy = reloaded._policy
+        self._index = 0
+
+
+__all__ = ["ScriptedAgent"]

--- a/src/codex_ml/tokenization/offline_vocab.py
+++ b/src/codex_ml/tokenization/offline_vocab.py
@@ -1,0 +1,51 @@
+"""Lightweight vocabulary-based tokenizer for offline fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Mapping
+
+from .adapter import TokenizerAdapter
+
+
+class TinyVocabTokenizer(TokenizerAdapter):
+    """Tokenizer that maps whitespace-delimited tokens via a static vocab."""
+
+    def __init__(self, vocab: Mapping[str, int], *, unk_token: str = "<unk>") -> None:
+        self.vocab = dict(vocab)
+        if unk_token not in self.vocab:
+            raise ValueError("Unknown token must be present in the vocabulary")
+        self.unk_token = unk_token
+        self.reverse_vocab = {idx: token for token, idx in self.vocab.items()}
+        self.unk_id = self.vocab[unk_token]
+
+    @classmethod
+    def from_vocab_file(cls, path: str | Path) -> "TinyVocabTokenizer":
+        candidate = Path(path)
+        if candidate.is_dir():
+            candidate = candidate / "vocab.json"
+        if not candidate.exists():
+            raise FileNotFoundError(f"Vocabulary file not found: {candidate}")
+        data = json.loads(candidate.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):  # pragma: no cover - defensive
+            raise TypeError("Vocabulary JSON must be a mapping of token -> id")
+        vocab = {str(token): int(index) for token, index in data.items()}
+        return cls(vocab)
+
+    def encode(self, text: str, **kwargs: object) -> List[int]:  # noqa: D401
+        return [self.vocab.get(token, self.unk_id) for token in text.split()]
+
+    def decode(self, tokens: Iterable[int], **kwargs: object) -> str:  # noqa: D401
+        return " ".join(self.reverse_vocab.get(int(token), self.unk_token) for token in tokens)
+
+    def batch_encode(self, texts: Iterable[str], **kwargs: object) -> List[List[int]]:  # noqa: D401
+        return [self.encode(text) for text in texts]
+
+    def save_pretrained(self, output_dir: str) -> None:  # noqa: D401 - trivial persistence
+        target = Path(output_dir)
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "vocab.json").write_text(json.dumps(self.vocab, indent=2), encoding="utf-8")
+
+
+__all__ = ["TinyVocabTokenizer"]

--- a/tests/plugins/test_registry_entries.py
+++ b/tests/plugins/test_registry_entries.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_ml.plugins import registries
+
+
+def test_offline_tokenizer_instantiates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CODEX_ML_TINY_TOKENIZER_PATH", raising=False)
+    tokenizer = registries.tokenizers.resolve_and_instantiate("offline:tiny-vocab")
+    assert tokenizer.encode("hello offline world") == [2, 3, 4]
+    assert tokenizer.decode([2, 3, 4]) == "hello offline world"
+
+
+def test_offline_tokenizer_missing_asset(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("CODEX_ML_TINY_TOKENIZER_PATH", str(tmp_path / "missing"))
+    with pytest.raises(FileNotFoundError) as excinfo:
+        registries.tokenizers.resolve_and_instantiate("offline:tiny-vocab")
+    message = str(excinfo.value)
+    assert "CODEX_ML_TINY_TOKENIZER_PATH" in message
+
+
+def test_offline_model_instantiates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CODEX_ML_TINY_SEQUENCE_PATH", raising=False)
+    model = registries.models.resolve_and_instantiate("offline:tiny-sequence")
+    assert model.generate("hello there") == "offline world"
+    assert model.generate("something else") == "tiny offline model"
+
+
+def test_offline_model_missing_asset(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("CODEX_ML_TINY_SEQUENCE_PATH", str(tmp_path / "missing"))
+    with pytest.raises(FileNotFoundError) as excinfo:
+        registries.models.resolve_and_instantiate("offline:tiny-sequence")
+    assert "CODEX_ML_TINY_SEQUENCE_PATH" in str(excinfo.value)
+
+
+def test_offline_dataset_instantiates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CODEX_ML_TINY_CORPUS_PATH", raising=False)
+    dataset = registries.datasets.resolve_and_instantiate("offline:tiny-corpus")
+    assert isinstance(dataset, list)
+    assert dataset
+
+
+def test_offline_dataset_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError) as excinfo:
+        registries.datasets.resolve_and_instantiate(
+            "offline:tiny-corpus", path=tmp_path / "missing.txt"
+        )
+    assert "offline:tiny-corpus" in str(excinfo.value)
+
+
+def test_offline_metric_instantiates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CODEX_ML_WEIGHTED_ACCURACY_PATH", raising=False)
+    metric = registries.metrics.resolve_and_instantiate("offline:weighted-accuracy")
+    score = metric(["a", "b", "c"], ["a", "x", "c"])
+    assert 0.0 <= score <= 1.0
+
+
+def test_offline_metric_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError) as excinfo:
+        registries.metrics.resolve_and_instantiate(
+            "offline:weighted-accuracy", weights_path=tmp_path / "missing.json"
+        )
+    assert "offline:weighted-accuracy" in str(excinfo.value)
+
+
+def test_offline_trainer_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("numpy")
+    monkeypatch.delenv("CODEX_ML_FUNCTIONAL_TRAINER_CONFIG", raising=False)
+    trainer = registries.trainers.resolve_and_instantiate("offline:functional")
+    defaults = getattr(trainer, "__codex_defaults__", {})
+    assert defaults["learning_rate"] == pytest.approx(0.001)
+    assert defaults["max_steps"] == 3
+
+
+def test_offline_trainer_missing_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    pytest.importorskip("numpy")
+    monkeypatch.setenv("CODEX_ML_FUNCTIONAL_TRAINER_CONFIG", str(tmp_path / "missing.json"))
+    with pytest.raises(FileNotFoundError) as excinfo:
+        registries.trainers.resolve_and_instantiate("offline:functional")
+    assert "offline:functional" in str(excinfo.value)
+
+
+def test_offline_reward_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CODEX_ML_LENGTH_REWARD_PATH", raising=False)
+    reward_model = registries.reward_models.resolve_and_instantiate("offline:length")
+    assert reward_model.evaluate("prompt", "abcd") == pytest.approx(2.0)
+
+
+def test_offline_reward_model_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError) as excinfo:
+        registries.reward_models.resolve_and_instantiate(
+            "offline:length", config_path=tmp_path / "missing.json"
+        )
+    assert "offline:length" in str(excinfo.value)
+
+
+def test_offline_rl_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CODEX_ML_SCRIPTED_AGENT_PATH", raising=False)
+    agent = registries.rl_agents.resolve_and_instantiate("offline:scripted")
+    actions = [agent.act(None) for _ in range(5)]
+    assert actions[:4] == [1, 0, 1, 1]
+    assert actions[4] == 1  # loops back to the start
+
+
+def test_offline_rl_agent_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError) as excinfo:
+        registries.rl_agents.resolve_and_instantiate(
+            "offline:scripted", policy_path=tmp_path / "missing.json"
+        )
+    assert "offline:scripted" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- add tiny offline tokenizer/model/trainer/reward/rl-agent fixtures and register them in the plugin catalogue
- provide Hydra fragments, preset config, and documentation covering the new offline catalogue entries
- add integration tests that exercise each offline registry entry and surface friendly errors when fixtures are missing

## Testing
- pytest tests/plugins/test_registry_entries.py
- pre-commit run --files src/codex_ml/plugins/registries.py src/codex_ml/tokenization/offline_vocab.py src/codex_ml/models/offline_tiny.py src/codex_ml/rl/scripted_agent.py src/codex_ml/reward_models/simple.py docs/guides/offline_catalogue.md CHANGELOG.md tests/plugins/test_registry_entries.py configs/offline/tiny_fixtures.yaml configs/tokenizer/offline/tiny_vocab.yaml configs/model/offline/tiny_sequence.yaml configs/training/offline/tiny_functional.yaml

------
https://chatgpt.com/codex/tasks/task_e_68d1153fd9188331853488bda49964f2