### PR TITLE
Fix Typer import guard in plugin CLI fallback

### DIFF
--- a/src/codex_ml/cli/plugins_cli.py
+++ b/src/codex_ml/cli/plugins_cli.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import inspect
 
-import typer
 from codex_ml.plugins import registries
 
 try:  # Optional dependency: Typer preferred when available


### PR DESCRIPTION
## Summary
- remove the unconditional Typer import so the CLI module loads without Typer installed

## Testing
- No additional tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d705d874ec83319510e83be7cdc8d7