### PR TITLE
chore(logging): align codex_utils NDJSON shim with core logger

### DIFF
--- a/codex_utils/ndjson.py
+++ b/codex_utils/ndjson.py
@@ -1,47 +1,63 @@
-# [Module]: NDJSON logger
-# > Generated: 2025-08-26 20:36:12 | Author: mbaetiong
-import json
-import os
-from typing import Any, Dict, Iterable
+"""Public shim that mirrors :mod:`codex_ml.logging.ndjson_logger` helpers."""
 
-__all__ = ["NDJSONLogger"]
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping
+
+from codex_ml.logging.ndjson_logger import (  # re-exported for backwards compat
+    NDJSONLogger as _CoreNDJSONLogger,
+    is_legacy_mode,
+    timestamped_record,
+)
+
+__all__ = ["NDJSONLogger", "timestamped_record", "is_legacy_mode"]
 
 
-class NDJSONLogger:
-    """Simple append-only NDJSON writer with context manager support."""
+class NDJSONLogger(_CoreNDJSONLogger):
+    """Compatibility wrapper around the core NDJSON logger implementation.
 
-    def __init__(self, path: str = ".artifacts/metrics.ndjson"):
-        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-        self._path = path
-        self._fh = open(path, "a", encoding="utf-8")
-        self._closed = False
+    Historically :mod:`codex_utils.ndjson` exposed a hand-rolled writer with
+    ``write``/``write_many`` helpers.  Downstream utilities (tests, examples)
+    still import this module, so we extend the richer core implementation with
+    aliases to preserve the previous interface while gaining rotation and
+    schema support (``run_id``/``timestamp`` fields, legacy toggle, etc.).
+    """
 
-    @property
-    def path(self) -> str:
-        return self._path
+    def __init__(
+        self,
+        path: str | Path = ".artifacts/metrics.ndjson",
+        *,
+        max_bytes: int | None = None,
+        max_age_s: float | None = None,
+        backup_count: int | None = None,
+        ensure_ascii: bool = False,
+        run_id: str | None = None,
+    ) -> None:
+        rotation: Dict[str, Any] = {}
+        if max_bytes is not None:
+            rotation["max_bytes"] = max_bytes
+        if max_age_s is not None:
+            rotation["max_age_s"] = max_age_s
+        if backup_count is not None:
+            rotation["backup_count"] = backup_count
+        super().__init__(
+            path,
+            ensure_ascii=ensure_ascii,
+            run_id=run_id,
+            **rotation,
+        )
 
-    def write(self, record: Dict[str, Any]) -> None:
-        if self._closed:
-            raise ValueError("NDJSONLogger is closed")
-        self._fh.write(json.dumps(record, ensure_ascii=False) + "\n")
-        self._fh.flush()
+    # ------------------------------------------------------------------
+    # Backwards compatible aliases (write/write_many previously exposed)
+    # ------------------------------------------------------------------
+    def write(self, record: Mapping[str, Any]) -> Path:
+        """Alias for :meth:`log` to preserve the historical API."""
 
-    def write_many(self, records: Iterable[Dict[str, Any]]) -> None:
-        for record in records:
-            self.write(record)
+        return self.log(record)
 
-    def close(self) -> None:
-        if self._closed:
-            return
-        try:
-            self._fh.flush()
-            self._fh.close()
-        finally:
-            self._closed = True
+    def write_many(self, records: Iterable[Mapping[str, Any]]) -> Path:
+        """Alias for :meth:`log_many` to preserve the historical API."""
 
-    def __enter__(self) -> "NDJSONLogger":
-        return self
+        return self.log_many(records)
 
-    def __exit__(self, exc_type, exc, tb) -> bool:
-        self.close()
-        return False

--- a/tests/test_ndjson_logger.py
+++ b/tests/test_ndjson_logger.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 
@@ -12,6 +13,13 @@ def test_ndjson_logger_writes_lines(tmp_path: Path):
     assert path.exists()
     lines = path.read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) == 2
-    assert "\"metric\": \"loss\"" in lines[0]
-    assert "\"_step\": 1" in lines[1]
+
+    first = json.loads(lines[0])
+    second = json.loads(lines[1])
+    assert first["metric"] == "loss"
+    assert first["value"] == 1.0
+    assert first["_step"] == 0
+    assert second["_step"] == 1
+    assert "run_id" in second
+    assert second["timestamp"].endswith("Z") or second["timestamp"].endswith("+00:00")
 


### PR DESCRIPTION
## Summary
- reuse the core `codex_ml.logging.ndjson_logger.NDJSONLogger` from the `codex_utils.ndjson` shim so legacy imports pick up rotation, schema, and legacy-mode behaviour
- adjust the legacy NDJSON logger smoke test to validate the enriched payload (run id, timestamp) emitted by the shared implementation

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/tracking/test_ndjson_logger_core.py tests/test_ndjson_logger.py


------
https://chatgpt.com/codex/tasks/task_e_68dde3e6ba648331b51e726309c03f5e