### PR TITLE
Add offline connector support and deployment sandbox adapters

### DIFF
--- a/src/codex_ml/connectors/__init__.py
+++ b/src/codex_ml/connectors/__init__.py
@@ -1,0 +1,13 @@
+"""Connector implementations available to Codex tooling."""
+
+from __future__ import annotations
+
+from .base import Connector, ConnectorError, LocalConnector
+from .remote import RemoteConnector
+
+__all__ = [
+    "Connector",
+    "ConnectorError",
+    "LocalConnector",
+    "RemoteConnector",
+]

--- a/src/codex_ml/connectors/registry.py
+++ b/src/codex_ml/connectors/registry.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 from typing import Dict, Type
 
 from .base import Connector, LocalConnector
+from .remote import RemoteConnector
 
-_REGISTRY: Dict[str, Type[Connector]] = {"local": LocalConnector}
+__all__ = ["register_connector", "get_connector", "list_connectors"]
+
+_REGISTRY: Dict[str, Type[Connector]] = {
+    "local": LocalConnector,
+    "remote": RemoteConnector,
+}
 
 
 def register_connector(name: str, cls: Type[Connector]) -> None:
@@ -15,3 +21,7 @@ def get_connector(name: str, **kwargs) -> Connector:
     if name not in _REGISTRY:
         raise KeyError(name)
     return _REGISTRY[name](**kwargs)  # type: ignore[call-arg]
+
+
+def list_connectors() -> Dict[str, Type[Connector]]:
+    return dict(_REGISTRY)

--- a/src/codex_ml/connectors/remote.py
+++ b/src/codex_ml/connectors/remote.py
@@ -1,0 +1,67 @@
+"""Offline-friendly remote connector implementations."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List
+
+from .base import Connector, ConnectorError, LocalConnector
+
+__all__ = ["RemoteConnector"]
+
+DEFAULT_CACHE_ROOT = Path.home() / ".codex" / "remote_cache"
+
+
+class RemoteConnector(Connector):
+    """Local emulation of remote storage with manifest tracking."""
+
+    def __init__(
+        self,
+        endpoint: str | None = None,
+        *,
+        cache_root: str | Path | None = None,
+        readonly: bool = False,
+    ) -> None:
+        self.endpoint = endpoint or "offline://remote"
+        root = Path(cache_root or DEFAULT_CACHE_ROOT).expanduser()
+        self._local = LocalConnector(root)
+        self.readonly = readonly
+        self._manifest_name = ".remote_manifest.json"
+        self._manifest_path = self._local.root / self._manifest_name
+        if not self._manifest_path.exists():
+            self._write_manifest(files=[], created=True)
+
+    @property
+    def cache_root(self) -> Path:
+        """Return the backing cache directory."""
+
+        return self._local.root
+
+    async def list_files(self, path: str) -> List[str]:  # type: ignore[override]
+        entries = await self._local.list_files(path)
+        return sorted(entry for entry in entries if entry != self._manifest_name)
+
+    async def read_file(self, path: str) -> bytes:  # type: ignore[override]
+        return await self._local.read_file(path)
+
+    async def write_file(self, path: str, data: bytes) -> None:  # type: ignore[override]
+        if self.readonly:
+            raise ConnectorError(f"remote connector is read-only for endpoint {self.endpoint}")
+        await self._local.write_file(path, data)
+        files = [item for item in await self._local.list_files(".") if item != self._manifest_name]
+        self._write_manifest(files=files)
+
+    def _write_manifest(self, *, files: Iterable[str], created: bool = False) -> None:
+        payload = {
+            "endpoint": self.endpoint,
+            "readonly": self.readonly,
+            "files": sorted(str(item) for item in files),
+        }
+        timestamp_key = "created_at" if created else "updated_at"
+        payload[timestamp_key] = datetime.utcnow().isoformat() + "Z"
+        self._manifest_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )

--- a/src/codex_ml/deployment/__init__.py
+++ b/src/codex_ml/deployment/__init__.py
@@ -1,0 +1,7 @@
+"""Deployment helpers for Codex ML."""
+
+from __future__ import annotations
+
+from .cloud import provision_stack
+
+__all__ = ["provision_stack"]

--- a/src/codex_ml/deployment/cloud.py
+++ b/src/codex_ml/deployment/cloud.py
@@ -1,0 +1,82 @@
+"""Offline-friendly cloud deployment utilities."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+__all__ = ["provision_stack"]
+
+_STATUS_DEFERRED = "deferred"
+_DEFAULT_PROJECT = "codex-offline"
+
+
+def _timestamp() -> str:
+    return datetime.utcnow().isoformat() + "Z"
+
+
+def _resolve_output_dir(output_dir: str | Path | None) -> Path | None:
+    if output_dir is None:
+        return None
+    return Path(output_dir).expanduser().resolve()
+
+
+def provision_stack(
+    *,
+    project: str | None = None,
+    output_dir: str | Path | None = None,
+    dry_run: bool = True,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Return a structured status block describing offline provisioning results."""
+
+    details: Dict[str, Any] = {
+        "status": _STATUS_DEFERRED,
+        "reason": "Cloud deployment is disabled for offline Codex runs.",
+        "project": project or _DEFAULT_PROJECT,
+        "dry_run": dry_run,
+        "timestamp": _timestamp(),
+    }
+    resolved_dir = _resolve_output_dir(output_dir)
+    if resolved_dir is not None:
+        details["output_dir"] = str(resolved_dir)
+    if metadata:
+        details["metadata"] = metadata
+
+    if dry_run:
+        return details
+
+    target_dir = resolved_dir or (Path.cwd() / "deployments" / details["project"])
+    sandbox_dir = target_dir / "sandbox"
+    manifest_path = target_dir / "manifest.json"
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    sandbox_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_payload = {
+        "project": details["project"],
+        "created_at": details["timestamp"],
+        "sandbox": str(sandbox_dir),
+        "metadata": metadata or {},
+    }
+    manifest_path.write_text(
+        json.dumps(manifest_payload, indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+    readme_path = sandbox_dir / "README.txt"
+    if not readme_path.exists():
+        readme_path.write_text(
+            "Offline sandbox created for Codex deployment. Add packaging artefacts here.",
+            encoding="utf-8",
+        )
+
+    details.update(
+        {
+            "output_dir": str(target_dir),
+            "manifest": str(manifest_path),
+            "sandbox_root": str(sandbox_dir),
+        }
+    )
+    return details

--- a/tests/connectors/test_registry.py
+++ b/tests/connectors/test_registry.py
@@ -1,7 +1,7 @@
 import pytest
 
 from codex_ml.connectors.base import Connector
-from codex_ml.connectors.registry import get_connector, register_connector
+from codex_ml.connectors.registry import get_connector, list_connectors, register_connector
 
 
 class DummyConnector(Connector):
@@ -19,5 +19,7 @@ def test_registry_get_and_register():
     register_connector("dummy", DummyConnector)
     conn = get_connector("dummy")
     assert isinstance(conn, DummyConnector)
+    available = list_connectors()
+    assert "local" in available and "remote" in available
     with pytest.raises(KeyError):
         get_connector("missing")

--- a/tests/connectors/test_remote.py
+++ b/tests/connectors/test_remote.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import pytest
+
+from codex_ml.connectors.remote import RemoteConnector
+
+
+@pytest.mark.asyncio
+async def test_remote_connector_roundtrip(tmp_path: Path) -> None:
+    connector = RemoteConnector(cache_root=tmp_path)
+    await connector.write_file("samples/data.txt", b"payload")
+    files = await connector.list_files(".")
+    assert "samples/data.txt" in files
+    data = await connector.read_file("samples/data.txt")
+    assert data == b"payload"
+
+    manifest = tmp_path / ".remote_manifest.json"
+    assert manifest.exists()
+    payload = manifest.read_text(encoding="utf-8")
+    assert "samples/data.txt" in payload

--- a/tests/data/test_loaders.py
+++ b/tests/data/test_loaders.py
@@ -1,4 +1,8 @@
+import asyncio
 from pathlib import Path
+
+from codex_ml.connectors.registry import register_connector
+from codex_ml.connectors.remote import RemoteConnector
 from codex_ml.data.loaders import stream_paths
 
 
@@ -6,7 +10,7 @@ def _make_files(tmp_path: Path, n: int) -> list[Path]:
     paths = []
     for i in range(n):
         p = tmp_path / f"{i}.jsonl"
-        p.write_text('{"prompt": "p'+str(i)+'", "completion": "c"}\n', encoding="utf-8")
+        p.write_text('{"prompt": "p' + str(i) + '", "completion": "c"}\n', encoding="utf-8")
         paths.append(p)
     return paths
 
@@ -23,3 +27,27 @@ def test_stream_paths_seed_differs(tmp_path: Path):
     a = [pc.prompt for pc in stream_paths(paths, seed=1)]
     b = [pc.prompt for pc in stream_paths(paths, seed=2)]
     assert a != b
+
+
+def test_stream_paths_connector_uri(tmp_path: Path, monkeypatch) -> None:
+    cache_root = tmp_path / "cache"
+    monkeypatch.setenv("CODEX_CONNECTOR_CACHE_ROOT", str(cache_root))
+
+    class _TestRemote(RemoteConnector):
+        def __init__(self, **kwargs):
+            super().__init__(cache_root=tmp_path / "remote", **kwargs)
+
+    register_connector("test-remote", _TestRemote)
+
+    connector = _TestRemote()
+    asyncio.run(
+        connector.write_file(
+            "datasets/sample.jsonl",
+            b'{"prompt": "p0", "completion": "c"}\n',
+        )
+    )
+
+    samples = list(stream_paths(["connector://test-remote/datasets/sample.jsonl"]))
+    assert [sample.prompt for sample in samples] == ["p0"]
+    cached = cache_root / "test-remote" / "datasets" / "sample.jsonl"
+    assert cached.exists()


### PR DESCRIPTION
## Summary
- add a real offline `RemoteConnector` module, register it in the connector package, and expose helper APIs
- update dataset streaming to materialise `connector://` URIs and extend the audit pipeline evidence handling
- provide an offline deployment sandbox helper and supporting tests for connectors and connector-backed datasets

## Testing
- `pytest tests/connectors/test_registry.py tests/connectors/test_remote.py tests/data/test_loaders.py` *(fails: missing pytest_asyncio dependency during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68e012d6a86083318f98c817ab87a99c