### PR TITLE
Prefer CODEX_MLFLOW_LOCAL_DIR when MLflow envs already set

### DIFF
--- a/src/codex_ml/tracking/mlflow_guard.py
+++ b/src/codex_ml/tracking/mlflow_guard.py
@@ -135,10 +135,12 @@ def _apply_guard(
                 preferred_local = local_override
         else:
             # ``Path`` treats things like ``C:\`` as absolute even though ``urlparse``
-            # reports a scheme. Guard against Windows drive letters by falling back to
-            # path semantics when ``Path`` sees an anchor.
+            # reports a scheme. Guard against Windows drive letters by normalising the
+            # override to a proper ``file:`` URI when ``Path`` sees an anchor. Without
+            # this, downstream normalisation would parse ``C:\mlruns`` as the scheme
+            # ``c`` and treat it as remote, clobbering the intended override.
             if Path(local_override).anchor:
-                preferred_local = local_override
+                preferred_local = _as_file_uri(local_override)
 
     candidate = explicit_request or preferred_local or tracking_env or codex_env
     recorded_request = candidate or ""


### PR DESCRIPTION
## Summary
- prefer the `CODEX_MLFLOW_LOCAL_DIR` override whenever it points to a local MLflow store, even if existing environment variables still reference an older path
- normalise Windows-style drive specifications so the override is honoured across platforms

## Testing
- pytest tests/tracking/test_mlflow_guard.py tests/tracking/test_tracking_guard_matrix.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e5610a110083319e72d964312d14e6