### PR TITLE
Add pickle-capable checkpointing and update resume helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -991,6 +991,23 @@ The training CLI exposes the same knobs via `--lora-r`, `--lora-alpha`,
 `--lora-dropout`, and `--lora-task-type` so offline fine-tuning workflows can
 toggle adapters without editing configuration files.
 
+### Checkpoint configuration
+
+`codex_ml.utils.checkpointing.save_checkpoint` automatically selects
+`torch.save` when PyTorch is installed and falls back to a pickle payload
+otherwise. The configuration surface is exposed via the shared `checkpoint`
+section in `configs/base.yaml`:
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `checkpoint.path` | `checkpoints/last.ckpt` | Location for the latest checkpoint artefact. |
+| `checkpoint.format` | `auto` | `auto` prefers `torch`, `pickle` forces the portable fallback. |
+| `checkpoint.strict` | `true` | Controls strict key matching when restoring module state. |
+| `checkpoint.map_location` | `cpu` | Device string forwarded to `torch.load` when available. |
+
+Both `save_checkpoint` and `load_training_checkpoint` accept a `format`
+parameter to override the configured default on a per-call basis.
+
 <!-- BEGIN: CODEX_README_UPDATE -->
 
 Local-only validations & explicit flags for monitoring/tracking.

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -17,6 +17,10 @@ logging:
 
 checkpoint:
   dir: ".checkpoints"
+  path: checkpoints/last.ckpt
+  format: auto  # "auto" | "torch" | "pickle"
+  strict: true
+  map_location: cpu
   save_every_steps: 100
   keep_best_k: 3
   metric: "eval/loss"

--- a/src/codex_ml/cli/__init__.py
+++ b/src/codex_ml/cli/__init__.py
@@ -106,3 +106,9 @@ else:  # pragma: no cover - optional dependency path
 
 if __name__ == "__main__":  # pragma: no cover
     cli()
+
+
+try:
+    from .codex_cli import app as infer  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - optional CLI wiring
+    infer = cli  # type: ignore[assignment]

--- a/tests/checkpointing/conftest.py
+++ b/tests/checkpointing/conftest.py
@@ -1,3 +1,0 @@
-import pytest
-
-pytest.importorskip("torch")

--- a/tests/checkpointing/test_corrupt_checkpoint_load.py
+++ b/tests/checkpointing/test_corrupt_checkpoint_load.py
@@ -1,7 +1,12 @@
 import pytest
-import torch
 
-from codex_ml.utils.checkpointing import load_training_checkpoint, save_checkpoint
+from codex_ml.utils.checkpointing import (
+    CheckpointLoadError,
+    load_training_checkpoint,
+    save_checkpoint,
+)
+
+torch = pytest.importorskip("torch")
 
 
 class TinyModel(torch.nn.Module):
@@ -22,5 +27,5 @@ def test_load_checkpoint_detects_corruption(tmp_path):
     # Corrupt the checkpoint file after saving
     ckpt.write_bytes(b"corrupted")
 
-    with pytest.raises(RuntimeError, match="checksum mismatch"):
+    with pytest.raises(CheckpointLoadError, match="checksum mismatch"):
         load_training_checkpoint(str(ckpt), model, opt)

--- a/tests/checkpointing/test_roundtrip.py
+++ b/tests/checkpointing/test_roundtrip.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_ml.utils.checkpointing import (
+    CheckpointLoadError,
+    load_training_checkpoint,
+    save_checkpoint,
+)
+
+
+class _DummyModel:
+    def __init__(self) -> None:
+        self._weights: dict[str, int] = {"w": 1}
+
+    def state_dict(self) -> dict[str, int]:
+        return dict(self._weights)
+
+    def load_state_dict(self, state_dict: dict[str, int], strict: bool = True) -> None:
+        self._weights.update(state_dict)
+
+
+def test_pickle_roundtrip(tmp_path: Path) -> None:
+    model = _DummyModel()
+    optimizer_state = {"lr": 0.5}
+    scheduler_state = {"step": 10}
+    extra = {"epoch": 3}
+    ckpt_path = tmp_path / "basic.ckpt"
+
+    save_checkpoint(
+        ckpt_path,
+        model,
+        optimizer_state,
+        scheduler_state,
+        epoch=4,
+        extra=extra,
+        format="pickle",
+    )
+
+    fresh_model = _DummyModel()
+    state = load_training_checkpoint(ckpt_path, fresh_model, None, None, format="pickle")
+
+    assert state["epoch"] == 4
+    assert state["extra"]["epoch"] == 3
+    assert state["optimizer_state_dict"]["lr"] == 0.5
+    assert fresh_model._weights["w"] == 1
+
+
+def test_corrupt_pickle_checkpoint(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.ckpt"
+    bad.write_bytes(b"not-a-checkpoint")
+
+    with pytest.raises(CheckpointLoadError):
+        load_training_checkpoint(bad, format="pickle")

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,6 +1,20 @@
+import importlib.util
+
 import pytest
 
 pytest.importorskip("yaml")
 pytest.importorskip("omegaconf")
-pytest.importorskip("torch")
 pytest.importorskip("hydra")
+
+spec = importlib.util.find_spec("torch")
+if spec is None:
+    pytest.skip("torch not installed", allow_module_level=True)
+
+try:
+    import torch  # noqa: F401  # ensure torch import succeeds
+    from torch.utils.data import Dataset  # noqa: F401
+except Exception:  # pragma: no cover - incomplete builds
+    pytest.skip(
+        "incomplete torch build (missing torch.utils dependencies)",
+        allow_module_level=True,
+    )

--- a/tests/gates/test_quality_gates.py
+++ b/tests/gates/test_quality_gates.py
@@ -9,7 +9,11 @@ from codex_ml.eval import metrics as M
 from codex_ml.interfaces import get_component
 from codex_ml.monitoring import codex_logging as cl
 from codex_ml.utils import set_reproducible
-from codex_ml.utils.checkpointing import load_training_checkpoint, save_checkpoint
+from codex_ml.utils.checkpointing import (
+    CheckpointLoadError,
+    load_training_checkpoint,
+    save_checkpoint,
+)
 
 
 # Checkpoint integrity test
@@ -20,7 +24,7 @@ def test_checkpoint_integrity(tmp_path):
     ckpt = tmp_path / "model.pt"
     save_checkpoint(str(ckpt), model, opt, scheduler=None, epoch=1, extra={})
     ckpt.write_bytes(b"corrupt")
-    with pytest.raises(RuntimeError, match="checksum mismatch"):
+    with pytest.raises(CheckpointLoadError, match="checksum mismatch"):
         load_training_checkpoint(str(ckpt), model, opt)
 
 

--- a/tests/test_checkpoint_corrupt_load.py
+++ b/tests/test_checkpoint_corrupt_load.py
@@ -5,8 +5,11 @@ import pytest
 pytest.importorskip("torch")
 
 import torch
-
-from codex_ml.utils.checkpointing import load_training_checkpoint, save_checkpoint
+from codex_ml.utils.checkpointing import (
+    CheckpointLoadError,
+    load_training_checkpoint,
+    save_checkpoint,
+)
 
 
 class DummyModel:
@@ -38,6 +41,6 @@ def test_load_checkpoint_detects_corruption(tmp_path: Path):
     save_checkpoint(str(ckpt), model, opt, scheduler=None, epoch=1, extra={})
     original = ckpt.read_bytes()
     ckpt.write_bytes(b"corrupted")
-    with pytest.raises(RuntimeError, match="checksum mismatch"):
+    with pytest.raises(CheckpointLoadError, match="checksum mismatch"):
         load_training_checkpoint(str(ckpt), model, opt)
     ckpt.write_bytes(original)

--- a/tests/test_checkpoint_corruption.py
+++ b/tests/test_checkpoint_corruption.py
@@ -3,8 +3,11 @@ import pytest
 pytest.importorskip("torch")
 
 import torch
-
-from codex_ml.utils.checkpointing import load_training_checkpoint, save_checkpoint
+from codex_ml.utils.checkpointing import (
+    CheckpointLoadError,
+    load_training_checkpoint,
+    save_checkpoint,
+)
 
 
 def test_load_checkpoint_detects_corruption(tmp_path):
@@ -17,5 +20,5 @@ def test_load_checkpoint_detects_corruption(tmp_path):
     # Corrupt checkpoint file after checksum was written
     ckpt.write_bytes(b"bad-data")
 
-    with pytest.raises(RuntimeError, match="checksum mismatch"):
+    with pytest.raises(CheckpointLoadError, match="checksum mismatch"):
         load_training_checkpoint(str(ckpt), model, opt)

--- a/tests/test_checkpoint_integrity.py
+++ b/tests/test_checkpoint_integrity.py
@@ -2,10 +2,13 @@ import pytest
 
 pytest.importorskip("torch")
 
+from codex_ml.utils.checkpointing import (
+    CheckpointLoadError,
+    load_training_checkpoint,
+    save_checkpoint,
+)
 from torch import nn
 from torch.optim import SGD
-
-from codex_ml.utils.checkpointing import load_training_checkpoint, save_checkpoint
 
 
 def test_load_checkpoint_detects_corruption(tmp_path):
@@ -18,5 +21,5 @@ def test_load_checkpoint_detects_corruption(tmp_path):
     data = ckpt.read_bytes()
     ckpt.write_bytes(b"corrupt" + data[7:])
 
-    with pytest.raises(RuntimeError, match="checksum"):
+    with pytest.raises(CheckpointLoadError, match="checksum"):
         load_training_checkpoint(str(ckpt), model, opt)

--- a/tests/test_checkpoint_integrity_corruption.py
+++ b/tests/test_checkpoint_integrity_corruption.py
@@ -3,8 +3,11 @@ import pytest
 pytest.importorskip("torch")
 
 import torch
-
-from codex_ml.utils.checkpointing import load_training_checkpoint, save_checkpoint
+from codex_ml.utils.checkpointing import (
+    CheckpointLoadError,
+    load_training_checkpoint,
+    save_checkpoint,
+)
 
 
 class DummyModel:
@@ -38,7 +41,7 @@ def test_load_checkpoint_detects_corruption(tmp_path):
     original = path.read_bytes()
     path.write_bytes(b"corrupted")
 
-    with pytest.raises(RuntimeError, match="checksum mismatch"):
+    with pytest.raises(CheckpointLoadError, match="checksum mismatch"):
         load_training_checkpoint(str(path), model, opt)
 
     path.write_bytes(original)

--- a/tests/test_checkpoint_manager.py
+++ b/tests/test_checkpoint_manager.py
@@ -5,8 +5,6 @@ import pytest
 pytest.importorskip("torch")
 
 import torch
-from torch.optim import SGD
-
 from codex_ml.utils.checkpointing import (
     CheckpointManager,
     dump_rng_state,
@@ -15,6 +13,7 @@ from codex_ml.utils.checkpointing import (
     save_checkpoint,
     set_seed,
 )
+from torch.optim import SGD
 
 
 def test_save_and_resume(tmp_path):
@@ -36,8 +35,9 @@ def test_save_load_checkpoint(tmp_path):
     sched = torch.optim.lr_scheduler.LambdaLR(opt, lambda epoch: 1.0)
     path = tmp_path / "ckpt.pt"
     save_checkpoint(str(path), model, opt, sched, epoch=5, extra={"foo": "bar"})
-    epoch, extra = load_training_checkpoint(str(path), model, opt, sched)
-    assert epoch == 5
+    state = load_training_checkpoint(str(path), model, opt, sched)
+    assert state.get("epoch") == 5
+    extra = state.get("extra", {})
     assert extra.get("foo") == "bar"
     # Environment/provenance metadata should be present
     assert "system" in extra or "env" in extra or "git_commit" in extra

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -5,9 +5,8 @@ import pytest
 
 pytest.importorskip("torch")
 
-from torch import nn, optim
-
 from src.codex_ml.utils.checkpointing import load_training_checkpoint, save_checkpoint
+from torch import nn, optim
 
 
 def test_checkpoint_roundtrip():
@@ -17,5 +16,6 @@ def test_checkpoint_roundtrip():
     with tempfile.TemporaryDirectory() as d:
         p = pathlib.Path(d) / "ckpt.pt"
         save_checkpoint(str(p), m, opt, sch, epoch=3, extra={"note": "ok"})
-        e, extra = load_training_checkpoint(str(p), m, opt, sch)
-        assert e == 3 and extra["note"] == "ok"
+        state = load_training_checkpoint(str(p), m, opt, sch)
+        assert state.get("epoch") == 3
+        assert state.get("extra", {}).get("note") == "ok"

--- a/tests/utils/test_checkpointing.py
+++ b/tests/utils/test_checkpointing.py
@@ -21,5 +21,5 @@ def test_load_checkpoint_corrupt(tmp_path):
         def load_state_dict(self, *a, **k):
             pass
 
-    with pytest.raises(Exception):
+    with pytest.raises(mod.CheckpointLoadError):
         mod.load_training_checkpoint(str(bad), M())

--- a/training/data_utils.py
+++ b/training/data_utils.py
@@ -5,6 +5,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
@@ -14,10 +15,18 @@ from typing import (
     Sequence,
     Tuple,
     TypeVar,
+    cast,
 )
 
 import numpy as np
+import numpy.typing as npt
+
 import torch
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from torch import Tensor
+else:  # pragma: no cover - runtime alias
+    Tensor = torch.Tensor
 
 T = TypeVar("T")
 
@@ -229,7 +238,7 @@ class TextDataset(torch.utils.data.Dataset):
 
     def __post_init__(self) -> None:
         # Prepare tensor examples eagerly
-        self.examples: List[Dict[str, torch.Tensor]] = []
+        self.examples: List[Dict[str, Tensor]] = []
         for txt in self.texts:
             try:
                 # Support both HF-style tokenizer dict-call and simple encode function
@@ -252,23 +261,23 @@ class TextDataset(torch.utils.data.Dataset):
             attn = [1] * len(input_ids)
             self.examples.append(
                 {
-                    "input_ids": torch.tensor(input_ids, dtype=torch.long),
-                    "labels": torch.tensor(labels, dtype=torch.long),
-                    "attention_mask": torch.tensor(attn, dtype=torch.long),
+                    "input_ids": torch.tensor(input_ids, dtype=torch.int64),
+                    "labels": torch.tensor(labels, dtype=torch.int64),
+                    "attention_mask": torch.tensor(attn, dtype=torch.int64),
                 }
             )
 
     def __len__(self) -> int:
         return len(self.examples)
 
-    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+    def __getitem__(self, idx: int) -> Dict[str, Tensor]:
         ex = self.examples[idx]
         # Return clones to avoid unwanted in-place mutations
         return {k: v.clone() for k, v in ex.items()}
 
 
 def cache_dataset(
-    ds: Iterable[Mapping[str, torch.Tensor | np.ndarray | Any]],
+    ds: Iterable[Mapping[str, Tensor | np.ndarray | Any]],
     cache_dir: str | Path,
 ) -> None:
     """Cache tokenised dataset ds under cache_dir as .npz shards.
@@ -280,17 +289,19 @@ def cache_dataset(
     path.mkdir(parents=True, exist_ok=True)
     for i, sample in enumerate(ds):
         try:
-            arrs: Dict[str, np.ndarray] = {
-                k: v.numpy() if isinstance(v, torch.Tensor) else np.asarray(v)  # type: ignore[arg-type]
-                for k, v in sample.items()
-            }
+            arrs: Dict[str, npt.NDArray[Any]] = {}
+            for key, value in sample.items():
+                if isinstance(value, torch.Tensor):
+                    arrs[key] = cast(npt.NDArray[Any], value.detach().cpu().numpy())
+                else:
+                    arrs[key] = np.asarray(value)
             np.savez(str(path / f"{i}.npz"), allow_pickle=False, **arrs)
         except Exception:
             # Skip samples that fail to serialize
             continue
 
 
-def load_cached(cache_dir: str | Path) -> Iterator[Dict[str, torch.Tensor]]:
+def load_cached(cache_dir: str | Path) -> Iterator[Dict[str, Tensor]]:
     """Yield cached samples stored by cache_dataset.
 
     Loads .npz files from cache_dir and yields tensors keyed by their original names.

--- a/training/functional_training.py
+++ b/training/functional_training.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Sequence
 
 import numpy as np
+
 import torch
 from torch.nn.utils import clip_grad_norm_
 from torch.utils.data import DataLoader
@@ -242,9 +243,9 @@ def run_custom_trainer(model, tokenizer, train_ds, val_ds, cfg: TrainCfg) -> Dic
     start_step = 0
     if cfg.resume_from:
         try:
-            start_epoch, extra = load_training_checkpoint(
-                cfg.resume_from, model, optimizer, scheduler
-            )
+            state = load_training_checkpoint(cfg.resume_from, model, optimizer, scheduler)
+            start_epoch = int(state.get("epoch") or 0)
+            extra = state.get("extra", {})
             global_step = int(extra.get("global_step", 0))
             best_val = float(extra.get("best_val", best_val))
             start_step = int(extra.get("step_in_epoch", 0))


### PR DESCRIPTION
## Summary
- implement torch-optional checkpointing helpers that raise `CheckpointLoadError`, support a pickle fallback, and standardize the loaded state dictionary
- update training utilities, configs, CLI exports, and docs to reference the new checkpoint API and defaults
- add regression tests (including torch-free round trip and corruption cases) while cleaning up legacy checkpoint test gating

## Testing
- `pytest tests/test_checkpointing.py tests/test_checkpoint_checksum.py tests/test_checkpoint_integrity.py tests/test_checkpoint_integrity_corruption.py tests/test_checkpoint_corrupt_load.py tests/test_checkpoint_corruption.py tests/test_checkpoint_manager.py tests/checkpointing/test_roundtrip.py tests/checkpointing/test_corrupt_checkpoint_load.py tests/utils/test_checkpointing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d3523f80a083319c1b313fec0cd779