### PR TITLE
Ensure dataset cache default stays writable outside repo

### DIFF
--- a/src/codex_ml/data/registry.py
+++ b/src/codex_ml/data/registry.py
@@ -160,7 +160,21 @@ def _repo_root() -> Path:
     return current.parents[fallback_index]
 
 
-DEFAULT_CACHE_DIR = _repo_root() / "artifacts" / "data_cache"
+def _default_cache_dir() -> Path:
+    """Select a writable cache directory for datasets."""
+
+    repo_root = _repo_root()
+    # ``_repo_root`` returns the package install directory when ``pyproject.toml``
+    # is absent (e.g. in site-packages). In that scenario default to the current
+    # working directory, matching the historical behaviour that keeps the cache
+    # writable in typical environments.
+    if (repo_root / "pyproject.toml").is_file():
+        return repo_root / "artifacts" / "data_cache"
+
+    return Path.cwd() / "artifacts" / "data_cache"
+
+
+DEFAULT_CACHE_DIR = _default_cache_dir()
 
 
 def _resolve_dataset_fixture(


### PR DESCRIPTION
## Summary
- add a helper that falls back to the working directory when the package root is inside site-packages
- retain the repository artifacts cache when developing from a source checkout

## Testing
- python -m pytest tests/test_data_registry.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d6ae6f37dc83318ff4bf3b73a3340c