### PR TITLE
Add detectors CLI run command and documentation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,3 +23,9 @@ python -m codex_ml.cli manifest hash --path path/to/manifest.json --update-readm
 Notes:
 - This layout replaces any single-file `cli.py` entry surface.
 - Scripts in `tools/` should call into the package CLI where possible.
+
+# Detectors
+
+```bash
+python -m codex_ml.cli detectors run --help
+```

--- a/docs/detectors.md
+++ b/docs/detectors.md
@@ -2,3 +2,18 @@
 
 Library detectors (planned) will expose checks for unified training, checkpoint
 schema/digest, and env posture. Scripts should be thin wrappers over library code.
+
+## CLI Usage
+
+Run the bundled detectors and print a JSON scorecard:
+
+```bash
+python -m codex_ml.cli detectors run
+```
+
+With a manifest and custom weights:
+
+```bash
+python -m codex_ml.cli detectors run --manifest artifacts/manifest.json \
+  --weight unified_training=2.0 --out reports/scorecard.json
+```

--- a/src/codex_ml/cli/__init__.py
+++ b/src/codex_ml/cli/__init__.py
@@ -147,3 +147,12 @@ except Exception:  # pragma: no cover - optional CLI wiring
 main = main_cli
 
 __all__ = ["cli", "main_cli", "main"]
+
+try:
+    from .detectors import app as _det_app  # type: ignore[attr-defined]
+
+    _typer_root = globals().get("app")
+    if _typer_root is not None:
+        _typer_root.add_typer(_det_app, name="detectors", help="Run repository detectors")  # type: ignore[attr-defined]
+except Exception:
+    pass

--- a/src/codex_ml/cli/detectors.py
+++ b/src/codex_ml/cli/detectors.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+try:  # pragma: no cover - optional dependency path
+    import typer
+except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency path
+    raise ImportError("typer is required for codex_ml.cli.detectors") from exc
+
+if not hasattr(typer, "Typer"):  # pragma: no cover - optional dependency path
+    raise ImportError("typer.Typer is required for codex_ml.cli.detectors")
+
+from codex_ml.detectors import run_detectors
+from codex_ml.detectors import unified_training
+from codex_ml.detectors import core as det_core
+from codex_ml.detectors.aggregate import aggregate, to_json_dict
+
+app = typer.Typer(no_args_is_help=True, add_completion=False)
+
+
+def _parse_weights(items: Iterable[str]) -> Dict[str, float]:
+    out: Dict[str, float] = {}
+    for it in items:
+        name, _, val = it.partition("=")
+        if not name or not val:
+            raise typer.BadParameter(f"invalid weight '{it}', expected name=weight")
+        try:
+            out[name] = float(val)
+        except ValueError as exc:
+            raise typer.BadParameter(f"invalid weight '{it}', expected numeric weight") from exc
+    return out
+
+
+@app.command("run")
+def run_cmd(
+    manifest: Optional[Path] = typer.Option(
+        None, "--manifest", "-m", help="Optional manifest JSON"
+    ),
+    out: Optional[Path] = typer.Option(None, "--out", "-o", help="Write scorecard JSON to file"),
+    weight: Optional[list[str]] = typer.Option(None, "--weight", help="name=weight (can repeat)"),
+) -> None:
+    """Run selected detectors and print an aggregated scorecard as JSON."""
+
+    detectors: list[det_core.Detector] = [unified_training.detect]
+    manifest_data = None
+    if manifest:
+        manifest_data = json.loads(manifest.read_text(encoding="utf-8"))
+    results = run_detectors(detectors, manifest_data)
+    weights = _parse_weights(weight or [])
+    card = aggregate(results, weights=weights)
+    js = json.dumps(to_json_dict(card), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    if out:
+        out.write_text(js + "\n", encoding="utf-8")
+    typer.echo(js)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/tests/cli/test_cli_detectors.py
+++ b/tests/cli/test_cli_detectors.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+typer = pytest.importorskip("typer", reason="typer not installed")
+pytest.importorskip("click", reason="click not installed")
+typer_testing = pytest.importorskip("typer.testing", reason="typer not installed")
+cli = pytest.importorskip("codex_ml.cli.detectors")
+
+
+def test_cli_detectors_run_stdout(tmp_path):
+    # no manifest provided; unified_training detector should still run
+    result = typer_testing.CliRunner().invoke(cli.app, ["run"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout.strip())
+    assert "total_score" in data and "by_detector" in data and "details" in data

--- a/tests/detectors/test_integration_card.py
+++ b/tests/detectors/test_integration_card.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from codex_ml.detectors.core import run_detectors
+from codex_ml.detectors.unified_training import detect as unified
+from codex_ml.detectors.aggregate import aggregate
+
+
+def test_integration_detectors_to_scorecard():
+    results = run_detectors([unified], manifest=None)
+    card = aggregate(results, weights={"unified_training": 1.0})
+    assert 0.0 <= card.total_score <= 1.0
+    assert "unified_training" in card.by_detector


### PR DESCRIPTION
## Summary
- add a Typer-based `detectors run` CLI that aggregates detector results with optional manifest and weights
- register the detectors CLI under the package entry point and add focused tests for the CLI and aggregation pipeline
- document the new CLI usage in the detectors and CLI guides

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src pytest -q tests/detectors/test_integration_card.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src pytest -q tests/cli/test_cli_detectors.py *(fails: environment lacks torch so cli test suite is skipped at collection time)*
- nox -s docs_smoke *(fails: nox command not available in environment)*
- nox -s docs_audit *(fails: nox command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d26cf5c08331a208b683cd842369