### PR TITLE
Apply Δ1–Δ4: canonical MLflow URIs, NDJSON CLI, atomic writes, docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Welcome! This site covers **Getting Started (Ubuntu)**, **Concepts**, **API Refe
 ## Core references
 
 * [Observability](modules/observability.md)
+* [Reproducibility & Integrity](repro_guidance.md)
 * [CLI Guide](cli.md)
 * [Checkpoint schema v2](checkpoint_schema_v2.md)
 * [Data determinism](data_determinism.md)

--- a/docs/repro_guidance.md
+++ b/docs/repro_guidance.md
@@ -1,0 +1,19 @@
+# Reproducibility & Integrity
+
+## Seeds & Determinism
+- Set all RNG seeds early; prefer deterministic kernels when available.
+- Use canonical data ordering and avoid nondeterministic transforms.
+
+## Tracking (Offline-first)
+- Default to local MLflow file store (`file:///.../mlruns`).
+- If using remote tools, prefer explicit offline modes during local runs.
+
+## NDJSON Metrics
+- Emit and summarize metrics via the package CLI:
+  ```bash
+  python -m codex_ml ndjson-summary --input artifacts/
+  ```
+
+References:
+- MLflow `file:///` examples for local tracking URIs.
+- JSON Lines (NDJSON): one JSON value per line, UTF-8.

--- a/src/codex_ml/checkpointing/schema_v2.py
+++ b/src/codex_ml/checkpointing/schema_v2.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 from dataclasses import dataclass, asdict
+from pathlib import Path
 from typing import Any, Dict, Optional
 import hashlib
 import json
 import math
 import time
-import pathlib
+
+from codex_ml.io.atomic import atomic_write_json
 
 CANON_SEPARATORS = (",", ":")  # compact; RFC8785-compatible shape
 
@@ -62,7 +64,7 @@ def compute_manifest_digest(manifest: Dict[str, Any]) -> str:
     return sha256_hexdigest(to_canonical_bytes(manifest))
 
 
-def load_json(path: pathlib.Path) -> Dict[str, Any]:
+def load_json(path: Path) -> Dict[str, Any]:
     with path.open("r", encoding="utf-8") as f:
         # Note: stdlib json doesn't expose duplicate-key hooks;
         # we assume upstream generation respects no-dup rule (I-JSON).
@@ -98,3 +100,10 @@ def new_manifest(run_id: str, step: int, epoch: int, notes: str | None = None) -
     m = meta.to_dict()
     m["digest"] = compute_manifest_digest(m)
     return m
+
+
+def write_manifest_json(path: Path, manifest: Dict[str, Any]) -> Path:
+    """Write the manifest JSON atomically."""
+
+    atomic_write_json(path, manifest)
+    return path

--- a/src/codex_ml/cli/ndjson_summary.py
+++ b/src/codex_ml/cli/ndjson_summary.py
@@ -1,50 +1,371 @@
-"""CLI wrappers for aggregating rotated ``metrics.ndjson`` shards."""
+"""Offline-friendly NDJSON metrics summarization helpers and CLI shims."""
 
 from __future__ import annotations
 
-import sys
+import argparse
+import csv
+import json
+from collections.abc import Iterable, Mapping as MappingABC, Sequence
 from pathlib import Path
-from typing import List, Sequence
+from typing import Any
 
-from codex_utils.cli import ndjson_summary as _ndjson_summary_utils
-from codex_ml.codex_structured_logging import (
-    ArgparseJSONParser,
-    capture_exceptions,
-    init_json_logging,
-    log_event,
-    run_cmd,
+FIELDNAMES: Sequence[str] = (
+    "run_id",
+    "split",
+    "metric",
+    "dataset",
+    "count",
+    "first_step",
+    "last_step",
+    "first_timestamp",
+    "last_timestamp",
+    "first_value",
+    "last_value",
+    "min_value",
+    "max_value",
+    "mean_value",
+    "first_manifest_id",
+    "last_manifest_id",
+    "first_phase",
+    "last_phase",
 )
 
-_ = run_cmd
 
-NdjsonSummarizer = _ndjson_summary_utils.NdjsonSummarizer
-build_parser = _ndjson_summary_utils.build_parser
-summarize_directory = _ndjson_summary_utils.summarize_directory
+def _iter_metric_files(run_dir: Path, pattern: str | None = None) -> list[Path]:
+    if run_dir.is_file():
+        return [run_dir]
+    if pattern:
+        return sorted(run_dir.glob(pattern))
+    base = run_dir / "metrics.ndjson"
+    rotated: list[tuple[int, Path]] = []
+    for candidate in run_dir.glob("metrics.ndjson.*"):
+        suffix = candidate.name.split("metrics.ndjson.")[-1]
+        if suffix.isdigit():
+            rotated.append((int(suffix), candidate))
+    ordered: list[Path] = [
+        path for _, path in sorted(rotated, key=lambda item: item[0], reverse=True)
+    ]
+    if base.exists():
+        ordered.append(base)
+    return ordered
 
 
-def summarize(directory: Path, fmt: str, destination: Path | None = None) -> Path:
-    """Aggregate metrics shards via :mod:`codex_utils.cli.ndjson_summary`."""
+def _load_rows(run_dir: Path, *, pattern: str | None = None) -> list[dict[str, Any]]:
+    files = _iter_metric_files(run_dir, pattern)
+    if not files:
+        raise FileNotFoundError(f"No metrics NDJSON files found in {run_dir}")
+    rows: list[dict[str, Any]] = []
+    for path in files:
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                for raw in handle:
+                    line = raw.strip()
+                    if not line:
+                        continue
+                    try:
+                        payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(payload, dict):
+                        rows.append(payload)
+        except FileNotFoundError:
+            continue
+    return rows
 
+
+def _coerce_numeric(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _sort_key(timestamp: str | None, step: int | None) -> tuple[str, int]:
+    ts_key = timestamp or ""
+    step_key = step if step is not None else -1
+    return ts_key, step_key
+
+
+def _summarise_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    summary: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+    for row in rows:
+        run_id = str(row.get("run_id") or "unknown")
+        split = str(row.get("split") or "")
+        metric = str(row.get("metric") or row.get("key") or "")
+        dataset_val = row.get("dataset")
+        dataset = "" if dataset_val in (None, "") else str(dataset_val)
+        key = (run_id, split, metric, dataset)
+        entry = summary.get(key)
+        if entry is None:
+            entry = {
+                "run_id": run_id,
+                "split": split,
+                "metric": metric,
+                "dataset": dataset,
+                "count": 0,
+                "first_step": None,
+                "last_step": None,
+                "first_timestamp": None,
+                "last_timestamp": None,
+                "first_value": None,
+                "last_value": None,
+                "min_value": None,
+                "max_value": None,
+                "mean_value": None,
+                "first_manifest_id": None,
+                "last_manifest_id": None,
+                "first_phase": "",
+                "last_phase": "",
+                "_numeric_sum": 0.0,
+                "_numeric_count": 0,
+                "_first_sort_key": None,
+                "_last_sort_key": None,
+                "_max_step": None,
+            }
+            summary[key] = entry
+
+        entry["count"] += 1
+
+        step_val = row.get("step")
+        try:
+            step_int = int(step_val) if step_val is not None else None
+        except (TypeError, ValueError):
+            step_int = None
+        if step_int is not None:
+            if entry["first_step"] is None or step_int < entry["first_step"]:
+                entry["first_step"] = step_int
+            if entry["_max_step"] is None or step_int > entry["_max_step"]:
+                entry["_max_step"] = step_int
+
+        timestamp = row.get("timestamp")
+        sort_key = _sort_key(timestamp if isinstance(timestamp, str) else None, step_int)
+
+        tags = row.get("tags")
+        phase_value: str | None = None
+        if isinstance(tags, MappingABC):
+            manifest_raw = tags.get("manifest_id")
+            if manifest_raw is not None:
+                manifest_id = str(manifest_raw)
+                entry["last_manifest_id"] = manifest_id
+                if entry["first_manifest_id"] is None:
+                    entry["first_manifest_id"] = manifest_id
+            phase_raw = tags.get("phase")
+            if phase_raw not in (None, ""):
+                phase_value = str(phase_raw)
+
+        first_sort_key = entry.get("_first_sort_key")
+        if first_sort_key is None or sort_key <= first_sort_key:
+            entry["_first_sort_key"] = sort_key
+            if timestamp:
+                entry["first_timestamp"] = timestamp
+            if step_int is not None and (
+                entry["first_step"] is None or step_int < entry["first_step"]
+            ):
+                entry["first_step"] = step_int
+            entry["first_value"] = row.get("value")
+            if phase_value is not None:
+                entry["first_phase"] = phase_value
+
+        last_sort_key = entry.get("_last_sort_key")
+        if last_sort_key is None or sort_key >= last_sort_key:
+            entry["_last_sort_key"] = sort_key
+            if timestamp:
+                entry["last_timestamp"] = timestamp
+            if step_int is not None:
+                entry["last_step"] = step_int
+            entry["last_value"] = row.get("value")
+            if phase_value is not None:
+                entry["last_phase"] = phase_value
+
+        numeric_value = _coerce_numeric(row.get("value"))
+        if numeric_value is not None:
+            entry["_numeric_sum"] += numeric_value
+            entry["_numeric_count"] += 1
+            if entry["min_value"] is None or numeric_value < entry["min_value"]:
+                entry["min_value"] = numeric_value
+            if entry["max_value"] is None or numeric_value > entry["max_value"]:
+                entry["max_value"] = numeric_value
+
+    result: list[dict[str, Any]] = []
+    for entry in summary.values():
+        numeric_count = entry.pop("_numeric_count")
+        numeric_sum = entry.pop("_numeric_sum")
+        entry.pop("_first_sort_key", None)
+        entry.pop("_last_sort_key", None)
+        max_step = entry.pop("_max_step", None)
+        if entry.get("last_step") is None and max_step is not None:
+            entry["last_step"] = max_step
+        if numeric_count:
+            entry["mean_value"] = numeric_sum / numeric_count
+        result.append(entry)
+
+    return sorted(
+        result,
+        key=lambda item: (item["run_id"], item["split"], item["metric"], item["dataset"]),
+    )
+
+
+def _write_csv(dest: Path, rows: Sequence[dict[str, Any]]) -> Path:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(FIELDNAMES))
+        writer.writeheader()
+        for row in rows:
+            payload = {key: row.get(key, "") for key in FIELDNAMES}
+            for key, value in list(payload.items()):
+                if value is None:
+                    payload[key] = ""
+            writer.writerow(payload)
+    return dest
+
+
+def _write_parquet(dest: Path, rows: Sequence[dict[str, Any]]) -> Path:
     try:
-        path = _ndjson_summary_utils.summarize_directory(directory, fmt, destination)
-    except FileNotFoundError as exc:  # pragma: no cover - propagates CLI semantics
+        import pandas as pd  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise SystemExit("pandas with parquet support is required for Parquet output") from exc
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    frame = pd.DataFrame.from_records(list(rows))
+    frame.to_parquet(dest, index=False)
+    return dest
+
+
+class NdjsonSummarizer:
+    """Summarise NDJSON metric shards from a run directory."""
+
+    fieldnames: Sequence[str] = FIELDNAMES
+
+    def __init__(self, run_dir: str | Path, *, pattern: str | None = None) -> None:
+        self.run_dir = Path(run_dir).expanduser().resolve()
+        self.pattern = pattern
+
+    def collect(self) -> list[dict[str, Any]]:
+        return _load_rows(self.run_dir, pattern=self.pattern)
+
+    def summarise(self) -> list[dict[str, Any]]:
+        rows = self.collect()
+        return _summarise_rows(rows)
+
+    def write(self, fmt: str, destination: str | Path | None = None) -> Path:
+        summary = self.summarise()
+        suffix = fmt.lower()
+        dest_path = (
+            Path(destination).expanduser().resolve()
+            if destination
+            else self.run_dir / f"metrics_summary.{suffix}"
+        )
+        if suffix == "csv":
+            return _write_csv(dest_path, summary)
+        if suffix == "parquet":
+            return _write_parquet(dest_path, summary)
+        raise SystemExit(f"Unsupported output format: {fmt}")
+
+
+def summarize_directory(
+    run_dir: str | Path, fmt: str, destination: str | Path | None = None
+) -> Path:
+    summarizer = NdjsonSummarizer(run_dir)
+    return summarizer.write(fmt, destination)
+
+
+def _handle_summarize(args: argparse.Namespace) -> int:
+    run_dir = Path(args.input).expanduser().resolve()
+    try:
+        summarizer = NdjsonSummarizer(run_dir)
+        summary = summarizer.summarise()
+    except FileNotFoundError as exc:
         raise SystemExit(str(exc)) from exc
-    return Path(path)
+    suffix = args.output.lower()
+    dest = (
+        Path(args.dest).expanduser().resolve()
+        if args.dest
+        else (run_dir / f"metrics_summary.{suffix}")
+    )
+    if suffix == "csv":
+        output_path = _write_csv(dest, summary)
+    elif suffix == "parquet":
+        output_path = _write_parquet(dest, summary)
+    else:  # pragma: no cover - argparse guards choices
+        raise SystemExit(f"Unsupported output format: {args.output}")
+    print(f"Wrote {output_path} ({len(summary)} rows)")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="codex-ndjson", description=__doc__)
+    sub = parser.add_subparsers(dest="command")
+    summarize = sub.add_parser("summarize", help="Aggregate NDJSON metric shards")
+    summarize.add_argument(
+        "--input", required=True, help="Run directory containing metrics.ndjson shards"
+    )
+    summarize.add_argument(
+        "--output",
+        choices=("csv", "parquet"),
+        default="csv",
+        help="Summary output format",
+    )
+    summarize.add_argument(
+        "--dest",
+        help="Optional explicit destination path. Defaults to <run_dir>/metrics_summary.<ext>",
+    )
+    summarize.set_defaults(func=_handle_summarize)
+    return parser
+
+
+def summarize(args: argparse.Namespace) -> int:
+    inp = Path(args.input).expanduser().resolve()
+    pattern = getattr(args, "pattern", "metrics.ndjson*")
+    try:
+        rows = _load_rows(inp if inp.is_dir() else inp, pattern=pattern if inp.is_dir() else None)
+    except FileNotFoundError as exc:
+        raise SystemExit(str(exc)) from exc
+    summary_rows = _summarise_rows(rows)
+    if args.output == "csv":
+        dest_raw = getattr(args, "dest", None)
+        if dest_raw:
+            dest = Path(dest_raw).expanduser().resolve()
+        else:
+            base_dir = inp if inp.is_dir() else inp.parent
+            dest = base_dir / "metrics_summary.csv"
+        _write_csv(dest, summary_rows)
+        print(str(dest))
+        return 0
+
+    metrics: dict[str, dict[str, Any]] = {}
+    for row in summary_rows:
+        metric_name = row.get("metric") or "unknown"
+        slot = metrics.setdefault(metric_name, {"count": 0, "min": None, "max": None})
+        slot["count"] += int(row.get("count") or 0)
+        if row.get("min_value") is not None:
+            current_min = slot["min"]
+            slot["min"] = (
+                row["min_value"] if current_min is None else min(current_min, row["min_value"])
+            )
+        if row.get("max_value") is not None:
+            current_max = slot["max"]
+            slot["max"] = (
+                row["max_value"] if current_max is None else max(current_max, row["max_value"])
+            )
+    print(json.dumps({"metrics": metrics}, ensure_ascii=False))
+    return 0
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Entry-point proxy returning the wrapped CLI's exit code."""
-
-    logger = init_json_logging()
-    parser = ArgparseJSONParser(prog=_ndjson_summary_utils.__name__)
-    arg_list: List[str] = list(argv) if argv is not None else sys.argv[1:]
-
-    with capture_exceptions(logger):
-        log_event(logger, "cli.start", prog=parser.prog, args=arg_list)
-        exit_code = _ndjson_summary_utils.main(argv)
-        status = "ok" if exit_code == 0 else "error"
-        log_event(logger, "cli.finish", prog=parser.prog, status=status, exit_code=exit_code)
-        return exit_code
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return 1
+    return args.func(args)
 
 
-__all__ = ["NdjsonSummarizer", "build_parser", "main", "summarize", "summarize_directory"]
+__all__ = [
+    "FIELDNAMES",
+    "NdjsonSummarizer",
+    "build_parser",
+    "main",
+    "summarize",
+    "summarize_directory",
+]

--- a/src/codex_ml/io/atomic.py
+++ b/src/codex_ml/io/atomic.py
@@ -1,0 +1,27 @@
+"""Atomic file-system helpers for sidecar persistence."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def atomic_write_json(path: Path, obj: dict[str, Any]) -> None:
+    """Write ``obj`` to ``path`` atomically via ``os.replace``."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=str(path.parent), delete=False
+    ) as handle:
+        json.dump(obj, handle, ensure_ascii=False, separators=(",", ":"))
+        handle.flush()
+        os.fsync(handle.fileno())
+        temp_path = Path(handle.name)
+    os.replace(temp_path, path)
+
+
+__all__ = ["atomic_write_json"]

--- a/tests/checkpointing/test_atomic_write.py
+++ b/tests/checkpointing/test_atomic_write.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+from codex_ml.io.atomic import atomic_write_json
+
+
+def test_atomic_write_json_creates_file(tmp_path: Path) -> None:
+    target = tmp_path / "meta" / "manifest.json"
+    payload = {"x": 1, "nested": {"y": 2}}
+
+    atomic_write_json(target, payload)
+
+    assert target.exists()
+    loaded = json.loads(target.read_text(encoding="utf-8"))
+    assert loaded == payload

--- a/tests/cli/test_cli_ndjson_summary.py
+++ b/tests/cli/test_cli_ndjson_summary.py
@@ -1,0 +1,46 @@
+import json
+import os
+import subprocess as sp
+import sys
+from pathlib import Path
+
+
+def _write_ndjson(path: Path, payloads: list[dict]) -> None:
+    text = "\n".join(json.dumps(obj) for obj in payloads) + "\n"
+    path.write_text(text, encoding="utf-8")
+
+
+def test_package_cli_summarizes_metrics(tmp_path: Path) -> None:
+    metrics = [
+        {"key": "loss", "value": 2.0},
+        {"key": "loss", "value": 1.0},
+        {"key": "acc", "value": 0.5},
+    ]
+    target = tmp_path / "metrics.ndjson"
+    _write_ndjson(target, metrics)
+
+    env = os.environ.copy()
+    src_root = Path(__file__).resolve().parents[2] / "src"
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = f"{src_root}{os.pathsep}{existing}" if existing else str(src_root)
+
+    result = sp.run(
+        [
+            sys.executable,
+            "-m",
+            "codex_ml",
+            "ndjson-summary",
+            "--input",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["metrics"]["loss"]["min"] == 1.0
+    assert payload["metrics"]["loss"]["max"] == 2.0
+    assert payload["metrics"]["loss"]["count"] == 2

--- a/tests/tracking/test_mlflow_guard.py
+++ b/tests/tracking/test_mlflow_guard.py
@@ -6,7 +6,6 @@ import os
 import sys
 import types
 from pathlib import Path
-from types import ModuleType
 from typing import Any
 from urllib.parse import urlparse
 
@@ -94,7 +93,7 @@ def test_ensure_file_backend_sets_local_uri(tmp_path: Path, monkeypatch):
 
     decision = guard.ensure_file_backend_decision()
     uri = decision.effective_uri
-    assert uri.startswith("file:")
+    assert uri.startswith("file:///")
     path = Path(urlparse(uri).path)
     assert path.exists()
     assert os.environ.get("MLFLOW_TRACKING_URI") == uri
@@ -111,7 +110,7 @@ def test_plain_paths_are_normalised_to_file_uri(tmp_path: Path, monkeypatch):
 
     decision = guard.ensure_file_backend_decision()
     uri = decision.effective_uri
-    assert uri.startswith("file:")
+    assert uri.startswith("file:///")
     assert os.environ["MLFLOW_TRACKING_URI"] == uri
     assert os.environ["CODEX_MLFLOW_URI"] == uri
     path = Path(urlparse(uri).path)
@@ -127,9 +126,9 @@ def test_bootstrap_blocks_remote_by_default(tmp_path: Path, monkeypatch):
     guard = _reload_guard()
 
     decision = guard.bootstrap_offline_tracking_decision()
-    assert decision.effective_uri.startswith("file:")
-    assert os.environ["MLFLOW_TRACKING_URI"].startswith("file:")
-    assert os.environ["CODEX_MLFLOW_URI"].startswith("file:")
+    assert decision.effective_uri.startswith("file:///")
+    assert os.environ["MLFLOW_TRACKING_URI"].startswith("file:///")
+    assert os.environ["CODEX_MLFLOW_URI"].startswith("file:///")
     assert decision.fallback_reason in {"non_file_scheme", "non_local_host"}
 
 
@@ -171,7 +170,7 @@ def test_summary_records_fallback_reason_when_downgraded(tmp_path, monkeypatch):
     assert lines, "summary should contain at least one record"
     extra = lines[-1]["extra"]
     assert extra["requested_uri"] == "https://example.com/mlflow"
-    assert extra["effective_uri"].startswith("file:")
+    assert extra["effective_uri"].startswith("file:///")
     assert extra["fallback_reason"] == "non_local_uri"
     assert extra["allow_remote_flag"] == ""
     assert extra["allow_remote"] is False

--- a/tests/tracking/test_tracking_guards.py
+++ b/tests/tracking/test_tracking_guards.py
@@ -56,13 +56,15 @@ def test_mlflow_guard_matrix(mlflow_uri, mlflow_offline, wandb_mode, allow_remot
 
     if offline:
         if mlflow_uri is None:
-            assert decision.uri and decision.uri.startswith("file://"), decision
+            assert decision.uri and decision.uri.startswith("file:///")
+            assert decision.uri.endswith("/mlruns")
             assert decision.reason == "offline_default_local_uri"
         elif isinstance(mlflow_uri, str) and mlflow_uri.startswith("http"):
-            assert decision.uri and decision.uri.startswith("file://"), decision
+            assert decision.uri and decision.uri.startswith("file:///")
+            assert decision.uri.endswith("/mlruns")
             assert decision.blocked and "rewrite" in decision.reason
         else:
-            assert decision.uri and decision.uri.startswith("file://")
+            assert decision.uri and decision.uri.startswith("file:///")
             assert decision.reason in {
                 "offline_local_ok",
                 "offline_enforced_rewrite_remote_to_local",
@@ -74,7 +76,7 @@ def test_mlflow_guard_matrix(mlflow_uri, mlflow_offline, wandb_mode, allow_remot
         elif mlflow_uri.startswith("http"):
             assert decision.uri == mlflow_uri
         else:
-            assert decision.uri.startswith("file://")
+            assert decision.uri.startswith("file:///")
 
 
 @pytest.mark.parametrize("enable", [None, "offline", "disabled"])


### PR DESCRIPTION
## Summary
- canonicalize MLflow file URIs to MLflow's triple-slash format and update offline guard coverage
- add a package-level `ndjson-summary` CLI with JSON/CSV outputs and refresh NDJSON summarizer implementation
- introduce an atomic JSON writer for checkpoint manifests and document reproducibility & integrity guidance

## Testing
- `pytest -q tests/tracking/test_mlflow_guard.py tests/tracking/test_tracking_guards.py tests/checkpointing/test_atomic_write.py`
- `pytest -q tests/cli/test_cli_ndjson_summary.py` *(fails: torch not installed in environment)*
- `PYTHONPATH=src python -m codex_ml ndjson-summary --help`


------
https://chatgpt.com/codex/tasks/task_e_68e695d6f3408331b89c9dce10b9fbd8