### PR TITLE
Harden URL and SQL helpers

### DIFF
--- a/src/codex_ml/train_loop.py
+++ b/src/codex_ml/train_loop.py
@@ -765,6 +765,9 @@ def run_training(
 
         state["latest_checkpoint"] = latest_payload
 
+        sha_for_log = locals().get("epoch_checkpoint_sha") or last_checkpoint_sha
+        if sha_for_log:
+            sha_for_log = sha_for_log[:12]
         logger.info(
             "Epoch %d/%d | loss=%s | steps=%d | opt_steps=%d | lr=%s | sha=%s",
             epoch,
@@ -773,11 +776,7 @@ def run_training(
             steps_this_epoch,
             optimizer_steps_this_epoch,
             current_lrs,
-            (
-                (epoch_checkpoint_sha or last_checkpoint_sha or "")[:12]
-                if (epoch_checkpoint_sha or last_checkpoint_sha)
-                else None
-            ),
+            sha_for_log,
         )
 
     for cb in cb_list:


### PR DESCRIPTION
This pull request updates the `.bandit.yml` configuration file to better align with repository security policies and improve the accuracy of Python security scanning. The most important changes include refining which directories are excluded from scans and specifying targeted tests.

Security configuration improvements:

* Updated `exclude_dirs` to exclude additional directories commonly used for virtual environments and cache files, such as `.git`, `.venv`, `venv`, `.mypy_cache`, and `.ruff_cache`, while removing exclusions for `tests` and `docs`.
* Removed global severity and confidence settings, as well as custom assertion and notes sections, to simplify configuration and rely more on in-code justifications.

Targeted test adjustments:

* Added specific Bandit tests to the `tests` section, including checks for bad file permissions (`B103`), unsafe URL opening (`B310`), use of `xml.etree.ElementTree` (`B314`), hardcoded SQL expressions (`B608`), and unsafe use of HuggingFace's `from_pretrained` (`B615`).

------
## Summary
- enforce an HTTPS allow-list for codex task downloads and cover it with regression tests
- harden SQLite/DuckDB helpers by validating and quoting identifiers plus constraining export destinations
- guard Hydra imports against local shadowing and declare the new defusedxml dependency for safe XML parsing
- guard epoch logging when checkpoints are disabled so runs without `checkpoint_dir` remain stable

## Testing
- pytest tests/test_codex_run_tasks.py tests/tools/test_export_security.py -q
- ruff check tools/codex_run_tasks.py tools/codex_sqlite_align.py tools/export_to_parquet.py src/codex_ml/utils/config_loader.py tests/test_codex_run_tasks.py tests/tools/test_export_security.py


------
https://chatgpt.com/codex/tasks/task_e_68d6cbaea2388331b1b75976476f149e