### PR TITLE
feat: guard mlflow tracking defaults

### DIFF
--- a/docs/guides/mlflow_offline.md
+++ b/docs/guides/mlflow_offline.md
@@ -1,0 +1,24 @@
+# MLflow: Offline-by-default Guard
+
+This project prefers **local file-backed** MLflow tracking by default to avoid accidental remote logging.
+
+## TL;DR
+```python
+from codex_ml.utils.experiment_tracking_mlflow import ensure_local_tracking
+ensure_local_tracking()  # defaults to file:./artifacts/mlruns
+```
+
+- Honors `MLFLOW_TRACKING_URI` if it points to a local path or `file:` URI.
+- **Blocks** `http(s)` URIs unless you **opt in**:
+  ```bash
+  export CODEX_MLFLOW_ALLOW_REMOTE=1
+  export MLFLOW_TRACKING_URI="http://127.0.0.1:5000"
+  ```
+- You can override the default local path in code:
+  ```python
+  ensure_local_tracking("file:/tmp/my_mlruns")
+  ```
+
+## Notes
+- MLflow supports configuring the tracking target via `MLFLOW_TRACKING_URI` or `mlflow.set_tracking_uri(...)`. A `file:` URI keeps runs local.
+- This guard is **offline-first** and does **not** start a server.

--- a/src/codex_ml/utils/experiment_tracking_mlflow.py
+++ b/src/codex_ml/utils/experiment_tracking_mlflow.py
@@ -2,10 +2,89 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import urllib.parse
 from contextlib import contextmanager
-from pathlib import Path
+from importlib import util
 from typing import Any, Iterator, Mapping
+
+if util.find_spec("mlflow") is not None:  # pragma: no branch - deterministic import path
+    import mlflow  # type: ignore[import-not-found]
+else:  # pragma: no cover - exercised when MLflow is absent
+    mlflow = None  # type: ignore[assignment]
+
+
+LOG = logging.getLogger(__name__)
+
+# Default to a local, file-backed store under the repo's artifacts/ path.
+# Safe for offline runs and avoids accidental remote logging.
+DEFAULT_LOCAL_URI = "file:./artifacts/mlruns"
+
+# Opt-in escape hatch for developers who *intentionally* want remote tracking.
+# Example: export CODEX_MLFLOW_ALLOW_REMOTE=1
+ALLOW_REMOTE_ENV = "CODEX_MLFLOW_ALLOW_REMOTE"
+
+
+def _is_remote_uri(uri: str) -> bool:
+    """Return ``True`` if the URI uses an HTTP(S) scheme."""
+
+    try:
+        scheme = urllib.parse.urlparse(uri).scheme.lower()
+    except Exception:  # pragma: no cover - defensive, shouldn't occur in practice
+        return False
+    return scheme in {"http", "https"}
+
+
+def ensure_local_tracking(default_uri: str = DEFAULT_LOCAL_URI) -> str:
+    """Guard MLflow to use a local file-backed tracking URI by default.
+
+    Behavior:
+        * When ``MLFLOW_TRACKING_URI`` is unset, force ``default_uri``.
+        * When ``MLFLOW_TRACKING_URI`` points at HTTP(S) and
+          ``CODEX_MLFLOW_ALLOW_REMOTE`` is **not** present, fall back to
+          ``default_uri``.
+        * Otherwise respect the configured URI.
+
+    Returns the effective MLflow tracking URI.
+    """
+
+    env_uri = os.environ.get("MLFLOW_TRACKING_URI")
+
+    if mlflow is None:
+        if not env_uri or (_is_remote_uri(env_uri) and not os.environ.get(ALLOW_REMOTE_ENV)):
+            os.environ["MLFLOW_TRACKING_URI"] = default_uri
+            effective = default_uri
+        else:
+            effective = env_uri
+        LOG.warning(
+            "MLflow not installed; tracking URI set to %s", effective,
+        )
+        return effective
+
+    if not env_uri:
+        os.environ["MLFLOW_TRACKING_URI"] = default_uri
+        mlflow.set_tracking_uri(default_uri)
+        LOG.info(
+            "MLflow tracking URI not set; using local store: %s",
+            default_uri,
+        )
+        return mlflow.get_tracking_uri()
+
+    if _is_remote_uri(env_uri) and not os.environ.get(ALLOW_REMOTE_ENV):
+        mlflow.set_tracking_uri(default_uri)
+        os.environ["MLFLOW_TRACKING_URI"] = default_uri
+        LOG.warning(
+            "Blocking remote MLFLOW_TRACKING_URI=%s (missing %s). Using local: %s",
+            env_uri,
+            ALLOW_REMOTE_ENV,
+            default_uri,
+        )
+        return mlflow.get_tracking_uri()
+
+    mlflow.set_tracking_uri(env_uri)
+    LOG.info("Using configured MLflow tracking URI: %s", env_uri)
+    return mlflow.get_tracking_uri()
 
 
 def _as_flat_params(data: Mapping[str, Any], prefix: str = "") -> dict[str, str]:
@@ -51,19 +130,15 @@ def maybe_mlflow(
         def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - trivial
             return False
 
-    if not enable:
+    if not enable or mlflow is None:
         yield _NoOpLogger()
         return
 
     try:  # pragma: no cover - optional dependency path
-        import mlflow
-
-        uri = tracking_uri or os.environ.get("MLFLOW_TRACKING_URI")
-        if not uri:
-            base = Path(".codex/mlruns").resolve()
-            base.mkdir(parents=True, exist_ok=True)
-            uri = f"file://{base}"
-        mlflow.set_tracking_uri(uri)
+        if tracking_uri:
+            mlflow.set_tracking_uri(tracking_uri)
+        else:
+            ensure_local_tracking()
         with mlflow.start_run(run_name=run_name) as _run:  # noqa: F841 - ensure context
             yield mlflow
     except Exception:
@@ -71,4 +146,4 @@ def maybe_mlflow(
         yield _NoOpLogger()
 
 
-__all__ = ["maybe_mlflow", "_as_flat_params"]
+__all__ = ["ensure_local_tracking", "maybe_mlflow", "_as_flat_params"]

--- a/tests/tracking/test_mlflow_offline_guard.py
+++ b/tests/tracking/test_mlflow_offline_guard.py
@@ -1,0 +1,48 @@
+import os
+
+import pytest
+
+pytest.importorskip("mlflow")
+import mlflow
+
+from src.codex_ml.utils import experiment_tracking_mlflow as etm
+
+
+def _reset_mlflow_uri() -> None:
+    """Reset MLflow tracking URI state between tests."""
+
+    mlflow.set_tracking_uri(None)
+
+
+def test_default_enforces_file_uri(tmp_path, monkeypatch):
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+    monkeypatch.delenv(etm.ALLOW_REMOTE_ENV, raising=False)
+    _reset_mlflow_uri()
+    uri = etm.ensure_local_tracking(default_uri=f"file:{tmp_path.as_posix()}")
+    assert uri.startswith("file:"), uri
+
+
+def test_blocks_remote_without_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://127.0.0.1:5000")
+    monkeypatch.delenv(etm.ALLOW_REMOTE_ENV, raising=False)
+    _reset_mlflow_uri()
+    uri = etm.ensure_local_tracking(default_uri=f"file:{tmp_path.as_posix()}")
+    assert uri.startswith("file:"), f"expected file: uri, got {uri}"
+    assert os.environ["MLFLOW_TRACKING_URI"].startswith("file:")
+
+
+def test_allows_remote_with_explicit_opt_in(monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://127.0.0.1:5000")
+    monkeypatch.setenv(etm.ALLOW_REMOTE_ENV, "1")
+    _reset_mlflow_uri()
+    uri = etm.ensure_local_tracking()
+    assert uri.startswith("http")
+
+
+def test_respects_existing_local_file_uri(monkeypatch, tmp_path):
+    local_uri = f"file:{tmp_path.as_posix()}"
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", local_uri)
+    monkeypatch.delenv(etm.ALLOW_REMOTE_ENV, raising=False)
+    _reset_mlflow_uri()
+    uri = etm.ensure_local_tracking()
+    assert uri == local_uri


### PR DESCRIPTION
## Summary
- add an ensure_local_tracking helper that defaults MLflow URIs to a local file store and blocks remote endpoints unless explicitly allowed
- integrate the guard into existing MLflow helper utilities and document usage with a dedicated offline guide
- cover the new behavior with targeted tests that verify defaulting, remote blocking, and explicit opt-in scenarios

## Testing
- `pytest -q tests/tracking/test_mlflow_offline_guard.py`
- `ruff check src/codex_ml/utils/experiment_tracking_mlflow.py tests/tracking/test_mlflow_offline_guard.py`
- `python3 tools/validate_fences.py --strict-inner docs/guides/mlflow_offline.md`

------
https://chatgpt.com/codex/tasks/task_e_68d9d09c26f08331a631109f252f2c53