### PR TITLE
0 d base 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1149,3 +1149,13 @@ telemetry:
   max_bytes: 1048576  # 1 MiB
   sample_rate: 0.25   # keep ~25% of events
 ```
+
+### Dataset casting policy
+
+Toy runs default to integer token IDs. Real pipelines may want to cast batches to
+match the model dtype (for example, ensuring FP32 inputs when training without
+AMP). Configure `dataset.cast_policy` in Hydra to control this behavior:
+
+- `to_model_dtype` casts samples to the requested model dtype (if available).
+- `to_fp32` coerces samples to float32 regardless of model dtype.
+- `null` (or omitted) leaves samples untouched.

--- a/configs/train/default.yaml
+++ b/configs/train/default.yaml
@@ -31,10 +31,6 @@ scheduler:
   gamma: 0.9
   final_lr_scale: 0.0
 
-dataset:
-  sources: []
-  cache_dir: artifacts/data_cache
-
 reproducibility:
   cudnn_deterministic: false
   # When true and dtype requests bf16, assert bf16 capability and fail fast

--- a/tests/telemetry/test_ndjson_disable_env.py
+++ b/tests/telemetry/test_ndjson_disable_env.py
@@ -1,9 +1,17 @@
+# ruff: noqa: E402
 from pathlib import Path
-import os
+
+import pytest
+
+pytest.importorskip("torch", reason="torch is required for telemetry emission tests")
+from src.codex_ml import train_loop as train_loop_module
+
+if train_loop_module.instantiate_model is None:  # pragma: no cover - optional dependency missing
+    pytest.skip("model registry unavailable", allow_module_level=True)
 
 
 def test_telemetry_ndjson_disable_env(tmp_path: Path, monkeypatch):
-    from src.codex_ml.train_loop import run_training
+    run_training = train_loop_module.run_training
 
     monkeypatch.setenv("CODEX_TELEMETRY_NDJSON_DISABLE", "1")
     outdir = tmp_path / "artifacts"

--- a/tests/telemetry/test_sample_rate_gate.py
+++ b/tests/telemetry/test_sample_rate_gate.py
@@ -1,8 +1,17 @@
+# ruff: noqa: E402
 from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch", reason="torch is required for telemetry emission tests")
+from src.codex_ml import train_loop as train_loop_module
+
+if train_loop_module.instantiate_model is None:  # pragma: no cover - optional dependency missing
+    pytest.skip("model registry unavailable", allow_module_level=True)
 
 
 def test_sample_rate_zero_disables_telemetry(tmp_path: Path, monkeypatch):
-    from src.codex_ml.train_loop import run_training
+    run_training = train_loop_module.run_training
 
     monkeypatch.setenv("CODEX_TELEMETRY_SAMPLE_RATE", "0")
     outdir = tmp_path / "artifacts"
@@ -18,4 +27,3 @@ def test_sample_rate_zero_disables_telemetry(tmp_path: Path, monkeypatch):
     # No telemetry files should be created when sample_rate=0
     assert not (outdir / "telemetry.json").exists()
     assert not (outdir / "telemetry.ndjson").exists()
-


### PR DESCRIPTION
This pull request primarily refactors exception handling throughout the `src/codex_ml/train_loop.py` file, replacing broad exception ignores with a more specific linting directive (`# noqa: BLE001`). Additionally, it removes unused helper functions related to telemetry configuration, and makes minor formatting improvements. These changes help improve code readability and maintainability, and clarify exception handling for static analysis tools.

**Exception Handling Improvements:**

* Replaced all instances of `# noqa: broad-except` with `# noqa: BLE001` in `src/codex_ml/train_loop.py` to comply with updated linting standards and make exception handling intentions clearer. [[1]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL36-R44) [[2]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL54-R54) [[3]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL69-R69) [[4]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL80-R90) [[5]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL100-R100) [[6]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL128-R136) [[7]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL194-R194) [[8]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL435-R435) [[9]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL533-R533) [[10]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL577-R577) [[11]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL718-R707) [[12]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL826-R783) [[13]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL835-R798) [[14]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL919-R876) [[15]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL967-R924) [[16]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL1024-R1003) [[17]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL1092-R1059) [[18]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL1103-R1070) [[19]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL1151-R1118) [[20]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL1173-R1147) [[21]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL1220-R1187) [[22]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL1232-R1199) [[23]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL1250-R1217) [[24]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL1259-R1226)

**Code Cleanup:**

* Removed unused helper functions `_telemetry_json_enabled` and `_telemetry_max_bytes` from `src/codex_ml/train_loop.py`, simplifying the codebase.
* Removed duplicate import and improved import ordering for better readability in `src/codex_ml/train_loop.py`.

**Formatting and Style:**

* Improved formatting of conditional statements and function definitions for better readability and compliance with style guides in `src/codex_ml/train_loop.py`. [[1]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL984-R952) [[2]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL718-R707) [[3]](diffhunk://#diff-dc7210bd1bbaa0afa653812a805bbcf6155240db9757eb6ebdeecf88771a2adaL757-R716)

**Documentation Update:**

* Added documentation in `README.md` describing the new dataset casting policy and configuration options for controlling batch dtype casting.

**Configuration Update:**

* Removed unused `dataset` configuration block from `configs/train/default.yaml`, cleaning up the default training configuration.