### PR TITLE
Add September 26 2025 status update audit report

### DIFF
--- a/docs/status_updates/status_update_2025-09-26.md
+++ b/docs/status_updates/status_update_2025-09-26.md
@@ -1,0 +1,192 @@
+Check for must recent active branch:
+//fetch https://github.com/Aries-Serpent/_codex_/activity?time_period=day
+
+Branches:
+//fetch https://github.com/Aries-Serpent/_codex_
+//fetch https://github.com/Aries-Serpent/_codex_/tree/0A_base_
+//fetch https://github.com/Aries-Serpent/_codex_/tree/0B_base_
+//fetch https://github.com/Aries-Serpent/_codex_/tree/0C_base_
+
+Objective:
+> Traverse the repository and provide a comprehensive status audit. The goal is to assess **modularity**, **reproducibility**, and **production readiness** of the Codex Environment for Ubuntu, following best practices in ML systems design.
+---
+
+Audit Scope
+
+# 📍_codex_: Status Update (2025-09-26)
+
+1. **Repo Map**
+   - **Top-level directories.** `analysis/`, `configs/`, `docs/`, `services/`, `src/`, `tests/`, `tools/`, plus pinned artefact buckets under `artifacts/` and `reports/` for audit outputs.【10532f†L3-L12】
+   - **Key files.** `README.md` documents offline-first setup, quickstart workflow, and safety policy expectations; `pyproject.toml` publishes entry points plus optional extras; `noxfile.py` enforces coverage, lockfile, and dependency guards; `Dockerfile` keeps runtime minimal via a multi-stage build.【2e662a†L1-L122】【15114f†L1-L96】【57e5bb†L1-L88】【b01d1f†L1-L32】
+   - **Stubs & placeholders.** Abstract tokenizer interfaces, registry adapters, and analysis providers still raise `NotImplementedError`, signalling extension points awaiting concrete implementations.【a0a77f†L1-L11】【b91895†L45-L160】
+   - **Recent changes.** The 2025-09-22 changelog entry refreshed the audit template, generated deterministic artefacts, and hardened offline prompts/gates across the repo.【e678f4†L1-L18】
+
+2. **Capability Audit Table**
+
+| Capability | Status | Existing Artifacts | Gaps | Risks | Minimal Patch Plan | Rollback Plan |
+| --- | --- | --- | --- | --- | --- | --- |
+| Tokenization (fast tokenizer, vocab, encode/decode, padding/truncation) | Implemented | Streaming-aware trainer, SentencePiece adapter, and whitespace fallback with deterministic vocab growth.【1cf26a†L1-L120】【b91895†L116-L160】 | SentencePiece remains optional; no integration tests cover dry-run/streaming toggles. | Missing dependency or silent CLI misuse can halt tokenizer generation. | Add pytest covering `_resolve_streaming_options` and CLI dry-run, bundling sentencepiece stub for offline smoke tests. | Revert added tests/configs; restore previous CLI behaviour if regressions emerge. |
+| ChatGPT Codex Modeling (model init, dtype, device placement, LoRA/PEFT hooks) | Partially Implemented | Registry resolves offline checkpoints, MiniLM stub, and LoRA adapters with optional remote fallback.【cb9c4e†L1-L108】 | Fallback errs when weights absent and `local_files_only` true; dtype/device heuristics live in train loop without validation. | Offline air-gapped runs fail fast if artefact mirrors missing; dtype mismatch may surface late. | Extend registry to suggest `CODEX_ML_OFFLINE_MODELS_DIR` scaffolding and add smoke test verifying LoRA branch executes with stub weights. | Disable new helper and revert registry tweaks, restoring current error paths. |
+| Training Engine (HF Trainer or custom loop, precision, gradient accumulation) | Implemented | Custom loop sets seeds, handles AMP flags, checkpoint resume, retention pruning, and LoRA/application wiring.【8dc39d†L1-L144】 | Torch imports optional; evaluation callbacks degrade to no-ops when dependencies absent. | Missing torch yields silent feature loss; resumed runs may skip metric hooks. | Add capability probe in CLI to warn when `_HAS_TORCH` false and document fallback path; wire evaluation callback stub to log degrade. | Drop probe logging to restore prior silent behaviour if necessary. |
+| Configuration Management (Hydra/YAML structure, overrides, sweeps) | Implemented | Hydra-backed training CLI plus structured `configs/train/default.yaml` for device, LoRA, scheduler, and reproducibility flags.【718501†L1-L40】【f1a213†L1-L39】 | Config tree lacks sweeps/examples for evaluation; reproducibility flags default `cudnn_deterministic` false. | Misconfigured Hydra overrides can slip without gating; determinism optional. | Ship `configs/train/offline.yaml` enabling deterministic mode by default and add docs referencing outstanding seeds checklist. | Remove new config and README reference if hydration regresses. |
+| Evaluation & Metrics (validation loops, metrics API, NDJSON/CSV logging) | Implemented | Eval runner logs NDJSON/CSV with bootstrap CI and metric registry exposes accuracy/perplexity/F1 helpers.【e7c05b†L1-L92】【d5068a†L1-L90】 | Metrics depend on optional datasets; bootstrap defaults may be slow without sampling controls. | Offline datasets missing will abort run; long bootstrap loops stall pipelines. | Provide CLI flag defaults for `max_samples` and integrate dataset fixture docs to keep tests bounded. | Revert CLI defaults to maintain previous behaviour. |
+| Logging & Monitoring (TensorBoard / W&B / MLflow, system metrics via `psutil`/NVML) | Partially Implemented | Monitoring module conditionally wires TensorBoard, W&B, MLflow, and Prometheus sampler with secret scrubbing and telemetry degradation banners.【b3d780†L1-L112】 | Optional dependencies not vendored; telemetry banner not unit-tested. | Absent deps cause silent telemetry disablement; operators miss observability regressions. | Add dependency probe CLI (`codex-monitor status`) and document fallback log in README. | Remove CLI, reverting to current lazy imports if issues found. |
+| Checkpointing & Resume (weights, optimizer state, scheduler, RNG, best-k retention) | Implemented | Train loop auto-discovers latest checkpoint and utilities persist model/optimizer/scheduler metadata with SHA tracking.【8dc39d†L94-L147】【8c7ce2†L1-L62】 | No automated retention pruning coverage; metadata schema lacks version bump history. | Corrupt metadata could break resume; retention policy errors may delete active checkpoints. | Add jsonschema validation during resume and unit tests for retention policy dry-run path. | Remove validator and tests to fall back to current permissive flow. |
+| Data Handling (dataset splits, deterministic shuffling, caching) | Partially Implemented | Data loaders, JSONL ingest, cache utilities, and dataset registries exist with TTL cache helpers.【1cf26a†L101-L120】【57a5f0†L1-L7】【082da4†L1-L27】 | Deterministic shuffling depends on optional numpy/torch; ingestion lacks schema validation. | Non-deterministic sampling jeopardises reproducibility; malformed datasets pass silently. | Add schema validators and deterministic seed handshake across loaders with pytest fixtures. | Disable validator if legitimate datasets fail validation unexpectedly. |
+| Security & Safety (dependency locking, secrets scanning, prompt safety) | Partially Implemented | README codifies safety policies, sanitisation hooks, and git-secrets enforcement; optional extras pinned in tooling docs.【2e662a†L49-L90】 | `pyproject.toml` keeps loose `>=` pins; safety configs rely on manual invocation. | Supply-chain drift and unmonitored policy bypass risk. | Align `pyproject.toml` pins with `requirements.lock` and surface safety policy tests in CI. | Revert pin alignment if packaging conflicts arise. |
+| Internal CI/Test (pytest targets, tox/nox local gates, coverage enforcement) | Implemented | README and `noxfile.py` enforce `nox -s tests`, coverage floor, lock validation, and torch/pytest-cov guards.【2e662a†L71-L118】【57e5bb†L1-L73】 | Coverage depends on optional `pytest-cov`; missing offline wheelhouse story for new deps. | Developers without wheelhouse blocked; gating drifts. | Document wheelhouse refresh script and ensure `make codex-gates` exports failure logs. | Remove doc update if gating instructions conflict with existing policy. |
+| Deployment (packaging, CLI entry points, Docker infra) | Partially Implemented | Dockerfile builds slim runtime; `pyproject.toml` exposes console scripts for tokenizer, training, and validation CLIs.【b01d1f†L1-L32】【15114f†L37-L64】 | Runtime image just prints banner; no default workspace volume or CLI entrypoint. | Users must override entrypoint; container may appear non-functional. | Update Dockerfile to set default CMD invoking `codex-ml-cli --help` and document volume usage. | Revert CMD change if automation relies on banner heartbeat. |
+| Documentation & Examples (README, quickstarts, diagrams, notebooks) | Implemented | README links quickstart, architecture diagrams, plugin guide, and safety docs.【2e662a†L1-L54】 | Quickstart assumes optional deps installed; notebooks lack CI coverage. | New contributors may fail to reproduce examples offline. | Add troubleshooting appendix mapping optional extras to commands and include offline dataset prep instructions. | Remove appendix if it diverges from actual tooling. |
+| Experiment Tracking (MLflow local tracking, W&B offline mode) | Partially Implemented | MLflow utility defers to env toggles and re-exports tracking helpers for compatibility.【ccd111†L1-L56】 | No local storage bootstrap; offline mode env var not documented. | Runs silently skip tracking when URI missing. | Provide `tools/bootstrap_mlflow_offline.py` to create local store and update README. | Drop helper script if duplication with existing docs occurs. |
+| Extensibility (pluggable components, registry patterns) | Implemented | Registry base supports entry points, overrides, and lazy loading across tokenizers/models/metrics.【693d66†L1-L96】 | Some registries still rely on manual import wiring; plugin error surfacing sparse. | Hidden failures degrade plugin discovery. | Add structured logging when entry points fail and surface via CLI `list-plugins`. | Disable logging if it spams during normal runs. |
+
+3. **High-Signal Findings**
+   1. Optional dependency drift remains the largest reproducibility risk: `pyproject.toml` still uses loose `>=` specifiers while lockfiles/policies expect pins.【15114f†L1-L49】
+   2. Monitoring stack silently degrades when TensorBoard/W&B/psutil are absent, leaving operators without explicit telemetry warnings despite secret scrubbing infrastructure.【b3d780†L1-L112】
+   3. Offline checkpoint resolution throws hard errors when artefacts are missing and `local_files_only` defaults to true, blocking air-gapped runs without clear remediation hints.【cb9c4e†L41-L108】
+   4. Dataset ingestion trusts unvalidated JSONL/ingest inputs; no schema or checksum enforcement to guard corrupted corpora.【1cf26a†L101-L118】【082da4†L1-L27】
+   5. Docker runtime emits only a readiness banner; teams must override entrypoint to access CLIs, contradicting quickstart expectations.【b01d1f†L1-L32】
+   6. Outstanding MkDocs strict-mode issue persists in the automation ledger and requires prioritisation once docs settle.【d7d20f†L31-L48】
+   7. Capability interfaces (tokenizer adapters, providers) still rely on `NotImplementedError` placeholders, underscoring the need for concrete extensions or defensive guards.【b91895†L45-L160】
+   8. Evaluation bootstrap defaults can induce long-running loops without sample caps, risking pipeline stalls during nightly validation.【e7c05b†L33-L74】
+   9. Train loop gracefully degrades when torch absent, but CLI surfaces no explicit warning, letting silent CPU-only stubs mask missing acceleration.【8dc39d†L14-L64】
+   10. Outstanding questions register emphasises dependency pinning success; ensure future updates keep ledger synchronised with new findings.【d7d20f†L1-L36】
+
+4. **Atomic Diffs**
+### Atomic Diff 1 — Harden optional-dependency warnings
+- **Why:** Surface explicit warnings when torch or telemetry deps missing to avoid silent feature loss.【8dc39d†L14-L64】【b3d780†L1-L112】
+- **Risk:** Over-eager warnings could frustrate users running intentionally minimal setups.
+- **Rollback:** Remove new logging block from CLI initialisation.
+- **Tests/docs:** Add CLI smoke test asserting warning emission under torch-free environment.
+```diff
+--- a/src/codex_ml/cli/train.py
++++ b/src/codex_ml/cli/train.py
+@@
+-    run_training(
++    if not run_training.has_torch():
++        logger.warning("PyTorch unavailable; falling back to dry-run instrumentation only")
++    run_training(
+         epochs=int(cfg.epochs),
+```
+
+### Atomic Diff 2 — Provide default CLI entrypoint in Docker runtime
+- **Why:** Align container behaviour with README quickstart by presenting CLI help instead of a static banner.【b01d1f†L1-L32】【2e662a†L1-L54】
+- **Risk:** Automation scripts relying on banner output must adjust expectations.
+- **Rollback:** Restore previous `ENTRYPOINT` that printed the readiness message.
+- **Tests/docs:** Update container usage docs and, if available, integration test to assert CLI help text.
+```diff
+--- a/Dockerfile
++++ b/Dockerfile
+@@
+-ENTRYPOINT ["python", "-c", "print('Codex ML container ready')"]
++ENTRYPOINT ["codex-ml-cli"]
++CMD ["--help"]
+```
+
+### Atomic Diff 3 — Constrain tokenizer streaming tests
+- **Why:** Guard tokenizer CLI by adding coverage for streaming/dry-run paths and ensuring SentencePiece absence degrades gracefully.【1cf26a†L1-L120】
+- **Risk:** Extra tests may lengthen pytest duration without sentencepiece wheels.
+- **Rollback:** Drop new tests or mark them optional to restore previous runtime.
+- **Tests/docs:** Document new pytest marker in `tests/tokenization/README.md` and update quickstart to mention stub path.
+```diff
+--- a/tests/tokenization/test_train_tokenizer.py
++++ b/tests/tokenization/test_train_tokenizer.py
+@@
++@pytest.mark.parametrize("streaming", [False, True])
++def test_train_dry_run_handles_streaming(tmp_path, streaming):
++    cfg = TrainTokenizerConfig(
++        corpus_glob=str(tmp_path / "*.txt"),
++        dry_run=True,
++        streaming=streaming,
++    )
++    (tmp_path / "sample.txt").write_text("hello world\n")
++    path = train(cfg)
++    assert path.name == cfg.name
+```
+
+5. **Local Tests & Gates**
+
+| Command | Purpose | Example Output | ML Test Score Coverage |
+| --- | --- | --- | --- |
+| `nox -s tests` | Canonical offline gate combining pytest, coverage, and dependency probes.【2e662a†L71-L118】【57e5bb†L1-L73】 | `sessions run: tests (pass)` | Infrastructure, Regression |
+| `pytest tests/tokenization -k train_tokenizer` | Targeted tokenizer coverage ensuring streaming/dry-run behaviour works offline.【1cf26a†L1-L120】 | `2 passed, 2 skipped` | Data, Model |
+| `python -m codex_ml.cli.train --config-name default --help` | Hydra wiring smoke test verifying CLI entrypoint stays functional post-changes.【718501†L1-L40】 | Usage banner rendered | Infrastructure |
+
+6. **Reproducibility Checklist**
+
+| Item | Status | Notes |
+| --- | --- | --- |
+| Seed management captured | ✅ | `_set_seed` syncs Python, NumPy, and torch when available.【8dc39d†L62-L90】 |
+| Deterministic CUDA toggles | ⚠️ | `configs/train/default.yaml` keeps `cudnn_deterministic: false`; needs hardened preset.【f1a213†L1-L39】 |
+| Dependency pinning | ⚠️ | Lockfiles exist, but `pyproject.toml` retains `>=` ranges for core deps.【15114f†L19-L48】 |
+| Artefact/version logging | ✅ | Checkpoint metadata records SHA-256 and latest checkpoint pointers.【8dc39d†L94-L147】 |
+| Offline data availability | ⚠️ | Dataset/metric loaders search repo artefacts but lack schema validation or checksum logs.【1cf26a†L101-L118】【d5068a†L49-L86】 |
+
+7. **Deferred Items**
+   - Re-enable MkDocs strict mode once docs navigation stabilises; outstanding question remains deferred.【d7d20f†L31-L48】
+   - Align optional dependency pins across `pyproject.toml` and lockfiles to close reproducibility gap documented above.【15114f†L19-L49】
+
+8. **Error Capture Blocks**
+   - No new errors encountered; refer to `docs/status_update_outstanding_questions.md` for the authoritative ledger and update if new issues arise.【d7d20f†L1-L48】
+
+---
+
+## Codex-ready Task Sequence
+```text
+Codex-ready Task Sequence:
+  1. Preparation:
+     - Export PYTHONHASHSEED=0 and activate local venv.
+     - Sync dependencies from requirements.lock/uv.lock to keep gates reproducible.
+  2. Search & Mapping:
+     - Refresh repo map snapshots in reports/ and verify outstanding MkDocs strict-mode blocker.
+     - Locate optional dependency warnings across CLI and monitoring modules.
+  3. Best-Effort Construction:
+     - Implement telemetry and torch warning hooks, add tokenizer streaming tests, adjust Docker entrypoint.
+     - Update docs/quickstart with new offline telemetry guidance.
+  4. Controlled Pruning:
+     - If telemetry CLI introduces noise, gate behind feature flag and record follow-up in DEFERRED.md.
+     - Defer MkDocs strict-mode flip pending documentation churn resolution.
+  5. Error Capture:
+     - On any gate failure, append the standard block to Codex_Questions.md with timestamp and remediation context.
+  6. Finalization:
+     - Run nox -s tests and targeted pytest suites.
+     - Update CHANGELOG.md and outstanding question ledger with resolved/new findings.
+```
+**Additional Deliverable — Executable Script**
+```python
+#!/usr/bin/env python3
+"""Offline audit helper tying together tokenizer tests and telemetry probes."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+def run(cmd: list[str]) -> dict[str, str]:
+    proc = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True)
+    return {
+        "cmd": " ".join(cmd),
+        "returncode": str(proc.returncode),
+        "stdout": proc.stdout.strip(),
+        "stderr": proc.stderr.strip(),
+    }
+
+def main() -> None:
+    results = {
+        "nox_tests": run(["nox", "-s", "tests"]),
+        "tokenizer_smoke": run(["pytest", "tests/tokenization", "-k", "train_tokenizer"]),
+        "train_help": run(["python", "-m", "codex_ml.cli.train", "--help"]),
+    }
+    reports = REPO_ROOT / "reports"
+    reports.mkdir(parents=True, exist_ok=True)
+    (reports / "status_update_run.json").write_text(
+        json.dumps(results, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+if __name__ == "__main__":
+    main()
+```
+> **Reminder:** Outstanding automation questions remain tracked in `docs/status_update_outstanding_questions.md`. Reference that ledger when relevant, but embedding the entire table in the daily status update is no longer required under the 2025-09-22 template.


### PR DESCRIPTION
## Summary
- add the 2025-09-26 repository status update covering capability audit findings and follow-on tasks

## Testing
- pre-commit (runs automatically)


------
https://chatgpt.com/codex/tasks/task_e_68d6245d040483319bf6f945bcacc8ac