### PR TITLE
P3: add manifest CLI and schema v2 helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # codex-universal
 
+<!-- manifest-digest:start -->
+[![Manifest SHA256](https://img.shields.io/badge/manifest-unknown-blue)](#)
+<!-- manifest-digest:end -->
+
 `codex-universal` is a reference implementation of the base Docker image available in OpenAI Codex.
 
 This repository is intended to help developers customize environments in Codex by providing a similar image that can be pulled and run locally. This is not an identical environment but should help for debugging and development.

--- a/src/codex_ml/checkpointing/schema_v2.py
+++ b/src/codex_ml/checkpointing/schema_v2.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+
+SCHEMA_ID = "codex.checkpoint.v2"
+SCHEMA_VERSION = (2, 0)
+
+
+@dataclass(frozen=True)
+class RunMeta:
+    id: str
+    created_at: str  # ISO8601 string
+    framework: str = "pytorch"
+    codex_version: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class WeightsMeta:
+    format: str  # "pt" | "safetensors" | ...
+    bytes: int
+    dtype: str = "float32"
+    sharded: bool = False
+
+
+@dataclass(frozen=True)
+class OptimizerMeta:
+    name: str
+    bytes: int
+
+
+@dataclass(frozen=True)
+class SchedulerMeta:
+    name: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class RNGMeta:
+    torch: Optional[str] = None
+    python: Optional[str] = None
+    numpy: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CheckpointManifest:
+    schema: str = SCHEMA_ID
+    run: RunMeta = field(default_factory=lambda: RunMeta(id="unknown", created_at=""))
+    weights: WeightsMeta = field(default_factory=lambda: WeightsMeta(format="pt", bytes=0))
+    optimizer: Optional[OptimizerMeta] = None
+    scheduler: Optional[SchedulerMeta] = None
+    rng: Optional[RNGMeta] = None
+    notes: Optional[str] = None
+
+
+def to_dict(obj: Any) -> dict[str, Any]:
+    return asdict(obj)
+
+
+def from_dict(d: Mapping[str, Any]) -> CheckpointManifest:
+    run = d.get("run", {})
+    weights = d.get("weights", {})
+    return CheckpointManifest(
+        schema=d.get("schema", SCHEMA_ID),
+        run=RunMeta(**run),
+        weights=WeightsMeta(**weights),
+        optimizer=OptimizerMeta(**d["optimizer"]) if d.get("optimizer") else None,
+        scheduler=SchedulerMeta(**d["scheduler"]) if d.get("scheduler") else None,
+        rng=RNGMeta(**d["rng"]) if d.get("rng") else None,
+        notes=d.get("notes"),
+    )
+
+
+def canonical_json(obj: Any) -> str:
+    if not isinstance(obj, Mapping):
+        obj = to_dict(obj)
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def digest(obj: Any) -> str:
+    s = canonical_json(obj)
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def validate_manifest(d: Mapping[str, Any]) -> None:
+    """
+    Minimal structural check: raises ValueError if required fields are absent.
+    Intentionally stdlib-only (no jsonschema).
+    """
+
+    for k in ("schema", "run", "weights"):
+        if k not in d:
+            raise ValueError(f"manifest missing required section: {k}")
+    if "id" not in d["run"] or "created_at" not in d["run"]:
+        raise ValueError("run.id and run.created_at required")
+    if "format" not in d["weights"] or "bytes" not in d["weights"]:
+        raise ValueError("weights.format and weights.bytes required")
+
+
+def is_v2(d: Mapping[str, Any]) -> bool:
+    return d.get("schema") == SCHEMA_ID
+
+
+def upgrade_from_v1(d: Mapping[str, Any]) -> Mapping[str, Any]:
+    """
+    Best-effort migration from a hypothetical v1 shape to v2.
+    Rules:
+      - map top-level 'meta' → 'run'
+      - ensure required fields exist, else raise
+    """
+
+    if is_v2(d):
+        return d
+    meta = d.get("meta") or {}
+    run = {
+        "id": meta.get("id") or "unknown",
+        "created_at": meta.get("created_at") or "",
+        "framework": meta.get("framework") or "pytorch",
+        "codex_version": meta.get("codex_version"),
+    }
+    weights = d.get("weights") or {}
+    out = {
+        "schema": SCHEMA_ID,
+        "run": run,
+        "weights": {
+            "format": weights.get("format") or "pt",
+            "bytes": int(weights.get("bytes") or 0),
+            "dtype": weights.get("dtype") or "float32",
+            "sharded": bool(weights.get("sharded") or False),
+        },
+        "optimizer": d.get("optimizer"),
+        "scheduler": d.get("scheduler"),
+        "rng": d.get("rng"),
+        "notes": d.get("notes"),
+    }
+    validate_manifest(out)
+    return out
+
+
+def manifest_digest_from_path(path: Path) -> str:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return digest(data)

--- a/src/codex_ml/cli/manifest.py
+++ b/src/codex_ml/cli/manifest.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import typer
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency path
+    raise ImportError("typer is required for codex_ml.cli.manifest") from exc
+
+if not hasattr(typer, "Typer"):  # pragma: no cover - optional dependency path
+    raise ImportError("typer.Typer is required for codex_ml.cli.manifest")
+
+from codex_ml.checkpointing.schema_v2 import (
+    SCHEMA_ID,
+    canonical_json as _canon,
+    manifest_digest_from_path,
+    validate_manifest as _validate,
+)
+
+
+app = typer.Typer(no_args_is_help=True, add_completion=False)
+
+
+def compute_digest(path: Path) -> str:
+    return manifest_digest_from_path(path)
+
+
+@app.command("hash")
+def hash_cmd(
+    path: Path = typer.Option(..., "--path", "-p", help="Path to manifest JSON"),
+    update_readme: Path | None = typer.Option(None, "--update-readme", help="README to update"),
+    start_marker: str = typer.Option("<!-- manifest-digest:start -->"),
+    end_marker: str = typer.Option("<!-- manifest-digest:end -->"),
+) -> None:
+    """
+    Compute SHA256 digest of a JSON manifest and optionally update README with a badge.
+    """
+
+    digest = compute_digest(path)
+    typer.echo(digest)
+    if update_readme:
+        rd = update_readme.read_text(encoding="utf-8")
+        badge = f"[![Manifest SHA256](https://img.shields.io/badge/manifest-{digest[:12]}-blue)](#)"
+        block = f"{start_marker}\n{badge}\n{end_marker}"
+        if start_marker in rd and end_marker in rd:
+            rd2 = re.sub(
+                f"{re.escape(start_marker)}[\\s\\S]*?{re.escape(end_marker)}",
+                block,
+                rd,
+                flags=re.M,
+            )
+        else:
+            lines = rd.splitlines()
+            for i, line in enumerate(lines):
+                if line.startswith("#"):
+                    lines[i : i + 1] = [line, "", block]
+                    rd2 = "\n".join(lines)
+                    break
+            else:
+                rd2 = rd + "\n\n" + block + "\n"
+        update_readme.write_text(rd2, encoding="utf-8")
+
+
+@app.command("validate")
+def validate_cmd(
+    path: Path = typer.Option(..., "--path", "-p", help="Path to manifest JSON"),
+    strict: bool = typer.Option(False, "--strict", help="Fail on unknown top-level keys"),
+) -> None:
+    """
+    Validate a manifest's minimal structure. Exit codes:
+      0 = valid, 2 = invalid schema, 1 = other error
+    """
+
+    try:
+        raw: Any = json.loads(path.read_text(encoding="utf-8"))
+        _validate(raw)
+        if strict:
+            allowed = {"schema", "run", "weights", "optimizer", "scheduler", "rng", "notes"}
+            unknown = set(raw.keys()) - allowed
+            if unknown:
+                typer.echo(f"unknown keys: {sorted(unknown)}")
+                raise typer.Exit(code=2)
+        typer.echo(_canon(raw))
+        raise typer.Exit(code=0)
+    except typer.Exit:
+        raise
+    except ValueError as ve:
+        typer.echo(f"invalid: {ve}")
+        raise typer.Exit(code=2)
+    except Exception as exc:  # pragma: no cover - unexpected path
+        typer.echo(f"error: {exc}")
+        raise typer.Exit(code=1)
+
+
+@app.command("init")
+def init_cmd(
+    out: Path = typer.Option(..., "--out", "-o", help="Output manifest path (.json)"),
+    run_id: str = typer.Option("unknown", "--run-id"),
+) -> None:
+    """
+    Write a minimal, valid v2 manifest template to --out.
+    """
+
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    manifest = {
+        "schema": SCHEMA_ID,
+        "run": {
+            "id": run_id,
+            "created_at": now,
+            "framework": "pytorch",
+            "codex_version": None,
+        },
+        "weights": {
+            "format": "pt",
+            "bytes": 0,
+            "dtype": "float32",
+            "sharded": False,
+        },
+        "optimizer": None,
+        "scheduler": None,
+        "rng": None,
+        "notes": None,
+    }
+    out.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    typer.echo(str(out))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/tests/checkpointing/test_schema_v2_basic.py
+++ b/tests/checkpointing/test_schema_v2_basic.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from codex_ml.checkpointing.schema_v2 import (
+    CheckpointManifest,
+    RunMeta,
+    WeightsMeta,
+    canonical_json,
+    digest,
+    from_dict,
+    to_dict,
+    validate_manifest,
+)
+
+
+def test_roundtrip_and_digest_stability(tmp_path):
+    m = CheckpointManifest(
+        run=RunMeta(id="run123", created_at="2025-10-07T12:00:00Z"),
+        weights=WeightsMeta(format="pt", bytes=42, dtype="float32", sharded=False),
+        notes="unit test",
+    )
+    d1 = to_dict(m)
+    j1 = canonical_json(d1)
+    h1 = digest(d1)
+    d2 = {
+        "weights": {"bytes": 42, "format": "pt", "dtype": "float32", "sharded": False},
+        "schema": "codex.checkpoint.v2",
+        "notes": "unit test",
+        "run": {
+            "id": "run123",
+            "created_at": "2025-10-07T12:00:00Z",
+            "framework": "pytorch",
+            "codex_version": None,
+        },
+        "optimizer": None,
+        "scheduler": None,
+        "rng": None,
+    }
+    j2 = canonical_json(d2)
+    h2 = digest(d2)
+    assert j1 == j2 and h1 == h2
+    m2 = from_dict(d2)
+    assert to_dict(m2) == d1
+
+
+def test_validate_manifest_minimum():
+    good = {
+        "schema": "codex.checkpoint.v2",
+        "run": {"id": "r", "created_at": "2025-10-07T00:00:00Z"},
+        "weights": {"format": "pt", "bytes": 1},
+    }
+    validate_manifest(good)
+    bad = {"run": {}, "weights": {}}
+    try:
+        validate_manifest(bad)
+    except ValueError as e:
+        assert "schema" in str(e)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected ValueError")

--- a/tests/checkpointing/test_schema_v2_upgrade.py
+++ b/tests/checkpointing/test_schema_v2_upgrade.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from codex_ml.checkpointing.schema_v2 import digest, is_v2, upgrade_from_v1, validate_manifest
+
+
+def test_upgrade_from_v1_minimal():
+    v1 = {
+        "meta": {"id": "x", "created_at": "2025-10-07T00:00:00Z"},
+        "weights": {"format": "pt", "bytes": 3},
+    }
+    v2 = upgrade_from_v1(v1)
+    assert is_v2(v2)
+    validate_manifest(v2)
+    _ = digest(v2)

--- a/tests/cli/test_cli_manifest.py
+++ b/tests/cli/test_cli_manifest.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+typer = pytest.importorskip("typer", reason="typer not installed")
+click = pytest.importorskip("click", reason="click not installed")
+if not hasattr(typer, "Typer"):
+    pytest.skip("typer missing Typer attribute", allow_module_level=True)
+from typer.testing import CliRunner  # type: ignore  # noqa: E402
+
+from codex_ml.cli import manifest as manifest_cli  # noqa: E402
+from codex_ml.checkpointing import schema_v2  # noqa: E402
+
+
+def test_hash_and_readme_update(tmp_path):
+    mpath = tmp_path / "manifest.json"
+    readme = tmp_path / "README.md"
+    manifest = {
+        "schema": "codex.checkpoint.v2",
+        "run": {"id": "abc", "created_at": "2025-10-07T00:00:00Z"},
+        "weights": {"format": "pt", "bytes": 10},
+    }
+    mpath.write_text(json.dumps(manifest), encoding="utf-8")
+    readme.write_text("# Title\n\n", encoding="utf-8")
+    expected = schema_v2.digest(manifest)
+    runner = CliRunner()
+    res = runner.invoke(
+        manifest_cli.app,
+        ["hash", "--path", str(mpath), "--update-readme", str(readme)],
+    )
+    assert res.exit_code == 0
+    out = res.stdout.strip().splitlines()[-1]
+    assert re.fullmatch(r"[0-9a-f]{64}", out) and out == expected
+    txt = readme.read_text(encoding="utf-8")
+    assert "<!-- manifest-digest:start -->" in txt and expected[:12] in txt

--- a/tests/cli/test_cli_manifest_init.py
+++ b/tests/cli/test_cli_manifest_init.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+typer = pytest.importorskip("typer", reason="typer not installed")
+click = pytest.importorskip("click", reason="click not installed")
+if not hasattr(typer, "Typer"):
+    pytest.skip("typer missing Typer attribute", allow_module_level=True)
+from typer.testing import CliRunner  # type: ignore  # noqa: E402
+
+from codex_ml.cli import manifest as cli  # noqa: E402
+
+
+def test_init_writes_valid_manifest(tmp_path):
+    out = tmp_path / "m.json"
+    runner = CliRunner()
+    res = runner.invoke(cli.app, ["init", "--out", str(out), "--run-id", "r1"])
+    assert res.exit_code == 0 and out.exists()
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["schema"] == "codex.checkpoint.v2"
+    assert data["run"]["id"] == "r1"

--- a/tests/cli/test_cli_manifest_validate.py
+++ b/tests/cli/test_cli_manifest_validate.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+typer = pytest.importorskip("typer", reason="typer not installed")
+click = pytest.importorskip("click", reason="click not installed")
+if not hasattr(typer, "Typer"):
+    pytest.skip("typer missing Typer attribute", allow_module_level=True)
+from typer.testing import CliRunner  # type: ignore  # noqa: E402
+
+from codex_ml.cli import manifest as cli  # noqa: E402
+
+
+def test_validate_ok_and_strict(tmp_path):
+    manifest = {
+        "schema": "codex.checkpoint.v2",
+        "run": {"id": "x", "created_at": "2025-10-07T00:00:00Z"},
+        "weights": {"format": "pt", "bytes": 1},
+    }
+    path = tmp_path / "m.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    runner = CliRunner()
+    res = runner.invoke(cli.app, ["validate", "--path", str(path)])
+    assert res.exit_code == 0
+
+    manifest["foo"] = 1
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    res2 = runner.invoke(cli.app, ["validate", "--path", str(path), "--strict"])
+    assert res2.exit_code == 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:  # pragma: no cover - optio
 
 
 OPTIONAL_TEST_GROUPS: dict[str, tuple[str, ...]] = {
+    "tests.checkpointing.test_schema_v2": (),
     "tests.checkpointing": ("torch",),
     "tests.cli": ("yaml", "omegaconf", "torch"),
     "tests.config": ("yaml", "omegaconf"),


### PR DESCRIPTION
## Summary
- add a Typer-powered manifest CLI with hash, validate, and init subcommands plus README badge markers
- introduce checkpoint manifest schema v2 dataclasses, canonical JSON helpers, upgrader, and digest utilities
- cover the new functionality with stdlib-focused tests and CLI integration tests (skipping when Typer/Click unavailable)

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src pytest -q tests/checkpointing/test_schema_v2_basic.py tests/checkpointing/test_schema_v2_upgrade.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src pytest -q tests/cli/test_cli_manifest_init.py tests/cli/test_cli_manifest_validate.py tests/cli/test_cli_manifest.py

------
https://chatgpt.com/codex/tasks/task_e_68e5c3c4aeb8833182326fc021ba65a6