### PR TITLE
Harden local gates fail fast

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ TORCH_DEFAULT_INDEX_URL = "https://download.pytorch.org/whl/cpu"
 try:  # pragma: no cover - packaging is an optional runtime dependency
     from packaging.requirements import Requirement
 except Exception:  # pragma: no cover - gracefully degrade if packaging missing
-    Requirement = None  # type: ignore[assignment]
+    Requirement = None  # type: ignore[assignment, misc]
 
 
 def _torch_index_url() -> str | None:
@@ -536,6 +536,13 @@ def coverage(session):
     _ensure_pip_cache(session)
     _ensure_torch(session)
     _install(session, "pytest", "pytest-cov")
+    # Hard fail if pytest-cov failed to install even though pip returned success.
+    session.run(
+        "python",
+        "-c",
+        "import pytest, pytest_cov; print(pytest.__version__)",
+        silent=True,
+    )
     _install(session, "-e", ".[test,cli]")
     _install(session, "numpy")
     try:


### PR DESCRIPTION
This pull request focuses on hardening and improving reliability in the local gate script and test coverage setup. The main changes include stricter error handling and dependency verification in the `scripts/codex_local_gates.sh` script, as well as a more robust check for test dependencies in the `noxfile.py` coverage session.

**Local gate reliability and dependency enforcement:**

* Hardened `scripts/codex_local_gates.sh` with strict error handling (`set -Eeuo pipefail`) and a custom trap to log and exit on any error, ensuring failures are surfaced early and clearly.
* Enforced installation and verification of core Python packaging tools (`pip`, `setuptools`, `wheel`), development dependencies, and CLI tools (`pre-commit`, `nox`). The script now fails immediately if any required CLI is missing after installation.
* Added explicit Python checks for critical test plugins (`pytest`, `pytest_cov`) before running gates, aborting if any are missing.

**Test coverage session robustness:**

* In `noxfile.py`, added a hard check that `pytest-cov` is actually importable after installation, failing early if the install succeeded but the package is not usable.

**Minor code quality improvement:**

* Updated a type ignore comment to include `misc` for better static analysis compatibility in `noxfile.py`.

------
## Summary
- fail fast in `codex_local_gates.sh` by trapping errors, verifying dev installs with `pip check`, and asserting `pre-commit`/`nox` plus `pytest` plugins are present before running hooks and tests
- add a guard in the `coverage` nox session to confirm `pytest-cov` imports cleanly and tighten the existing packaging fallback ignore for mypy

## Testing
- bash -n scripts/codex_local_gates.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2e22dbaec8331b88fb67078a828c3