### PR TITLE
Fix JSON dataset loading regression

### DIFF
--- a/src/codex_ml/data/loader.py
+++ b/src/codex_ml/data/loader.py
@@ -243,7 +243,7 @@ _TEXT_FIELD_CANDIDATES = ("text", "content", "value")
 
 def _detect_dataset_format(path: Path) -> str:
     suffix = path.suffix.lower()
-    if suffix in {".jsonl", ".json"}:
+    if suffix == ".jsonl":
         return "jsonl"
     if suffix == ".csv":
         return "csv"


### PR DESCRIPTION
## Summary
- restrict the JSONL format detector to only treat `.jsonl` files as JSONL so multi-line `.json` payloads load as raw text again

## Testing
- pytest tests/data/test_load_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68d7968540b08331a88f204459cbb3b4