### PR TITLE
Fix dataset registry import in evaluate CLI

### DIFF
--- a/src/codex_ml/cli/evaluate.py
+++ b/src/codex_ml/cli/evaluate.py
@@ -8,6 +8,7 @@ from typing import Dict, List
 
 import hydra
 import torch
+from codex_ml.data.registry import get_dataset
 from codex_ml.eval.metrics import (
     accuracy,
     classification_f1,
@@ -15,7 +16,6 @@ from codex_ml.eval.metrics import (
     token_accuracy,
 )
 from codex_ml.monitoring.codex_logging import write_ndjson
-from codex_ml.registry.data import get_dataset
 from codex_ml.registry.models import get_model
 from codex_ml.registry.tokenizers import get_tokenizer
 from codex_ml.utils.seeding import set_reproducible


### PR DESCRIPTION
## Summary
- import `get_dataset` from `codex_ml.data.registry` so the evaluation CLI can locate dataset loaders

## Testing
- `python -m pre_commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68d5f38e655c8331ba261da45964a24b