### PR TITLE
Fix Hydra config roots for train/evaluate CLIs

### DIFF
--- a/src/codex_ml/cli/evaluate.py
+++ b/src/codex_ml/cli/evaluate.py
@@ -52,7 +52,7 @@ def _to_path(value: str | Path | None) -> Path | None:
     return Path(to_absolute_path(str(value)))
 
 
-@hydra.main(version_base=None, config_path="../../configs/eval", config_name="default")
+@hydra.main(version_base=None, config_path="../../../configs/eval", config_name="default")
 def main(cfg: DictConfig) -> None:
     set_reproducible(int(cfg.seed))
     dataset_cfg = cfg.dataset

--- a/src/codex_ml/cli/train.py
+++ b/src/codex_ml/cli/train.py
@@ -17,7 +17,7 @@ def _to_path(value: str | Path | None) -> Path | None:
     return Path(to_absolute_path(str(value)))
 
 
-@hydra.main(version_base=None, config_path="../../configs/train", config_name="default")
+@hydra.main(version_base=None, config_path="../../../configs/train", config_name="default")
 def main(cfg: DictConfig) -> None:
     model_cfg: Dict[str, Any] = dict(cfg.model.get("cfg", {}))
     art_dir = _to_path(cfg.artifacts_dir)


### PR DESCRIPTION
## Summary
- adjust the training CLI's Hydra config path so it resolves to the repository-level `configs/train`
- point the evaluation CLI at the repository-level `configs/eval` directory to avoid config search errors

## Testing
- ⚠️ `python -m pre_commit run --files src/codex_ml/cli/train.py src/codex_ml/cli/evaluate.py` *(fails: No module named pre_commit in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d611d5f85c8331b4ea95fa0fa7ff99