### PR TITLE
Make psutil optional and document extras opt-in

### DIFF
--- a/docs/quickstarts/offline_microperf.md
+++ b/docs/quickstarts/offline_microperf.md
@@ -4,6 +4,12 @@ This builds on the existing offline quickstart with a tiny perf harness and syst
 
 ## One-liners
 
+> Optional deps are **opt-in**. If you want everything used below:
+>
+> ```bash
+> pip install -e '.[perf,monitoring,gpu]'
+> ```
+
 ```bash
 python -c "from codex_ml.monitoring.microhelpers import sample; import json; print(json.dumps(sample(), indent=2))"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 dependencies = [
   "omegaconf>=2.3",
   "hydra-core>=1.3",
-  "psutil>=5.9",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_microhelpers.py
+++ b/tests/test_microhelpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from numbers import Number
 
 from codex_ml.monitoring.microhelpers import get_gpu_stats, sample
 
@@ -11,6 +12,15 @@ def test_sample_shape_never_raises():
     assert isinstance(s["proc"], dict)
     assert isinstance(s["sys"], dict)
     assert isinstance(s["gpu"], list)
+    # values (when present) should be numeric JSON-safe types
+    for k in ("cpu_pct", "rss_mb"):
+        v = s["proc"].get(k)
+        if v is not None:
+            assert isinstance(v, Number)
+    for k in ("cpu_pct", "mem_pct"):
+        v = s["sys"].get(k)
+        if v is not None:
+            assert isinstance(v, Number)
 
 
 def test_gpu_stats_dont_crash_without_nvml(monkeypatch):


### PR DESCRIPTION
## Summary
- remove psutil from the core dependencies so it stays under the monitoring extra
- add an offline micro-perf quickstart note about installing optional extras for the examples
- tighten the microhelpers sampler test to require numeric, JSON-friendly values when present

## Testing
- pytest tests/test_microhelpers.py

------
https://chatgpt.com/codex/tasks/task_e_68d8c8b881d08331ba79129c51468c39