### PR TITLE
Fix ExternalWebSearch tilde offline file endpoints

### DIFF
--- a/src/codex_ml/analysis/providers.py
+++ b/src/codex_ml/analysis/providers.py
@@ -158,18 +158,20 @@ class ExternalWebSearch(SearchProvider):
             else:
                 location = path_part
 
-            if location.startswith("//") and len(location) > 3 and location[3] == ":":
+            if location.startswith("//~"):
+                location = location[2:]
+            elif location.startswith("//") and len(location) > 3 and location[3] == ":":
                 location = location.lstrip("/")
             if location.startswith("/") and len(location) > 2 and location[2] == ":":
                 location = location.lstrip("/")
-            path = Path(location)
+            path = Path(location).expanduser()
             return "file", path
         if scheme and len(scheme) == 1 and self.endpoint[1:3] in (":/", ":\\"):
-            return "file", Path(self.endpoint)
+            return "file", Path(self.endpoint).expanduser()
         if scheme:
             return "unknown", None
 
-        candidate = Path(self.endpoint)
+        candidate = Path(self.endpoint).expanduser()
         return "file", candidate
 
     def _perform_http(self, query: str, result: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/analysis/test_external_search.py
+++ b/tests/analysis/test_external_search.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_ml.analysis.providers import ExternalWebSearch
+
+
+def _write_offline_index(path: Path, query: str = "codex") -> None:
+    payload = {
+        query: [
+            {
+                "Text": "Codex reference",
+                "FirstURL": "https://example.com/codex",
+                "snippet": "Details about Codex",
+            }
+        ]
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_external_web_search_loads_offline_index(tmp_path: Path) -> None:
+    offline_index = tmp_path / "index.json"
+    _write_offline_index(offline_index)
+
+    search = ExternalWebSearch(endpoint=offline_index.as_uri(), enabled=True)
+    result = search.search("codex")
+
+    assert result["status"] == "ok"
+    assert result["results"], "offline payload should populate results"
+    entry = result["results"][0]
+    assert entry["title"] == "Codex reference"
+    assert entry["url"].endswith("/codex")
+
+
+def test_external_web_search_supports_tilde_endpoint(monkeypatch, tmp_path: Path) -> None:
+    offline_index = tmp_path / "index.json"
+    _write_offline_index(offline_index)
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    search = ExternalWebSearch(endpoint="file://~/index.json", enabled=True)
+    result = search.search("codex")
+
+    assert result["status"] == "ok"
+    assert any(entry["url"].endswith("/codex") for entry in result["results"])


### PR DESCRIPTION
## Summary
- allow `ExternalWebSearch` to expand user directories when resolving file-based endpoints
- add regression tests covering offline indexes and tilde-style endpoints

## Testing
- pytest tests/analysis -q

------
https://chatgpt.com/codex/tasks/task_e_68df65c17efc83319fbb4980f107f948