### PR TITLE
Allow local Hugging Face identifiers without revision

### DIFF
--- a/src/codex_ml/hf_loader.py
+++ b/src/codex_ml/hf_loader.py
@@ -1,5 +1,7 @@
 import os
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Union
+from urllib.parse import unquote, urlparse
 
 from transformers import (
     AutoModel,
@@ -10,7 +12,33 @@ from transformers import (
 )
 
 
-def _required_revision(explicit: Optional[str]) -> str:
+RepoId = Union[str, os.PathLike[str]]
+
+
+def _is_local_identifier(repo_id: RepoId) -> bool:
+    if isinstance(repo_id, os.PathLike):
+        candidate_path = Path(repo_id).expanduser()
+        if candidate_path.exists():
+            return True
+        candidate_str = str(candidate_path)
+    else:
+        candidate_str = str(repo_id)
+        candidate_path = Path(candidate_str).expanduser()
+        if candidate_path.exists():
+            return True
+
+    parsed = urlparse(candidate_str)
+    if parsed.scheme != "file":
+        return False
+    local_path = Path(unquote(parsed.path)).expanduser()
+    if parsed.netloc and not local_path.is_absolute():
+        local_path = Path(f"//{parsed.netloc}{local_path}")
+    return local_path.exists()
+
+
+def _required_revision(repo_id: RepoId, explicit: Optional[str]) -> Optional[str]:
+    if _is_local_identifier(repo_id):
+        return explicit
     rev = explicit or os.environ.get("HF_REVISION") or os.environ.get("HUGGINGFACE_REVISION")
     if not rev:
         raise RuntimeError(
@@ -21,12 +49,12 @@ def _required_revision(explicit: Optional[str]) -> str:
 
 
 def load_tokenizer(
-    repo_id: str,
+    repo_id: RepoId,
     *,
     revision: Optional[str] = None,
     trust_remote_code: bool = False,
 ) -> PreTrainedTokenizerBase:
-    rev = _required_revision(revision)
+    rev = _required_revision(repo_id, revision)
     return AutoTokenizer.from_pretrained(  # nosec B615 - revision enforced via _required_revision
         repo_id,
         revision=rev,
@@ -35,12 +63,12 @@ def load_tokenizer(
 
 
 def load_model(
-    repo_id: str,
+    repo_id: RepoId,
     *,
     revision: Optional[str] = None,
     trust_remote_code: bool = False,
 ) -> PreTrainedModel:
-    rev = _required_revision(revision)
+    rev = _required_revision(repo_id, revision)
     return AutoModel.from_pretrained(  # nosec B615 - revision enforced via _required_revision
         repo_id,
         revision=rev,
@@ -49,12 +77,12 @@ def load_model(
 
 
 def load_causal_lm(
-    repo_id: str,
+    repo_id: RepoId,
     *,
     revision: Optional[str] = None,
     trust_remote_code: bool = False,
 ) -> PreTrainedModel:
-    rev = _required_revision(revision)
+    rev = _required_revision(repo_id, revision)
     return AutoModelForCausalLM.from_pretrained(  # nosec B615 - revision enforced via _required_revision
         repo_id,
         revision=rev,


### PR DESCRIPTION
## Summary
- detect Hugging Face identifiers that resolve to existing local paths or file URIs so cached/offline assets load without forcing a revision
- continue enforcing revision pins for remote repositories with the existing environment variable fallback
- normalize file-URI handling when resolving local paths during revision checks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d60b4aea8c83319ed5049c8ccaba45