### PR TITLE
Add CLI documentation and new guide stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ codex-train training.max_epochs=1 training.batch_size=2 \
 
 Artifacts are written under `.codex/` (metrics, checkpoints, provenance).
 
+## Documentation quick links
+
+- [CLI Guide](docs/cli.md)
+- [Quality Gates](docs/quality_gates.md)
+- [Data Determinism](docs/data_determinism.md)
+- [Detectors Overview](docs/detectors.md)
+- [Checkpoint Schema v2](docs/checkpoint_schema_v2.md)
+- [Manifest Integrity](docs/manifest_integrity.md)
+
 ## LoRA fine-tuning (minimal example)
 
 ```python

--- a/artifacts/docs_link_audit/links.json
+++ b/artifacts/docs_link_audit/links.json
@@ -1,3706 +1,2888 @@
 [
   {
-    "path": "CONTRIBUTING.md",
-    "line": 74,
-    "text": "Manual Verification Template",
-    "link": "documentation/manual_verification_template.md",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "CONTRIBUTING.md",
-    "line": 78,
-    "text": "docs/experiments.md",
-    "link": "docs/experiments.md",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "CONTRIBUTING.md",
-    "line": 84,
-    "text": "docs/guides/AGENTS.md",
-    "link": "docs/guides/AGENTS.md",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "README.md",
-    "line": 70,
-    "text": "Quickstart: tokenizer \u2192 training \u2192 evaluation",
-    "link": "docs/quickstart.md",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "README.md",
-    "line": 71,
-    "text": "Architecture overview",
-    "link": "docs/architecture.md",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "README.md",
-    "line": 72,
-    "text": "Registry & plugin guide",
-    "link": "docs/dev/plugins.md",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "README.md",
-    "line": 73,
-    "text": "Codex \u2194 Copilot bridge documentation",
-    "link": "docs/bridge/README.md",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "README.md",
-    "line": 79,
-    "text": "docs/guides/AGENTS.md",
-    "link": "docs/guides/AGENTS.md",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "README.md",
-    "line": 150,
-    "text": "`docs/safety/policy_guidance.md`",
-    "link": "docs/safety/policy_guidance.md",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "README.md",
-    "line": 151,
-    "text": "`examples/safety/policy_bypass_example.yaml`",
-    "link": "examples/safety/policy_bypass_example.yaml",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "README.md",
-    "line": 235,
-    "text": "documentation/codex_symbolic_training_summary.md",
-    "link": "documentation/codex_symbolic_training_summary.md",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "README.md",
-    "line": 237,
-    "text": "docs/ops/experiment_tracking.md",
-    "link": "docs/ops/experiment_tracking.md",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "README.md",
-    "line": 341,
-    "text": "docs/architecture.md",
-    "link": "docs/architecture.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": true,
+    "file": "/workspace/_codex_/CONTRIBUTING.md",
+    "target": "documentation/manual_verification_template.md",
+    "type": "relative"
   },
   {
-    "path": "README.md",
-    "line": 400,
-    "text": "`parsers.py`",
-    "link": "src/codex_ml/analysis/parsers.py",
-    "type": "internal",
-    "target_exists": true
+    "exists": true,
+    "file": "/workspace/_codex_/CONTRIBUTING.md",
+    "target": "docs/experiments.md",
+    "type": "relative"
   },
   {
-    "path": "README.md",
-    "line": 401,
-    "text": "`metrics.py`",
-    "link": "src/codex_ml/analysis/metrics.py",
-    "type": "internal",
-    "target_exists": true
+    "exists": true,
+    "file": "/workspace/_codex_/CONTRIBUTING.md",
+    "target": "docs/guides/AGENTS.md",
+    "type": "relative"
   },
   {
-    "path": "README.md",
-    "line": 502,
-    "text": "documentation/session_log_rotation.md",
-    "link": "documentation/session_log_rotation.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/cli.md",
+    "type": "relative"
   },
   {
-    "path": "README.md",
-    "line": 613,
-    "text": "Dockerfile",
-    "link": "Dockerfile",
-    "type": "internal",
-    "target_exists": true
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/quality_gates.md",
+    "type": "relative"
   },
   {
-    "path": "README.md",
-    "line": 774,
-    "text": "documentation/end_to_end_logging.md",
-    "link": "documentation/end_to_end_logging.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/data_determinism.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log-large.md",
-    "line": 6875,
-    "text": "What are attention masks?",
-    "link": "../glossary#attention-mask",
-    "type": "internal",
-    "target_exists": false
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/detectors.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log-large.md",
-    "line": 7795,
-    "text": "pipeline tutorial",
-    "link": "../pipeline_tutorial",
-    "type": "internal",
-    "target_exists": false
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/checkpoint_schema_v2.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log-large.md",
-    "line": 7828,
-    "text": "pipeline tutorial",
-    "link": "../pipeline_tutorial",
-    "type": "internal",
-    "target_exists": false
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/manifest_integrity.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log-large.md",
-    "line": 8101,
-    "text": "`dvclive.Live()`",
-    "link": "https://dvc.org/doc/dvclive/live",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/quickstart.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log-large.md",
-    "line": 15809,
-    "text": "cyan",
-    "link": "must be at least 5 characters",
-    "type": "internal",
-    "target_exists": false
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/architecture.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 1112,
-    "text": "Dockerfile",
-    "link": "Dockerfile",
-    "type": "internal",
-    "target_exists": false
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/dev/plugins.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 3653,
-    "text": "pre-commit",
-    "link": "https://pre-commit.com",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/bridge/README.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 5933,
-    "text": "![CI",
-    "link": "https://github.com/openai/codex-universal/actions/workflows/ci.yml/badge.svg",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/guides/AGENTS.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 5935,
-    "text": "OpenAI Codex",
-    "link": "http://platform.openai.com/docs/codex",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/safety/policy_guidance.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 5939,
-    "text": "OpenAI Codex",
-    "link": "http://platform.openai.com/docs/codex",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "examples/safety/policy_bypass_example.yaml",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 5941,
-    "text": "docs/guides/AGENTS.md",
-    "link": "docs/guides/AGENTS.md",
-    "type": "internal",
-    "target_exists": false
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "documentation/codex_symbolic_training_summary.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 5945,
-    "text": "`.github/workflows/ci.yml`",
-    "link": ".github/workflows/ci.yml",
-    "type": "internal",
-    "target_exists": false
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/ops/experiment_tracking.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 5990,
-    "text": "![CI",
-    "link": "https://github.com/openai/codex-universal/actions/workflows/ci.yml/badge.svg",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "docs/architecture.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 5992,
-    "text": "OpenAI Codex",
-    "link": "http://platform.openai.com/docs/codex",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "src/codex_ml/analysis/parsers.py",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 5996,
-    "text": "OpenAI Codex",
-    "link": "http://platform.openai.com/docs/codex",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "src/codex_ml/analysis/metrics.py",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 5998,
-    "text": "docs/guides/AGENTS.md",
-    "link": "docs/guides/AGENTS.md",
-    "type": "internal",
-    "target_exists": false
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "documentation/session_log_rotation.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 6002,
-    "text": "`.github/workflows/ci.yml`",
-    "link": ".github/workflows/ci.yml",
-    "type": "internal",
-    "target_exists": false
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "Dockerfile",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 6051,
-    "text": "![CI",
-    "link": "https://github.com/openai/codex-universal/actions/workflows/ci.yml/badge.svg",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/README.md",
+    "target": "documentation/end_to_end_logging.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 6053,
-    "text": "OpenAI Codex",
-    "link": "http://platform.openai.com/docs/codex",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/documentation/end_to_end_logging.md",
+    "target": "../scripts/codex_end_to_end.py",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 6057,
-    "text": "OpenAI Codex",
-    "link": "http://platform.openai.com/docs/codex",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/documentation/option_c_datasette_lite.md",
+    "target": "https://lite.datasette.io/",
+    "type": "external"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 6059,
-    "text": "docs/guides/AGENTS.md",
-    "link": "docs/guides/AGENTS.md",
-    "type": "internal",
-    "target_exists": false
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/guardrails.md",
+    "target": "http://platform.openai.com/docs/codex",
+    "type": "external"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 6063,
-    "text": "`.github/workflows/ci.yml`",
-    "link": ".github/workflows/ci.yml",
-    "type": "internal",
-    "target_exists": false
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/guardrails.md",
+    "target": "http://platform.openai.com/docs/codex",
+    "type": "external"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 6108,
-    "text": "![CI",
-    "link": "https://github.com/openai/codex-universal/actions/workflows/ci.yml/badge.svg",
-    "type": "external",
-    "target_exists": null
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/guardrails.md",
+    "target": "Dockerfile",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 6110,
-    "text": "OpenAI Codex",
-    "link": "http://platform.openai.com/docs/codex",
-    "type": "external",
-    "target_exists": null
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/guardrails.md",
+    "target": "documentation/end_to_end_logging.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 6114,
-    "text": "OpenAI Codex",
-    "link": "http://platform.openai.com/docs/codex",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/guardrails.md",
+    "target": "https://pre-commit.com",
+    "type": "external"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 6116,
-    "text": "docs/guides/AGENTS.md",
-    "link": "docs/guides/AGENTS.md",
-    "type": "internal",
-    "target_exists": false
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log-large.md",
+    "target": "https://docs.astral.sh/\n- docs/ops/RUNBOOK.md:24: pytest -q --cov --cov-fail-under=70               # pass=\u03a0_tests \u22c2 \u03a0_cov \u2713   [oai_citation:1\u2021pytest-cov](https://pytest-\n- docs/ops/RUNBOOK.md:27: pyright                                            # pass=\u03a0_types \u2713\n- docs/ops/RUNBOOK.md:52: * **Quality gate projector** $\\mathcal P_G$: filter onto passing subspace.\n- docs/ops/RUNBOOK.md:59: | Gate (projector",
+    "type": "external"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 6120,
-    "text": "`.github/workflows/ci.yml`",
-    "link": ".github/workflows/ci.yml",
-    "type": "internal",
-    "target_exists": false
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log-large.md",
+    "target": "../glossary#attention-mask",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 7189,
-    "text": "`.github/workflows/ci.yml`",
-    "link": ".github/workflows/ci.yml",
-    "type": "internal",
-    "target_exists": false
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log-large.md",
+    "target": "../pipeline_tutorial",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 12844,
-    "text": "Hydra",
-    "link": "https://github.com/facebookresearch/hydra",
-    "type": "external",
-    "target_exists": null
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log-large.md",
+    "target": "../pipeline_tutorial",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 13505,
-    "text": "![CI (manual)",
-    "link": "https://img.shields.io/badge/CI-manual-blue",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log-large.md",
+    "target": "https://dvc.org/doc/dvclive/live",
+    "type": "external"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 13506,
-    "text": "![Coverage \u2265 threshold",
-    "link": "https://img.shields.io/badge/coverage-local--gate-successful-brightgreen",
-    "type": "external",
-    "target_exists": null
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log-large.md",
+    "target": "must be at least 5 characters",
+    "type": "relative"
   },
   {
-    "path": ".codex\\change_log.md",
-    "line": 13507,
-    "text": "![pre-commit",
-    "link": "https://img.shields.io/badge/pre--commit-enabled-brightgreen",
-    "type": "external",
-    "target_exists": null
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "Dockerfile",
+    "type": "relative"
   },
   {
-    "path": ".codex\\guardrails.md",
-    "line": 7,
-    "text": "OpenAI Codex",
-    "link": "http://platform.openai.com/docs/codex",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "https://pre-commit.com",
+    "type": "external"
   },
   {
-    "path": ".codex\\guardrails.md",
-    "line": 11,
-    "text": "OpenAI Codex",
-    "link": "http://platform.openai.com/docs/codex",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform'\n\n### 2025-08-19T11:02:46Z \u2014 Write .codex/inventory.tsv \u2014 Inventory snapshot\n- existed: True\n- before (first 200 chars",
+    "type": "external"
   },
   {
-    "path": ".codex\\guardrails.md",
-    "line": 59,
-    "text": "Dockerfile",
-    "link": "Dockerfile",
-    "type": "internal",
-    "target_exists": false
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform'\n- after  (first 200 chars",
+    "type": "external"
   },
   {
-    "path": ".codex\\guardrails.md",
-    "line": 155,
-    "text": "documentation/end_to_end_logging.md",
-    "link": "documentation/end_to_end_logging.md",
-    "type": "internal",
-    "target_exists": false
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform'\n\n### 2025-08-19T11:04:20Z \u2014 Write .codex/inventory.tsv \u2014 Inventory snapshot\n- existed: True\n- before (first 200 chars",
+    "type": "external"
   },
   {
-    "path": ".codex\\guardrails.md",
-    "line": 250,
-    "text": "pre-commit",
-    "link": "https://pre-commit.com",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform'\n- after  (first 200 chars",
+    "type": "external"
   },
   {
-    "path": ".pytest_cache\\README.md",
-    "line": 8,
-    "text": "the docs",
-    "link": "https://docs.pytest.org/en/stable/how-to/cache.html",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform'\n\n### 2025-08-19T11:04:48Z \u2014 Write .codex/inventory.tsv \u2014 Inventory snapshot\n- existed: True\n- before (first 200 chars",
+    "type": "external"
   },
   {
-    "path": "docs\\ephemeral-runners.md",
-    "line": 81,
-    "text": "GitHub Docs \u2013 Using self-hosted runners in a workflow",
-    "link": "https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/use-in-a-workflow",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "https://github.com/openai/codex-universal/actions/workflows/ci.yml/badge.svg",
+    "type": "external"
   },
   {
-    "path": "docs\\ephemeral-runners.md",
-    "line": 82,
-    "text": "GitHub Docs \u2013 REST API: Self-hosted runners",
-    "link": "https://docs.github.com/en/rest/actions/self-hosted-runners",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform.openai.com/docs/codex",
+    "type": "external"
   },
   {
-    "path": "docs\\ephemeral-runners.md",
-    "line": 83,
-    "text": "pre-commit \u2013 Installation & usage",
-    "link": "https://pre-commit.com/#installation",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform.openai.com/docs/codex",
+    "type": "external"
   },
   {
-    "path": "docs\\question_handling_reference.md",
-    "line": 7,
-    "text": "`docs/status_update_outstanding_questions.md`",
-    "link": "status_update_outstanding_questions.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "docs/guides/AGENTS.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\question_handling_reference.md",
-    "line": 8,
-    "text": "`.codex/notes/Codex_Questions.md`",
-    "link": "../.codex/notes/Codex_Questions.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": ".github/workflows/ci.yml",
+    "type": "relative"
   },
   {
-    "path": "docs\\question_handling_reference.md",
-    "line": 9,
-    "text": "`ERROR_LOG.md`",
-    "link": "../ERROR_LOG.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "https://github.com/openai/codex-universal/actions/workflows/ci.yml/badge.svg",
+    "type": "external"
   },
   {
-    "path": "docs\\question_handling_reference.md",
-    "line": 10,
-    "text": "`CODEBASE_AUDIT_2025-08-26_203612.md`",
-    "link": "../CODEBASE_AUDIT_2025-08-26_203612.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform.openai.com/docs/codex",
+    "type": "external"
   },
   {
-    "path": "docs\\quickstart.md",
-    "line": 27,
-    "text": "`guides/offline_catalogue.md`",
-    "link": "guides/offline_catalogue.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform.openai.com/docs/codex",
+    "type": "external"
   },
   {
-    "path": "docs\\quickstart.md",
-    "line": 149,
-    "text": "`docs/examples/lora_quickstart.md`",
-    "link": "examples/lora_quickstart.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "docs/guides/AGENTS.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\README.md",
-    "line": 3,
-    "text": "System Architecture",
-    "link": "./architecture.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": ".github/workflows/ci.yml",
+    "type": "relative"
   },
   {
-    "path": "docs\\README.md",
-    "line": 5,
-    "text": "Training Engine",
-    "link": "./modules/training_engine.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "https://github.com/openai/codex-universal/actions/workflows/ci.yml/badge.svg",
+    "type": "external"
   },
   {
-    "path": "docs\\README.md",
-    "line": 6,
-    "text": "Evaluation Runner",
-    "link": "./modules/evaluation_runner.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform.openai.com/docs/codex",
+    "type": "external"
   },
   {
-    "path": "docs\\README.md",
-    "line": 7,
-    "text": "Checkpoint Manager",
-    "link": "./modules/checkpoint_manager.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform.openai.com/docs/codex",
+    "type": "external"
   },
   {
-    "path": "docs\\README.md",
-    "line": 8,
-    "text": "Tokenizer Trainer",
-    "link": "./modules/tokenizer_trainer.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "docs/guides/AGENTS.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\safety.md",
-    "line": 15,
-    "text": "RealToxicityPrompts",
-    "link": "https://huggingface.co/datasets/allenai/real-toxicity-prompts",
-    "type": "external",
-    "target_exists": null
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": ".github/workflows/ci.yml",
+    "type": "relative"
   },
   {
-    "path": "docs\\troubleshooting.md",
-    "line": 20,
-    "text": "docs/experiments/README.md",
-    "link": "experiments/README.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "https://github.com/openai/codex-universal/actions/workflows/ci.yml/badge.svg",
+    "type": "external"
   },
   {
-    "path": "docs\\troubleshooting.md",
-    "line": 22,
-    "text": "docs/experiments/mlflow_offline.md",
-    "link": "experiments/mlflow_offline.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform.openai.com/docs/codex",
+    "type": "external"
   },
   {
-    "path": "documentation\\end_to_end_logging.md",
-    "line": 91,
-    "text": "`scripts/codex_end_to_end.py`",
-    "link": "../scripts/codex_end_to_end.py",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "http://platform.openai.com/docs/codex",
+    "type": "external"
   },
   {
-    "path": "documentation\\option_c_datasette_lite.md",
-    "line": 4,
-    "text": "Datasette Lite",
-    "link": "https://lite.datasette.io/",
-    "type": "external",
-    "target_exists": null
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "docs/guides/AGENTS.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\archive\\README_UPDATED.md",
-    "line": 3,
-    "text": "OpenAI Codex",
-    "link": "http://platform.openai.com/docs/codex",
-    "type": "external",
-    "target_exists": null
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": ".github/workflows/ci.yml",
+    "type": "relative"
   },
   {
-    "path": ".codex\\archive\\README_UPDATED.md",
-    "line": 7,
-    "text": "OpenAI Codex",
-    "link": "http://platform.openai.com/docs/codex",
-    "type": "external",
-    "target_exists": null
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": ".github/workflows/ci.yml",
+    "type": "relative"
   },
   {
-    "path": ".codex\\archive\\README_UPDATED.md",
-    "line": 55,
-    "text": "Dockerfile",
-    "link": "Dockerfile",
-    "type": "internal",
-    "target_exists": false
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "https://github.com/facebookresearch/hydra",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-08-31.md",
-    "line": 9,
-    "text": "`.codex/deferred_items.md`",
-    "link": ".codex/deferred_items.md",
-    "type": "internal",
-    "target_exists": false
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "https://img.shields.io/badge/CI-manual-blue",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-07.md",
-    "line": 21,
-    "text": "docs/guides/AGENTS.md",
-    "link": "docs/guides/AGENTS.md",
-    "type": "internal",
-    "target_exists": false
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "https://img.shields.io/badge/coverage-local--gate-successful-brightgreen",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 10,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L17-L84",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/change_log.md",
+    "target": "https://img.shields.io/badge/pre--commit-enabled-brightgreen",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 10,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L191-L260",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/safety.md",
+    "target": "https://huggingface.co/datasets/allenai/real-toxicity-prompts",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 13,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/env/ubuntu.yaml#L1-L6",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/index.md",
+    "target": "modules/observability.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 13,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/model/base.yaml#L1-L10",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/index.md",
+    "target": "cli.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 13,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/training/base.yaml#L1-L20",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/index.md",
+    "target": "manifest_integrity.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 13,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/tokenization/base.yaml#L1-L14",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/index.md",
+    "target": "tokenization_api.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 13,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/data/base.yaml#L1-L2",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/index.md",
+    "target": "safety_api.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 13,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/tracking/base.yaml#L1-L6",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/index.md",
+    "target": "ops.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 15,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L1-L34",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/README.md",
+    "target": "./architecture.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 15,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/model_registry.md#L1-L38",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/README.md",
+    "target": "./modules/training_engine.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 15,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/evaluation_runner.md#L1-L11",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/README.md",
+    "target": "./modules/evaluation_runner.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 15,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/repro.md#L1-L14",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/README.md",
+    "target": "./modules/checkpoint_manager.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 16,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/test_engine_hf_trainer.py#L97-L141",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/README.md",
+    "target": "./modules/tokenizer_trainer.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/cli/main.py#L98-L130",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/question_handling_reference.md",
+    "target": "status_update_outstanding_questions.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/models/registry.py#L1-L118",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/question_handling_reference.md",
+    "target": "../.codex/notes/Codex_Questions.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/peft/peft_adapter.py#L1-L138",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/question_handling_reference.md",
+    "target": "../ERROR_LOG.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/eval/eval_runner.py#L49-L108",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/question_handling_reference.md",
+    "target": "../CODEBASE_AUDIT_2025-08-26_203612.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/eval/datasets.py#L22-L62",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/quickstart.md",
+    "target": "guides/offline_catalogue.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/metrics/registry.py#L65-L100",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/quickstart.md",
+    "target": "examples/lora_quickstart.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/metrics/registry.py#L171-L195",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/ephemeral-runners.md",
+    "target": "https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/use-in-a-workflow",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/interfaces/tokenizer.py#L35-L91",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/ephemeral-runners.md",
+    "target": "https://docs.github.com/en/rest/actions/self-hosted-runners",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/interfaces/reward_model.py#L8-L36",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/ephemeral-runners.md",
+    "target": "https://pre-commit.com/#installation",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/interfaces/rl.py#L8-L29",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/troubleshooting.md",
+    "target": "experiments/README.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/interfaces/registry.py#L61-L88",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/troubleshooting.md",
+    "target": "experiments/mlflow_offline.md",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/reward_models/simple.py#L8-L27",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/services/ita/README.md",
+    "target": "openapi.yaml",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/reward_models/rlhf.py#L1-L27",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/services/ita/README.md",
+    "target": "openapi.yaml",
+    "type": "relative"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/determinism.py#L33-L89",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/main/README.md#:~:text=NCCL%20backend%20are%20installed,run_hf_trainer%28...%2C%20distributed%3DFalse",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L26-L83",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.scripts%5D%20codex,config%20%3D%20%22codex_ml.cli.validate%3Amain",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 20,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/ingestion/utils.py#L118-L188",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/__init__.py#:~:text=",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 21,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/services/api/main.py#L26-L117",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/hf_tokenizer.py#:~:text=%40dataclass%20class%20HFTokenizerAdapter%28TokenizerAdapter%29%3A%20,tokenizer",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 23,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/training/test_config_loading.py#L1-L87",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/sentencepiece_adapter.py#:~:text=BEGIN%3A%20CODEX_SENTENCEPIECE_ADAPTER%20,with%20minimal%20conveniences",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 23,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/test_interfaces_compat.py#L1-L115",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/train_tokenizer.py#:~:text=,tokenizers",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 29,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/reward_models/rlhf.py#L1-L27",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/models/decoder_only.py#:~:text=class%20DecoderOnlyLM%28nn.Module%29%3A%20%22%22%22A%20minimal%20GPT,language%20model",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 41,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/interfaces/tokenizer.py#L35-L91",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/peft/peft_adapter.py#:~:text=,LoRA%20integration%20for%20Codex%20models",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 41,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/tokenization/base.yaml#L1-L14",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/training/__init__.py#:~:text=seed%3A%20int%20%3D%2042%20model%3A,%5B%5D%2C%20%7D",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 42,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/models/registry.py#L1-L118",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/training/functional_training.py#:~:text=,Codex%20models",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 42,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/model/base.yaml#L1-L10",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/train_loop.py#:~:text=BEGIN%3A%20CODEX_TRAIN_LOOP%20,evaluation%20hooks%20and%20metrics%20persistence",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 43,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/training/engine_hf_trainer.py#L1-L23",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/data/loaders.py#:~:text=def%20_parse_jsonl_line%28line%3A%20str%2C%20,c",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 43,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/training/engine_hf_trainer.py#L30-L104",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/eval/metrics.py#:~:text=logits_or_nll%3A%20Iterable%2C%20targets%3A%20Iterable%5Bint%5D%2C%20,for%20a%20batch%20of%20predictions",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 43,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/test_engine_hf_trainer.py#L97-L141",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/monitoring/codex_logging.py#:~:text=def%20write_ndjson%28path%3A%20str%20,as%20NDJSON%20with%20basic%20redaction",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 44,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L26-L83",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/logging/run_logger.py#:~:text=class%20RunLogger%3A%20,run%20using%20a%20shared%20schema",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 44,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/cli/main.py#L98-L130",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/logging/ndjson_logger.py#:~:text=def%20__init__,Lock",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 45,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/eval/eval_runner.py#L49-L108",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tracking/mlflow_utils.py#:~:text=if%20not%20cfg.enable%3A%20%23%20No,nullcontext%28None",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 45,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/eval/datasets.py#L39-L62",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tracking/init_experiment.py#:~:text=def%20log_metric,metric%20to%20all%20configured%20writers",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 45,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/metrics/registry.py#L65-L100",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/telemetry/metrics.py#:~:text=REQUEST_LATENCY%20%3D%20Histogram%28,if%20_HAS_PROM%20else%20None",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 45,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/metrics/registry.py#L171-L195",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/telemetry/server.py#:~:text=def%20start_metrics_server,is%20available",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 46,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/codex_utils/ndjson.py#L8-L21",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/safety/filters.py#:~:text=",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 46,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/tracking/base.yaml#L1-L6",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/registry/__init__.py#:~:text=tokenizer_registry%2C%20%29%20from%20,get_trainer%2C%20list_trainers%2C%20register_trainer%2C%20trainer_registry",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 46,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/logging/session_logger.py#L1-L18",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/models/registry.py#:~:text=,apply%20LoRA%2Fdevice%20settings%20when%20requested",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 46,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/logging/session_logger.py#L96-L135",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/checkpointing.py#:~:text=def%20save_checkpoint,%29%20except%20Exception%3A%20pass",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 47,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/codex_utils/repro.py#L33-L59",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/provenance.py#:~:text=def%20environment_summary%28%29%20,package%2C%20and%20Python%20runtime%20metadata",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 48,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/training/data_utils.py#L45-L75",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/seeding.py#:~:text=def%20set_reproducible%28seed%3A%20int%29%20,effort%20deterministic%20behaviour",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 48,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/training/data_utils.py#L177-L217",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/cli/main.py#:~:text=%40hydra.main%28version_base%3D,eval",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 48,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/training/data_utils.py#L270-L315",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/cli/validate.py#:~:text=config_path%3A%20Path%20%3D%20typer,",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 48,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/ingestion/utils.py#L118-L188",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pytest.ini#:~:text=addopts%20%3D%20,in%20via%20RUN_NET_TESTS%3D1",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 49,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/services/api/main.py#L76-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/tests/test_peft_adapter.py#:~:text=def%20test_apply_lora_merges_config_without_peft%28monkeypatch%29%3A%20monkeypatch.setattr%28,",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 50,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L17-L84",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/tests/test_registry.py#:~:text=def%20test_registry_register_get_roundtrip%28%29%3A%20reg%20%3D%20Registry%28",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 52,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L1-L34",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/tests/test_mlflow_utils.py#:~:text=def%20test_start_run_no_mlflow_accepts_noop_or_raise%28monkeypatch%29%3A%20,import_module",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 52,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/model_registry.md#L1-L38",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/tests/test_train_loop.py#:~:text=,loop%20utilities",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 52,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/evaluation_runner.md#L1-L11",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/tests/test_train_loop.py#:~:text=,loop%20utilities",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 52,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/repro.md#L1-L14",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/__init__.py#:~:text=",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 53,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/tracking/base.yaml#L1-L6",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/hf_tokenizer.py#:~:text=%40dataclass%20class%20HFTokenizerAdapter%28TokenizerAdapter%29%3A%20,tokenizer",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 53,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/utils/trackers.py#L8-L29",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/train_tokenizer.py#:~:text=,tokenizers",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 54,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/interfaces/registry.py#L61-L88",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/models/decoder_only.py#:~:text=class%20DecoderOnlyLM%28nn.Module%29%3A%20%22%22%22A%20minimal%20GPT,language%20model",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 54,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/peft/peft_adapter.py#L1-L138",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/models/registry.py#:~:text=,apply%20LoRA%2Fdevice%20settings%20when%20requested",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 54,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/metrics/registry.py#L65-L100",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/training/functional_training.py#:~:text=,Codex%20models",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 275,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/test_engine_hf_trainer.py#L11-L27",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/train_loop.py#:~:text=def%20run_training%28%20,record_metrics",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 276,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/training/test_config_loading.py#L1-L87",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/cli/main.py#:~:text=%40hydra.main%28version_base%3D,eval",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 276,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/test_interfaces_compat.py#L1-L115",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/config_schema.py#:~:text=class%20TrainConfig,",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 285,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/determinism.py#L33-L89",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/training/__init__.py#:~:text=def%20_merge_dataset_config%28dataset%3A%20Dict,eval_texts",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 286,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/determinism.py#L33-L89",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/eval/metrics.py#:~:text=logits_or_nll%3A%20Iterable%2C%20targets%3A%20Iterable%5Bint%5D%2C%20,for%20a%20batch%20of%20predictions",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 287,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/codex_utils/repro.py#L73-L115",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/analysis/metrics.py#:~:text=def%20mccabe_minimal%28ast_tree%3A%20ast.AST%29%20,walk%28ast_tree%29%20if%20isinstance%28n%2C%20branches",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 289,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/training/data_utils.py#L45-L75",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/monitoring/codex_logging.py#:~:text=def%20write_ndjson%28path%3A%20str%20,as%20NDJSON%20with%20basic%20redaction",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-14.md",
-    "line": 290,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/codex_utils/repro.py#L33-L59",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/telemetry/server.py#:~:text=def%20start_metrics_server,is%20available",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 14,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/logging/session_logger.py#L1-L137",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/checkpointing.py#:~:text=def%20save_checkpoint,%29%20except%20Exception%3A%20pass",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 15,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/training/engine_hf_trainer.py#L1-L23",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/data/loaders.py#:~:text=def%20_parse_jsonl_line%28line%3A%20str%2C%20,c",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 16,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L10-L28",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/safety/filters.py#:~:text=",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 16,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/training_engine.md#L2-L17",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/noxfile.py#:~:text=%40nox,only%22%2C",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 16,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/repro.md#L1-L13",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/scripts/codex_local_gates.sh#:~:text=set%20,under%3D70%20fi",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 16,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/ops/experiment_tracking.md#L1-L64",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.optional,peft%3E%3D0.10.0",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 17,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tools/package_functional_training.py#L1-L42",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/main/README.md#:~:text=NCCL%20backend%20are%20installed,run_hf_trainer%28...%2C%20distributed%3DFalse",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 19,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/.codex/inventory.tsv#L1-L95",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tracking/init_experiment.py#:~:text=def%20log_metric,metric%20to%20all%20configured%20writers",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 21,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L1-L32",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/registry/__init__.py#:~:text=tokenizer_registry%2C%20%29%20from%20,get_trainer%2C%20list_trainers%2C%20register_trainer%2C%20trainer_registry",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 21,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L68-L93",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.entry",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 25,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/tests/test_train_loop.py#:~:text=,loop%20utilities",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 26,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/codex_cli.py#L50-L59",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/models/decoder_only.py#:~:text=class%20DecoderOnlyLM%28nn.Module%29%3A%20%22%22%22A%20minimal%20GPT,language%20model",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 27,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L10-L28",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/peft/peft_adapter.py#:~:text=%23%20task_type%20is%20a%20top,CAUSAL_LM",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 44,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/tokenization/hf_tokenizer.py#L1-L144",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/config_schema.py#:~:text=class%20TrainConfig,",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 44,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/tokenization/sentencepiece_adapter.py#L1-L111",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/training/__init__.py#:~:text=seed%3A%20int%20%3D%2042%20model%3A,%5B%5D%2C%20%7D",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 44,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/tokenization/__init__.py#L1-L84",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/eval/metrics.py#:~:text=logits_or_nll%3A%20Iterable%2C%20targets%3A%20Iterable%5Bint%5D%2C%20,for%20a%20batch%20of%20predictions",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 44,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/tokenization/train_tokenizer.py#L39-L143",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/train_loop.py#:~:text=def%20run_training%28%20,record_metrics",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 45,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/minilm.py#L1-L98",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/safety/filters.py#:~:text=",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 45,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/registry.py#L19-L118",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/monitoring/codex_logging.py#:~:text=def%20write_ndjson%28path%3A%20str%20,as%20NDJSON%20with%20basic%20redaction",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 45,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/peft/peft_adapter.py#L37-L138",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/main/README.md#:~:text=NCCL%20backend%20are%20installed,run_hf_trainer%28...%2C%20distributed%3DFalse",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 45,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/modeling/codex_model_loader.py#L39-L116",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/seeding.py#:~:text=def%20set_reproducible%28seed%3A%20int%29%20,effort%20deterministic%20behaviour",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 45,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/generate.py#L13-L70",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/provenance.py#:~:text=def%20environment_summary%28%29%20,package%2C%20and%20Python%20runtime%20metadata",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 46,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/training.py#L176-L332",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/checkpointing.py#:~:text=def%20save_checkpoint,%29%20except%20Exception%3A%20pass",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 46,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/training.py#L341-L500",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/checkpointing.py#:~:text=def%20save_checkpoint,best",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 46,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/training/engine_hf_trainer.py#L1-L23",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/data/loaders.py#:~:text=%29%20,None%3A%20import%20random%20as%20_rnd",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 46,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/seeding.py#:~:text=def%20set_reproducible%28seed%3A%20int%29%20,effort%20deterministic%20behaviour",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 47,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-16.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/train_loop.py#:~:text=ART_DIR.mkdir%28parents%3DTrue%2C%20exist_ok%3DTrue%29%20payload%20%3D%20,write_ndjson%28out_ndjson%2C%20payload",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 47,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/provenance.py#L38-L89",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L17-L84",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 48,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/eval/evaluator.py#L26-L42",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L191-L260",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 48,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/eval/run_eval.py#L31-L70",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/env/ubuntu.yaml#L1-L6",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 48,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/training.py#L341-L500",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/model/base.yaml#L1-L10",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 49,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/codex_logging.py#L116-L187",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/training/base.yaml#L1-L20",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 49,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/async_writer.py#L42-L132",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/tokenization/base.yaml#L1-L14",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 49,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/logging/session_logger.py#L1-L137",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/data/base.yaml#L1-L2",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 49,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/tracking/base.yaml#L1-L6",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 50,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L1-L34",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 51,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/data_utils.py#L1-L143",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/model_registry.md#L1-L38",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 52,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/evaluation_runner.md#L1-L11",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 52,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/filters.py#L15-L113",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/repro.md#L1-L14",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 52,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sandbox.py#L2-L89",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/test_engine_hf_trainer.py#L97-L141",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 52,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/error_log.py#L15-L51",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/cli/main.py#L98-L130",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 54,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/generate.py#L13-L70",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/models/registry.py#L1-L118",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 55,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L10-L28",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/peft/peft_adapter.py#L1-L138",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 55,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/training_engine.md#L2-L17",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/eval/eval_runner.py#L49-L108",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 55,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/ops/experiment_tracking.md#L1-L64",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/eval/datasets.py#L22-L62",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 55,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/repro.md#L1-L13",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/metrics/registry.py#L65-L100",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 55,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L1-L32",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/metrics/registry.py#L171-L195",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 56,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/ops/experiment_tracking.md#L1-L64",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/interfaces/tokenizer.py#L35-L91",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 57,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/registry.py#L19-L118",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/interfaces/reward_model.py#L8-L36",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 62,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/interfaces/rl.py#L8-L29",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 63,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/codex_cli.py#L50-L59",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/interfaces/registry.py#L61-L88",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 64,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/tokenization/train_tokenizer.py#L39-L143",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/reward_models/simple.py#L8-L27",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 65,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/reward_models/rlhf.py#L1-L27",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 67,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/determinism.py#L33-L89",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 68,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L26-L83",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 69,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/codex_logging.py#L116-L187",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/ingestion/utils.py#L118-L188",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 70,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/minilm.py#L1-L98",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/services/api/main.py#L26-L117",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 72,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/data_utils.py#L1-L143",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/training/test_config_loading.py#L1-L87",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 73,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/repro.py#L1-L77",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/test_interfaces_compat.py#L1-L115",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 74,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/provenance.py#L38-L89",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/reward_models/rlhf.py#L1-L27",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 79,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/codex_logging.py#L116-L187",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/interfaces/tokenizer.py#L35-L91",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 80,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/peft/peft_adapter.py#L37-L138",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/tokenization/base.yaml#L1-L14",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 90,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/models/registry.py#L1-L118",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 118,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/codex_cli.py#L50-L59",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/model/base.yaml#L1-L10",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 154,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/training/engine_hf_trainer.py#L1-L23",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 180,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/training/engine_hf_trainer.py#L30-L104",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 214,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/test_engine_hf_trainer.py#L97-L141",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 247,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L26-L83",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 266,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/repro.py#L1-L77",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/cli/main.py#L98-L130",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 267,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/provenance.py#L38-L89",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/eval/eval_runner.py#L49-L108",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 267,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/eval/datasets.py#L39-L62",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 269,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/data_utils.py#L1-L143",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/metrics/registry.py#L65-L100",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 271,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/metrics/registry.py#L171-L195",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 272,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/codex_utils/ndjson.py#L8-L21",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 314,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/error_log.py#L15-L51",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/tracking/base.yaml#L1-L6",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 334,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/logging/session_logger.py#L1-L137",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/logging/session_logger.py#L1-L18",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 335,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/training/engine_hf_trainer.py#L1-L23",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/logging/session_logger.py#L96-L135",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 336,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L10-L28",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/codex_utils/repro.py#L33-L59",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 336,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/training_engine.md#L2-L17",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/training/data_utils.py#L45-L75",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 336,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/repro.md#L1-L13",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/training/data_utils.py#L177-L217",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 336,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/ops/experiment_tracking.md#L1-L64",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/training/data_utils.py#L270-L315",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 337,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tools/package_functional_training.py#L1-L42",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/ingestion/utils.py#L118-L188",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 339,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/.codex/inventory.tsv#L1-L95",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/services/api/main.py#L76-L82",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 341,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L1-L32",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L17-L84",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 341,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L68-L93",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L1-L34",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 345,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/model_registry.md#L1-L38",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 346,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/codex_cli.py#L50-L59",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/evaluation_runner.md#L1-L11",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 347,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L10-L28",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/repro.md#L1-L14",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 364,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/tokenization/hf_tokenizer.py#L1-L144",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/configs/tracking/base.yaml#L1-L6",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 364,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/tokenization/sentencepiece_adapter.py#L1-L111",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/utils/trackers.py#L8-L29",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 364,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/tokenization/__init__.py#L1-L84",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/interfaces/registry.py#L61-L88",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 364,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/tokenization/train_tokenizer.py#L39-L143",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/peft/peft_adapter.py#L1-L138",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 365,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/minilm.py#L1-L98",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/metrics/registry.py#L65-L100",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 365,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/registry.py#L19-L118",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/test_engine_hf_trainer.py#L11-L27",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 365,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/peft/peft_adapter.py#L37-L138",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/training/test_config_loading.py#L1-L87",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 365,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/modeling/codex_model_loader.py#L39-L116",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tests/test_interfaces_compat.py#L1-L115",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 365,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/generate.py#L13-L70",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/determinism.py#L33-L89",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 366,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/training.py#L176-L332",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/determinism.py#L33-L89",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 366,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/training.py#L341-L500",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/codex_utils/repro.py#L73-L115",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 366,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/training/engine_hf_trainer.py#L1-L23",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/training/data_utils.py#L45-L75",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 366,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-14.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/codex_utils/repro.py#L33-L59",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 367,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/logging/session_logger.py#L1-L137",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 367,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/provenance.py#L38-L89",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/training/engine_hf_trainer.py#L1-L23",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 368,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/eval/evaluator.py#L26-L42",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L10-L28",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 368,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/eval/run_eval.py#L31-L70",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/training_engine.md#L2-L17",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 368,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/training.py#L341-L500",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/repro.md#L1-L13",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 369,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/codex_logging.py#L116-L187",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/ops/experiment_tracking.md#L1-L64",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 369,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/async_writer.py#L42-L132",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tools/package_functional_training.py#L1-L42",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 369,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/logging/session_logger.py#L1-L137",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/.codex/inventory.tsv#L1-L95",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 369,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L1-L32",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 370,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L68-L93",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 371,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/data_utils.py#L1-L143",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 372,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/codex_cli.py#L50-L59",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 372,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/filters.py#L15-L113",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L10-L28",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 372,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sandbox.py#L2-L89",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/tokenization/hf_tokenizer.py#L1-L144",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 372,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/error_log.py#L15-L51",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/tokenization/sentencepiece_adapter.py#L1-L111",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 374,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/generate.py#L13-L70",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/tokenization/__init__.py#L1-L84",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 375,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L10-L28",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/tokenization/train_tokenizer.py#L39-L143",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 375,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/training_engine.md#L2-L17",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/minilm.py#L1-L98",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 375,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/ops/experiment_tracking.md#L1-L64",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/registry.py#L19-L118",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 375,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/repro.md#L1-L13",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/peft/peft_adapter.py#L37-L138",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 375,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L1-L32",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/modeling/codex_model_loader.py#L39-L116",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 376,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/ops/experiment_tracking.md#L1-L64",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/generate.py#L13-L70",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 377,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/registry.py#L19-L118",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/training.py#L176-L332",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 382,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/training.py#L341-L500",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 383,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/codex_cli.py#L50-L59",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/training/engine_hf_trainer.py#L1-L23",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 384,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/tokenization/train_tokenizer.py#L39-L143",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 385,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 387,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/provenance.py#L38-L89",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 388,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/eval/evaluator.py#L26-L42",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 389,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/codex_logging.py#L116-L187",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/eval/run_eval.py#L31-L70",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 390,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/minilm.py#L1-L98",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/training.py#L341-L500",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 392,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/data_utils.py#L1-L143",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/codex_logging.py#L116-L187",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 393,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/repro.py#L1-L77",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/async_writer.py#L42-L132",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 394,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/provenance.py#L38-L89",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/logging/session_logger.py#L1-L137",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 399,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/codex_logging.py#L116-L187",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 400,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/peft/peft_adapter.py#L37-L138",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 410,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/data_utils.py#L1-L143",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 438,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/codex_cli.py#L50-L59",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 473,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/filters.py#L15-L113",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 498,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sandbox.py#L2-L89",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 533,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/error_log.py#L15-L51",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 565,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/generate.py#L13-L70",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 584,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/repro.py#L1-L77",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L10-L28",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 585,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/provenance.py#L38-L89",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/training_engine.md#L2-L17",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 585,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/ops/experiment_tracking.md#L1-L64",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 587,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/data_utils.py#L1-L143",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/repro.md#L1-L13",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 589,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L1-L32",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 590,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/ops/experiment_tracking.md#L1-L64",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-15.md",
-    "line": 632,
-    "text": "GitHub",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/error_log.py#L15-L51",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/registry.py#L19-L118",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 7,
-    "text": "github.com",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/main/README.md#:~:text=NCCL%20backend%20are%20installed,run_hf_trainer%28...%2C%20distributed%3DFalse",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 8,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.scripts%5D%20codex,config%20%3D%20%22codex_ml.cli.validate%3Amain",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/codex_cli.py#L50-L59",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 9,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/__init__.py#:~:text=",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/tokenization/train_tokenizer.py#L39-L143",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 9,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/hf_tokenizer.py#:~:text=%40dataclass%20class%20HFTokenizerAdapter%28TokenizerAdapter%29%3A%20,tokenizer",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 9,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/sentencepiece_adapter.py#:~:text=BEGIN%3A%20CODEX_SENTENCEPIECE_ADAPTER%20,with%20minimal%20conveniences",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 9,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/train_tokenizer.py#:~:text=,tokenizers",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 10,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/models/decoder_only.py#:~:text=class%20DecoderOnlyLM%28nn.Module%29%3A%20%22%22%22A%20minimal%20GPT,language%20model",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/codex_logging.py#L116-L187",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 10,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/peft/peft_adapter.py#:~:text=,LoRA%20integration%20for%20Codex%20models",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/minilm.py#L1-L98",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 11,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/training/__init__.py#:~:text=seed%3A%20int%20%3D%2042%20model%3A,%5B%5D%2C%20%7D",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/data_utils.py#L1-L143",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 11,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/training/functional_training.py#:~:text=,Codex%20models",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/repro.py#L1-L77",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 11,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/train_loop.py#:~:text=BEGIN%3A%20CODEX_TRAIN_LOOP%20,evaluation%20hooks%20and%20metrics%20persistence",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/provenance.py#L38-L89",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 12,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/data/loaders.py#:~:text=def%20_parse_jsonl_line%28line%3A%20str%2C%20,c",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/codex_logging.py#L116-L187",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 13,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/eval/metrics.py#:~:text=logits_or_nll%3A%20Iterable%2C%20targets%3A%20Iterable%5Bint%5D%2C%20,for%20a%20batch%20of%20predictions",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/peft/peft_adapter.py#L37-L138",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 14,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/monitoring/codex_logging.py#:~:text=def%20write_ndjson%28path%3A%20str%20,as%20NDJSON%20with%20basic%20redaction",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 14,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/logging/run_logger.py#:~:text=class%20RunLogger%3A%20,run%20using%20a%20shared%20schema",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/codex_cli.py#L50-L59",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 14,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/logging/ndjson_logger.py#:~:text=def%20__init__,Lock",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 14,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tracking/mlflow_utils.py#:~:text=if%20not%20cfg.enable%3A%20%23%20No,nullcontext%28None",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 14,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tracking/init_experiment.py#:~:text=def%20log_metric,metric%20to%20all%20configured%20writers",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 15,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/telemetry/metrics.py#:~:text=REQUEST_LATENCY%20%3D%20Histogram%28,if%20_HAS_PROM%20else%20None",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 15,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/telemetry/server.py#:~:text=def%20start_metrics_server,is%20available",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/repro.py#L1-L77",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 16,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/safety/filters.py#:~:text=",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/provenance.py#L38-L89",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 17,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/registry/__init__.py#:~:text=tokenizer_registry%2C%20%29%20from%20,get_trainer%2C%20list_trainers%2C%20register_trainer%2C%20trainer_registry",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 17,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/models/registry.py#:~:text=,apply%20LoRA%2Fdevice%20settings%20when%20requested",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/data_utils.py#L1-L143",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 18,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/checkpointing.py#:~:text=def%20save_checkpoint,%29%20except%20Exception%3A%20pass",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 18,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/provenance.py#:~:text=def%20environment_summary%28%29%20,package%2C%20and%20Python%20runtime%20metadata",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 18,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/seeding.py#:~:text=def%20set_reproducible%28seed%3A%20int%29%20,effort%20deterministic%20behaviour",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/error_log.py#L15-L51",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 19,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/cli/main.py#:~:text=%40hydra.main%28version_base%3D,eval",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/logging/session_logger.py#L1-L137",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 19,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/cli/validate.py#:~:text=config_path%3A%20Path%20%3D%20typer,",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/training/engine_hf_trainer.py#L1-L23",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 20,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pytest.ini#:~:text=addopts%20%3D%20,in%20via%20RUN_NET_TESTS%3D1",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L10-L28",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 20,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/tests/test_peft_adapter.py#:~:text=def%20test_apply_lora_merges_config_without_peft%28monkeypatch%29%3A%20monkeypatch.setattr%28,",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/training_engine.md#L2-L17",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 20,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/tests/test_registry.py#:~:text=def%20test_registry_register_get_roundtrip%28%29%3A%20reg%20%3D%20Registry%28",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/repro.md#L1-L13",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 20,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/tests/test_mlflow_utils.py#:~:text=def%20test_start_run_no_mlflow_accepts_noop_or_raise%28monkeypatch%29%3A%20,import_module",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/ops/experiment_tracking.md#L1-L64",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 20,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/tests/test_train_loop.py#:~:text=,loop%20utilities",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/tools/package_functional_training.py#L1-L42",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 21,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/tests/test_train_loop.py#:~:text=,loop%20utilities",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/.codex/inventory.tsv#L1-L95",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 27,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/__init__.py#:~:text=",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L1-L32",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 27,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/hf_tokenizer.py#:~:text=%40dataclass%20class%20HFTokenizerAdapter%28TokenizerAdapter%29%3A%20,tokenizer",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L68-L93",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 27,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tokenization/train_tokenizer.py#:~:text=,tokenizers",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 28,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/models/decoder_only.py#:~:text=class%20DecoderOnlyLM%28nn.Module%29%3A%20%22%22%22A%20minimal%20GPT,language%20model",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/codex_cli.py#L50-L59",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 28,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/models/registry.py#:~:text=,apply%20LoRA%2Fdevice%20settings%20when%20requested",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L10-L28",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 29,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/training/functional_training.py#:~:text=,Codex%20models",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/tokenization/hf_tokenizer.py#L1-L144",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 29,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/train_loop.py#:~:text=def%20run_training%28%20,record_metrics",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/tokenization/sentencepiece_adapter.py#L1-L111",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 29,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/cli/main.py#:~:text=%40hydra.main%28version_base%3D,eval",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/tokenization/__init__.py#L1-L84",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 30,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/config_schema.py#:~:text=class%20TrainConfig,",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/tokenization/train_tokenizer.py#L39-L143",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 30,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/training/__init__.py#:~:text=def%20_merge_dataset_config%28dataset%3A%20Dict,eval_texts",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/minilm.py#L1-L98",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 31,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/eval/metrics.py#:~:text=logits_or_nll%3A%20Iterable%2C%20targets%3A%20Iterable%5Bint%5D%2C%20,for%20a%20batch%20of%20predictions",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/registry.py#L19-L118",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 31,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/analysis/metrics.py#:~:text=def%20mccabe_minimal%28ast_tree%3A%20ast.AST%29%20,walk%28ast_tree%29%20if%20isinstance%28n%2C%20branches",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/peft/peft_adapter.py#L37-L138",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 32,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/monitoring/codex_logging.py#:~:text=def%20write_ndjson%28path%3A%20str%20,as%20NDJSON%20with%20basic%20redaction",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/modeling/codex_model_loader.py#L39-L116",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 32,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/telemetry/server.py#:~:text=def%20start_metrics_server,is%20available",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/generate.py#L13-L70",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 33,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/checkpointing.py#:~:text=def%20save_checkpoint,%29%20except%20Exception%3A%20pass",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/training.py#L176-L332",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 34,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/data/loaders.py#:~:text=def%20_parse_jsonl_line%28line%3A%20str%2C%20,c",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/training.py#L341-L500",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 35,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/safety/filters.py#:~:text=",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/training/engine_hf_trainer.py#L1-L23",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 36,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/noxfile.py#:~:text=%40nox,only%22%2C",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 36,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/scripts/codex_local_gates.sh#:~:text=set%20,under%3D70%20fi",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 37,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.optional,peft%3E%3D0.10.0",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/provenance.py#L38-L89",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 38,
-    "text": "github.com",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/main/README.md#:~:text=NCCL%20backend%20are%20installed,run_hf_trainer%28...%2C%20distributed%3DFalse",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/eval/evaluator.py#L26-L42",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 39,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/tracking/init_experiment.py#:~:text=def%20log_metric,metric%20to%20all%20configured%20writers",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/eval/run_eval.py#L31-L70",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 40,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/registry/__init__.py#:~:text=tokenizer_registry%2C%20%29%20from%20,get_trainer%2C%20list_trainers%2C%20register_trainer%2C%20trainer_registry",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/training.py#L341-L500",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 40,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.entry",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/codex_logging.py#L116-L187",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 44,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/tests/test_train_loop.py#:~:text=,loop%20utilities",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/async_writer.py#L42-L132",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 45,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/models/decoder_only.py#:~:text=class%20DecoderOnlyLM%28nn.Module%29%3A%20%22%22%22A%20minimal%20GPT,language%20model",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex/logging/session_logger.py#L1-L137",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 46,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/peft/peft_adapter.py#:~:text=%23%20task_type%20is%20a%20top,CAUSAL_LM",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 47,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/config_schema.py#:~:text=class%20TrainConfig,",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 48,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/training/__init__.py#:~:text=seed%3A%20int%20%3D%2042%20model%3A,%5B%5D%2C%20%7D",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/data_utils.py#L1-L143",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 49,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/eval/metrics.py#:~:text=logits_or_nll%3A%20Iterable%2C%20targets%3A%20Iterable%5Bint%5D%2C%20,for%20a%20batch%20of%20predictions",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 50,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/train_loop.py#:~:text=def%20run_training%28%20,record_metrics",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/filters.py#L15-L113",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 51,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/safety/filters.py#:~:text=",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sandbox.py#L2-L89",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 52,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/monitoring/codex_logging.py#:~:text=def%20write_ndjson%28path%3A%20str%20,as%20NDJSON%20with%20basic%20redaction",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/error_log.py#L15-L51",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 53,
-    "text": "github.com",
-    "link": "https://github.com/Aries-Serpent/_codex_/blob/main/README.md#:~:text=NCCL%20backend%20are%20installed,run_hf_trainer%28...%2C%20distributed%3DFalse",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/generate.py#L13-L70",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 293,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/seeding.py#:~:text=def%20set_reproducible%28seed%3A%20int%29%20,effort%20deterministic%20behaviour",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/data_handling.md#L10-L28",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 294,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/provenance.py#:~:text=def%20environment_summary%28%29%20,package%2C%20and%20Python%20runtime%20metadata",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/modules/training_engine.md#L2-L17",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 294,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/checkpointing.py#:~:text=def%20save_checkpoint,%29%20except%20Exception%3A%20pass",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/ops/experiment_tracking.md#L1-L64",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 295,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/checkpointing.py#:~:text=def%20save_checkpoint,best",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/repro.md#L1-L13",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 296,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/data/loaders.py#:~:text=%29%20,None%3A%20import%20random%20as%20_rnd",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/README.md#L1-L32",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 296,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/utils/seeding.py#:~:text=def%20set_reproducible%28seed%3A%20int%29%20,effort%20deterministic%20behaviour",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/docs/ops/experiment_tracking.md#L1-L64",
+    "type": "external"
   },
   {
-    "path": ".codex\\status\\_codex_status_update-2025-09-16.md",
-    "line": 297,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex_ml/train_loop.py#:~:text=ART_DIR.mkdir%28parents%3DTrue%2C%20exist_ok%3DTrue%29%20payload%20%3D%20,write_ndjson%28out_ndjson%2C%20payload",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/registry.py#L19-L118",
+    "type": "external"
   },
   {
-    "path": "docs\\bridge\\governance.md",
-    "line": 47,
-    "text": "bridge overview",
-    "link": "overview.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": "docs\\bridge\\overview.md",
-    "line": 50,
-    "text": "Ubuntu CLI integration guide",
-    "link": "ubuntu_cli.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/codex_cli.py#L50-L59",
+    "type": "external"
   },
   {
-    "path": "docs\\bridge\\README.md",
-    "line": 23,
-    "text": "Bridge overview",
-    "link": "overview.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/tokenization/train_tokenizer.py#L39-L143",
+    "type": "external"
   },
   {
-    "path": "docs\\bridge\\README.md",
-    "line": 24,
-    "text": "Governance and guardrails",
-    "link": "governance.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": "docs\\bridge\\README.md",
-    "line": 25,
-    "text": "Ubuntu CLI integration",
-    "link": "ubuntu_cli.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
+    "type": "external"
   },
   {
-    "path": "docs\\bridge\\README.md",
-    "line": 26,
-    "text": "GitHub App permissions",
-    "link": "../../copilot/app/README.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": "docs\\bridge\\README.md",
-    "line": 27,
-    "text": "Threat model snapshot",
-    "link": "../../ops/threat_model/STRIDE.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/codex_logging.py#L116-L187",
+    "type": "external"
   },
   {
-    "path": "docs\\bridge\\ubuntu_cli.md",
-    "line": 74,
-    "text": "governance guide",
-    "link": "governance.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/models/minilm.py#L1-L98",
+    "type": "external"
   },
   {
-    "path": "docs\\dev\\plugins.md",
-    "line": 27,
-    "text": "`examples/plugins`",
-    "link": "../../examples/plugins/",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/data_utils.py#L1-L143",
+    "type": "external"
   },
   {
-    "path": "docs\\dev\\testing.md",
-    "line": 3,
-    "text": "nox",
-    "link": "https://nox.thea.codes/",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/repro.py#L1-L77",
+    "type": "external"
   },
   {
-    "path": "docs\\examples\\training-configs.md",
-    "line": 5,
-    "text": "`configs/training/base.yaml`",
-    "link": "../../configs/training/base.yaml",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/provenance.py#L38-L89",
+    "type": "external"
   },
   {
-    "path": "docs\\examples\\training-configs.md",
-    "line": 7,
-    "text": "`examples/train_toy.py`",
-    "link": "../../examples/train_toy.py",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/monitoring/codex_logging.py#L116-L187",
+    "type": "external"
   },
   {
-    "path": "docs\\examples\\training-configs.md",
-    "line": 9,
-    "text": "`examples/chat_finetune.py`",
-    "link": "../../examples/chat_finetune.py",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/peft/peft_adapter.py#L37-L138",
+    "type": "external"
   },
   {
-    "path": "docs\\experiments\\mlflow_offline.md",
-    "line": 18,
-    "text": "`examples/mlflow_offline.py`",
-    "link": "../../examples/mlflow_offline.py",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": "docs\\experiments\\README.md",
-    "line": 29,
-    "text": "`examples/mlflow_offline.py`",
-    "link": "../../examples/mlflow_offline.py",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/cli/codex_cli.py#L50-L59",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\CHECKPOINT_SAFETY.md",
-    "line": 13,
-    "text": "PyTorch serialization warnings",
-    "link": "https://pytorch.org/docs/stable/notes/serialization.html#warnings",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\CHECKPOINT_SAFETY.md",
-    "line": 16,
-    "text": "Saving and loading models \u2014 PyTorch tutorial",
-    "link": "https://docs.pytorch.org/tutorials/beginner/saving_loading_models.html",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\CHECKPOINT_SAFETY.md",
-    "line": 20,
-    "text": "`torch.load` reference",
-    "link": "https://pytorch.org/docs/stable/generated/torch.load.html",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/HEAD/src/codex_ml/utils/config_loader.py#L13-L82",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\CHECKPOINT_SAFETY.md",
-    "line": 28,
-    "text": "Bandit security rule B614",
-    "link": "https://bandit.readthedocs.io/en/latest/plugins/b614_pytorch_load.html",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/safety/sanitizers.py#L25-L61",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\CHECKPOINT_SAFETY.md",
-    "line": 31,
-    "text": "`safetensors`",
-    "link": "https://huggingface.co/docs/safetensors/index",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/repro.py#L1-L77",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\CHECKPOINT_SAFETY.md",
-    "line": 62,
-    "text": "`pytest.importorskip`",
-    "link": "https://docs.pytest.org/en/stable/reference/reference.html#pytest.importorskip",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/provenance.py#L38-L89",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\CHECKPOINT_SAFETY.md",
-    "line": 68,
-    "text": "Serialization notes: warnings",
-    "link": "https://pytorch.org/docs/stable/notes/serialization.html#warnings",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\CHECKPOINT_SAFETY.md",
-    "line": 69,
-    "text": "Saving and loading models tutorial",
-    "link": "https://docs.pytorch.org/tutorials/beginner/saving_loading_models.html",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/data_utils.py#L1-L143",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\CHECKPOINT_SAFETY.md",
-    "line": 70,
-    "text": "`torch.load` API reference",
-    "link": "https://pytorch.org/docs/stable/generated/torch.load.html",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\CHECKPOINT_SAFETY.md",
-    "line": 71,
-    "text": "`B614: pytorch_load`",
-    "link": "https://bandit.readthedocs.io/en/latest/plugins/b614_pytorch_load.html",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/checkpointing.py#L181-L259",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\CHECKPOINT_SAFETY.md",
-    "line": 72,
-    "text": "`safetensors` documentation",
-    "link": "https://huggingface.co/docs/safetensors/index",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-15.md",
+    "target": "https://github.com/Aries-Serpent/_codex_/blob/9c76af46886b0aa06944992086a904384f63e304/src/codex_ml/utils/error_log.py#L15-L51",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\CHECKPOINT_SAFETY.md",
-    "line": 73,
-    "text": "`importorskip` reference",
-    "link": "https://docs.pytest.org/en/stable/reference/reference.html#pytest.importorskip",
-    "type": "external",
-    "target_exists": null
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-09-07.md",
+    "target": "docs/guides/AGENTS.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\guides\\offline_transformers.md",
-    "line": 60,
-    "text": "PyTorch \u2014 Get Started Locally",
-    "link": "https://pytorch.org/get-started/locally/",
-    "type": "external",
-    "target_exists": null
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/status/_codex_status_update-2025-08-31.md",
+    "target": ".codex/deferred_items.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\guides\\offline_transformers.md",
-    "line": 61,
-    "text": "Transformers \u2014 Offline Mode",
-    "link": "https://huggingface.co/docs/transformers/main/installation",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/archive/README_UPDATED.md",
+    "target": "http://platform.openai.com/docs/codex",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\offline_transformers.md",
-    "line": 62,
-    "text": "huggingface_hub \u2014 Download files from the Hub",
-    "link": "https://huggingface.co/docs/huggingface_hub/en/guides/download",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/.codex/archive/README_UPDATED.md",
+    "target": "http://platform.openai.com/docs/codex",
+    "type": "external"
   },
   {
-    "path": "docs\\guides\\offline_transformers.md",
-    "line": 63,
-    "text": "pytest API Reference \u2014 `importorskip`",
-    "link": "https://docs.pytest.org/en/stable/reference/reference.html",
-    "type": "external",
-    "target_exists": null
+    "exists": false,
+    "file": "/workspace/_codex_/.codex/archive/README_UPDATED.md",
+    "target": "Dockerfile",
+    "type": "relative"
   },
   {
-    "path": "docs\\guides\\offline_transformers.md",
-    "line": 64,
-    "text": "nox \u2014 Sessions and environment variables",
-    "link": "https://nox.thea.codes/en/stable/usage.html",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/bridge/governance.md",
+    "target": "overview.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\guides\\tokenization.md",
-    "line": 62,
-    "text": "\ud83e\udd17 `tokenizers`",
-    "link": "https://github.com/huggingface/tokenizers",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/bridge/overview.md",
+    "target": "ubuntu_cli.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\guides\\tokenization.md",
-    "line": 65,
-    "text": "`sentencepiece`",
-    "link": "https://github.com/google/sentencepiece",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/bridge/README.md",
+    "target": "overview.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\modules\\configuration.md",
-    "line": 3,
-    "text": "Hydra",
-    "link": "https://hydra.cc",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/bridge/README.md",
+    "target": "governance.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\modules\\model_registry.md",
-    "line": 64,
-    "text": "docs/dev/plugins.md",
-    "link": "../dev/plugins.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": true,
+    "file": "/workspace/_codex_/docs/bridge/README.md",
+    "target": "ubuntu_cli.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\modules\\model_registry.md",
-    "line": 66,
-    "text": "docs/examples/training-configs.md",
-    "link": "../examples/training-configs.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": true,
+    "file": "/workspace/_codex_/docs/bridge/README.md",
+    "target": "../../copilot/app/README.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\modules\\plugins.md",
-    "line": 54,
-    "text": "`docs/guides/offline_catalogue.md`",
-    "link": "../guides/offline_catalogue.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": true,
+    "file": "/workspace/_codex_/docs/bridge/README.md",
+    "target": "../../ops/threat_model/STRIDE.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\ops\\RUNBOOK.md",
-    "line": 21,
-    "text": "oai_citation:0\u2021Astral Docs",
-    "link": "https://docs.astral.sh/ruff/?utm_source=chatgpt.com",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/bridge/ubuntu_cli.md",
+    "target": "governance.md",
+    "type": "relative"
   },
   {
-    "path": "docs\\ops\\RUNBOOK.md",
-    "line": 24,
-    "text": "oai_citation:1\u2021pytest-cov",
-    "link": "https://pytest-cov.readthedocs.io/en/latest/config.html?utm_source=chatgpt.com",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/dev/testing.md",
+    "target": "https://nox.thea.codes/",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-16.md",
-    "line": 5,
-    "text": "`docs/status_update_outstanding_questions.md`",
-    "link": "../status_update_outstanding_questions.md",
-    "type": "internal",
-    "target_exists": true
+    "exists": true,
+    "file": "/workspace/_codex_/docs/dev/plugins.md",
+    "target": "../../examples/plugins/",
+    "type": "relative"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 7,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents#:~:text=%7D%20%7D%2C%20%7B%20,Serpent%2F_codex_%2Fblob%2Fmain%2Fpyproject.toml%22",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/experiments/README.md",
+    "target": "../../examples/mlflow_offline.py",
+    "type": "relative"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 7,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=,backend%20%3D%20%22setuptools.build_meta",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/experiments/mlflow_offline.md",
+    "target": "../../examples/mlflow_offline.py",
+    "type": "relative"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 8,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/src/tokenization#:~:text=,",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/examples/training-configs.md",
+    "target": "../../configs/training/base.yaml",
+    "type": "relative"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 8,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=try%3A%20%20%23%20re,training%20optional",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/examples/training-configs.md",
+    "target": "../../examples/train_toy.py",
+    "type": "relative"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 8,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/src/codex#:~:text=,Serpent%2F_codex_%2Fmain%2Fsrc%2Fcodex%2Ftraining.py01%22%2C%20%22type%22%3A%20%22file",
-    "type": "external",
-    "target_exists": null
+    "exists": true,
+    "file": "/workspace/_codex_/docs/examples/training-configs.md",
+    "target": "../../examples/chat_finetune.py",
+    "type": "relative"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 8,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/configs#:~:text=,Serpent%2F_codex_%2Ftree%2Fmain%2Fconfigs%2Fdata%22",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents#:~:text=%7D%20%7D%2C%20%7B%20,Serpent%2F_codex_%2Fblob%2Fmain%2Fpyproject.toml%22",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 11,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/src/codex#:~:text=,Serpent%2F_codex_%2Fgit%2Ftrees%2F47161a022f6ea2c501b50ab140da0db41d2d26f8%22%2C%20%22html%22%3A%20%22https%3A%2F%2Fgithub.com%2FAries",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=,backend%20%3D%20%22setuptools.build_meta",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 21,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/tokenization/cli.py#:~:text=def%20_load%28path%3A%20Path%29%20,tokenizer.json",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/src/tokenization#:~:text=,",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 21,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/tokenization/train_tokenizer.py#:~:text=%40dataclass%20class%20TrainTokenizerConfig%3A%20corpus_glob%3A%20Sequence,dry_run%3A%20bool%20%3D%20False",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=try%3A%20%20%23%20re,training%20optional",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 22,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.scripts%5D%20codex,config%20%3D%20%22codex_ml.cli.validate%3Amain",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/src/codex#:~:text=,Serpent%2F_codex_%2Fmain%2Fsrc%2Fcodex%2Ftraining.py01%22%2C%20%22type%22%3A%20%22file",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 22,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=from%20codex_ml,tokenization%20import%20TokenizerAdapter%2C%20load_tokenizer",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/configs#:~:text=,Serpent%2F_codex_%2Ftree%2Fmain%2Fconfigs%2Fdata%22",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 22,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20_codex_config_hash%28cfg%3A%20dict%29%20,16",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/src/codex#:~:text=,Serpent%2F_codex_%2Fgit%2Ftrees%2F47161a022f6ea2c501b50ab140da0db41d2d26f8%22%2C%20%22html%22%3A%20%22https%3A%2F%2Fgithub.com%2FAries",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 23,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=%23%20,bool%3A%20import%20torch",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/tokenization/cli.py#:~:text=def%20_load%28path%3A%20Path%29%20,tokenizer.json",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 23,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=try%3A%20%20%23%20re,training%20optional",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/tokenization/train_tokenizer.py#:~:text=%40dataclass%20class%20TrainTokenizerConfig%3A%20corpus_glob%3A%20Sequence,dry_run%3A%20bool%20%3D%20False",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 24,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/configs#:~:text=,Serpent%2F_codex_%2Fgit%2Fblobs%2F74d325d64288265f05cd938ededacb2976e47ee9%22%2C%20%22download_url%22%3A%20%22https%3A%2F%2Fraw.githubusercontent.com%2FAries",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.scripts%5D%20codex,config%20%3D%20%22codex_ml.cli.validate%3Amain",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 24,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/src/codex_ml#:~:text=,Serpent%2F_codex_%2Fmain%2Fsrc%2Fcodex_ml%2Fconfig_schema.py%22%2C%20%22type%22%3A%20%22file",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=from%20codex_ml,tokenization%20import%20TokenizerAdapter%2C%20load_tokenizer",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 25,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20_codex_epoch_metrics%28y_true%2C%20y_pred%29%20,metrics%20import%20perplexity%2C%20token_accuracy",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20_codex_config_hash%28cfg%3A%20dict%29%20,16",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 25,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20emit_validation_metric_record%28path%3A%20str%2C%20payload%3A%20Dict,n",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=%23%20,bool%3A%20import%20torch",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 26,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.optional,peft%3E%3D0.10.0",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=try%3A%20%20%23%20re,training%20optional",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 27,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20save_checkpoint,checkpoint%20and%20emit%20hashing%20sidecars",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/configs#:~:text=,Serpent%2F_codex_%2Fgit%2Fblobs%2F74d325d64288265f05cd938ededacb2976e47ee9%22%2C%20%22download_url%22%3A%20%22https%3A%2F%2Fraw.githubusercontent.com%2FAries",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 28,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/tokenization/train_tokenizer.py#:~:text=def%20_iter_text%28files%3A%20Sequence%5Bstr%5D%29%20,txt%20else%3A%20yield%20from%20txt",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/src/codex_ml#:~:text=,Serpent%2F_codex_%2Fmain%2Fsrc%2Fcodex_ml%2Fconfig_schema.py%22%2C%20%22type%22%3A%20%22file",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 29,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=from%20codex_ml,codex_logging%20import",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20_codex_epoch_metrics%28y_true%2C%20y_pred%29%20,metrics%20import%20perplexity%2C%20token_accuracy",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 29,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents#:~:text=,",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20emit_validation_metric_record%28path%3A%20str%2C%20payload%3A%20Dict,n",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 30,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/tests#:~:text=%5B%20%7B%20,Serpent%2F_codex_%2Fblob%2Fmain%2Ftests%2F__init__.py%22%20%7D",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.optional,peft%3E%3D0.10.0",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 30,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents#:~:text=,Serpent%2F_codex_%2Fblob%2Fmain%2Fpytest.ini%22",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20save_checkpoint,checkpoint%20and%20emit%20hashing%20sidecars",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 31,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.scripts%5D%20codex,config%20%3D%20%22codex_ml.cli.validate%3Amain",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/tokenization/train_tokenizer.py#:~:text=def%20_iter_text%28files%3A%20Sequence%5Bstr%5D%29%20,txt%20else%3A%20yield%20from%20txt",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 31,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject%5D%20name%20%3D%20,Serpent%22",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=from%20codex_ml,codex_logging%20import",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 33,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.optional,peft%3E%3D0.10.0",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents#:~:text=,",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 33,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20emit_validation_metric_record%28path%3A%20str%2C%20payload%3A%20Dict,n",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/tests#:~:text=%5B%20%7B%20,Serpent%2F_codex_%2Fblob%2Fmain%2Ftests%2F__init__.py%22%20%7D",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 34,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.entry,codex_ml.models.registry%3A_build_default_bert",
-    "type": "external",
-    "target_exists": null
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents#:~:text=,Serpent%2F_codex_%2Fblob%2Fmain%2Fpytest.ini%22",
+    "type": "external"
   },
   {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 38,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/src/codex#:~:text=,Serpent%2F_codex_%2Fmain%2Fsrc%2Fcodex%2Ftraining.py01%22%2C%20%22type%22%3A%20%22file",
-    "type": "external",
-    "target_exists": null
-  },
-  {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 39,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=try%3A%20%20%23%20re,training%20optional",
-    "type": "external",
-    "target_exists": null
-  },
-  {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 40,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/src/codex#:~:text=,Serpent%2F_codex_%2Fgit%2Ftrees%2F47161a022f6ea2c501b50ab140da0db41d2d26f8%22%2C%20%22html%22%3A%20%22https%3A%2F%2Fgithub.com%2FAries",
-    "type": "external",
-    "target_exists": null
-  },
-  {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 41,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20save_checkpoint,checkpoint%20and%20emit%20hashing%20sidecars",
-    "type": "external",
-    "target_exists": null
-  },
-  {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 43,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents#:~:text=,Serpent%2F_codex_%2Fblob%2Fmain%2F.env%22",
-    "type": "external",
-    "target_exists": null
-  },
-  {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 45,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20_codex_epoch_metrics%28y_true%2C%20y_pred%29%20,metrics%20import%20perplexity%2C%20token_accuracy",
-    "type": "external",
-    "target_exists": null
-  },
-  {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 52,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents#:~:text=,",
-    "type": "external",
-    "target_exists": null
-  },
-  {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 280,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/tokenization/train_tokenizer.py#:~:text=random,mkdir%28parents%3DTrue%2C%20exist_ok%3DTrue",
-    "type": "external",
-    "target_exists": null
-  },
-  {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 282,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject%5D%20name%20%3D%20,Serpent%22",
-    "type": "external",
-    "target_exists": null
-  },
-  {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 282,
-    "text": "raw.githubusercontent.com",
-    "link": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20save_checkpoint,checkpoint%20and%20emit%20hashing%20sidecars",
-    "type": "external",
-    "target_exists": null
-  },
-  {
-    "path": "docs\\suggested_tasks\\status_update_2025-09-17.md",
-    "line": 284,
-    "text": "api.github.com",
-    "link": "https://api.github.com/repos/Aries-Serpent/_codex_/contents#:~:text=,",
-    "type": "external",
-    "target_exists": null
-  },
-  {
-    "path": "services\\ita\\README.md",
-    "line": 4,
-    "text": "`openapi.yaml`",
-    "link": "openapi.yaml",
-    "type": "internal",
-    "target_exists": true
-  },
-  {
-    "path": "services\\ita\\README.md",
-    "line": 37,
-    "text": "`openapi.yaml`",
-    "link": "openapi.yaml",
-    "type": "internal",
-    "target_exists": true
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.scripts%5D%20codex,config%20%3D%20%22codex_ml.cli.validate%3Amain",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject%5D%20name%20%3D%20,Serpent%22",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.optional,peft%3E%3D0.10.0",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20emit_validation_metric_record%28path%3A%20str%2C%20payload%3A%20Dict,n",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject.entry,codex_ml.models.registry%3A_build_default_bert",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/src/codex#:~:text=,Serpent%2F_codex_%2Fmain%2Fsrc%2Fcodex%2Ftraining.py01%22%2C%20%22type%22%3A%20%22file",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=try%3A%20%20%23%20re,training%20optional",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents/src/codex#:~:text=,Serpent%2F_codex_%2Fgit%2Ftrees%2F47161a022f6ea2c501b50ab140da0db41d2d26f8%22%2C%20%22html%22%3A%20%22https%3A%2F%2Fgithub.com%2FAries",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20save_checkpoint,checkpoint%20and%20emit%20hashing%20sidecars",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents#:~:text=,Serpent%2F_codex_%2Fblob%2Fmain%2F.env%22",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20_codex_epoch_metrics%28y_true%2C%20y_pred%29%20,metrics%20import%20perplexity%2C%20token_accuracy",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents#:~:text=,",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/tokenization/train_tokenizer.py#:~:text=random,mkdir%28parents%3DTrue%2C%20exist_ok%3DTrue",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/pyproject.toml#:~:text=%5Bproject%5D%20name%20%3D%20,Serpent%22",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://raw.githubusercontent.com/Aries-Serpent/_codex_/main/src/codex/training.py#:~:text=def%20save_checkpoint,checkpoint%20and%20emit%20hashing%20sidecars",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-17.md",
+    "target": "https://api.github.com/repos/Aries-Serpent/_codex_/contents#:~:text=,",
+    "type": "external"
+  },
+  {
+    "exists": true,
+    "file": "/workspace/_codex_/docs/suggested_tasks/status_update_2025-09-16.md",
+    "target": "../status_update_outstanding_questions.md",
+    "type": "relative"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/CHECKPOINT_SAFETY.md",
+    "target": "https://pytorch.org/docs/stable/notes/serialization.html#warnings",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/CHECKPOINT_SAFETY.md",
+    "target": "https://docs.pytorch.org/tutorials/beginner/saving_loading_models.html",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/CHECKPOINT_SAFETY.md",
+    "target": "https://pytorch.org/docs/stable/generated/torch.load.html",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/CHECKPOINT_SAFETY.md",
+    "target": "https://bandit.readthedocs.io/en/latest/plugins/b614_pytorch_load.html",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/CHECKPOINT_SAFETY.md",
+    "target": "https://huggingface.co/docs/safetensors/index",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/CHECKPOINT_SAFETY.md",
+    "target": "https://docs.pytest.org/en/stable/reference/reference.html#pytest.importorskip",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/CHECKPOINT_SAFETY.md",
+    "target": "https://pytorch.org/docs/stable/notes/serialization.html#warnings",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/CHECKPOINT_SAFETY.md",
+    "target": "https://docs.pytorch.org/tutorials/beginner/saving_loading_models.html",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/CHECKPOINT_SAFETY.md",
+    "target": "https://pytorch.org/docs/stable/generated/torch.load.html",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/CHECKPOINT_SAFETY.md",
+    "target": "https://bandit.readthedocs.io/en/latest/plugins/b614_pytorch_load.html",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/CHECKPOINT_SAFETY.md",
+    "target": "https://huggingface.co/docs/safetensors/index",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/CHECKPOINT_SAFETY.md",
+    "target": "https://docs.pytest.org/en/stable/reference/reference.html#pytest.importorskip",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/tokenization.md",
+    "target": "https://github.com/huggingface/tokenizers",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/tokenization.md",
+    "target": "https://github.com/google/sentencepiece",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/offline_transformers.md",
+    "target": "https://pytorch.org/get-started/locally/",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/offline_transformers.md",
+    "target": "https://huggingface.co/docs/transformers/main/installation",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/offline_transformers.md",
+    "target": "https://huggingface.co/docs/huggingface_hub/en/guides/download",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/offline_transformers.md",
+    "target": "https://docs.pytest.org/en/stable/reference/reference.html",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/guides/offline_transformers.md",
+    "target": "https://nox.thea.codes/en/stable/usage.html",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/ops/RUNBOOK.md",
+    "target": "https://docs.astral.sh/ruff/?utm_source=chatgpt.com",
+    "type": "external"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/ops/RUNBOOK.md",
+    "target": "https://pytest-cov.readthedocs.io/en/latest/config.html?utm_source=chatgpt.com",
+    "type": "external"
+  },
+  {
+    "exists": true,
+    "file": "/workspace/_codex_/docs/modules/model_registry.md",
+    "target": "../dev/plugins.md",
+    "type": "relative"
+  },
+  {
+    "exists": true,
+    "file": "/workspace/_codex_/docs/modules/model_registry.md",
+    "target": "../examples/training-configs.md",
+    "type": "relative"
+  },
+  {
+    "exists": true,
+    "file": "/workspace/_codex_/docs/modules/plugins.md",
+    "target": "../guides/offline_catalogue.md",
+    "type": "relative"
+  },
+  {
+    "exists": null,
+    "file": "/workspace/_codex_/docs/modules/configuration.md",
+    "target": "https://hydra.cc",
+    "type": "external"
+  },
+  {
+    "exists": true,
+    "file": "/workspace/_codex_/docs/modules/metrics.md",
+    "target": "../tests_overview.md",
+    "type": "relative"
   }
 ]

--- a/docs/checkpoint_schema_v2.md
+++ b/docs/checkpoint_schema_v2.md
@@ -1,0 +1,4 @@
+# Checkpoint Schema v2 (Planned)
+
+Scope: weights, optimizer, scheduler, RNG snapshots, epoch/step metadata.
+Retention and digest invariants documented here. Implementation lands in P3.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,25 @@
+# CLI Guide (package-style)
+
+Use the package-style CLI to avoid import coupling and keep the surface stable:
+
+```bash
+python -m codex_ml.cli --help
+python -m codex_ml.cli <subcommand> [args]
+```
+
+Common examples:
+
+```bash
+# Show versions / quick sanity
+python -m codex_ml.cli --version
+
+# NDJSON summary of a metrics file
+python -m codex_ml.cli ndjson-summary --input artifacts/metrics.ndjson
+
+# (P3) Manifest: compute digest and update README badge (after P3 lands)
+python -m codex_ml.cli manifest hash --path path/to/manifest.json --update-readme README.md
+```
+
+Notes:
+- This layout replaces any single-file `cli.py` entry surface.
+- Scripts in `tools/` should call into the package CLI where possible.

--- a/docs/data_determinism.md
+++ b/docs/data_determinism.md
@@ -1,0 +1,5 @@
+# Data Determinism
+
+* Seed all RNGs (Python, NumPy, torch when used).
+* Deterministic shuffles and splits (document the seed used).
+* Avoid nondeterministic kernels; note AMP/precision trade-offs.

--- a/docs/detectors.md
+++ b/docs/detectors.md
@@ -1,0 +1,4 @@
+# Detectors Overview
+
+Library detectors (planned) will expose checks for unified training, checkpoint
+schema/digest, and env posture. Scripts should be thin wrappers over library code.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,3 +5,10 @@
 Welcome! This site covers **Getting Started (Ubuntu)**, **Concepts**, **API Reference**, **Tutorials**, **Ops**, and **Safety**.
 
 > **Note to Codex:** Expand each section based on evolving modules (data loaders, checkpointing, safety, API service).
+
+* [Observability](modules/observability.md)
+* [CLI Guide](cli.md)
+* [Manifest Integrity](manifest_integrity.md)
+* [Tokenization API](tokenization_api.md)
+* [Safety API](safety_api.md)
+* [Ops Index](ops.md)

--- a/docs/manifest_integrity.md
+++ b/docs/manifest_integrity.md
@@ -1,0 +1,4 @@
+# Manifest Integrity (Alias Page)
+
+This page tracks the repository's manifest integrity concept (digest, badge).
+Implementation notes land in P3 (CLI `manifest` subcommand).

--- a/docs/modules/metrics.md
+++ b/docs/modules/metrics.md
@@ -5,6 +5,16 @@ without pulling in heavy external dependencies.  The
 `codex_ml.metrics.evaluator` module focuses on deriving metrics directly
 from model outputs and batch metadata.
 
+## Stable import surface
+
+Use a stable API layer for common metrics:
+
+```python
+from codex_ml.metrics.api import accuracy, micro_f1, macro_f1, perplexity, token_accuracy, bleu, rouge_l
+```
+
+See also: [Tests Overview](../tests_overview.md)
+
 ## `batch_metrics`
 
 ```python

--- a/docs/modules/observability.md
+++ b/docs/modules/observability.md
@@ -47,6 +47,11 @@ Use `track_time` to instrument functions and expose metrics on `/metrics`.
   - `CODEX_TRACKING_NDJSON_BACKUP_COUNT` → retain this many rotated files (`metrics.ndjson`, `metrics.ndjson.1`, …).
 - Legacy consumers can opt out of the extended schema by exporting `CODEX_TRACKING_LEGACY_NDJSON=1` (alias: `LOGGING_NDJSON_LEGACY=1`).
 - Summarise rotated metric shards with `codex-ndjson summarize --input <run-dir> --output csv` (CSV) or `--output parquet` (requires pandas). The CLI merges all `metrics.ndjson*` shards oldest→newest, computes per-metric aggregates (count/min/max/mean plus first/last timestamps/values/phases), tracks manifest IDs, and emits a tidy table ordered chronologically. Both `codex_ml` and utility CLIs route through the same summarizer implementation.
+- Offline NDJSON summarisation is also available via the package CLI:
+
+  ```bash
+  python -m codex_ml.cli ndjson-summary --input artifacts/metrics.ndjson
+  ```
 - Offline MLflow bootstrap can be smoke-tested with `python examples/mlflow_offline.py --output /tmp/mlruns`. Pass `--tracking-uri https://…` to validate that a remote URI is rejected unless `MLFLOW_ALLOW_REMOTE=1` is set. The CLI asserts a local `file:` URI, logs params/metrics/artifacts, and ensures both `metrics.ndjson` and `tracking_summary.ndjson` are populated.
 
 ### Residual risks

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,0 +1,4 @@
+# Ops Index
+
+Operational docs live under `docs/ops/`. Use this page as a landing index
+for on-call and runbooks in this tree.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,5 @@
+# Performance Notes
+
+* Use small, repeatable micro-benchmarks.
+* Capture CPU/Wall time and memory; avoid network I/O.
+* Keep benchmarks optional and out of default gates.

--- a/docs/quality_gates.md
+++ b/docs/quality_gates.md
@@ -1,0 +1,9 @@
+# Quality Gates (Local Only)
+
+Run locally; no GitHub Actions.
+
+```bash
+nox -s lint
+nox -s tests        # or: nox -s coverage
+nox -s docs_smoke
+```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,5 @@
+# Releasing (Local-only)
+
+1. Run gates.
+2. Build artifacts locally (`nox -s package`).
+3. Tag + changelog; avoid remote CI triggers.

--- a/docs/safety_api.md
+++ b/docs/safety_api.md
@@ -1,0 +1,4 @@
+# Safety API (Alias Page)
+
+This alias page anchors the safety APIs (filters/sanitizers) used in data paths.
+Refer to the package modules for usage examples.

--- a/docs/tests_overview.md
+++ b/docs/tests_overview.md
@@ -1,0 +1,4 @@
+# Tests Overview (Traceability)
+
+This page maps tests to capabilities at a high level (tokenization, training,
+checkpointing, metrics, tracking/NDJSON, detectors).

--- a/docs/tokenization_api.md
+++ b/docs/tokenization_api.md
@@ -1,0 +1,8 @@
+# Tokenization API (Alias Page)
+
+This alias page points to the canonical tokenization API surface.
+Import tip:
+
+```python
+from codex_ml.tokenization.api import encode, decode  # example surface
+```


### PR DESCRIPTION
## Summary
- add a package-style CLI usage guide and reference it from the docs index and README
- create alias landing pages and focused guides for determinism, quality gates, performance, releasing, detectors, and checkpoint schema v2
- wire cross-links in observability and metrics docs and refresh the documentation link audit inventory

## Testing
- nox -s docs_smoke
- nox -s docs_audit

------
https://chatgpt.com/codex/tasks/task_e_68e5bed8691c833199d88bf48081fe35