### PR TITLE
Prevent validate-fences hook recursion when run inside pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,15 @@ repos:
         stages: [manual]
       - id: validate-fences
         name: validate markdown code fences
-        entry: python tools/validate_fences.py --strict-inner
+        # Ensure the validator knows it is running *inside* pre-commit to avoid
+        # delegating back to `pre-commit run ...` and recursing.
+        entry: bash
         language: system
+        args:
+          - -lc
+          - 'PRE_COMMIT=1 python tools/validate_fences.py --strict-inner "$@"'
+          # Provide a placeholder for $0 so the first filename is preserved in "$@".
+          - validate-fences
         pass_filenames: true
         types: [markdown]
         exclude: '^tests/data/validate_fences_sample\.md$'

--- a/docs/guides/AGENTS.md
+++ b/docs/guides/AGENTS.md
@@ -55,6 +55,8 @@ pre-commit run --all-files
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
 ```
 
+> Tip: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` disables 3rd-party plugin auto-loading for deterministic test runs in minimal environments. ([Happy Test][2])
+
 ## Config composition & overrides
 
 You can inspect the composed defaults and override at the CLI:
@@ -65,3 +67,5 @@ python -m codex_ml.cli.config trainer.seed=123 trainer.deterministic=true loggin
 ```
 
 See Hydra's docs for background on defaults lists and composition order.
+
+[2]: https://docs.pytest.org/en/stable/how-to/plugins.html#disabling-plugin-auto-loading

--- a/docs/validation/Offline_Audit_Validation.md
+++ b/docs/validation/Offline_Audit_Validation.md
@@ -42,6 +42,6 @@ Troubleshooting
 - If AUDIT_PROMPT.md is missing, the vendor builder will exit early; a default is now provided at repo root.
 - Pre-commit hooks failing or hanging: the script cleans and retries automatically; consult `.codex/errors.ndjson` for details.
 - Coverage gate: `pytest --cov-fail-under=70` enforces a baseline; on failure, a minimal fallback test run is attempted.
-- Fence validation: run `python3 tools/validate_fences.py --strict-inner` (or `pre-commit run validate-fences`) to ensure code block integrity; tildes (~~~) are supported and notebooks/site/ are skipped.
+- Fence validation: run `python3 tools/validate_fences.py --strict-inner` (or `pre-commit run validate-fences`) to ensure code block integrity; tildes (~~~) are supported and notebooks/site/ are skipped. The validator auto-detects when it is invoked from pre-commit and will not delegate back to pre-commit to avoid recursion; to force local mode explicitly, pass `--no-pre-commit`.
 - Optional no-plugins test shim: `scripts/pytest_noplugins.sh -q tests/tools/test_validate_fences.py`
 - CI guard: do **not** enable GitHub Actions; all checks run locally within the Codex environment.

--- a/tools/validate_fences.py
+++ b/tools/validate_fences.py
@@ -24,6 +24,7 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import os
 import shutil
 import subprocess
 import sys
@@ -186,7 +187,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.strict_inner = True  # Default to strict mode for CLI parity with legacy script.
 
     use_pre_commit = (
-        not args.no_pre_commit and not args.warn_inner and shutil.which("pre-commit") is not None
+        not args.no_pre_commit
+        and not args.warn_inner
+        and shutil.which("pre-commit") is not None
+        and os.environ.get("PRE_COMMIT") != "1"
     )
     files = [str(path) for path in _collect_targets(args.paths)]
 


### PR DESCRIPTION
## Summary
- update the fence validator to detect the PRE_COMMIT environment flag and skip delegating back to pre-commit when already inside a hook
- wrap the validate-fences hook in a bash shim that sets PRE_COMMIT=1 while preserving forwarded filenames, preventing recursive invocation
- document the new behavior and add a pytest plugin auto-load tip for deterministic local runs

## Testing
- python tools/validate_fences.py --strict-inner --no-pre-commit docs/validation/Offline_Audit_Validation.md
- PRE_COMMIT=1 python tools/validate_fences.py --strict-inner docs/validation/Offline_Audit_Validation.md


------
https://chatgpt.com/codex/tasks/task_e_68d9f329a79c8331a94f55acce9e45ee