### PR TITLE
Improve optional dependency detection in test harness

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+import importlib.util
 import os
 import pathlib
 import random
@@ -101,6 +102,23 @@ OPTIONAL_TEST_GROUPS: dict[str, tuple[str, ...]] = {
 }
 
 
+OPTIONAL_MARKERS: dict[str, str] = {
+    "requires_transformers": "transformers",
+    "requires_torch": "torch",
+    "requires_sentencepiece": "sentencepiece",
+}
+
+
+def _module_available(name: str) -> bool:
+    if name == "torch" and TORCH_SKIP_REASON:
+        return False
+    try:
+        spec = importlib.util.find_spec(name)
+    except (ImportError, ValueError):
+        return name in sys.modules
+    return spec is not None
+
+
 def _missing_modules(names: tuple[str, ...]) -> list[str]:
     missing: list[str] = []
     for name in names:
@@ -120,8 +138,10 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     else:
         skip_slow = None
     run_deferred = os.getenv("RUN_DEFERRED_TESTS", "0") == "1"
-    skip_deferred = None if run_deferred else pytest.mark.skip(
-        reason="deferred module (set RUN_DEFERRED_TESTS=1 to enable)"
+    skip_deferred = (
+        None
+        if run_deferred
+        else pytest.mark.skip(reason="deferred module (set RUN_DEFERRED_TESTS=1 to enable)")
     )
     for item in items:
         if skip_deferred and "deferred" in item.keywords:
@@ -129,6 +149,13 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             continue
         if skip_slow and "slow" in item.keywords:
             item.add_marker(skip_slow)
+        for marker_name, module_name in OPTIONAL_MARKERS.items():
+            if item.get_closest_marker(marker_name) and not _module_available(module_name):
+                reason = module_name
+                if module_name == "torch" and TORCH_SKIP_REASON:
+                    reason = f"torch ({TORCH_SKIP_REASON})"
+                item.add_marker(pytest.mark.skip(reason=f"optional dependency missing: {reason}"))
+                break
         module_name = getattr(item.module, "__name__", "")
         for prefix, deps in OPTIONAL_TEST_GROUPS.items():
             if module_name.startswith(prefix):

--- a/tests/tokenization/conftest.py
+++ b/tests/tokenization/conftest.py
@@ -1,3 +1,4 @@
+import importlib.util
 import os
 import sys
 import types
@@ -60,8 +61,17 @@ if _SPM_STUB_FLAG:
     )
     sys.modules.setdefault("sentencepiece", _SPM_STUB)
 
-pytest.importorskip("transformers")
-pytest.importorskip("sentencepiece")
+if not _TRANSFORMERS_STUB and importlib.util.find_spec("transformers") is None:
+    pytest.skip(
+        "transformers not installed; set CODEX_TEST_TRANSFORMERS_STUB=1 to stub",
+        allow_module_level=True,
+    )
+
+if not _SPM_STUB_FLAG and importlib.util.find_spec("sentencepiece") is None:
+    pytest.skip(
+        "sentencepiece not installed; set CODEX_TEST_SPM_STUB=1 to stub",
+        allow_module_level=True,
+    )
 
 
 if _SPM_STUB_FLAG and _SPM_STUB is not None:


### PR DESCRIPTION
## Summary
- add marker-aware optional dependency detection in the global pytest configuration
- gate tokenization tests behind explicit module availability checks to support stubbed dependencies

## Testing
- pytest --collect-only tests/tokenization -q

------
https://chatgpt.com/codex/tasks/task_e_68d89adcc9f88331b82c19b3cabbb66d