### PR TITLE
fix: guard functional trainer logging dependencies

### DIFF
--- a/src/codex_ml/training/functional_training.py
+++ b/src/codex_ml/training/functional_training.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import math
 import random
+import threading
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Optional
@@ -164,6 +165,7 @@ def train(
             else base_metrics_dir / "tensorboard"
         )
     tb_writer = TBWriter(config.tensorboard, str(tb_path))
+    writer = tb_writer
 
     scaler = get_amp_scaler(config.amp_enable)
 


### PR DESCRIPTION
## Summary
- import the standard threading module so the functional trainer can create its system metrics thread
- bind the tensorboard writer variable before the training loop to keep metric logging working

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d791a994588331b0fef2aaebba41a6