### PR TITLE
Refactor torch policy checks into shared helper

### DIFF
--- a/scripts/libtorch_policy.sh
+++ b/scripts/libtorch_policy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Shared helpers for Torch policy validation flows.
+
+# Decide which Torch policy component to use:
+# - prefer Python module checker if available
+# - otherwise fall back to the JSON-emitting script checker
+choose_torch_policy_component() {
+  python - <<'PY'
+try:
+    import codex_ml.utils.torch_checks as _C  # module-based checker
+    print("module")
+except Exception:
+    print("script")
+PY
+}
+
+torch_policy_module_check() {
+  python - <<'PY'
+from codex_ml.utils.torch_checks import inspect_torch, diagnostic_report
+state = inspect_torch()
+print("[torch-policy]", diagnostic_report(state))
+import sys; sys.exit(0 if state.ok else 1)
+PY
+}

--- a/scripts/torch_repair_cpu.sh
+++ b/scripts/torch_repair_cpu.sh
@@ -1,15 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 log() { printf '%s\n' "$*"; }
-choose_torch_policy_component() {
-  python - <<'PY'
-try:
-    import codex_ml.utils.torch_checks as _C
-    print("module")
-except Exception:
-    print("script")
-PY
-}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/libtorch_policy.sh"
 log "[*] Torch CPU repair starting"
 if [ -d ".venv" ]; then . ".venv/bin/activate"; fi
 PY=${UV_PYTHON:-}
@@ -37,12 +32,7 @@ log "[*] Policy check:"
 set +e
 component="$(choose_torch_policy_component)"
 if [ "$component" = "module" ]; then
-  python - <<'PY'
-from codex_ml.utils.torch_checks import inspect_torch, diagnostic_report
-state = inspect_torch()
-print("[torch-policy]", diagnostic_report(state))
-import sys; sys.exit(0 if state.ok else 1)
-PY
+  torch_policy_module_check
 else
   python scripts/torch_policy_check.py
 fi


### PR DESCRIPTION
## Summary
- extract shared Torch policy helper functions into `scripts/libtorch_policy.sh`
- update the local gates and repair scripts to source the shared helpers for consistent behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9f6f73b0483318808038b39936da8