### PR TITLE
feat: hydra trainer defaults, file logging, and reproducibility helpers

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -1,6 +1,14 @@
 defaults:
   - override hydra/job_logging: disabled
-seed: 42
+  - trainer: base
+  - _self_
+
+seed: ${trainer.seed}
+deterministic: ${trainer.deterministic}
+log:
+  dir: ${trainer.log.dir}
+  formats: ${trainer.log.formats}
+
 model:
   name: sshleifer/tiny-gpt2
   dtype: fp32

--- a/conf/trainer/base.yaml
+++ b/conf/trainer/base.yaml
@@ -1,0 +1,11 @@
+# minimal trainer defaults surfaced via Hydra
+seed: 42
+# toggle PyTorch deterministic algorithms; see torch reproducibility docs for caveats
+# https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html
+# GPU users may also need to export CUBLAS_WORKSPACE_CONFIG=":4096:8" or ":16:8".
+deterministic: false
+log:
+  dir: logs
+  # supported formats: ndjson (default), csv
+  formats:
+    - ndjson

--- a/docs/guides/config_overrides.md
+++ b/docs/guides/config_overrides.md
@@ -1,0 +1,33 @@
+# Hydra overrides: the fast track
+
+Codex uses a minimal **defaults list** so you can compose configs and tweak
+parameters straight from the command line.
+
+```yaml
+# conf/config.yaml
+defaults:
+  - override hydra/job_logging: disabled
+  - trainer: base
+  - _self_
+```
+
+Examples:
+
+```bash
+# change seed and enable deterministic mode
+codex-train trainer.seed=1234 trainer.deterministic=true
+
+# switch the metrics sink to both NDJSON and CSV
+codex-train trainer.log.formats='[ndjson,csv]'
+```
+
+Hydra understands `dot.path=value` for single values, `node=[a,b]` for lists, and
+`foo.bar='{json:1}'` when you need structured overrides. See the Hydra docs for
+the full grammar; the snippets above map 1:1 to our defaults list.
+
+> **Tip**: combine overrides with `--config-name` to swap entire component trees,
+> then override individual leaves as needed.
+
+***
+ENDNOTES: Hydra defaults list & override syntax
+***

--- a/docs/quickstarts/offline_microperf.md
+++ b/docs/quickstarts/offline_microperf.md
@@ -37,3 +37,9 @@ flowchart LR
 
 > All optional deps (psutil, pynvml, torch, numpy, mlflow) are **guarded**. Missing deps degrade gracefully.
 
+### Tip: file logging for quick evals
+Use the new `FileLogger` sink to emit **NDJSON** (one JSON object per line) and/or
+**CSV** into `./logs/`.
+NDJSON is a newline-delimited JSON format that plays nicely with tail/grep or
+streaming ingestion.
+

--- a/src/codex_ml/cli/config.py
+++ b/src/codex_ml/cli/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Tuple
 
 
 @dataclass
@@ -43,6 +43,7 @@ class TrainCfg:
     """Training loop parameters."""
 
     seed: int = 42
+    deterministic: bool = True
     batch_size: int = 8
     max_epochs: int = 1
     gradient_accumulation: int = 1
@@ -50,6 +51,8 @@ class TrainCfg:
     amp_dtype: Optional[str] = None
     eval_every_epochs: int = 1
     metrics_out: str = ".codex/metrics.ndjson"
+    log_dir: str = "logs"
+    log_formats: Tuple[str, ...] = ("ndjson",)
 
 
 @dataclass

--- a/src/codex_ml/config.py
+++ b/src/codex_ml/config.py
@@ -128,6 +128,7 @@ class SchedulerConfig:
 @dataclass
 class TrainingConfig:
     seed: int = 42
+    deterministic: bool = True
     learning_rate: float = 0.0003
     batch_size: int = 32
     max_epochs: int = 5
@@ -156,6 +157,8 @@ class TrainingConfig:
             "mlflow_enable": False,
         }
     )
+    log_dir: str = "logs"
+    log_formats: Tuple[str, ...] = ("ndjson",)
 
     def validate(self, path: str = "training") -> None:
         if self.learning_rate <= 0:

--- a/src/codex_ml/logging/__init__.py
+++ b/src/codex_ml/logging/__init__.py
@@ -1,5 +1,30 @@
 """Structured logging helpers for Codex ML runs."""
 
-from .run_logger import METRICS_SCHEMA_URI, PARAMS_SCHEMA_URI, RunLogger
+from __future__ import annotations
 
-__all__ = ["RunLogger", "PARAMS_SCHEMA_URI", "METRICS_SCHEMA_URI"]
+from typing import Any
+
+from .file_logger import FileLogger, JsonLogFmt
+
+__all__ = [
+    "RunLogger",
+    "PARAMS_SCHEMA_URI",
+    "METRICS_SCHEMA_URI",
+    "FileLogger",
+    "JsonLogFmt",
+]
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"RunLogger", "PARAMS_SCHEMA_URI", "METRICS_SCHEMA_URI"}:
+        from .run_logger import METRICS_SCHEMA_URI, PARAMS_SCHEMA_URI, RunLogger
+
+        globals().update(
+            {
+                "RunLogger": RunLogger,
+                "PARAMS_SCHEMA_URI": PARAMS_SCHEMA_URI,
+                "METRICS_SCHEMA_URI": METRICS_SCHEMA_URI,
+            }
+        )
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/codex_ml/logging/file_logger.py
+++ b/src/codex_ml/logging/file_logger.py
@@ -1,0 +1,86 @@
+"""Simple file-based metric logging sinks."""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Literal, Mapping, Optional, Tuple, cast
+
+JsonLogFmt = Literal["ndjson", "csv"]
+
+_VALID_FORMATS: Tuple[str, ...] = ("ndjson", "csv")
+
+
+def _normalize_formats(formats: Iterable[JsonLogFmt | str]) -> Tuple[JsonLogFmt, ...]:
+    seen: list[str] = []
+    for raw in formats:
+        fmt = str(raw).lower()
+        if fmt not in _VALID_FORMATS:
+            raise ValueError(f"unsupported format: {fmt}")
+        if fmt not in seen:
+            seen.append(fmt)
+    if not seen:
+        seen.append("ndjson")
+    return tuple(cast(JsonLogFmt, fmt) for fmt in seen)
+
+
+def _iter_fieldnames(row: Mapping[str, object]) -> Iterator[str]:
+    for key in row.keys():
+        yield str(key)
+
+
+@dataclass
+class FileLogger:
+    """Write metric dictionaries to structured files (NDJSON/CSV)."""
+
+    root: Path | str
+    formats: Iterable[JsonLogFmt] = field(default_factory=lambda: ("ndjson",))
+    filename_stem: str = "metrics"
+
+    def __post_init__(self) -> None:
+        self.root = Path(self.root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._formats = _normalize_formats(self.formats)
+        self._ndjson_path: Optional[Path] = None
+        self._csv_path: Optional[Path] = None
+        self._csv_fieldnames: list[str] | None = None
+        if "ndjson" in self._formats:
+            self._ndjson_path = self.root / f"{self.filename_stem}.ndjson"
+        if "csv" in self._formats:
+            self._csv_path = self.root / f"{self.filename_stem}.csv"
+
+    def log(self, row: Mapping[str, object]) -> None:
+        payload = dict(row)
+        if self._ndjson_path is not None:
+            self._append_ndjson(payload)
+        if self._csv_path is not None:
+            self._append_csv(payload)
+
+    def _append_ndjson(self, row: Mapping[str, object]) -> None:
+        assert self._ndjson_path is not None
+        with self._ndjson_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    def _append_csv(self, row: Mapping[str, object]) -> None:
+        assert self._csv_path is not None
+        if self._csv_fieldnames is None:
+            self._csv_fieldnames = list(_iter_fieldnames(row))
+        else:
+            for name in _iter_fieldnames(row):
+                if name not in self._csv_fieldnames:
+                    self._csv_fieldnames.append(name)
+        path = self._csv_path
+        write_header = not path.exists() or path.stat().st_size == 0
+        with path.open("a", encoding="utf-8", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=self._csv_fieldnames, extrasaction="ignore")
+            if write_header:
+                writer.writeheader()
+            writer.writerow({k: row.get(k) for k in self._csv_fieldnames})
+
+    def paths(self) -> Dict[str, Optional[Path]]:
+        return {"ndjson": self._ndjson_path, "csv": self._csv_path}
+
+
+__all__ = ["FileLogger", "JsonLogFmt"]

--- a/src/codex_ml/utils/checkpointing.py
+++ b/src/codex_ml/utils/checkpointing.py
@@ -272,7 +272,9 @@ def _minimal_env_summary() -> Dict[str, Optional[str]]:
         try:
             info["torch"] = getattr(torch, "__version__", None)
             info["cuda"] = (
-                torch.version.cuda if hasattr(torch, "version") and torch.cuda.is_available() else None  # type: ignore[attr-defined]
+                torch.version.cuda
+                if hasattr(torch, "version") and torch.cuda.is_available()
+                else None  # type: ignore[attr-defined]
             )
         except Exception:
             info["torch"] = (
@@ -571,9 +573,17 @@ def load_rng_state(state: Dict[str, Any]) -> None:
     _rng_load(state)
 
 
-def set_seed(seed: int, out_dir: Optional[Path | str] = None) -> Dict[str, int]:
+def set_seed(
+    seed: int,
+    out_dir: Optional[Path | str] = None,
+    *,
+    deterministic: bool | None = None,
+) -> Dict[str, int]:
     """Set RNG seeds across libraries and optionally persist seeds.json."""
-    set_reproducible(seed)
+    if deterministic is None:
+        set_reproducible(seed)
+    else:
+        set_reproducible(seed, deterministic=deterministic)
     seeds: Dict[str, int] = {"python": seed}
     if NUMPY_AVAILABLE:
         seeds["numpy"] = seed

--- a/tests/logging/test_file_logger.py
+++ b/tests/logging/test_file_logger.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_ml.logging.file_logger import FileLogger
+
+
+def test_file_logger_writes_ndjson_and_csv(tmp_path: Path) -> None:
+    logger = FileLogger(root=tmp_path, formats=("ndjson", "csv"), filename_stem="metrics")
+    logger.log({"step": 1, "loss": 0.5})
+    logger.log({"step": 2, "loss": 0.4})
+
+    paths = logger.paths()
+    ndjson_path = paths["ndjson"]
+    csv_path = paths["csv"]
+
+    assert ndjson_path is not None and ndjson_path.exists()
+    assert csv_path is not None and csv_path.exists()
+
+    with ndjson_path.open("r", encoding="utf-8") as fh:
+        lines = [json.loads(line) for line in fh.read().strip().splitlines()]
+    assert lines == [{"step": 1, "loss": 0.5}, {"step": 2, "loss": 0.4}]
+
+    csv_rows = csv_path.read_text(encoding="utf-8").strip().splitlines()
+    assert csv_rows[0].split(",") == ["step", "loss"]
+    assert csv_rows[1:] == ["1,0.5", "2,0.4"]

--- a/tests/utils/test_repro_rng.py
+++ b/tests/utils/test_repro_rng.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from codex_ml.utils.repro import (
+    restore_rng_state,
+    set_deterministic,
+    set_seed,
+    snapshot_rng_state,
+)
+
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - numpy optional
+    np = None  # type: ignore[assignment]
+
+try:
+    import torch
+except Exception:  # pragma: no cover - torch optional
+    torch = None  # type: ignore[assignment]
+
+
+@pytest.mark.parametrize("seed", [7, 1234])
+def test_rng_snapshot_roundtrip(seed: int) -> None:
+    set_seed(seed, deterministic=False)
+    baseline = [random.random() for _ in range(3)]
+    np_baseline = np.random.random(3) if np is not None else None
+
+    if torch is not None:
+        if not hasattr(torch, "random") or not hasattr(torch.random, "get_rng_state"):
+            pytest.skip("torch RNG APIs unavailable")
+
+    try:
+        state = snapshot_rng_state()
+    except AttributeError as exc:
+        pytest.skip(f"snapshot unavailable: {exc}")
+
+    _ = [random.random() for _ in range(5)]
+    if np is not None:
+        _ = np.random.random(5)
+
+    restore_rng_state(state)
+    assert [random.random() for _ in range(3)] == baseline
+    if np is not None:
+        assert np.allclose(np.random.random(3), np_baseline)
+
+
+def test_set_deterministic_noop() -> None:
+    set_deterministic(True)
+    set_deterministic(False)


### PR DESCRIPTION
## Summary
- add trainer defaults and CLI docs for overriding Hydra components, including deterministic seeding and log format toggles
- introduce a FileLogger sink that writes NDJSON and CSV outputs and integrate it into the functional trainer
- expand reproducibility helpers with deterministic controls and RNG snapshot/restore utilities plus targeted tests

## Testing
- pytest tests/logging/test_file_logger.py tests/utils/test_repro_rng.py

------
https://chatgpt.com/codex/tasks/task_e_68d8fe85f0f4833199b8c99dff5c04ac