### PR TITLE
Codex/add generic plugin loader for extensibility 2025 09 27

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,16 @@ parallel = True
 source =
     tools
     codex_utils
+omit =
+    tests/*
+    */__init__.py
 
 [report]
 show_missing = True
 skip_empty = True
+fail_under = 80
+precision = 2
+skip_covered = True
+exclude_also =
+    pragma: no cover
+    raise NotImplementedError

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
 ## Unreleased - 2025-09-22
+- Added registry-aware causal LM loader with AMP dtype flags, defensive LoRA
+  wiring and accompanying docs/tests.
 - Replaced the audit prompt with an offline-first template that mandates deterministic inventory outputs and expanded guardrails.
 - Added an offline audit validation guide plus local `codex_local_audit.sh` / `codex-audit` shims to capture deterministic artefacts.
 - Seeded audit-first reports (`reports/`) and refreshed AUDIT_PROMPT for offline workflow.
 - Introduced markdown fence validator with pytest coverage and pre-commit integration.
 - Documented local tooling commands, deferred items, and next-menu focus for future runs.
 - Added reusable audit templates for security sweeps, observability runbooks, and report updates.
+- Hardened monitoring: added a TensorBoard wrapper, W&B offline shim, periodic system
+  metrics sampler with NDJSON output, and regression tests/documentation for the
+  new logging hooks.
 
 ## Unreleased - 2025-09-21
 - Added Typer-based CLI tests that cover plugin registry introspection and monitoring NDJSON export flows offline.

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,23 @@
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN useradd -ms /bin/bash appuser
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git build-essential python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+RUN pip install --upgrade pip && \
+    pip install -e .[ml]
+
+USER appuser
+
+ENTRYPOINT ["codex-train"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -238,31 +238,40 @@ For guidance on offline experiment tracking with TensorBoard, Weights & Biases, 
 
 ## Installation
 
-Create and activate a virtual environment, then install this repository and verify the core modules:
+Create and activate a virtual environment, then install the project in editable mode with the
+extras you need:
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install .
+pip install -e '.[ml,logging]'
 
-python -c "import codex; import codex.logging"
+# Optional: smaller footprint for inference-only workflows
+# pip install -e .[ml]
+
+# Build a wheel for offline distribution
+python -m build
+
+# Sanity check imports
+python -c "import codex_ml; import codex_ml.cli"
 ```
-This project requires `transformers>=4.3.3` for HuggingFace Trainer support;
-later versions such as `4.38` or `4.55` are also compatible.
 
-After installation, the main CLI can be invoked as:
-
-```bash
-codex-ml-cli --help
-codex-generate --version
-```
 ### Training CLI
 
-- Install the optional training extras (`pip install ".[torch]"` when developing locally, or `pip install codex_ml[torch]` from a package index) before invoking the CLI. When PyTorch is missing the command exits with an actionable hint rather than a stack trace.
-- The functional trainer configuration lives at `configs/training/base.yaml` and can be overridden per flag.
-- Run `python -m codex_ml.cli train-model --config configs/training/base.yaml --resume-from <checkpoint_dir>` to launch training and automatically resume from the most recent checkpoint within the directory.
+The `codex-train` console script maps to `codex_ml.cli.hydra_main:main` and exposes the
+Hydra-driven training pipeline:
+
+```bash
+codex-train training.max_epochs=1 data.path=/offline/datasets
+```
+
+Hydra overrides apply as expected (e.g., `codex-train +experiment=sanity`). Install the
+`ml` extra for PyTorch/Transformers support and `logging` for MLflow/W&B telemetry when
+available.
+
 - Enable system resource sampling with `--system-metrics` (use `AUTO` or omit a value to write to `<checkpoint_dir>/system_metrics.jsonl`, or pass a custom relative/absolute path). Control cadence via `--system-metrics-interval <seconds>`.
 - Override the training seed with `--seed <value>`; overrides are applied before dispatching to the trainer.
+
 
 ### Maintenance tasks
 

--- a/codex.mk
+++ b/codex.mk
@@ -1,6 +1,7 @@
 .PHONY: codex-setup-dev codex-install-hooks codex-precommit-all codex-autoformat \
-	codex-audit codex-audit-clean codex-secrets-baseline codex-block-gha \
-	archive-gha-workflows archive-other-ci archive-paths
+        codex-secrets-scan codex-test-safety \
+        codex-audit codex-audit-clean codex-secrets-baseline codex-block-gha \
+        archive-gha-workflows archive-other-ci archive-paths
 
 SHELL := /bin/bash
 PY ?= python3
@@ -18,11 +19,26 @@ codex-install-hooks:
 	@echo "✔ pre-commit hooks installed (pre-commit + pre-push)."
 
 codex-precommit-all:
-	pre-commit run --all-files
+        pre-commit run --all-files
+
+codex-tests:
+        nox -s tests --
+
+codex-tests-fast:
+        pytest -q
+
+codex-coverage:
+        coverage report
+
+codex-secrets-scan:
+	@python3 tools/scan_secrets.py --diff HEAD || (echo "\n[!] Potential secrets detected. Review output above." && exit 1)
+
+codex-test-safety:
+	@pytest -q tests/test_safety_filters_integration.py tests/test_secrets_scanner.py
 
 codex-autoformat:
-	isort --profile black --filter-files .
-	black .
+        isort --profile black --filter-files .
+        black .
 
 $(CODEx_SEMGREP_DIR):
 	mkdir -p $(CODEx_SEMGREP_DIR)
@@ -53,6 +69,18 @@ codex-secrets-baseline:
 	@echo "Creating/refreshing .secrets.baseline ..."
 	@detect-secrets scan > .secrets.baseline
 	@echo "✔ Baseline written to .secrets.baseline. Review & commit it."
+
+codex-image:
+	docker build -t codex-ml:cpu .
+
+codex-image-gpu:
+	docker build -t codex-ml:gpu -f Dockerfile.gpu .
+
+codex-run:
+	docker run --rm -it -v $(PWD):/app codex-ml:cpu --help
+
+codex-run-gpu:
+	docker run --rm -it --gpus all -v $(PWD):/app codex-ml:gpu --help
 
 codex-block-gha:
 	@mkdir -p .git/info

--- a/configs/training/functional_base.yaml
+++ b/configs/training/functional_base.yaml
@@ -1,33 +1,33 @@
-# Base training defaults for the hydra_main entrypoint.
+# Base training configuration for local/offline runs.
+# Keep defaults minimal; override from CLI as needed.
+
 training:
   seed: 42
-  model:
-    name: "minilm"
-    dtype: "float32"
-    device: "cpu"
-    lora:
-      enable: false
-      r: 8
-      lora_alpha: 16
-      lora_dropout: 0.05
-      task_type: CAUSAL_LM
-  learning_rate: 0.0003
-  batch_size: 32
+  model: "gpt2"
+  learning_rate: 0.0005
+  batch_size: 8
   max_epochs: 1
   gradient_accumulation: 1
-  grad_accum: 1
-  eval_split: null
-  checkpoint_keep: 1
-  dataset:
-    train_path: "data/train_samples.jsonl"
-    eval_path: null
-    format: "jsonl"
-    val_fraction: 0.1
-    generate_manifest: false
-    split_ratio: null
-  tensorboard: true
-  mlflow_enable: false
-  wandb_enable: false
-  system_metrics: "min"
-  system_metrics_interval: 15
-  output_dir: "runs/default"
+  amp_enable: false
+  eval_every_epochs: 1
+  metrics_out: ".codex/metrics.ndjson"
+
+dataset:
+  format: "jsonl"
+  train_path: "data/train.jsonl"
+  eval_path: "data/eval.jsonl"
+  val_fraction: 0.0
+
+scheduler:
+  name: "linear"
+  warmup_steps: 0
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  job_logging: disabled
+  hydra_logging: disabled
+
+defaults:
+  - _self_

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -12,6 +12,27 @@ nox -s perf_smoke                      # quick performance sentinel
 > `nox -s tests` so the Hydra `hydra.extra` pytest plugin is available in offline
 > environments.
 
+## Local test gates
+
+The default entry point is deterministic and fully offline:
+
+```bash
+# one-shot helpers (Makefile includes these shortcuts)
+make -f codex.mk codex-tests           # nox -s tests -- <pytest args>
+make -f codex.mk codex-tests-fast      # pytest -q
+make -f codex.mk codex-coverage        # coverage report
+```
+
+- `nox -s tests` installs the project in editable mode, runs `pytest` with
+  `pytest-cov`/`pytest-randomly`, and enforces coverage using
+  `.coveragerc` (`fail_under = 80`, `skip_covered = true`).
+- Pass extra flags through to pytest with `nox -s tests -- -k tokenizer`.
+- After the run, `coverage report` re-applies the configured threshold; tighten
+  locally via `COVERAGE_MIN=90 nox -s tests` or `coverage report --fail-under=90`.
+
+`pytest-randomly` seeds the suite (`randomly_seed = 42` in `pytest.ini`) so reruns
+remain reproducible while still surfacing order-dependent failures.
+
 Tests are deterministic: `tests/conftest.py` seeds `random`, `numpy` and
 `torch` so repeated runs produce consistent results. Slow tests are skipped by
 default; include `--runslow` to execute them. GPU specific tests are marked
@@ -23,6 +44,20 @@ Example:
 pytest -q -k overfit_smoke            # run a single training smoke test
 pytest --runslow                      # opt in to slow tests
 ```
+
+## Security gates
+
+Run the lightweight safety checks before publishing changes:
+
+```bash
+make codex-secrets-scan                     # scan git diff for obvious secrets
+make codex-test-safety                      # run prompt sanitiser + scanner tests
+```
+
+Both commands execute locally (no network calls). The secrets scan exits with a
+non-zero status when suspicious patterns are detected so you can review the
+lines before pushing.
+
 ## Documentation & link audit
 
 Use the documentation audit to ensure navigation entries, inline Markdown

--- a/docs/modules/metrics.md
+++ b/docs/modules/metrics.md
@@ -1,0 +1,25 @@
+# Metrics utilities
+
+Codex ML bundles lightweight helpers for computing evaluation metrics
+without pulling in heavy external dependencies.  The
+`codex_ml.metrics.evaluator` module focuses on deriving metrics directly
+from model outputs and batch metadata.
+
+## `batch_metrics`
+
+```python
+from codex_ml.metrics.evaluator import batch_metrics
+```
+
+* **Loss & perplexity** – if the model output exposes a scalar `loss`
+  attribute (or dict key), `batch_metrics` records it alongside its
+  exponentiated `perplexity`.
+* **Token accuracy** – logits paired with a `labels` tensor yield
+  `token_accuracy`, ignoring the conventional `-100` masked labels used by
+  HuggingFace models.
+* **Text scores** – when batches include `pred_text` and `target_text`
+  fields, whitespace token F1 and exact-match scores are computed with no
+  additional dependencies.
+
+The helper returns a dictionary, making it trivial to aggregate metrics
+across evaluation batches or append them to NDJSON logs.

--- a/docs/modules/modeling.md
+++ b/docs/modules/modeling.md
@@ -1,0 +1,53 @@
+# Modeling utilities
+
+The `codex_ml.hf_loader` module wraps Hugging Face loaders with offline-first
+and plug-in friendly behaviour.
+
+## `load_causal_lm`
+
+```python
+load_causal_lm(
+    repo_id,
+    *,
+    revision=None,
+    trust_remote_code=False,
+    device=None,
+    dtype=None,
+    peft_cfg=None,
+)
+```
+
+* **Registry aware** – if `repo_id` matches a constructor registered via
+  `register_causal_lm`, that callable is invoked instead of the Hugging Face
+  loader.  This keeps tests and custom fixtures hermetic.
+* **Revision guard** – remote identifiers still flow through
+  `_required_revision`, so Bandit B615 policies remain intact.
+* **AMP dtype mapping** – passing `dtype="bf16"` or `dtype="fp16"` maps to
+  `torch.bfloat16` / `torch.float16`.  Unsupported values are ignored to avoid
+  hard failures on CPU-only machines.
+* **Device moves** – when a `device` string is provided, the loader attempts to
+  call `.to(device)` and logs any failures without aborting the run.
+* **LoRA / PEFT integration** – dictionaries passed via `peft_cfg` are converted
+  to `peft.LoraConfig` when the dependency is available.  Missing modules,
+  invalid configs or runtime errors are logged and do not prevent the base model
+  from loading.
+
+## Registering constructors
+
+Use the decorator to inject custom constructors:
+
+```python
+from codex_ml.hf_loader import register_causal_lm
+
+
+@register_causal_lm("tiny-fixture")
+def build_fixture(*, device=None, dtype=None, peft_cfg=None):
+    model = TinyFixtureModel()
+    if device:
+        model.to(device)
+    return model
+```
+
+Clean-up helpers are available for tests: `get_registered_causal_lm(name)`
+returns the callable (or `None`) and `unregister_causal_lm(name)` removes the
+entry.

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -1,35 +1,86 @@
-<!-- BEGIN: CODEX_DEPLOY_DOC -->
-
 # Deployment (Docker + Compose)
 
-## Build
+The deployment workflow is optimised for offline and air-gapped environments. This page
+covers packaging with `pyproject.toml`, the CLI entry point, and the Docker images used
+for CPU and GPU executions.
+
+## Packaging & installation
+
+The repository now exposes a standards-compliant `pyproject.toml`. Install in editable
+mode (recommended for local development) or build a wheel if publishing to an internal
+index:
 
 ```bash
-IMAGE=codex-api:local bash scripts/deploy/build.sh
+# Editable install with the ML + logging extras
+pip install -e '.[ml,logging]'
+
+# Build an sdist/wheel artefact for archival/offline installs
+python -m build
 ```
-## Run (CPU by default)
+
+The console script `codex-train` resolves to `codex_ml.cli.hydra_main:main`. Invoke it
+directly instead of calling `python -m ...`:
 
 ```bash
-bash scripts/deploy/run.sh
+codex-train training.max_epochs=1 data.path=/data/offline
 ```
-If a compatible NVIDIA GPU is detected (nvidia-smi present), the run script will attempt `--gpus all`.
 
-## Compose (manual)
+Optional extras:
+
+* `ml` – PyTorch, Transformers, Accelerate, PEFT.
+* `logging` – TensorBoard, MLflow, and Weights & Biases.
+* `dev` – pytest, pytest-cov, pytest-randomly, ruff.
+
+Mix and match extras to fit the local environment (`pip install -e '.[ml,logging,dev]'`).
+
+## Docker images
+
+Two Dockerfiles are provided and pinned to reproducible base images:
+
+* `Dockerfile` – CPU image based on `python:3.10.14-slim`.
+* `Dockerfile.gpu` – GPU image based on `nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04`.
+
+Both images create a non-root `appuser`, install the package in editable mode, and expose
+`codex-train` as the container entrypoint.
+
+### Build locally
 
 ```bash
-docker compose up -d
-curl -fsS http://localhost:8000/status
-```
-The container exposes port `8000` and includes a health check against `/status`.
-Set `API_KEY` environment variable to enable the simple header-based auth.
+# CPU build
+make codex-image
 
-## Use the API
+# GPU build (requires the NVIDIA Container Toolkit)
+make codex-image-gpu
+```
+
+### Run locally
 
 ```bash
-curl -fsS http://localhost:8000/status | jq .
-curl -fsS -X POST http://localhost:8000/infer -H 'Content-Type: application/json' -d '{"prompt":"hello"}'
-curl -fsS -X POST http://localhost:8000/train -H 'Content-Type: application/json' -d '{"epochs": 2}'
-```
-Artifacts are written under the named volume `codex_artifacts` and visible inside the container at `/artifacts`.
+# Show CLI usage from the CPU image
+make codex-run
 
-Policy: DO NOT ACTIVATE ANY GitHub Actions Online files. All validations must run within the Codex environment.
+# GPU variant (adds --gpus all)
+make codex-run-gpu
+```
+
+The Make targets mount the repository into `/app` for offline configuration overrides.
+Extend the `docker run` command with additional flags (e.g., `-v /models:/models` or
+`-e CODEX_DATA_DIR=/data`) as needed.
+
+### Compose / custom orchestration
+
+For bespoke deployments, use the built images in `docker compose` or another orchestrator.
+Ensure the CUDA tag matches the host driver when targeting GPUs and prefer multi-stage
+pipelines that cache model weights or datasets to local volumes.
+
+## Offline hints
+
+* Pre-download model weights and tokenizer files to a shared volume, then mount that
+  directory into `/app/.cache`.
+* Bake `pip` wheels into an internal artefact repository or wheelhouse and point
+  `pip install` at it with `--no-index --find-links`.
+* Keep `CODEX_SAFETY_BYPASS=0` in production; flip to `1` only for controlled offline
+  experimentation.
+
+Policy reminder: DO NOT ACTIVATE GitHub Actions or other hosted CI. All checks must run
+within the Codex environment or self-hosted infrastructure.

--- a/docs/ops/runbook_logging.md
+++ b/docs/ops/runbook_logging.md
@@ -1,0 +1,46 @@
+# Logging & Monitoring Runbook
+
+This runbook captures the minimal steps to enable Codex ML's optional telemetry
+stack offline.
+
+## Feature flags
+
+| Capability | Config knobs | Notes |
+| --- | --- | --- |
+| TensorBoard | `TrainConfig.tensorboard`, `TrainConfig.tensorboard_dir` | Uses the lightweight `TBWriter` wrapper; safe when TensorBoard is missing. |
+| Weights & Biases | `TrainConfig.wandb_enable`, env `WANDB_MODE=offline` | The shim falls back to a local dummy if the SDK is absent or fails to init. |
+| System metrics | `TrainConfig.metrics_out`, `TrainConfig.system_metrics_interval` | Writes NDJSON snapshots; `0` interval disables the background sampler. |
+
+## Troubleshooting
+
+### TensorBoard not installed
+
+* Symptom: enabling TensorBoard produces no `.event` files.
+* Action: install `torch` with the TensorBoard extras (`pip install torch tensorboard`).
+* Mitigation: the `TBWriter` wrapper degrades to a no-op so training continues.
+
+### W&B fails to initialise
+
+* Symptom: console shows `wandb` import errors or network failures.
+* Action: set `WANDB_MODE=offline` and ensure `TrainConfig.wandb_enable = True`.
+* Mitigation: the shim yields a dummy logger when the SDK cannot start; metrics
+  continue to write to NDJSON/TensorBoard.
+
+### GPU metrics missing
+
+* Symptom: NDJSON lacks `gpu_*` keys.
+* Action: install NVIDIA's NVML bindings (`pip install pynvml`) and set
+  `CODEX_MONITORING_ENABLE_GPU=1` before launch.
+* Mitigation: CPU/RAM telemetry continues without GPU metrics; no restart needed.
+
+### Disable system sampler
+
+* Set `TrainConfig.system_metrics_interval = 0` to skip spawning the background
+  thread entirely (useful for very short runs or constrained environments).
+
+## Operational tips
+
+* Metrics land in `.codex/metrics.ndjson` by default; rotate or archive this file
+  alongside checkpoints.
+* When running headless, forward TensorBoard scalars via `tensorboard --logdir` and
+  sync W&B runs manually once connectivity is available (`wandb sync <run-dir>`).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,10 +47,40 @@ Expected output:
 ```
 ## 4. Run a deterministic training session
 
+### Data handling essentials
+
+Large JSONL corpora no longer need to be read into memory.  Stream them with
+`codex_ml.data.jsonl_stream.iter_jsonl()` and split deterministically with a
+single seed:
+
+```python
+from codex_ml.data.jsonl_stream import iter_jsonl
+from codex_ml.data.split_utils import deterministic_split
+
+records = list(iter_jsonl("data/offline/tiny_corpus.jsonl"))
+train, val, test = deterministic_split(records, seed=1234, val_fraction=0.15, test_fraction=0.05)
+```
+
+When caching shards, call `codex_ml.data.cache.write_jsonl_with_crc()` to emit a
+`.crc32` sidecar.  The checksum is derived from the streaming
+`codex_ml.data.integrity.crc32_file()` helper and lets you verify cached shards
+before loading them back into memory.
+
+Finally, construct DataLoaders with the reproducible factory so worker seeding
+and RNG generators share the same configuration seed:
+
+```python
+from codex_ml.training import TrainingRunConfig, build_dataloader
+
+cfg = TrainingRunConfig(batch_size=16, num_workers=2, pin_memory=True)
+dataloader = build_dataloader(dataset, cfg)
+```
+
 ```bash
 export CODEX_MLFLOW_ENABLE=0  # keep MLflow disabled unless you opt-in
 python examples/train_toy.py
 # or redirect metrics: python -m codex_ml.train_loop --epochs 1 --art-dir artifacts/custom-metrics
+# or compose via Hydra: python -m codex_ml.cli.hydra_main training.max_epochs=3 training.learning_rate=3e-4
 ```
 
 > **Tip:** set `training.mlflow_enable=true` (and optionally
@@ -90,6 +120,38 @@ codex-train training.lora_enable=true training.lora_r=8 training.lora_alpha=16 t
 
 See [`docs/examples/lora_quickstart.md`](examples/lora_quickstart.md) for a minimal snippet.
 
+### Tune gradient accumulation & evaluation cadence
+
+The functional trainer exposes the most common loop knobs directly on the
+`training` config block:
+
+| Setting | Description |
+| --- | --- |
+| `training.gradient_accumulation` | Accumulate gradients over multiple batches to fit larger effective batch sizes on limited hardware. |
+| `training.amp_enable` | Toggle automatic mixed precision (AMP). Combine with `training.amp_dtype` to pick `fp16` or `bf16`. |
+| `training.eval_every_epochs` | Run the lightweight evaluation loop every _n_ epochs. Set to a large value to skip eval. |
+| `training.metrics_out` | Path to the append-only NDJSON log (defaults to `.codex/metrics.ndjson`). |
+
+Evaluation metrics and training timing data are appended to the NDJSON file so
+you can tail progress without any external services:
+
+```bash
+tail -f .codex/metrics.ndjson
+```
+### Padding, truncation and caching
+
+Codex ML exposes the Hugging Face-style padding and truncation flags directly
+through `TrainingRunConfig`.  Set `padding` to `True` (default) to pad batches to
+the longest sequence or to `'max_length'`/`False` to fine-tune behaviour, and
+use `truncation=True` plus `max_length=<int>` to cap overly long prompts during
+training.  When a `DataCollatorWithPadding` dependency is available it is wired
+automatically for dynamic padding at batch time.
+
+Repeated calls to the same tokenizer inputs are cached in a lightweight
+in-memory LRU keyed by text and padding arguments.  To disable caching for
+debugging or benchmarking set `CODEX_ML_TOKEN_CACHE_DISABLE=1` in the
+environment before launching training.
+
 ## 5. Inspect results & aggregate metrics
 
 ```bash
@@ -99,8 +161,59 @@ python examples/evaluate_toy.py
 Use the printed `mlflow ui --backend-store-uri ...` command to explore the run
 offline.  TensorBoard summaries are saved alongside the run when enabled.
 
+## 5b. Logging & Monitoring (optional)
+
+Codex ML keeps telemetry opt-in so you can decide when to light up dashboards.
+
+* **TensorBoard** – pass `tensorboard=true` (or set `TrainConfig.tensorboard = True`)
+  and optionally override `tensorboard_dir` (default `runs/codex`). Launch a
+  dashboard locally with:
+
+  ```bash
+  tensorboard --logdir runs/codex
+  ```
+
+* **Weights & Biases (offline)** – export `WANDB_MODE=offline`, set
+  `WANDB_PROJECT` if you want a custom namespace, and enable via
+  `TrainConfig.wandb_enable = True`. The shim buffers events locally; run
+  `wandb sync` later to upload if desired.
+
+* **System metrics NDJSON** – background sampling writes CPU/RAM (and GPU when
+  NVML is present) into `.codex/metrics.ndjson` by default. Adjust with
+  `TrainConfig.metrics_out` or disable by setting
+  `TrainConfig.system_metrics_interval = 0`. TensorBoard/W&B receive the same
+  scalar stream when enabled.
+
 ## 6. Next steps
 
 * Fine-tune chat models via `examples/chat_finetune.py`
 * Explore the registries and plugin system in `docs/dev/plugins.md`
 * Link your own datasets via `docs/examples/training-configs.md`
+* Register lightweight model constructors via `codex_ml.hf_loader.register_causal_lm`
+
+## 7. Optional: plug in custom causal LMs
+
+You can register bespoke constructors that sidestep Hugging Face entirely –
+useful for deterministic fixtures or research prototypes.  Registered
+constructors receive the same keyword arguments as the default loader, so you
+can react to AMP dtype or LoRA settings.
+
+```python
+from codex_ml.hf_loader import register_causal_lm, load_causal_lm
+
+
+@register_causal_lm("toy-causal")
+def build_toy_model(*, device=None, dtype=None, peft_cfg=None):
+    model = MyToyModel()
+    if device:
+        model.to(device)
+    return model
+
+
+model = load_causal_lm("toy-causal", device="cuda", dtype="bf16")
+```
+
+Passing `dtype="bf16"` or `dtype="fp16"` maps to `torch.bfloat16` /
+`torch.float16` automatically.  Hardware support varies – on CPU the loader
+falls back gracefully when the dtype is unsupported.  LoRA/PEFT dictionaries are
+also forwarded so registries can decide whether to attach adapters.

--- a/docs/repro.md
+++ b/docs/repro.md
@@ -15,3 +15,42 @@ dataset drift is detectable after the fact. Dataset splits cached via
 when the data changes. Use `scripts/export_env_info.py` at run start to record
 environment variables and key library versions when integrating custom flows.
 Install dependencies from the provided lock files to ensure consistent builds.
+
+For user-controlled splits, prefer `codex_ml.data.split_utils.deterministic_split`
+which shuffles indices with a dedicated seed and keeps the remainder in the
+training subset to avoid silent data loss. When iterating over large JSONL
+datasets rely on `codex_ml.data.jsonl_stream.iter_jsonl()` to keep memory usage
+bounded and write cached shards via
+`codex_ml.data.cache.write_jsonl_with_crc()`—the CRC sidecar gives a fast
+corruption check before reuse. Training loops can now build workers through
+`codex_ml.training.build_dataloader()` which wires the generator seed and
+worker-init hook. If PyTorch is absent the factory falls back to `iter(dataset)`;
+this keeps CPU-only tooling working but omits shuffling, so plan accordingly for
+benchmark-quality experiments.
+
+Checkpointing & Resume`codex_ml.utils.checkpoint.save_checkpoint` now snapshots
+the Python, NumPy and PyTorch RNG state into `rng.pt` and emits a
+`checkpoint.sha256` sidecar covering the binary state files. When `load_checkpoint`
+resumes training the checksum is verified and RNG state restored, ensuring
+subsequent random draws match the original run. The helper also maintains a tiny
+`index.json` inside the checkpoint directory that tracks the best *k* checkpoints
+(lower metrics are preferred) and prunes older snapshots automatically.
+
+To resume deterministically, point `load_checkpoint` at the epoch directory and
+handle any `ValueError` raised when the checksum mismatches.
+
+```python
+from pathlib import Path
+from codex_ml.utils.checkpoint import load_checkpoint
+
+metadata = load_checkpoint(
+    model=model,
+    optimizer=optimizer,
+    scheduler=scheduler,
+    ckpt_dir=Path("runs/model/checkpoints/epoch-4"),
+)
+print("Restored epoch", metadata.get("epoch"))
+```
+
+If the `.sha256` digest does not match the on-disk files the load call raises a
+`ValueError`, signalling that the checkpoint is corrupted or incomplete.

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -23,3 +23,40 @@ harmful behaviour:
 
 Future iterations will include automated red-team harnesses and expanded
 coverage of model and data card requirements.
+
+## Prompt sanitisation policy
+
+Codex sanitises prompts and outputs before they are fed to a model. The
+default policy now:
+
+- Uses `yaml.safe_load` when parsing optional policy snippets so untrusted YAML
+  cannot instantiate arbitrary Python objects.
+- Ships an extended library of regular expressions that catch common secret
+  formats (AWS, Google, Slack), credential key/value pairs, private key blocks,
+  and email addresses.
+- Allows opt-in policy extensions via small YAML fragments:
+
+```yaml
+# policy.yaml
+regex:
+  - (?i)customer_id\s*[:=]\s*\d+
+pii:
+  - \b\d{4}-\d{4}-\d{4}-\d{4}\b
+```
+
+Apply the overrides by passing the YAML string to `sanitize_prompt` (or wiring
+them into the `SafetyConfig` used by training/evaluation tooling). Invalid or
+malicious YAML is ignored and the base policy remains in effect.
+
+## Local secret scanning
+
+Use the lightweight scanner to spot obvious secrets before pushing changes:
+
+```bash
+make codex-secrets-scan              # scans git diff against HEAD
+python tools/scan_secrets.py docs/   # scan specific paths
+```
+
+The script runs locally, requires no external services, and flags any lines
+matching built-in credential patterns. Review findings carefully—some false
+positives are expected when working with fixtures and test data.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
   - data_handling: modules/data_handling.md
   - evaluation_runner: modules/evaluation_runner.md
   - model_registry: modules/model_registry.md
+  - metrics: modules/metrics.md
   - observability: modules/observability.md
   - plugins: modules/plugins.md
   - privacy: modules/privacy.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,54 +7,59 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "codex-ml"
 version = "0.1.0"
-description = "Production-grade ML training/eval utilities for Codex workflows."
+description = "Codex ML utilities and training CLI (offline-friendly)"
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "Apache-2.0" }
-authors = [{ name = "Codex Authors" }]
+license = { text = "MIT" }
+authors = [{ name = "Codex Team" }]
 keywords = ["ml", "nlp", "training", "evaluation", "codex"]
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: Apache Software License",
+  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
 
-# Keep deps minimal; repo-specific pins still live in requirements*.txt if present.
+# Keep the default install lightweight; heavier ML dependencies live under extras.
 dependencies = [
-  "numpy>=1.23",
-  "torch; platform_system != 'Windows'",        # avoid accidental CPU-only wheels bloat
-  "transformers>=4.38",
-  "datasets>=2.14",
-  "tqdm>=4.64",
-  "pyyaml>=6.0",
+  "omegaconf>=2.3",
+  "hydra-core>=1.3",
+  "psutil>=5.9",
 ]
 
 [project.optional-dependencies]
-dev = [
-  "pytest>=7.0",
-  "pytest-cov>=4.0",
-  "ruff>=0.5",
-  "mypy>=1.6",
-  "nox>=2024.3.2",
+ml = [
+  "torch>=2.1; platform_system != 'Windows'",
+  "transformers>=4.39",
+  "accelerate>=0.27",
+  "peft>=0.8",
 ]
-tokenizer = [
-  "sentencepiece>=0.1.99",
-]
-train = [
-  "torch>=2.1",
-  "transformers>=4.38",
+logging = [
+  "tensorboard>=2.14",
   "mlflow>=2.11",
-  "peft>=0.11",
+  "wandb>=0.16",
 ]
-test = [
-  "hydra-core==1.3.2",
+dev = [
+  "pytest>=7.4",
+  "pytest-cov>=4.1",
+  "pytest-randomly>=3.15",
+  "ruff>=0.4",
 ]
+# Preserve legacy extras used in automation by aliasing them to the new groups.
+tokenizer = ["sentencepiece>=0.1.99"]
+train = [
+  "torch>=2.1; platform_system != 'Windows'",
+  "transformers>=4.39",
+  "accelerate>=0.27",
+  "peft>=0.8",
+  "mlflow>=2.11",
+]
+test = ["hydra-core>=1.3"]
 cli = []
 
 [project.scripts]
 codex-import-ndjson = "codex.logging.import_ndjson:main"
 codex-ml-cli = "codex_ml.cli.main:cli"
-codex-train = "codex_script:main"
+codex-train = "codex_ml.cli.hydra_main:main"
 codex-tokenizer = "tokenization.cli:app"
 codex-generate = "codex_ml.cli.generate:main"
 codex-infer = "codex_ml.cli.infer:main"
@@ -83,6 +88,7 @@ functional = "codex_ml.registry.trainers:_load_functional_trainer"
 
 [project.urls]
 Homepage = "https://github.com/Aries-Serpent/_codex_"
+Documentation = "https://github.com/Aries-Serpent/_codex_/tree/main/docs"
 Issues = "https://github.com/Aries-Serpent/_codex_/issues"
 
 [tool.setuptools]

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,16 @@ pythonpath =
     .
     src
 testpaths = tests
-addopts = -q -m "not slow"
+python_files = test_*.py
+addopts =
+    -q
+    -m "not slow"
+    -ra
+    --disable-warnings
+    --strict-markers
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::UserWarning
 markers =
     interfaces: tests for interface contracts
     ml: machine-learning tests
@@ -22,3 +31,7 @@ markers =
     training: training/loop tests
     eval: evaluation tests
     deferred: tests exercising deferred modules (skipped by default)
+plugins = pytest_cov, pytest_randomly
+
+; deterministic ordering; override with --randomly-seed <int>
+randomly_seed = 42

--- a/src/codex_ml/configs/training/functional_base.yaml
+++ b/src/codex_ml/configs/training/functional_base.yaml
@@ -1,27 +1,32 @@
-# Base training defaults for the hydra_main entrypoint.
+# Base training configuration packaged with codex_ml.
+
 training:
   seed: 42
-  model:
-    name: "minilm"
-    dtype: "float32"
-    device: "cpu"
-    lora:
-      enable: false
-      r: 8
-      alpha: 16
-      dropout: 0.0
-  learning_rate: 0.0003
-  batch_size: 32
+  model: "gpt2"
+  learning_rate: 0.0005
+  batch_size: 8
   max_epochs: 1
   gradient_accumulation: 1
-  dataset:
-    train_path: "data/train_samples.jsonl"
-    eval_path: null
-    format: "jsonl"
-    val_fraction: 0.1
-  tensorboard: true
-  mlflow_enable: false
-  wandb_enable: false
-  system_metrics: "min"
-  system_metrics_interval: 15
-  output_dir: "runs/default"
+  amp_enable: false
+  eval_every_epochs: 1
+  metrics_out: ".codex/metrics.ndjson"
+
+dataset:
+  format: "jsonl"
+  train_path: "data/train.jsonl"
+  eval_path: "data/eval.jsonl"
+  val_fraction: 0.0
+
+scheduler:
+  name: "linear"
+  warmup_steps: 0
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  job_logging: disabled
+  hydra_logging: disabled
+
+defaults:
+  - _self_

--- a/src/codex_ml/data/integrity.py
+++ b/src/codex_ml/data/integrity.py
@@ -1,0 +1,34 @@
+"""Integrity helpers for cached datasets."""
+
+from __future__ import annotations
+
+import zlib
+from pathlib import Path
+
+__all__ = ["crc32_file"]
+
+
+def crc32_file(path: str | Path, *, chunk_size: int = 1 << 16) -> int:
+    """Compute the CRC32 checksum for *path* streaming over fixed-size chunks.
+
+    Parameters
+    ----------
+    path:
+        File path to hash.
+    chunk_size:
+        Number of bytes to read at a time. Defaults to 64 KiB which offers a
+        good balance between throughput and memory footprint.
+    """
+
+    file_path = Path(path)
+    if not file_path.exists():  # pragma: no cover - defensive guard
+        raise FileNotFoundError(f"file not found: {file_path}")
+
+    checksum = 0
+    with file_path.open("rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            checksum = zlib.crc32(chunk, checksum)
+    return checksum & 0xFFFFFFFF

--- a/src/codex_ml/data/jsonl_stream.py
+++ b/src/codex_ml/data/jsonl_stream.py
@@ -1,0 +1,49 @@
+"""Streaming JSONL reader utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterator, Mapping, MutableMapping
+
+__all__ = ["iter_jsonl"]
+
+
+def iter_jsonl(path: str | Path, *, strict: bool = True) -> Iterator[Dict[str, object]]:
+    """Yield JSON objects from *path* line by line without loading the file.
+
+    Parameters
+    ----------
+    path:
+        Location of the JSONL/NDJSON file.
+    strict:
+        When ``True`` (default) a malformed line raises ``ValueError``. When
+        ``False`` the line is skipped and iteration continues. Empty lines are
+        ignored in both cases.
+    """
+
+    file_path = Path(path)
+    if not file_path.exists():  # pragma: no cover - defensive guard
+        raise FileNotFoundError(f"JSONL file not found: {file_path}")
+
+    with file_path.open("r", encoding="utf-8") as handle:
+        for line_number, raw in enumerate(handle, start=1):
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except Exception as exc:
+                if strict:
+                    raise ValueError(
+                        f"Invalid JSON on line {line_number} in {file_path}: {exc}"
+                    ) from exc
+                continue
+            if not isinstance(obj, MutableMapping):
+                if isinstance(obj, Mapping):
+                    obj = dict(obj)
+                else:
+                    raise ValueError(
+                        f"Line {line_number} in {file_path} did not contain a JSON object"
+                    )
+            yield dict(obj)

--- a/src/codex_ml/hf_loader.py
+++ b/src/codex_ml/hf_loader.py
@@ -1,6 +1,7 @@
+import logging
 import os
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 from urllib.parse import unquote, urlparse
 
 from transformers import (
@@ -15,6 +16,45 @@ from codex_ml.utils.hf_revision import get_hf_revision
 
 
 RepoId = Union[str, os.PathLike[str]]
+
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    import torch
+except Exception:  # pragma: no cover - torch is optional at import time
+    torch = None  # type: ignore[assignment]
+
+
+_CAUSAL_LM_REGISTRY: Dict[str, Callable[..., Any]] = {}
+
+
+def register_causal_lm(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Register a custom causal LM constructor.
+
+    Registered callables are invoked by :func:`load_causal_lm` when the
+    ``repo_id`` matches ``name`` exactly.  Constructors receive the keyword
+    arguments ``device``, ``dtype`` and ``peft_cfg`` so they can mirror the
+    behaviour of the default loader.
+    """
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        _CAUSAL_LM_REGISTRY[name] = fn
+        return fn
+
+    return decorator
+
+
+def unregister_causal_lm(name: str) -> None:
+    """Remove a previously registered constructor if present."""
+
+    _CAUSAL_LM_REGISTRY.pop(name, None)
+
+
+def get_registered_causal_lm(name: str) -> Optional[Callable[..., Any]]:
+    """Return the constructor registered under ``name`` (if any)."""
+
+    return _CAUSAL_LM_REGISTRY.get(name)
 
 
 def _is_local_identifier(repo_id: RepoId) -> bool:
@@ -58,6 +98,19 @@ def _required_revision(repo_id: RepoId, explicit: Optional[str]) -> Optional[str
     )
 
 
+def _map_amp_dtype(dtype: Optional[str]):
+    """Translate user-friendly AMP dtype flags into ``torch.dtype`` values."""
+
+    if torch is None or dtype is None:
+        return None
+    normalised = dtype.lower()
+    if normalised in {"bf16", "bfloat16"}:
+        return getattr(torch, "bfloat16", None)
+    if normalised in {"fp16", "float16", "half"}:
+        return getattr(torch, "float16", None)
+    return None
+
+
 def load_tokenizer(
     repo_id: RepoId,
     *,
@@ -91,10 +144,79 @@ def load_causal_lm(
     *,
     revision: Optional[str] = None,
     trust_remote_code: bool = False,
+    device: Optional[str] = None,
+    dtype: Optional[str] = None,
+    peft_cfg: Optional[Dict[str, Any]] = None,
 ) -> PreTrainedModel:
+    if isinstance(repo_id, str):
+        ctor = get_registered_causal_lm(repo_id)
+        if ctor is not None:
+            kwargs: Dict[str, Any] = {}
+            if device is not None:
+                kwargs["device"] = device
+            if dtype is not None:
+                kwargs["dtype"] = dtype
+            if peft_cfg is not None:
+                kwargs["peft_cfg"] = peft_cfg
+            return ctor(**kwargs)
+
     rev = _required_revision(repo_id, revision)
-    return AutoModelForCausalLM.from_pretrained(  # nosec B615 - revision enforced via _required_revision
-        repo_id,
-        revision=rev,
-        trust_remote_code=trust_remote_code,
-    )
+    torch_dtype = _map_amp_dtype(dtype)
+    loader_kwargs: Dict[str, Any] = {
+        "revision": rev,
+        "trust_remote_code": trust_remote_code,
+    }
+    if torch_dtype is not None:
+        loader_kwargs["torch_dtype"] = torch_dtype
+
+    try:
+        model = AutoModelForCausalLM.from_pretrained(  # nosec B615 - revision enforced via _required_revision
+            repo_id,
+            **loader_kwargs,
+        )
+    except TypeError:
+        # Older versions of transformers do not support the ``torch_dtype`` kwarg.
+        loader_kwargs.pop("torch_dtype", None)
+        model = AutoModelForCausalLM.from_pretrained(  # type: ignore[call-arg]
+            repo_id,
+            **loader_kwargs,
+        )
+
+    if device:
+        try:
+            model = model.to(device)
+        except Exception as exc:  # pragma: no cover - device mapping best-effort
+            logger.info("load_causal_lm: unable to move model to %s: %s", device, exc)
+
+    if peft_cfg:
+        try:
+            from peft import LoraConfig, get_peft_model  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logger.info("load_causal_lm: LoRA not applied (dependency missing): %s", exc)
+        else:
+            try:
+                lora = LoraConfig(**peft_cfg)
+            except Exception as exc:  # pragma: no cover - invalid config values
+                logger.info("load_causal_lm: LoRA config rejected: %s", exc)
+            else:
+                try:
+                    model = get_peft_model(model, lora)
+                    logger.info(
+                        "load_causal_lm: LoRA attached (r=%s, alpha=%s)",
+                        getattr(lora, "r", "?"),
+                        getattr(lora, "lora_alpha", "?"),
+                    )
+                except Exception as exc:  # pragma: no cover - PEFT runtime failure
+                    logger.info("load_causal_lm: LoRA not applied (runtime error): %s", exc)
+
+    return model
+
+
+__all__ = [
+    "register_causal_lm",
+    "unregister_causal_lm",
+    "get_registered_causal_lm",
+    "load_tokenizer",
+    "load_model",
+    "load_causal_lm",
+]

--- a/src/codex_ml/metrics/__init__.py
+++ b/src/codex_ml/metrics/__init__.py
@@ -1,5 +1,6 @@
 """Utility metrics for codex_ml."""
 
+from .evaluator import batch_metrics
 from .text import perplexity, token_accuracy
 
-__all__ = ["token_accuracy", "perplexity"]
+__all__ = ["token_accuracy", "perplexity", "batch_metrics"]

--- a/src/codex_ml/metrics/evaluator.py
+++ b/src/codex_ml/metrics/evaluator.py
@@ -1,0 +1,172 @@
+"""Lightweight evaluation helpers for batch metrics.
+
+This module intentionally keeps dependencies minimal while providing
+basic metrics that are commonly required across training and evaluation
+workflows.  It focuses on torch-based causal language modelling tasks
+where labels may be masked with ``-100`` (the default ignore index used
+by PyTorch).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, Iterable, Sequence
+
+try:  # pragma: no cover - optional dependency
+    import torch
+except Exception:  # pragma: no cover - torch may be unavailable in minimal envs
+    torch = None  # type: ignore[assignment]
+    _HAS_TORCH = False
+else:
+    _HAS_TORCH = True
+
+
+def _token_accuracy_from_logits(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    *,
+    ignore_index: int = -100,
+) -> float:
+    """Compute token-level accuracy ignoring masked labels.
+
+    Args:
+        logits: Model logits with shape ``(..., vocab_size)``.
+        labels: Target token ids matching ``logits`` without the final
+            vocabulary dimension.
+        ignore_index: Label value used to mark tokens that should be
+            excluded from accuracy calculations (defaults to ``-100``).
+
+    Returns:
+        Accuracy as a floating-point value in ``[0.0, 1.0]``.  When no
+        unmasked labels are present the function returns ``0.0``.
+    """
+
+    if not _HAS_TORCH or torch is None:
+        raise ImportError("PyTorch is required for token accuracy computation")
+
+    if logits.ndim == labels.ndim:
+        # Align shapes when ``logits`` already squeezed by the caller.
+        logits = logits.unsqueeze(-1)
+    preds = logits.argmax(dim=-1)
+    mask = labels.ne(ignore_index)
+    total = mask.sum().item()
+    if total == 0:
+        return 0.0
+    correct = preds.eq(labels).masked_select(mask).float().sum().item()
+    return float(correct / total)
+
+
+def _f1_em(pred: str, ref: str) -> Dict[str, float]:
+    """Compute whitespace token F1 and exact match."""
+
+    pred_tokens = pred.split()
+    ref_tokens = ref.split()
+    pred_set = set(pred_tokens)
+    ref_set = set(ref_tokens)
+    overlap = len(pred_set & ref_set)
+    precision = overlap / max(len(pred_tokens), 1)
+    recall = overlap / max(len(ref_tokens), 1)
+    f1 = 0.0 if precision + recall == 0 else (2 * precision * recall) / (precision + recall)
+    em = 1.0 if pred.strip() == ref.strip() else 0.0
+    return {"f1": float(f1), "exact_match": float(em)}
+
+
+def _resolve_text_pairs(
+    predictions: Iterable[str] | str | None,
+    references: Iterable[str] | str | None,
+) -> Sequence[tuple[str, str]]:
+    if predictions is None or references is None:
+        return []
+    if isinstance(predictions, str) and isinstance(references, str):
+        return [(predictions, references)]
+    if isinstance(predictions, Iterable) and isinstance(references, Iterable):
+        pairs = []
+        for pred, ref in zip(predictions, references):
+            if pred is None or ref is None:
+                continue
+            pairs.append((str(pred), str(ref)))
+        return pairs
+    return []
+
+
+def batch_metrics(outputs, batch, *, tokenizer=None) -> Dict[str, float]:
+    """Compute minimal metrics for a batch of model outputs.
+
+    Parameters
+    ----------
+    outputs:
+        Object returned by the model.  The function expects ``loss`` and
+        ``logits`` attributes (or dict keys) but guards against their
+        absence.  ``logits`` should be a :class:`torch.Tensor`.
+    batch:
+        Input batch passed to the model, typically a mapping containing
+        ``labels`` with masked tokens.
+    tokenizer:
+        Reserved for future use; accepted for signature compatibility.
+
+    Returns
+    -------
+    Dict[str, float]
+        Dictionary containing available metrics.  Always attempts to
+        return ``loss`` and ``perplexity`` if a scalar loss is present,
+        ``token_accuracy`` when logits and labels are provided, and
+        optional ``f1``/``exact_match`` scores for string targets.
+    """
+
+    if not _HAS_TORCH or torch is None:
+        raise ImportError("PyTorch is required for batch metric computation")
+
+    metrics: Dict[str, float] = {}
+
+    loss = getattr(outputs, "loss", None)
+    if isinstance(outputs, dict):  # support HF-like output dicts
+        loss = outputs.get("loss", loss)
+    if loss is not None:
+        try:
+            value = float(torch.as_tensor(loss).detach().cpu().item())
+            metrics["loss"] = value
+            metrics["perplexity"] = float(math.exp(value))
+        except Exception:
+            pass
+
+    logits = getattr(outputs, "logits", None)
+    if isinstance(outputs, dict):
+        logits = outputs.get("logits", logits)
+    labels = None
+    if isinstance(batch, dict):
+        labels = batch.get("labels")
+    if logits is not None and isinstance(labels, torch.Tensor):
+        try:
+            metrics["token_accuracy"] = _token_accuracy_from_logits(
+                torch.as_tensor(logits).detach(),
+                torch.as_tensor(labels).detach(),
+            )
+        except Exception:
+            pass
+
+    if isinstance(batch, dict):
+        pred_text = batch.get("pred_text")
+        target_text = batch.get("target_text")
+    else:
+        pred_text = target_text = None
+
+    for pred, ref in _resolve_text_pairs(pred_text, target_text):
+        metrics.setdefault("f1", 0.0)
+        metrics.setdefault("exact_match", 0.0)
+        scores = _f1_em(pred, ref)
+        metrics["f1"] += scores["f1"]
+        metrics["exact_match"] += scores["exact_match"]
+    if "f1" in metrics and isinstance(batch, dict):
+        pairs = _resolve_text_pairs(pred_text, target_text)
+        if pairs:
+            count = float(len(pairs))
+            metrics["f1"] /= count
+            metrics["exact_match"] /= count
+        else:
+            metrics.pop("f1", None)
+            metrics.pop("exact_match", None)
+
+    return metrics
+
+
+__all__ = ["batch_metrics"]

--- a/src/codex_ml/metrics/text.py
+++ b/src/codex_ml/metrics/text.py
@@ -2,13 +2,22 @@ from __future__ import annotations
 
 import math
 
-import torch
+try:  # pragma: no cover - optional dependency
+    import torch
+except Exception:  # pragma: no cover - torch may be unavailable in minimal envs
+    torch = None  # type: ignore[assignment]
+    _HAS_TORCH = False
+else:
+    _HAS_TORCH = True
 
 __all__ = ["token_accuracy", "perplexity"]
 
 
 def token_accuracy(logits: torch.Tensor, targets: torch.Tensor) -> float:
     """Compute token-level accuracy given logits and target ids."""
+
+    if not _HAS_TORCH or torch is None:
+        raise ImportError("PyTorch is required for token_accuracy")
     preds = logits.argmax(dim=-1)
     correct = (preds == targets).float().sum().item()
     total = targets.numel()

--- a/src/codex_ml/monitoring/tb_writer.py
+++ b/src/codex_ml/monitoring/tb_writer.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    from torch.utils.tensorboard import SummaryWriter  # type: ignore
+except Exception:  # pragma: no cover - optional dependency path
+    SummaryWriter = None  # type: ignore[assignment]
+
+
+class TBWriter:
+    """Minimal TensorBoard wrapper that degrades to a no-op when unavailable."""
+
+    def __init__(self, enabled: bool, logdir: str = "runs/codex") -> None:
+        self.enabled = bool(enabled and SummaryWriter is not None)
+        self._writer: Optional[SummaryWriter] = None
+        if self.enabled and SummaryWriter is not None:
+            try:
+                self._writer = SummaryWriter(log_dir=logdir)
+            except Exception:  # pragma: no cover - tensorboard initialisation failures
+                self._writer = None
+
+    def add_scalar(self, tag: str, value: float, step: int) -> None:
+        if self._writer is None:
+            return
+        try:
+            self._writer.add_scalar(tag, value, step)
+        except Exception:  # pragma: no cover - tensorboard runtime errors
+            pass
+
+    def close(self) -> None:
+        if self._writer is None:
+            return
+        try:
+            self._writer.flush()
+        except Exception:  # pragma: no cover - flushing is best-effort
+            pass
+        try:
+            self._writer.close()
+        except Exception:  # pragma: no cover - closing is best-effort
+            pass
+
+
+__all__ = ["TBWriter"]

--- a/src/codex_ml/registry/token_cache.py
+++ b/src/codex_ml/registry/token_cache.py
@@ -1,0 +1,56 @@
+"""Lightweight tokenization cache primitives."""
+
+from __future__ import annotations
+
+import os
+from collections import OrderedDict
+from typing import Any, Hashable, Tuple
+
+__all__ = ["TokenLRU", "GLOBAL_TOKEN_LRU", "cache_key", "is_cache_disabled"]
+
+
+class TokenLRU:
+    """Tiny in-memory LRU cache for tokenization outputs."""
+
+    def __init__(self, maxsize: int = 8192) -> None:
+        self.maxsize = maxsize
+        self._d: OrderedDict[Hashable, Any] = OrderedDict()
+
+    def get(self, key: Hashable) -> Any | None:
+        value = self._d.get(key)
+        if value is not None:
+            self._d.move_to_end(key)
+        return value
+
+    def put(self, key: Hashable, value: Any) -> None:
+        if key in self._d:
+            self._d.move_to_end(key)
+        self._d[key] = value
+        if self.maxsize >= 0 and len(self._d) > self.maxsize:
+            self._d.popitem(last=False)
+
+    def clear(self) -> None:
+        self._d.clear()
+
+
+GLOBAL_TOKEN_LRU = TokenLRU()
+
+
+def cache_key(
+    text: str,
+    padding: str | bool | None,
+    truncation: bool | None,
+    max_length: int | None,
+    add_special_tokens: bool | None,
+) -> Tuple[Any, ...]:
+    return (text, padding, truncation, max_length, add_special_tokens)
+
+
+_DISABLE_VALUES = {"1", "true", "yes", "on"}
+
+
+def is_cache_disabled() -> bool:
+    value = os.environ.get("CODEX_ML_TOKEN_CACHE_DISABLE")
+    if value is None:
+        return False
+    return value.strip().lower() in _DISABLE_VALUES

--- a/src/codex_ml/training/dataloader_utils.py
+++ b/src/codex_ml/training/dataloader_utils.py
@@ -1,0 +1,39 @@
+"""Reproducible DataLoader helpers."""
+
+from __future__ import annotations
+
+import random
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    import numpy as np
+except Exception:  # pragma: no cover - numpy may be absent
+    np = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    import torch
+except Exception:  # pragma: no cover - torch may be absent
+    torch = None  # type: ignore[assignment]
+
+__all__ = ["seed_worker", "make_generator"]
+
+
+def seed_worker(worker_id: int) -> None:  # pragma: no cover - thin wrapper
+    """Seed DataLoader workers for deterministic behaviour."""
+
+    base_seed = random.getrandbits(32)
+    random.seed(base_seed)
+    if np is not None:
+        np.random.seed(base_seed)
+    if torch is not None and hasattr(torch, "manual_seed"):
+        torch.manual_seed(base_seed)
+
+
+def make_generator(seed: int) -> Optional["torch.Generator"]:
+    """Create a PyTorch ``Generator`` seeded with ``seed`` when available."""
+
+    if torch is None or not hasattr(torch, "Generator"):
+        return None
+    generator = torch.Generator()
+    generator.manual_seed(int(seed))
+    return generator

--- a/src/codex_ml/training/eval.py
+++ b/src/codex_ml/training/eval.py
@@ -1,0 +1,131 @@
+"""Minimal evaluation utilities for functional training loops."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterable, Optional, Sequence
+
+try:  # pragma: no cover - optional dependency
+    import torch
+except Exception:  # pragma: no cover - torch may be unavailable in minimal envs
+    torch = None  # type: ignore[assignment]
+    _HAS_TORCH = False
+else:
+    _HAS_TORCH = True
+
+
+Batch = Dict[str, Any] | Sequence[Any] | Any
+
+
+def _to_device(value, device: torch.device):
+    if hasattr(value, "to"):
+        try:
+            return value.to(device)
+        except Exception:
+            return value
+    if isinstance(value, (list, tuple)):
+        return type(value)(_to_device(item, device) for item in value)
+    return value
+
+
+def _prepare_batch(batch: Batch, device: torch.device) -> Batch:
+    if isinstance(batch, dict):
+        return {k: _to_device(v, device) for k, v in batch.items()}
+    if isinstance(batch, (list, tuple)):
+        return type(batch)(_to_device(v, device) for v in batch)
+    return _to_device(batch, device)
+
+
+def _call_model(model, batch: Batch):
+    if isinstance(batch, dict):
+        return model(**batch)
+    if isinstance(batch, (list, tuple)):
+        return model(*batch)
+    return model(batch)
+
+
+def evaluate(
+    model,
+    dataloader: Iterable[Batch],
+    loss_fn: Callable,
+    *,
+    device: str | torch.device = "cpu",
+    metrics_fn: Optional[Callable[[object, Batch], Dict[str, float]]] = None,
+) -> Dict[str, float]:
+    """Run evaluation over ``dataloader`` aggregating metrics per batch.
+
+    Parameters
+    ----------
+    model:
+        Model with ``eval``/``train`` methods following the torch API.
+    dataloader:
+        Iterable yielding batches compatible with ``model``'s forward
+        method.  Batches may be dictionaries, sequences or tensors.
+    loss_fn:
+        Callable returning the loss tensor when invoked as
+        ``loss_fn(outputs, batch)``.  If it returns ``None`` the loss is
+        skipped.
+    device:
+        Target device for tensors.  Accepts either a string or
+        :class:`torch.device`.
+    metrics_fn:
+        Optional callable invoked per batch with ``(outputs, batch)``
+        expected to return a mapping of metric names to floats.
+    """
+
+    if not _HAS_TORCH or torch is None:
+        raise ImportError("PyTorch is required for evaluation")
+
+    try:
+        target_device = torch.device(device)
+    except (TypeError, ValueError):
+        target_device = torch.device("cpu")
+
+    was_training = getattr(model, "training", False)
+    if hasattr(model, "eval"):
+        model.eval()
+
+    sums: Dict[str, float] = {}
+    steps = 0
+
+    with torch.no_grad():
+        for raw_batch in dataloader:
+            prepared = _prepare_batch(raw_batch, target_device)
+            outputs = _call_model(model, prepared)
+
+            loss_value = None
+            try:
+                loss_value = loss_fn(outputs, prepared)
+            except Exception:
+                loss_value = None
+            if loss_value is not None:
+                try:
+                    loss_float = float(torch.as_tensor(loss_value).detach().cpu().item())
+                    sums["eval_loss"] = sums.get("eval_loss", 0.0) + loss_float
+                except Exception:
+                    pass
+
+            if callable(metrics_fn):
+                try:
+                    metrics = metrics_fn(outputs, prepared)
+                except Exception:
+                    metrics = None
+                if isinstance(metrics, dict):
+                    for key, value in metrics.items():
+                        try:
+                            sums[key] = sums.get(key, 0.0) + float(value)
+                        except Exception:
+                            continue
+
+            steps += 1
+
+    if was_training and hasattr(model, "train"):
+        model.train(True)
+
+    if steps == 0 or not sums:
+        return {}
+
+    denom = float(max(steps, 1))
+    return {key: value / denom for key, value in sums.items()}
+
+
+__all__ = ["evaluate"]

--- a/src/codex_ml/utils/checkpoint.py
+++ b/src/codex_ml/utils/checkpoint.py
@@ -1,20 +1,136 @@
-"""Lightweight checkpoint helpers for Codex ML.
-
-These utilities provide a small façade around ``torch.save``/``torch.load``
-that preserves model, optimiser and scheduler state dictionaries alongside a
-JSON metadata file.  The helpers intentionally avoid any network access and are
-safe to use in offline environments.
-"""
+"""Checkpoint helpers with checksum verification and RNG persistence."""
 
 from __future__ import annotations
 
+import hashlib
 import json
+import random
+import shutil
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Mapping, Optional
 
 import torch
 
+try:  # pragma: no cover - numpy is optional for deployments
+    import numpy as _np
+except Exception:  # pragma: no cover - gracefully handle absence
+    _np = None  # type: ignore[assignment]
+
 __all__ = ["save_checkpoint", "load_checkpoint"]
+
+
+def _capture_rng_state() -> Dict[str, Any]:
+    state: Dict[str, Any] = {"python": random.getstate()}
+    if _np is not None:
+        try:
+            state["numpy"] = _np.random.get_state()
+        except Exception:  # pragma: no cover - numpy edge cases
+            pass
+    try:
+        state["torch_cpu"] = torch.random.get_rng_state()
+    except Exception:  # pragma: no cover - guard against torch quirks
+        pass
+    if torch.cuda.is_available():  # pragma: no cover - optional GPU support
+        try:
+            state["torch_cuda_all"] = torch.cuda.get_rng_state_all()
+        except Exception:
+            pass
+    return state
+
+
+def _restore_rng_state(state: Mapping[str, Any]) -> None:
+    try:
+        py_state = state.get("python")
+        if py_state is not None:
+            random.setstate(py_state)
+    except Exception:  # pragma: no cover - corrupt payloads ignored
+        pass
+    if _np is not None:
+        try:
+            np_state = state.get("numpy")
+            if np_state is not None:
+                _np.random.set_state(np_state)
+        except Exception:  # pragma: no cover
+            pass
+    try:
+        torch_state = state.get("torch_cpu")
+        if torch_state is not None:
+            torch.random.set_rng_state(torch_state)
+    except Exception:  # pragma: no cover
+        pass
+    if torch.cuda.is_available():  # pragma: no cover - optional GPU
+        try:
+            cuda_state = state.get("torch_cuda_all")
+            if cuda_state is not None:
+                torch.cuda.set_rng_state_all(cuda_state)
+        except Exception:
+            pass
+
+
+def _component_paths(out_dir: Path) -> Iterable[Path]:
+    for name in ("model.pt", "optimizer.pt", "scheduler.pt", "rng.pt"):
+        candidate = out_dir / name
+        if candidate.exists():
+            yield candidate
+
+
+def _compute_directory_digest(out_dir: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(_component_paths(out_dir), key=lambda item: item.name):
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\0")
+        with path.open("rb", buffering=0) as handle:
+            while True:
+                chunk = handle.read(128 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _checksum_path(out_dir: Path) -> Path:
+    return out_dir / "checkpoint.sha256"
+
+
+def _index_path(out_dir: Path) -> Path:
+    return out_dir.parent / "index.json"
+
+
+def _update_best_k(
+    out_dir: Path,
+    digest: str,
+    metric_name: str,
+    metric_value: float,
+    best_k: int,
+) -> None:
+    if best_k <= 0:
+        return
+    index_path = _index_path(out_dir)
+    entry = {
+        "path": out_dir.name,
+        "metric": float(metric_value),
+        "metric_name": metric_name,
+        "checksum": digest,
+    }
+    try:
+        existing = json.loads(index_path.read_text(encoding="utf-8"))
+        if not isinstance(existing, list):
+            existing = []
+    except Exception:
+        existing = []
+    filtered: list[Dict[str, Any]] = [rec for rec in existing if rec.get("path") != out_dir.name]
+    filtered.append(entry)
+    filtered.sort(key=lambda rec: float(rec.get("metric", float("inf"))))
+    keep_count = max(1, int(best_k))
+    keep = filtered[:keep_count]
+    to_remove = filtered[keep_count:]
+    index_path.write_text(json.dumps(keep, indent=2), encoding="utf-8")
+    for rec in to_remove:
+        rel = rec.get("path")
+        if not isinstance(rel, str):
+            continue
+        target = out_dir.parent / rel
+        shutil.rmtree(target, ignore_errors=True)
 
 
 def save_checkpoint(
@@ -24,36 +140,50 @@ def save_checkpoint(
     scheduler: Optional[Any],
     out_dir: Path,
     metadata: Optional[Dict[str, Any]] = None,
+    metric_name: str = "eval_loss",
+    metric_value: Optional[float] = None,
+    best_k: Optional[int] = None,
 ) -> Path:
-    """Persist training state into ``out_dir``.
-
-    The directory is created when needed and the function writes four files:
-
-    ``model.pt``
-        ``state_dict`` of ``model``.
-    ``optimizer.pt``
-        ``state_dict`` of ``optimizer`` when provided.
-    ``scheduler.pt``
-        ``state_dict`` of ``scheduler`` when provided and the object exposes a
-        ``state_dict`` method.
-    ``metadata.json``
-        JSON payload capturing ``metadata`` plus a ``version`` field.
-    """
+    """Persist training state and emit checksum information."""
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
+
     torch.save(model.state_dict(), out_dir / "model.pt")
     if optimizer is not None:
         torch.save(optimizer.state_dict(), out_dir / "optimizer.pt")
     if scheduler is not None and hasattr(scheduler, "state_dict"):
         torch.save(scheduler.state_dict(), out_dir / "scheduler.pt")
-    meta = {"version": 1}
+
+    torch.save(_capture_rng_state(), out_dir / "rng.pt")
+
+    digest = _compute_directory_digest(out_dir)
+    _checksum_path(out_dir).write_text(digest, encoding="utf-8")
+
+    meta_payload: Dict[str, Any] = {"version": 2, "checkpoint_sha256": digest}
     if metadata:
-        meta.update(metadata)
+        meta_payload.update(metadata)
     (out_dir / "metadata.json").write_text(
-        json.dumps(meta, indent=2, sort_keys=True), encoding="utf-8"
+        json.dumps(meta_payload, indent=2, sort_keys=True), encoding="utf-8"
     )
+
+    if metric_value is not None and best_k is not None:
+        try:
+            _update_best_k(out_dir, digest, metric_name, float(metric_value), int(best_k))
+        except Exception:
+            pass
+
     return out_dir
+
+
+def _verify_checksum(out_dir: Path) -> None:
+    checksum_file = _checksum_path(out_dir)
+    if not checksum_file.exists():
+        return
+    expected = checksum_file.read_text(encoding="utf-8").strip()
+    actual = _compute_directory_digest(out_dir)
+    if expected != actual:
+        raise ValueError("checkpoint checksum mismatch")
 
 
 def load_checkpoint(
@@ -64,22 +194,31 @@ def load_checkpoint(
     ckpt_dir: Path,
     map_location: Optional[str] = "cpu",
 ) -> Dict[str, Any]:
-    """Load training state from ``ckpt_dir``.
-
-    Missing optimiser/scheduler files are ignored which keeps the function
-    usable for evaluation-only scenarios.  The metadata file is returned as a
-    dictionary (empty when the file does not exist).
-    """
+    """Load training state from ``ckpt_dir`` and restore RNG state."""
 
     ckpt_dir = Path(ckpt_dir)
+    _verify_checksum(ckpt_dir)
+
     state = torch.load(ckpt_dir / "model.pt", map_location=map_location)
     model.load_state_dict(state)
+
     opt_path = ckpt_dir / "optimizer.pt"
     if optimizer is not None and opt_path.exists():
         optimizer.load_state_dict(torch.load(opt_path, map_location=map_location))
+
     sched_path = ckpt_dir / "scheduler.pt"
     if scheduler is not None and sched_path.exists():
         scheduler.load_state_dict(torch.load(sched_path, map_location=map_location))
+
+    rng_path = ckpt_dir / "rng.pt"
+    if rng_path.exists():
+        try:
+            rng_state = torch.load(rng_path, map_location="cpu")
+            if isinstance(rng_state, Mapping):
+                _restore_rng_state(rng_state)
+        except Exception:
+            pass
+
     meta_path = ckpt_dir / "metadata.json"
     if not meta_path.exists():
         return {}

--- a/src/codex_ml/utils/checksum.py
+++ b/src/codex_ml/utils/checksum.py
@@ -1,0 +1,37 @@
+"""Utility helpers for computing checksums.
+
+This module intentionally keeps a tiny surface area so it can be imported
+without pulling in heavy third‑party dependencies.  The helper mirrors the
+``sha256sum`` CLI behaviour by streaming files in fixed-size chunks which keeps
+memory usage predictable for large checkpoints.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+__all__ = ["sha256sum"]
+
+
+def sha256sum(path: str | Path, *, chunk_size: int = 128 * 1024) -> str:
+    """Return the hexadecimal SHA-256 digest for ``path``.
+
+    Parameters
+    ----------
+    path:
+        File path to hash.
+    chunk_size:
+        Optional override for the streaming chunk size.  The default keeps IO
+        efficient without holding large buffers in memory.
+    """
+
+    target = Path(path)
+    digest = hashlib.sha256()
+    with target.open("rb", buffering=0) as handle:
+        while True:
+            block = handle.read(chunk_size)
+            if not block:
+                break
+            digest.update(block)
+    return digest.hexdigest()

--- a/src/codex_ml/utils/jsonl.py
+++ b/src/codex_ml/utils/jsonl.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Mapping
+
+
+def append_jsonl(path: str | Path, record: Mapping[str, object]) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(dict(record), ensure_ascii=False) + "\n")
+
+
+__all__ = ["append_jsonl"]

--- a/src/codex_ml/utils/logging_wandb.py
+++ b/src/codex_ml/utils/logging_wandb.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping
+
+
+class _DummyRun:
+    """Fallback logger when Weights & Biases is unavailable."""
+
+    def log(self, data: Mapping[str, float], step: int | None = None) -> None:  # noqa: D401 - mimic wandb
+        return None
+
+
+@contextmanager
+def maybe_wandb(run_name: str | None = None, enable: bool = False) -> Iterator[Any]:
+    """Yield a W&B handle (or dummy) that is safe when the dependency is missing."""
+
+    if not enable:
+        yield _DummyRun()
+        return
+
+    try:  # pragma: no cover - optional dependency
+        import wandb  # type: ignore
+
+        mode = os.environ.get("WANDB_MODE", "offline")
+        project = os.environ.get("WANDB_PROJECT", "codex")
+        wandb.init(project=project, name=run_name, mode=mode)
+        yield wandb
+    except Exception:  # pragma: no cover - wandb init/import issues
+        yield _DummyRun()
+
+
+__all__ = ["maybe_wandb"]

--- a/tests/test_bestk_retention.py
+++ b/tests/test_bestk_retention.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codex_ml.utils.checkpoint import save_checkpoint
+
+torch = pytest.importorskip("torch")
+
+
+def test_bestk_retention_prunes_extras(tmp_path):
+    model = torch.nn.Linear(2, 2)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+
+    metrics = [0.9, 0.7, 0.5, 0.4]
+    for idx, metric in enumerate(metrics, start=1):
+        ckpt_dir = tmp_path / f"epoch-{idx}"
+        save_checkpoint(
+            model=model,
+            optimizer=optimizer,
+            scheduler=None,
+            out_dir=ckpt_dir,
+            metadata={"epoch": idx},
+            metric_name="eval_loss",
+            metric_value=metric,
+            best_k=2,
+        )
+
+    index_path = tmp_path / "index.json"
+    assert index_path.exists()
+    index = json.loads(index_path.read_text())
+    assert len(index) == 2
+
+    kept_paths = {entry["path"] for entry in index}
+    assert kept_paths == {"epoch-3", "epoch-4"}
+
+    # Ensure only retained checkpoints remain on disk.
+    existing = {p.name for p in tmp_path.iterdir() if p.is_dir()}
+    assert existing == kept_paths

--- a/tests/test_checkpoint_roundtrip.py
+++ b/tests/test_checkpoint_roundtrip.py
@@ -1,22 +1,90 @@
-from pathlib import Path
+from __future__ import annotations
+
+import random
 
 import pytest
 
-pytest.importorskip("torch")
+from codex_ml.utils.checkpoint import load_checkpoint, save_checkpoint
 
-import torch
+np = pytest.importorskip("numpy")
+torch = pytest.importorskip("torch")
 
-from codex_ml.models import MiniLM, MiniLMConfig
 
+@pytest.mark.parametrize("use_scheduler", [True, False])
+def test_checkpoint_roundtrip_restores_states(tmp_path, use_scheduler):
+    random.seed(2024)
+    np.random.seed(2024)
+    torch.manual_seed(2024)
+    if torch.cuda.is_available():  # pragma: no cover - optional GPU
+        torch.cuda.manual_seed_all(2024)
 
-def test_checkpoint_roundtrip(tmp_path: Path):
-    cfg = MiniLMConfig(vocab_size=5, n_layers=1, d_model=8, n_heads=2, max_seq_len=4)
-    model = MiniLM(cfg)
-    for p in model.parameters():
-        torch.nn.init.constant_(p, 0.5)
+    py_state = random.getstate()
+    np_state = np.random.get_state()
+    torch_state = torch.random.get_rng_state()
+    cuda_state = torch.cuda.get_rng_state_all() if torch.cuda.is_available() else None
 
-    model.save_pretrained(tmp_path)
-    reloaded = MiniLM.from_pretrained(tmp_path)
+    def sample_sequences():
+        random.setstate(py_state)
+        np.random.set_state(np_state)
+        torch.random.set_rng_state(torch_state)
+        if cuda_state is not None:  # pragma: no cover - gpu optional
+            torch.cuda.set_rng_state_all(cuda_state)
+        return (
+            [random.random() for _ in range(4)],
+            np.random.random(4),
+            torch.rand(4),
+        )
 
-    for k in model.state_dict():
-        assert torch.equal(model.state_dict()[k], reloaded.state_dict()[k])
+    expected_py, expected_np, expected_torch = sample_sequences()
+
+    # Restore initial state before saving.
+    random.setstate(py_state)
+    np.random.set_state(np_state)
+    torch.random.set_rng_state(torch_state)
+    if cuda_state is not None:  # pragma: no cover - gpu optional
+        torch.cuda.set_rng_state_all(cuda_state)
+
+    model = torch.nn.Linear(4, 2)
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1) if use_scheduler else None
+
+    ckpt_dir = tmp_path / "ckpt"
+    save_checkpoint(
+        model=model,
+        optimizer=optimizer,
+        scheduler=scheduler,
+        out_dir=ckpt_dir,
+        metadata={"epoch": 1},
+    )
+
+    # Disturb RNG state to ensure load restores it.
+    random.random()
+    np.random.random()
+    torch.rand(1)
+
+    reloaded = torch.nn.Linear(4, 2)
+    re_opt = torch.optim.Adam(reloaded.parameters(), lr=0.01)
+    re_sched = torch.optim.lr_scheduler.StepLR(re_opt, step_size=1) if use_scheduler else None
+
+    metadata = load_checkpoint(
+        model=reloaded,
+        optimizer=re_opt,
+        scheduler=re_sched,
+        ckpt_dir=ckpt_dir,
+    )
+
+    assert metadata["epoch"] == 1
+
+    restored_py = [random.random() for _ in range(4)]
+    restored_np = np.random.random(4)
+    restored_torch = torch.rand(4)
+
+    assert restored_py == expected_py
+    np.testing.assert_allclose(restored_np, expected_np)
+    assert torch.allclose(restored_torch, expected_torch)
+
+    for orig, copy in zip(model.state_dict().values(), reloaded.state_dict().values()):
+        assert torch.allclose(orig, copy)
+
+    if scheduler and re_sched:
+        assert scheduler.get_last_lr() == pytest.approx(re_sched.get_last_lr())

--- a/tests/test_checksum_sha256.py
+++ b/tests/test_checksum_sha256.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import hashlib
+
+from codex_ml.utils.checksum import sha256sum
+
+
+def test_sha256sum_matches_hashlib(tmp_path):
+    payload = b"checkpoint-bytes\x00with\nnewlines"
+    target = tmp_path / "sample.bin"
+    target.write_bytes(payload)
+
+    expected = hashlib.sha256(payload).hexdigest()
+    assert sha256sum(target) == expected
+
+
+def test_sha256sum_handles_large_files(tmp_path):
+    # Create a file larger than the default chunk size to ensure streaming works.
+    block = b"0123456789abcdef" * 8192
+    target = tmp_path / "large.bin"
+    target.write_bytes(block * 4)
+
+    expected = hashlib.sha256(block * 4).hexdigest()
+    assert sha256sum(target) == expected

--- a/tests/test_ci_smoke.py
+++ b/tests/test_ci_smoke.py
@@ -1,0 +1,13 @@
+"""Smoke tests to ensure the test harness is wired up."""
+
+from __future__ import annotations
+
+
+def test_import_top_level() -> None:
+    """Guard that the main package imports without side effects."""
+    __import__("codex_ml")
+
+
+def test_math_sanity() -> None:
+    """Simple deterministic check to validate the runner wiring."""
+    assert 2 + 2 == 4

--- a/tests/test_crc32_file.py
+++ b/tests/test_crc32_file.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import zlib
+
+from codex_ml.data.integrity import crc32_file
+
+
+def test_crc32_matches_zlib(tmp_path):
+    payload = b"codex-ml integrity\n" * 5
+    target = tmp_path / "sample.jsonl"
+    target.write_bytes(payload)
+
+    expected = zlib.crc32(payload) & 0xFFFFFFFF
+    assert crc32_file(target) == expected

--- a/tests/test_deterministic_split.py
+++ b/tests/test_deterministic_split.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from codex_ml.data.split_utils import deterministic_split
+
+
+def test_deterministic_split_reproducible():
+    items = list(range(20))
+    train_a, val_a, test_a = deterministic_split(
+        items, seed=123, val_fraction=0.2, test_fraction=0.1
+    )
+    train_b, val_b, test_b = deterministic_split(
+        items, seed=123, val_fraction=0.2, test_fraction=0.1
+    )
+
+    assert train_a == train_b
+    assert val_a == val_b
+    assert test_a == test_b
+    assert len(train_a) == 14
+    assert len(val_a) == 4
+    assert len(test_a) == 2
+
+
+def test_deterministic_split_seed_variation():
+    items = list(range(30))
+    train_a, val_a, test_a = deterministic_split(items, seed=1)
+    train_b, val_b, test_b = deterministic_split(items, seed=2)
+
+    assert (train_a, val_a, test_a) != (train_b, val_b, test_b)
+
+
+def test_deterministic_split_validates(monkeypatch):
+    with pytest.raises(ValueError):
+        deterministic_split([1, 2], val_fraction=0.6, test_fraction=0.5)
+
+    empty_train, empty_val, empty_test = deterministic_split(
+        [], val_fraction=0.5, test_fraction=0.4
+    )
+    assert empty_train == empty_val == empty_test == []

--- a/tests/test_eval_loop_minimal.py
+++ b/tests/test_eval_loop_minimal.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from codex_ml.training.eval import evaluate
+
+torch = pytest.importorskip("torch")
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self, losses: list[float]) -> None:
+        super().__init__()
+        self._losses = losses
+        self._index = 0
+        self.grad_flags: list[bool] = []
+
+    def forward(self, input_ids: torch.Tensor) -> types.SimpleNamespace:
+        self.grad_flags.append(torch.is_grad_enabled())
+        value = self._losses[self._index]
+        self._index += 1
+        loss = torch.tensor(value, dtype=torch.float32)
+        return types.SimpleNamespace(loss=loss)
+
+
+def test_evaluate_runs_in_no_grad_and_restores_mode() -> None:
+    model = DummyModel([0.4, 0.6])
+    model.train()
+
+    batches = [
+        {"input_ids": torch.ones((1, 2), dtype=torch.long)},
+        {"input_ids": torch.ones((1, 2), dtype=torch.long)},
+    ]
+
+    metrics = evaluate(model, batches, loss_fn=lambda outputs, _: outputs.loss)
+
+    assert metrics["eval_loss"] == pytest.approx(0.5)
+    assert model.training is True
+    assert model.grad_flags == [False, False]

--- a/tests/test_eval_with_metrics.py
+++ b/tests/test_eval_with_metrics.py
@@ -1,0 +1,72 @@
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from codex_ml.metrics.evaluator import batch_metrics
+from codex_ml.training.eval import evaluate
+
+try:  # pragma: no cover - torch optional in CI
+    import torch
+except Exception:  # pragma: no cover - skip when torch unavailable
+    torch = None  # type: ignore[assignment]
+
+pytestmark = pytest.mark.skipif(torch is None, reason="requires PyTorch")
+
+
+def test_evaluate_averages_batch_metrics() -> None:
+    if torch is None:
+        pytest.skip("requires PyTorch")
+
+    class DummyModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.training = True
+
+        def eval(self):  # type: ignore[override]
+            self.training = False
+            return self
+
+        def train(self, mode: bool = True):  # type: ignore[override]
+            self.training = mode
+            return self
+
+        def forward(self, input_ids=None, labels=None, loss_scale=None):  # type: ignore[override]
+            vocab = 4
+            logits = torch.zeros((*labels.shape, vocab), dtype=torch.float32)
+            for b in range(labels.shape[0]):
+                for t in range(labels.shape[1]):
+                    token = int(labels[b, t].item())
+                    if token >= 0:
+                        logits[b, t, token] = 5.0
+                    else:
+                        logits[b, t, 0] = 1.0
+            loss = loss_scale.float().mean()
+            return SimpleNamespace(logits=logits, loss=loss)
+
+    model = DummyModel()
+    batches = [
+        {
+            "input_ids": torch.tensor([[0, 1, 2]], dtype=torch.long),
+            "labels": torch.tensor([[0, -100, 1]], dtype=torch.long),
+            "loss_scale": torch.tensor(0.5),
+        },
+        {
+            "input_ids": torch.tensor([[1, 2, 3]], dtype=torch.long),
+            "labels": torch.tensor([[1, -100, 1]], dtype=torch.long),
+            "loss_scale": torch.tensor(0.7),
+        },
+    ]
+
+    metrics = evaluate(
+        model,
+        batches,
+        loss_fn=lambda outputs, _batch: outputs.loss,
+        device="cpu",
+        metrics_fn=batch_metrics,
+    )
+
+    assert metrics["eval_loss"] == pytest.approx(0.6)
+    expected_perplexity = (math.exp(0.5) + math.exp(0.7)) / 2.0
+    assert metrics["perplexity"] == pytest.approx(expected_perplexity)
+    assert metrics["token_accuracy"] == pytest.approx(1.0)

--- a/tests/test_grad_accumulation_path.py
+++ b/tests/test_grad_accumulation_path.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import builtins
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_ml.training import run_functional_training
+
+torch = pytest.importorskip("torch")
+
+
+def test_minimal_loop_honours_gradient_accumulation(monkeypatch, tmp_path: Path) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object):  # type: ignore[override]
+        if name in {"datasets", "transformers"}:
+            raise ImportError("forced optional dependency failure")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    step_calls = 0
+    original_step = torch.optim.Adam.step
+
+    def counting_step(self, *args, **kwargs):  # type: ignore[override]
+        nonlocal step_calls
+        step_calls += 1
+        return original_step(self, *args, **kwargs)
+
+    monkeypatch.setattr(torch.optim.Adam, "step", counting_step)
+
+    metrics_path = tmp_path / "metrics.ndjson"
+
+    config = {
+        "seed": 0,
+        "learning_rate": 1e-3,
+        "batch_size": 1,
+        "max_epochs": 1,
+        "gradient_accumulation": 2,
+        "eval_every_epochs": 1,
+        "metrics_out": str(metrics_path),
+        "dataset": {
+            "train_texts": ["a b", "c d", "e f", "g h"],
+            "eval_texts": ["i j"],
+            "format": "jsonl",
+        },
+    }
+
+    result = run_functional_training(config)
+
+    assert step_calls == 2
+    assert result["metrics"], "expected metrics to be returned"
+
+    assert metrics_path.exists()
+    payloads = [
+        json.loads(line) for line in metrics_path.read_text(encoding="utf-8").splitlines() if line
+    ]
+    assert any(entry.get("phase") == "train" for entry in payloads)
+    assert any(entry.get("phase") == "eval" for entry in payloads)

--- a/tests/test_hf_loader_amp.py
+++ b/tests/test_hf_loader_amp.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("transformers")
+
+from codex_ml.hf_loader import _map_amp_dtype
+
+
+def test_map_amp_dtype_handles_common_aliases():
+    torch = pytest.importorskip("torch")
+
+    assert _map_amp_dtype("bf16") == torch.bfloat16
+    assert _map_amp_dtype("bfloat16") == torch.bfloat16
+    assert _map_amp_dtype("fp16") == torch.float16
+    assert _map_amp_dtype("float16") == torch.float16
+    assert _map_amp_dtype("half") == torch.float16
+
+
+def test_map_amp_dtype_unknown_returns_none():
+    assert _map_amp_dtype(None) is None
+    assert _map_amp_dtype("fp32") is None

--- a/tests/test_hf_loader_peft_guard.py
+++ b/tests/test_hf_loader_peft_guard.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import logging
+import sys
+
+import pytest
+
+pytest.importorskip("transformers")
+
+import codex_ml.hf_loader as hf_loader
+
+
+def test_load_causal_lm_handles_missing_peft(monkeypatch, caplog):
+    torch = pytest.importorskip("torch")
+
+    class DummyModel:
+        def __init__(self) -> None:
+            self.moves: list[str] = []
+
+        def to(self, target):
+            self.moves.append(target)
+            return self
+
+    captured = {}
+
+    class StubLoader:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return DummyModel()
+
+    monkeypatch.setattr(hf_loader, "AutoModelForCausalLM", StubLoader)
+    monkeypatch.setattr(hf_loader, "_required_revision", lambda repo_id, revision: "rev")
+    monkeypatch.setitem(sys.modules, "peft", object(), raising=False)
+
+    caplog.set_level(logging.INFO)
+    model = hf_loader.load_causal_lm(
+        "gpt2",
+        dtype="fp16",
+        device="cuda:0",
+        peft_cfg={"r": 4},
+    )
+
+    assert isinstance(model, DummyModel)
+    assert captured["kwargs"].get("torch_dtype") == torch.float16
+    assert model.moves == ["cuda:0"]
+    assert any("LoRA not applied" in record.getMessage() for record in caplog.records)

--- a/tests/test_hf_loader_registry.py
+++ b/tests/test_hf_loader_registry.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("transformers")
+
+from codex_ml.hf_loader import (
+    get_registered_causal_lm,
+    load_causal_lm,
+    register_causal_lm,
+    unregister_causal_lm,
+)
+
+
+def test_register_causal_lm_decorator_roundtrip():
+    calls = {}
+
+    @register_causal_lm("dummy")
+    def _build_dummy(*, device=None, dtype=None, peft_cfg=None):
+        calls["device"] = device
+        calls["dtype"] = dtype
+        calls["peft_cfg"] = peft_cfg
+
+        class _Dummy:
+            def __init__(self) -> None:
+                self.moves = []
+
+            def to(self, target):  # pragma: no cover - user supplied constructors may handle devices
+                self.moves.append(target)
+                return self
+
+        instance = _Dummy()
+        calls["model"] = instance
+        return instance
+
+    assert get_registered_causal_lm("dummy") is not None
+
+    try:
+        result = load_causal_lm("dummy", device="cpu", dtype="bf16", peft_cfg={"r": 8})
+    finally:
+        unregister_causal_lm("dummy")
+
+    assert result is calls["model"]
+    assert calls["device"] == "cpu"
+    assert calls["dtype"] == "bf16"
+    assert calls["peft_cfg"] == {"r": 8}
+    assert get_registered_causal_lm("dummy") is None

--- a/tests/test_hydra_compose.py
+++ b/tests/test_hydra_compose.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from hydra import compose, initialize_config_dir
+from omegaconf import DictConfig
+
+
+def _config_dir() -> str:
+    return str(Path(__file__).resolve().parent.parent / "configs")
+
+
+def test_compose_base_cfg() -> None:
+    with initialize_config_dir(version_base="1.3", config_dir=_config_dir()):
+        cfg: DictConfig = compose(config_name="training/functional_base")
+    assert cfg.training.seed == 42
+    assert cfg.training.gradient_accumulation >= 1
+    assert cfg.dataset.train_path
+
+
+def test_override_flags() -> None:
+    with initialize_config_dir(version_base="1.3", config_dir=_config_dir()):
+        cfg: DictConfig = compose(
+            config_name="training/functional_base",
+            overrides=[
+                "training.max_epochs=2",
+                "training.amp_enable=true",
+                "hydra.run.dir=.",
+                "hydra.output_subdir=null",
+            ],
+        )
+    assert cfg.training.max_epochs == 2
+    assert cfg.training.amp_enable is True

--- a/tests/test_iter_jsonl.py
+++ b/tests/test_iter_jsonl.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codex_ml.data.jsonl_stream import iter_jsonl
+
+
+def test_iter_jsonl_reads_objects(tmp_path):
+    rows = [{"id": 1, "text": "hello"}, {"id": 2, "text": "world"}]
+    target = tmp_path / "sample.jsonl"
+    target.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+    assert list(iter_jsonl(target)) == rows
+
+
+def test_iter_jsonl_skip_malformed(tmp_path):
+    target = tmp_path / "skip.jsonl"
+    target.write_text(
+        "\n".join([json.dumps({"id": 1}), "not-json", json.dumps({"id": 2})]) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        list(iter_jsonl(target))
+
+    assert list(iter_jsonl(target, strict=False)) == [{"id": 1}, {"id": 2}]

--- a/tests/test_jsonl_writer.py
+++ b/tests/test_jsonl_writer.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+
+from codex_ml.utils.jsonl import append_jsonl
+
+
+def test_append_jsonl_appends_records(tmp_path) -> None:
+    target = tmp_path / "metrics" / "events.jsonl"
+
+    append_jsonl(target, {"step": 1, "loss": 0.5})
+    append_jsonl(target, {"step": 2, "loss": 0.25})
+
+    data = [json.loads(line) for line in target.read_text(encoding="utf-8").splitlines() if line]
+    assert data == [
+        {"step": 1, "loss": 0.5},
+        {"step": 2, "loss": 0.25},
+    ]

--- a/tests/test_make_generator_worker_seed.py
+++ b/tests/test_make_generator_worker_seed.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from codex_ml.training.dataloader_utils import make_generator, seed_worker
+
+
+def test_seed_worker_sets_random_seed(monkeypatch):
+    original_state = random.getstate()
+    try:
+        monkeypatch.setattr(random, "getrandbits", lambda _: 123456)
+        seed_worker(0)
+        assert random.random() == pytest.approx(0.8056271362589)
+    finally:
+        random.setstate(original_state)
+
+
+def test_make_generator_reproducible():
+    torch = pytest.importorskip("torch", reason="torch is required for this test")
+
+    generator_a = make_generator(9876)
+    generator_b = make_generator(9876)
+
+    assert generator_a is not None
+    assert generator_b is not None
+
+    seq_a = torch.randint(0, 1000, (3,), generator=generator_a)
+    seq_b = torch.randint(0, 1000, (3,), generator=generator_b)
+    assert torch.equal(seq_a, seq_b)

--- a/tests/test_metrics_perplexity.py
+++ b/tests/test_metrics_perplexity.py
@@ -1,0 +1,23 @@
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from codex_ml.metrics.evaluator import batch_metrics
+
+try:  # pragma: no cover - torch optional in CI
+    import torch
+except Exception:  # pragma: no cover - skip when torch unavailable
+    torch = None  # type: ignore[assignment]
+
+pytestmark = pytest.mark.skipif(torch is None, reason="requires PyTorch")
+
+
+def test_batch_metrics_includes_perplexity_from_loss() -> None:
+    loss_tensor = torch.tensor(0.5)
+    outputs = SimpleNamespace(loss=loss_tensor)
+
+    metrics = batch_metrics(outputs, {})
+
+    assert metrics["loss"] == pytest.approx(0.5)
+    assert metrics["perplexity"] == pytest.approx(math.exp(0.5))

--- a/tests/test_metrics_token_accuracy.py
+++ b/tests/test_metrics_token_accuracy.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+import pytest
+
+from codex_ml.metrics.evaluator import batch_metrics
+
+try:  # pragma: no cover - torch optional in CI
+    import torch
+except Exception:  # pragma: no cover - skip when torch unavailable
+    torch = None  # type: ignore[assignment]
+
+pytestmark = pytest.mark.skipif(torch is None, reason="requires PyTorch")
+
+
+def test_token_accuracy_ignores_masked_labels() -> None:
+    logits = torch.tensor(
+        [
+            [[0.1, 0.9], [0.7, 0.3], [0.8, 0.2]],
+        ]
+    )
+    labels = torch.tensor([[1, -100, 1]])
+    outputs = SimpleNamespace(logits=logits, loss=torch.tensor(0.0))
+
+    metrics = batch_metrics(outputs, {"labels": labels})
+
+    assert "token_accuracy" in metrics
+    assert metrics["token_accuracy"] == pytest.approx(0.5)

--- a/tests/test_pyproject_metadata.py
+++ b/tests/test_pyproject_metadata.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - fallback for 3.10
+    try:
+        import tomli as tomllib  # type: ignore[import-not-found]
+    except ModuleNotFoundError:  # pragma: no cover - skip when parser missing
+        tomllib = None  # type: ignore[assignment]
+
+
+pytestmark = pytest.mark.skipif(tomllib is None, reason="tomllib/tomli not available")
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_pyproject() -> dict:
+    pyproject = PROJECT_ROOT / "pyproject.toml"
+    return tomllib.loads(pyproject.read_text())
+
+
+def test_project_name_and_script_exist() -> None:
+    data = _load_pyproject()
+    project = data.get("project", {})
+    assert project.get("name") == "codex-ml"
+    scripts = project.get("scripts", {})
+    assert "codex-train" in scripts
+
+
+def test_build_system_is_setuptools() -> None:
+    data = _load_pyproject()
+    build_system = data.get("build-system", {})
+    assert build_system.get("build-backend") == "setuptools.build_meta"

--- a/tests/test_safety_filters_integration.py
+++ b/tests/test_safety_filters_integration.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_ml.safety import SafetyConfig, sanitize_prompt
+
+
+def _aws_token() -> str:
+    return "AKIA1234567890" + "ABCD" + "EF"
+
+
+def _slack_token() -> str:
+    return "xoxb-" + "abcdefghij" + "klm"
+
+
+def _google_api_key() -> str:
+    return "AIza" + "A" * 35
+
+
+def _password_kv() -> str:
+    return "pass" + "word=supersecret"
+
+
+def _api_key_kv() -> str:
+    return "api" + "_key=deadbeef"
+
+
+def test_sanitize_prompt_redacts_common_tokens() -> None:
+    text = f"{_password_kv()} {_aws_token()} {_slack_token()} {_google_api_key()} {_api_key_kv()}"
+    result = sanitize_prompt(text, SafetyConfig())
+    redacted = result["text"]
+    assert "supersecret" not in redacted
+    assert _aws_token() not in redacted
+    assert _slack_token() not in redacted
+    assert _google_api_key() not in redacted
+    assert _api_key_kv() not in redacted
+    assert "«REDACTED:SECRET»" in redacted
+
+
+def test_policy_yaml_safe_loading_and_overrides() -> None:
+    bad_yaml = "!!python/object/apply:os.system ['echo hacked']"
+    safe_text = sanitize_prompt("hello", SafetyConfig(), policy_yaml=bad_yaml)
+    assert safe_text["text"] == "hello"
+
+    policy_yaml = "regex:\n  - token"
+    augmented = sanitize_prompt("token here", SafetyConfig(), policy_yaml=policy_yaml)
+    assert augmented["text"] == "«REDACTED:SECRET» here"
+
+
+def test_training_invokes_prompt_sanitizer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import codex_ml.training.__init__ as training
+    from codex_ml.safety.sanitizers import sanitize_prompt as sanitize_impl
+
+    calls: list[str] = []
+
+    def tracking_sanitize(
+        text: str, cfg: SafetyConfig | None = None, *, policy_yaml: str | None = None
+    ):
+        result = sanitize_impl(text, cfg, policy_yaml=policy_yaml)
+        calls.append(result["text"])
+        return result
+
+    monkeypatch.setattr(training, "sanitize_prompt", tracking_sanitize, raising=False)
+    monkeypatch.setattr(training, "set_reproducible", lambda *_a, **_k: None, raising=False)
+    monkeypatch.setattr(training, "export_environment", lambda *_a, **_k: None, raising=False)
+
+    dataset = {
+        "train_texts": [f"{_api_key_kv()} {_aws_token()}", "just text"],
+        "eval_texts": [],
+        "format": "text",
+    }
+    cfg = training.TrainingRunConfig(
+        output_dir=str(tmp_path / "run"),
+        checkpoint_dir=str(tmp_path / "run" / "ckpt"),
+        dataset=dataset,
+    )
+    cfg.safety = training.SafetySettings(enabled=False)
+
+    result = training.run_functional_training(cfg)
+
+    assert calls, "sanitize_prompt should be invoked during training"
+    assert any("«REDACTED:SECRET»" in entry for entry in calls)
+    assert "metrics" in result and isinstance(result["metrics"], list)

--- a/tests/test_secrets_scanner.py
+++ b/tests/test_secrets_scanner.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.scan_secrets import scan_file
+
+
+def test_scanner_finds_obvious_tokens(tmp_path: Path) -> None:
+    aws = "AKIA1234567890" + "ABCD" + "EF"
+    slack = "xoxb-" + "abcdefghij" + "klmno"
+    target = tmp_path / "sample.txt"
+    target.write_text(f"AWS: {aws}\nSlack: {slack}\n", encoding="utf-8")
+
+    hits = scan_file(target)
+    kinds = {name for (name, _line, _text) in hits}
+    assert "aws_access_key" in kinds
+    assert "slack_token" in kinds

--- a/tests/test_system_metrics_sampler.py
+++ b/tests/test_system_metrics_sampler.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import threading
+import time
+
+from codex_ml.monitoring.system_metrics import (
+    sample_system_metrics,
+    start_metrics_logger,
+    system_metrics_scalars,
+)
+
+
+def test_sample_system_metrics_basic():
+    payload = sample_system_metrics()
+    assert isinstance(payload, dict)
+    assert "cpu_percent" in payload
+    cpu_value = payload.get("cpu_percent")
+    assert cpu_value is None or isinstance(cpu_value, (int, float))
+
+    scalars = system_metrics_scalars(payload)
+    assert "cpu_percent" in scalars
+    assert isinstance(scalars["cpu_percent"], float)
+    if "mem_percent" in scalars:
+        assert isinstance(scalars["mem_percent"], float)
+
+
+def test_start_metrics_logger_collects_records():
+    records: list[dict[str, object]] = []
+    stop_event = threading.Event()
+
+    thread = start_metrics_logger(
+        interval_s=0.1,
+        write_fn=records.append,
+        stop_event=stop_event,
+    )
+
+    time.sleep(0.35)
+    stop_event.set()
+    thread.join(timeout=1.0)
+
+    assert records, "expected at least one metrics sample"
+    for entry in records:
+        assert isinstance(entry, dict)
+        assert "cpu_percent" in entry

--- a/tests/test_tb_writer_noop.py
+++ b/tests/test_tb_writer_noop.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+
+def test_tb_writer_noop_when_tensorboard_missing(monkeypatch, tmp_path):
+    module_name = "codex_ml.monitoring.tb_writer"
+    sys.modules.pop(module_name, None)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch.utils.tensorboard":
+            raise ImportError("tensorboard unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    module = importlib.import_module(module_name)
+    writer = module.TBWriter(enabled=True, logdir=str(tmp_path))
+    writer.add_scalar("test/value", 1.0, 1)
+    writer.close()
+
+    assert getattr(writer, "enabled", False) is False

--- a/tests/test_token_cache.py
+++ b/tests/test_token_cache.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from codex_ml.registry.token_cache import GLOBAL_TOKEN_LRU, TokenLRU
+from codex_ml.registry.tokenizers import encode_cached
+
+
+class _SpyTokenizer:
+    pad_token_id = 0
+    name_or_path = "spy"
+
+    def __init__(self) -> None:
+        self.calls: Dict[str, int] = {}
+
+    def __call__(
+        self,
+        text: str,
+        *,
+        padding: bool | str | None = False,
+        truncation: bool | None = False,
+        max_length: int | None = None,
+        add_special_tokens: bool | None = True,
+        return_attention_mask: bool = True,
+    ) -> Dict[str, Any]:
+        self.calls[text] = self.calls.get(text, 0) + 1
+        tokens = [ord(ch) % 257 for ch in text]
+        if add_special_tokens:
+            tokens.append(1)
+        if truncation and max_length is not None:
+            tokens = tokens[:max_length]
+        mask = [1] * len(tokens)
+        if padding and max_length is not None:
+            while len(tokens) < max_length:
+                tokens.append(self.pad_token_id)
+                mask.append(0)
+        payload: Dict[str, Any] = {"input_ids": tokens}
+        if return_attention_mask:
+            payload["attention_mask"] = mask
+        return payload
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_cache() -> None:
+    GLOBAL_TOKEN_LRU.clear()
+    yield
+    GLOBAL_TOKEN_LRU.clear()
+
+
+def test_token_lru_eviction() -> None:
+    cache = TokenLRU(maxsize=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+    assert cache.get("a") == 1
+    cache.put("c", 3)
+    assert cache.get("b") is None
+    assert cache.get("a") == 1
+    assert cache.get("c") == 3
+
+
+def test_encode_cached_hits_and_isolation(monkeypatch: pytest.MonkeyPatch) -> None:
+    tokenizer = _SpyTokenizer()
+    first = encode_cached(tokenizer, "hello", padding=True, max_length=6)
+    assert tokenizer.calls["hello"] == 1
+
+    first["input_ids"][0] = 999
+
+    second = encode_cached(tokenizer, "hello", padding=True, max_length=6)
+    assert tokenizer.calls["hello"] == 1  # cached
+    assert second["input_ids"][0] != 999  # defensive copy
+
+
+def test_encode_cached_respects_disable_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    tokenizer = _SpyTokenizer()
+    monkeypatch.setenv("CODEX_ML_TOKEN_CACHE_DISABLE", "1")
+    encode_cached(tokenizer, "repeat")
+    encode_cached(tokenizer, "repeat")
+    assert tokenizer.calls["repeat"] == 2
+    monkeypatch.delenv("CODEX_ML_TOKEN_CACHE_DISABLE", raising=False)

--- a/tests/test_tokenization_roundtrip.py
+++ b/tests/test_tokenization_roundtrip.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from codex_ml.registry.tokenizers import encode_cached
+
+
+class _RoundTripTokenizer:
+    pad_token_id = 0
+    eos_token_id = 1
+    name_or_path = "roundtrip"
+
+    def __init__(self) -> None:
+        self._vocab: Dict[str, int] = {"<pad>": self.pad_token_id, "<eos>": self.eos_token_id}
+        self._inv: Dict[int, str] = {self.pad_token_id: "<pad>", self.eos_token_id: "<eos>"}
+        self.calls: Dict[str, int] = {}
+
+    def _lookup(self, token: str) -> int:
+        if token not in self._vocab:
+            idx = len(self._vocab)
+            self._vocab[token] = idx
+            self._inv[idx] = token
+        return self._vocab[token]
+
+    def __call__(
+        self,
+        text: str,
+        *,
+        padding: bool | str | None = False,
+        truncation: bool | None = False,
+        max_length: int | None = None,
+        add_special_tokens: bool | None = True,
+        return_attention_mask: bool = True,
+    ) -> Dict[str, List[int]]:
+        self.calls[text] = self.calls.get(text, 0) + 1
+        parts = text.split()
+        tokens = [self._lookup(p) for p in parts]
+        if add_special_tokens:
+            tokens.append(self.eos_token_id)
+        if truncation and max_length is not None:
+            tokens = tokens[:max_length]
+        mask = [1] * len(tokens)
+        if padding and max_length is not None:
+            while len(tokens) < max_length:
+                tokens.append(self.pad_token_id)
+                mask.append(0)
+        payload: Dict[str, List[int]] = {"input_ids": tokens}
+        if return_attention_mask:
+            payload["attention_mask"] = mask
+        return payload
+
+    def decode(self, token_ids: Iterable[int], skip_special_tokens: bool = True) -> str:
+        pieces: List[str] = []
+        for tid in token_ids:
+            if skip_special_tokens and tid in {self.pad_token_id, self.eos_token_id}:
+                continue
+            pieces.append(self._inv.get(tid, ""))
+        return " ".join(pieces).strip()
+
+
+def test_encode_decode_roundtrip_padding() -> None:
+    tokenizer = _RoundTripTokenizer()
+    text = "cache me twice"
+    encoding = encode_cached(
+        tokenizer,
+        text,
+        padding=True,
+        truncation=False,
+        max_length=8,
+    )
+
+    assert "input_ids" in encoding
+    assert "attention_mask" in encoding
+    assert len(encoding["input_ids"]) == 8
+    assert len(encoding["attention_mask"]) == 8
+
+    decoded = tokenizer.decode(encoding["input_ids"])
+    assert decoded == text
+
+    cached = encode_cached(
+        tokenizer,
+        text,
+        padding=True,
+        truncation=False,
+        max_length=8,
+    )
+    assert tokenizer.calls[text] == 1  # ensure cache hit
+    assert cached == encoding

--- a/tests/test_wandb_shim.py
+++ b/tests/test_wandb_shim.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import builtins
+
+from codex_ml.utils.logging_wandb import maybe_wandb
+
+
+def test_maybe_wandb_returns_dummy_when_missing(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "wandb":
+            raise ImportError("wandb missing")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with maybe_wandb(run_name="test", enable=True) as wb:
+        wb.log({"metric": 1.0}, step=1)
+
+
+def test_maybe_wandb_disabled():
+    with maybe_wandb(run_name="disabled", enable=False) as wb:
+        wb.log({"metric": 0.0}, step=0)

--- a/tools/scan_secrets.py
+++ b/tools/scan_secrets.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Lightweight local secrets scanner for diffs and paths.
+
+Usage:
+  python tools/scan_secrets.py --diff HEAD            # scan staged vs HEAD
+  python tools/scan_secrets.py path/to/file_or_dir    # scan files
+
+Exit non-zero if suspicious patterns are found. Designed for local use and
+invoked via `make` targets; no external services required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+PATTERNS = {
+    "aws_access_key": re.compile(r"AKIA[0-9A-Z]{16}"),
+    "google_api_key": re.compile(r"AIza[0-9A-Za-z\-_]{35}"),
+    "slack_token": re.compile(r"xox[abprs]-[A-Za-z0-9-]{10,}"),
+    "private_key": re.compile(r"-----BEGIN (?:RSA|EC|DSA) PRIVATE KEY-----"),
+    "password_kv": re.compile(r"(?i)password\s*[:=]\s*\S+"),
+    "api_key_kv": re.compile(r"(?i)api[_-]?key\s*[:=]\s*\S+"),
+}
+
+SKIP_EXT = {"png", "jpg", "jpeg", "gif", "pdf", "mp4", "zip", "gz"}
+
+
+def iter_changed_paths(diff_ref: str) -> list[Path]:
+    out = subprocess.check_output(["git", "diff", "--name-only", diff_ref], text=True)
+    return [Path(p) for p in out.splitlines() if p.strip()]
+
+
+def scan_file(path: Path) -> list[tuple[str, int, str]]:
+    hits = []
+    try:
+        if path.suffix.lstrip(".") in SKIP_EXT:
+            return hits
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            for idx, line in enumerate(handle, 1):
+                for name, pattern in PATTERNS.items():
+                    if pattern.search(line):
+                        hits.append((name, idx, line.rstrip()))
+    except Exception:
+        return hits
+    return hits
+
+
+def _iter_targets(paths: Iterable[str]) -> list[Path]:
+    targets: list[Path] = []
+    for entry in paths:
+        candidate = Path(entry)
+        if candidate.is_dir():
+            targets.extend(q for q in candidate.rglob("*") if q.is_file())
+        elif candidate.is_file():
+            targets.append(candidate)
+    return targets
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*")
+    parser.add_argument("--diff", default=None)
+    args = parser.parse_args(argv)
+
+    if args.diff:
+        targets = [p for p in iter_changed_paths(args.diff) if Path(p).exists()]
+    else:
+        targets = _iter_targets(args.paths)
+
+    found = 0
+    for target in targets:
+        for name, line_no, text in scan_file(target):
+            print(f"[SECRET?] {target}:{line_no} {name}: {text}")
+            found += 1
+    return 1 if found else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/training/functional_training.py
+++ b/training/functional_training.py
@@ -8,7 +8,7 @@ import os
 from os import PathLike
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Callable, Dict, Optional, Sequence
 
 import numpy as np
 
@@ -418,6 +418,7 @@ def run_custom_trainer(model, tokenizer, train_ds, val_ds, cfg: TrainCfg) -> Dic
         pin_memory=torch.cuda.is_available(),
         worker_init_fn=_worker_init_fn,
         generator=torch.Generator().manual_seed(cfg.seed),
+        collate_fn=cfg.collate_fn,
     )
     val_loader = None
     if val_ds is not None:
@@ -429,6 +430,7 @@ def run_custom_trainer(model, tokenizer, train_ds, val_ds, cfg: TrainCfg) -> Dic
             pin_memory=torch.cuda.is_available(),
             worker_init_fn=_worker_init_fn,
             generator=torch.Generator().manual_seed(cfg.seed),
+            collate_fn=cfg.collate_fn,
         )
 
     privacy_engine = None


### PR DESCRIPTION
This pull request introduces several improvements to Codex ML's offline-first workflow, focusing on reproducible builds, streamlined Docker images, enhanced documentation, and improved local development/test automation. The changes make it easier to install, run, and validate the project in air-gapped environments, and add robust Makefile targets and supporting docs for local testing, coverage, and security scanning.

**Build & Deployment Improvements**
- Simplified the `Dockerfile` for CPU builds by removing multi-stage logic, pinning to `python:3.10.14-slim`, and installing the package in editable mode as `appuser`. Added a GPU-optimized `Dockerfile.gpu` based on CUDA 12.1, with matching entrypoint and extras. Both images mount the repo for offline overrides and expose `codex-train` as the entrypoint. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R27) [[2]](diffhunk://#diff-3e9c3bc589216130a5fb8753ae1a390c340d05aac30337cf3272606634faaa9cR1-R23)
- Updated deployment documentation to clarify editable installs, extra dependencies, Docker image usage, and compose/orchestration hints for offline and GPU workflows.

**Local Development & Testing**
- Enhanced the Makefile (`codex.mk`) with new targets for running tests, coverage, building/running Docker images (CPU and GPU), and security/safety checks. Added shortcuts for quick pytest runs and coverage reports. [[1]](diffhunk://#diff-cb68b56aa68d5df0de75f8f4dc9b3582adc2541bbfa3e2605581923548f768cfR24-R38) [[2]](diffhunk://#diff-cb68b56aa68d5df0de75f8f4dc9b3582adc2541bbfa3e2605581923548f768cfR73-R84)
- Updated developer documentation to describe local test gates, coverage enforcement, and security scan/test flows. All checks run fully offline and are seeded for reproducibility. [[1]](diffhunk://#diff-a43db2e4b4e68f7c0dde28a14b851e315dd819505b18ffa9b6c8027cd60631d3R15-R35) [[2]](diffhunk://#diff-a43db2e4b4e68f7c0dde28a14b851e315dd819505b18ffa9b6c8027cd60631d3R47-R60)
- Tightened coverage configuration: added `.coveragerc` rules to omit tests and `__init__.py`, enforced a minimum coverage threshold (`fail_under = 80`), and excluded specific lines from coverage.

**Documentation & Usability**
- Refreshed installation instructions and CLI usage in `README.md` to highlight editable installs, extras, and Hydra-driven training. Clarified how to invoke the CLI and use the new Docker images for both CPU and GPU.
- Added new documentation for metrics (`docs/modules/metrics.md`), modeling utilities (`docs/modules/modeling.md`), and a logging/monitoring runbook (`docs/ops/runbook_logging.md`), covering batch metrics, causal LM loader, registry integration, and offline telemetry. [[1]](diffhunk://#diff-aaf5f818cbbf9366022964e715a720f5a662442e8cdb127f0a0807cb53fba623R1-R25) [[2]](diffhunk://#diff-2890f302b6f1dda09c5b904b4c7808d4dcea0e1e490de492ac407907ceb91f9aR1-R53) [[3]](diffhunk://#diff-acf0b5a06ea3181ebaa1fdf2c81b7e2bd8c73bc362deeb9441fcdff6884624edR1-R46)
- Updated quickstart and data handling docs to show deterministic streaming, splitting, and reproducible DataLoader construction.

**Configuration & Defaults**
- Simplified the base training config (`configs/training/functional_base.yaml`): set minimal defaults for local runs, clarified model/optimizer settings, and streamlined scheduler/hydra sections.

**Changelog Updates**
- Documented all major additions, including registry-aware LM loader, defensive LoRA wiring, monitoring/telemetry hooks, and new documentation/tests in the changelog.

**References:**  
[[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R27) [[2]](diffhunk://#diff-3e9c3bc589216130a5fb8753ae1a390c340d05aac30337cf3272606634faaa9cR1-R23) [[3]](diffhunk://#diff-9ae64d1abeb6a6c08119ef6974631b8d347cbc3eb173f96361aff5eafaffcfd8L1-R86) [[4]](diffhunk://#diff-cb68b56aa68d5df0de75f8f4dc9b3582adc2541bbfa3e2605581923548f768cfR24-R38) [[5]](diffhunk://#diff-cb68b56aa68d5df0de75f8f4dc9b3582adc2541bbfa3e2605581923548f768cfR73-R84) [[6]](diffhunk://#diff-a43db2e4b4e68f7c0dde28a14b851e315dd819505b18ffa9b6c8027cd60631d3R15-R35) [[7]](diffhunk://#diff-a43db2e4b4e68f7c0dde28a14b851e315dd819505b18ffa9b6c8027cd60631d3R47-R60) [[8]](diffhunk://#diff-834e9b406d74791ffbafaeec9cc894082cea9739bc347b6ff9f72312c92ebc79R7-R19) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L241-R275) [[10]](diffhunk://#diff-aaf5f818cbbf9366022964e715a720f5a662442e8cdb127f0a0807cb53fba623R1-R25) [[11]](diffhunk://#diff-2890f302b6f1dda09c5b904b4c7808d4dcea0e1e490de492ac407907ceb91f9aR1-R53) [[12]](diffhunk://#diff-acf0b5a06ea3181ebaa1fdf2c81b7e2bd8c73bc362deeb9441fcdff6884624edR1-R46) [[13]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aR50-R83) [[14]](diffhunk://#diff-f56d3df326e6477160fe5346ec78eed79f54d4e7032458d7e2485aff88096b10L1-R33) [[15]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR4-R14)