### PR TITLE
feat: add entry-point plugin loader

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -1,0 +1,80 @@
+# Extending Codex ML via entry points
+
+Codex ML exposes a lightweight plugin surface that lets external packages add
+optional metrics and tokenizers without modifying the core repository.  Plugin
+loading is entirely offline and best-effort: discovery failures are swallowed so
+that first-party workflows keep running in constrained environments.
+
+## Discovery lifecycle
+
+Two convenience helpers trigger plugin discovery:
+
+- `codex_ml.metrics.registry.init_metric_plugins()`
+- `codex_ml.registry.tokenizers.init_tokenizer_plugins()`
+
+Call one (or both) during application start-up before looking up components via
+`get_metric()` / `list_metrics()` or `get_tokenizer()` / `list_tokenizers()`.
+The helpers ensure discovery only happens once per process unless `force=True`
+is passed—useful in tests.
+
+The loader looks for Python entry points named after the component group.  For
+metrics the group is `codex_ml.metrics`; for tokenizers it is
+`codex_ml.tokenizers`.
+
+## Writing a plugin
+
+Entry points can target either a callable or a module.  In both cases the
+plugin receives a `register` function from the core registry and should call it
+for every component it wishes to expose.
+
+```python
+# my_pkg/codex_plugins.py
+from __future__ import annotations
+
+from codex_ml.metrics.registry import register_metric
+
+
+def register(register_fn=register_metric):
+    # Register a metric using the core helper
+    register_fn("weighted_accuracy", weighted_accuracy)
+
+
+def weighted_accuracy(predictions, targets, weights=None):
+    ...
+```
+
+The same pattern works for tokenizers using
+`codex_ml.registry.tokenizers.register_tokenizer`:
+
+```python
+from codex_ml.registry.tokenizers import register_tokenizer
+
+
+def register_tokenizers(register_fn=register_tokenizer):
+    register_fn("custom", build_custom_tokenizer)
+
+
+def build_custom_tokenizer(**kwargs):
+    ...
+```
+
+### pyproject.toml
+
+```toml
+[project.entry-points."codex_ml.metrics"]
+weighted = "my_pkg.codex_plugins:register"
+
+[project.entry-points."codex_ml.tokenizers"]
+my_tokenizer = "my_pkg.codex_plugins:register_tokenizers"
+```
+
+Each plugin entry point is invoked once.  Implementations can contribute more
+than one component by calling `register_fn` multiple times.
+
+## Troubleshooting
+
+- Discovery is silent-by-default: broken plugins are skipped.  Set
+  `force=True` when calling `init_*_plugins()` in tests to re-trigger discovery
+  after adjusting mocks.
+- Registrations are last-write wins.  If two plugins register the same name the
+  most recent registration replaces the earlier one.

--- a/src/codex_ml/plugins/__init__.py
+++ b/src/codex_ml/plugins/__init__.py
@@ -1,5 +1,6 @@
 """Plugin registry utilities for codex_ml."""
 
+from .loader import load_plugins
 from .registries import (
     datasets,
     load_dataset_entry_points,
@@ -32,4 +33,5 @@ __all__ = [
     "load_trainer_entry_points",
     "load_reward_model_entry_points",
     "load_rl_agent_entry_points",
+    "load_plugins",
 ]

--- a/src/codex_ml/plugins/loader.py
+++ b/src/codex_ml/plugins/loader.py
@@ -1,0 +1,116 @@
+"""Entry-point plugin loader utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Optional
+
+try:
+    from importlib import metadata
+except Exception:  # pragma: no cover - importlib metadata not available
+    metadata = None  # type: ignore[assignment]
+
+RegisterFn = Callable[..., Any]
+
+
+def _iter_entry_points(group: str) -> Iterable[Any]:
+    """Return iterable of entry points for *group* or an empty tuple."""
+
+    if metadata is None:  # pragma: no cover - fallback for very old Python
+        return ()
+
+    try:
+        return metadata.entry_points(group=group)
+    except TypeError:
+        # Python <3.10 compatibility: entry_points() returns dict-like object
+        try:
+            eps = metadata.entry_points()
+        except Exception:
+            return ()
+        if hasattr(eps, "select"):
+            return eps.select(group=group)
+        return [ep for ep in eps if getattr(ep, "group", None) == group]
+    except Exception:
+        return ()
+
+
+def _call_plugin_hook(target: Any, register: Optional[RegisterFn]) -> bool:
+    """Invoke plugin hook if *target* exposes a register-style API."""
+
+    if register is None:
+        return False
+
+    hook = getattr(target, "register", None)
+    if callable(hook):
+        try:
+            hook(register)
+            return True
+        except Exception:
+            return False
+
+    if callable(target):
+        try:
+            target(register)
+            return True
+        except TypeError:
+            return False
+        except Exception:
+            return False
+
+    return False
+
+
+def _register_direct(register: Optional[RegisterFn], name: str, target: Any) -> bool:
+    """Attempt direct registration via ``register`` for the given entry point."""
+
+    if register is None:
+        return False
+
+    try:
+        register(name, target)
+        return True
+    except TypeError:
+        try:
+            decorator = register(name)
+            decorator(target)
+            return True
+        except Exception:
+            return False
+    except Exception:
+        return False
+
+
+def load_plugins(group: str, *, register: Optional[RegisterFn] = None) -> int:
+    """Best-effort load of entry-point plugins for ``group``.
+
+    The loader understands two plugin styles:
+
+    * A callable accepting a ``register`` function to perform custom
+      registrations.
+    * A module (or object) exposing a ``register(register_fn)`` attribute.
+
+    When a callable or module does not implement one of the above conventions,
+    the loader falls back to direct registration via ``register(entrypoint,
+    obj)`` when a ``register`` function is provided.  All exceptions are
+    swallowed so plugin discovery cannot break the host application.
+
+    Returns the number of successfully invoked plugin registrations.
+    """
+
+    loaded = 0
+    for ep in _iter_entry_points(group):
+        try:
+            target = ep.load()
+        except Exception:
+            continue
+
+        if _call_plugin_hook(target, register):
+            loaded += 1
+            continue
+
+        if _register_direct(register, getattr(ep, "name", ""), target):
+            loaded += 1
+
+    return loaded
+
+
+__all__ = ["load_plugins"]

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+
+def test_load_plugins_monkeypatched(monkeypatch):
+    """Simulate entry points without installing external packages."""
+
+    calls = {"hook": 0, "registered": 0}
+
+    class FakeEP:
+        def __init__(self, name, fn):
+            self.name = name
+            self._fn = fn
+
+        def load(self):
+            return self._fn
+
+    class FakeEPs(list):
+        def select(self, *, group: str):
+            assert group == "codex_ml.metrics"
+            return self
+
+    def fake_entry_points(*, group: str):
+        def plugin(register):
+            calls["hook"] += 1
+            if register is not None:
+                register("demo", lambda *a, **k: None)
+                calls["registered"] += 1
+
+        return FakeEPs([FakeEP("demo_plugin", plugin)])
+
+    from importlib import metadata as imd
+
+    monkeypatch.setattr(imd, "entry_points", fake_entry_points)
+
+    registered = []
+
+    def register(name, fn=None, **kwargs):
+        registered.append(SimpleNamespace(name=name, fn=fn))
+
+    from codex_ml.plugins.loader import load_plugins
+
+    count = load_plugins("codex_ml.metrics", register=register)
+    assert count == 1
+    assert calls == {"hook": 1, "registered": 1}
+    assert registered and registered[0].name == "demo"
+
+
+def test_metric_registry_init_uses_loader(monkeypatch):
+    sys.modules["torch"] = ModuleType("torch")
+
+    from codex_ml.metrics import registry as metrics_registry
+
+    def fake_load_plugins(group, register=None):
+        assert group == "codex_ml.metrics"
+        assert register is not None
+        register("external_metric", lambda: "metric")
+        return 2
+
+    monkeypatch.setattr("codex_ml.plugins.load_plugins", fake_load_plugins)
+
+    metrics_registry.init_metric_plugins(force=True)
+    assert "external_metric" in metrics_registry.list_metrics()
+    assert metrics_registry.get_metric("external_metric")() == "metric"


### PR DESCRIPTION
This pull request introduces a new plugin system for Codex ML, allowing external packages to register custom metrics and tokenizers via Python entry points. The changes add robust, offline-safe plugin discovery for both metrics and tokenizers, update the registries to support plugin loading, and document the extensibility surface. Additionally, a plugin loader utility is implemented and tested, ensuring that plugin registration is flexible and error-tolerant.

**Extensibility and Plugin System:**

* Added documentation (`docs/extensibility.md`) describing how to extend Codex ML via entry points, including lifecycle, plugin writing, and troubleshooting.
* Implemented a plugin loader utility (`src/codex_ml/plugins/loader.py`) that discovers and loads entry-point plugins for metrics and tokenizers, supporting both callable and module-based plugins.
* Updated metrics (`src/codex_ml/metrics/registry.py`) and tokenizer (`src/codex_ml/registry/tokenizers.py`) registries to support plugin discovery and registration, including new `init_metric_plugins()` and `init_tokenizer_plugins()` helpers and lazy loading for registry queries. [[1]](diffhunk://#diff-e9f0bf213b8f7088236e9acbf72ef8a8f1e89a7e7ab9822397cbb762b276ca73L24-R91) [[2]](diffhunk://#diff-528c7b679d1ce4185686d56af82f8d0b9d620ed75430e6f975d64bc1df43fde9L11-R54)

**Testing and Integration:**

* Added tests (`tests/test_plugin_loader.py`) to verify plugin loader behavior and registry integration, including monkeypatching entry point discovery and simulating external plugin registration.

**General Code Quality:**

* Minor code formatting improvements for consistency in metrics registry implementation. [[1]](diffhunk://#diff-e9f0bf213b8f7088236e9acbf72ef8a8f1e89a7e7ab9822397cbb762b276ca73L83-R133) [[2]](diffhunk://#diff-e9f0bf213b8f7088236e9acbf72ef8a8f1e89a7e7ab9822397cbb762b276ca73L188-R236) [[3]](diffhunk://#diff-e9f0bf213b8f7088236e9acbf72ef8a8f1e89a7e7ab9822397cbb762b276ca73L210-R256) [[4]](diffhunk://#diff-e9f0bf213b8f7088236e9acbf72ef8a8f1e89a7e7ab9822397cbb762b276ca73L228-R277) [[5]](diffhunk://#diff-e9f0bf213b8f7088236e9acbf72ef8a8f1e89a7e7ab9822397cbb762b276ca73L268-R310) [[6]](diffhunk://#diff-e9f0bf213b8f7088236e9acbf72ef8a8f1e89a7e7ab9822397cbb762b276ca73L294-R334)

These changes collectively enable a flexible, extensible plugin surface for Codex ML, allowing users to add custom metrics and tokenizers without modifying the core codebase.