### PR TITLE
feat: metrics NDJSON CLI with docs and semgrep rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,12 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-commit]
+      - id: semgrep-local
+        name: semgrep (local rules, optional)
+        entry: bash -lc 'command -v semgrep >/dev/null 2>&1 && semgrep scan --quiet --config semgrep_rules || echo "[semgrep] skipped (not installed)"'
+        language: system
+        pass_filenames: false
+        types: [python]
       - id: ci-guard
         name: Guard against unintended CI workflows
         entry: bash

--- a/docs/explanations/docs_architecture_diataxis.md
+++ b/docs/explanations/docs_architecture_diataxis.md
@@ -1,0 +1,10 @@
+# Why Diátaxis for Codex docs?
+
+Codex documentation is being reorganized iteratively around the four complementary pillars of the Diátaxis framework:
+
+- **Tutorials** — learning-oriented walkthroughs that teach new capabilities.
+- **How-to guides** — goal-oriented procedures for accomplishing specific tasks.
+- **Reference** — information-oriented pages that describe commands and APIs.
+- **Explanation** — understanding-oriented context, rationale, and design notes.
+
+We add pages opportunistically as they become ready and cross-link them from the index to help contributors discover coverage gaps.

--- a/docs/how-to/metrics_ingestion.md
+++ b/docs/how-to/metrics_ingestion.md
@@ -1,0 +1,25 @@
+# How-to: Ingest training metrics (NDJSON → CSV/Parquet)
+
+This guide demonstrates converting newline-delimited JSON (**NDJSON**) metrics into tidy tabular files for downstream analysis.
+
+## Prerequisites
+- Metrics logging already writes an NDJSON artifact (for example `metrics.ndjson`).
+- Python environment with optional `pandas` (for Parquet output).
+
+## Steps
+```bash
+# Convert NDJSON → CSV (always)
+python -m codex_ml.cli metrics ingest --input artifacts/metrics.ndjson --out-csv artifacts/metrics.csv
+
+# Optional: also emit Parquet (requires pandas + pyarrow/fastparquet)
+python -m codex_ml.cli metrics ingest --input artifacts/metrics.ndjson \
+  --out-csv artifacts/metrics.csv --out-parquet artifacts/metrics.parquet
+
+# Print quick stats (last/min/max by key)
+python -m codex_ml.cli metrics summary --input artifacts/metrics.ndjson
+```
+
+### Notes
+- NDJSON = "one JSON object per line"; the CLI streams the file to keep memory usage low.
+- Provide `--schema schema.json` to validate against a JSON Schema (requires `jsonschema`).
+- Parquet output is attempted only when `--out-parquet` is supplied *and* `pandas` is installed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,4 +27,16 @@ Welcome! This site covers **Getting Started (Ubuntu)**, **Concepts**, **API Refe
 * [Tests overview](tests_overview.md)
 * [Tokenization API](tokenization_api.md)
 
+## How-to guides
+
+* [Ingest training metrics (NDJSON → CSV/Parquet)](how-to/metrics_ingestion.md)
+
+## Reference
+
+* [`codex_ml.cli metrics`](reference/metrics_cli.md)
+
+## Explanations
+
+* [Why Diátaxis for Codex docs?](explanations/docs_architecture_diataxis.md)
+
 <!-- END: CODEX_DOCS_INDEX -->

--- a/docs/reference/metrics_cli.md
+++ b/docs/reference/metrics_cli.md
@@ -1,0 +1,20 @@
+# Reference: `codex_ml.cli metrics`
+
+## Synopsis
+```bash
+python -m codex_ml.cli metrics <subcommand> [options]
+```
+
+## Subcommands
+- `ingest` — read NDJSON and produce a tidy CSV (and optionally Parquet).
+- `summary` — print quick statistics from NDJSON metrics.
+
+## Options (ingest)
+- `--input PATH` (required): NDJSON input file.
+- `--out-csv PATH` (required): CSV output path.
+- `--out-parquet PATH` (optional): Parquet output path (requires `pandas`).
+- `--run-id STR` (optional): Label written into the `run_id` column.
+- `--schema PATH` (optional): JSON Schema to validate each record.
+
+## Options (summary)
+- `--input PATH` (required): NDJSON input file.

--- a/semgrep_rules/python-security.yaml
+++ b/semgrep_rules/python-security.yaml
@@ -1,0 +1,39 @@
+rules:
+  - id: py-requests-verify-disabled
+    message: "requests called with verify=False disables TLS verification"
+    languages: [python]
+    severity: WARNING
+    pattern: requests.$METHOD(..., verify=False, ...)
+    metavars:
+      METHOD:
+        regex: "(get|post|put|patch|delete|head|options)"
+
+  - id: py-subprocess-shell-true
+    message: "subprocess with shell=True can lead to command injection"
+    languages: [python]
+    severity: ERROR
+    patterns:
+      - pattern-either:
+          - pattern: subprocess.run(..., shell=True, ...)
+          - pattern: subprocess.Popen(..., shell=True, ...)
+          - pattern: subprocess.call(..., shell=True, ...)
+
+  - id: py-yaml-unsafe-load
+    message: "Use yaml.safe_load()/SafeLoader (avoid unsafe loaders)"
+    languages: [python]
+    severity: ERROR
+    patterns:
+      - pattern: yaml.load(...)
+      - pattern-not: yaml.load(..., Loader=yaml.SafeLoader, ...)
+      - pattern-not: yaml.load(..., Loader=yaml.CSafeLoader, ...)
+      - pattern-not: yaml.load_all(..., Loader=yaml.SafeLoader, ...)
+      - pattern-not: yaml.full_load(...)
+      - pattern-not: yaml.safe_load(...)
+
+  - id: py-pickle-load
+    message: "Avoid loading pickles from untrusted sources"
+    languages: [python]
+    severity: WARNING
+    pattern-either:
+      - pattern: pickle.load(...)
+      - pattern: pickle.loads(...)

--- a/src/codex_ml/cli/__init__.py
+++ b/src/codex_ml/cli/__init__.py
@@ -40,6 +40,17 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     ndjson.set_defaults(func=_cmd_ndjson_summary)
 
+    metrics = sub.add_parser(
+        "metrics",
+        help="Metrics NDJSON utilities (ingest/summary)",
+    )
+    metrics.add_argument(
+        "metrics_args",
+        nargs=argparse.REMAINDER,
+        help=argparse.SUPPRESS,
+    )
+    metrics.set_defaults(func=_cmd_metrics)
+
     offline = sub.add_parser(
         "offline-bootstrap",
         help="Prepare local MLflow/W&B offline tracking",
@@ -75,6 +86,13 @@ def _cmd_ndjson_summary(args: argparse.Namespace) -> int:
     from . import ndjson_summary
 
     return ndjson_summary.summarize(args)
+
+
+def _cmd_metrics(args: argparse.Namespace) -> int:
+    from . import metrics_cli
+
+    metrics_args = list(args.metrics_args or [])
+    return metrics_cli.main(metrics_args)
 
 
 def package_main(argv: list[str] | None = None) -> int:

--- a/src/codex_ml/cli/metrics_cli.py
+++ b/src/codex_ml/cli/metrics_cli.py
@@ -1,0 +1,193 @@
+"""Metrics NDJSON ingestion and summary utilities."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+
+Row = dict[str, Any]
+
+
+def _iter_ndjson(path: Path) -> Iterable[dict[str, Any]]:
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            yield json.loads(stripped)
+
+
+def _flatten_records(records: Iterable[dict[str, Any]], run_id: str | None) -> Iterable[Row]:
+    """Convert metrics records into tidy {run_id, epoch, key, value} rows."""
+
+    for record in records:
+        epoch = record.get("epoch")
+        for key, value in record.items():
+            if key == "epoch":
+                continue
+            if isinstance(value, (int, float, str)):
+                rendered = value
+            else:
+                rendered = json.dumps(value, ensure_ascii=False)
+            yield {
+                "run_id": run_id,
+                "epoch": epoch,
+                "key": key,
+                "value": rendered,
+            }
+
+
+def _write_csv(rows: Iterable[Row], out_csv: Path) -> int:
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with out_csv.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["run_id", "epoch", "key", "value"])
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+            written += 1
+    return written
+
+
+def _try_write_parquet(in_csv: Path, out_parquet: Path) -> bool:
+    try:
+        import pandas as pd  # type: ignore
+
+        df = pd.read_csv(in_csv)
+        df.to_parquet(out_parquet)
+        return True
+    except Exception:
+        return False
+
+
+def _validate_with_jsonschema(data_path: Path, schema_path: Path) -> None:
+    try:
+        import jsonschema  # type: ignore
+    except Exception as exc:  # pragma: no cover - import guards
+        print(
+            f"[metrics-cli] jsonschema not installed; skipping validation ({exc!r})",
+            file=sys.stderr,
+        )
+        return
+
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    validator = jsonschema.Draft7Validator(schema)
+    for idx, record in enumerate(_iter_ndjson(data_path), start=1):
+        try:
+            validator.validate(record)
+        except jsonschema.exceptions.ValidationError as exc:  # type: ignore[attr-defined]
+            raise ValueError(f"schema validation failed at record {idx}: {exc.message}") from exc
+
+
+def cmd_ingest(args: argparse.Namespace) -> int:
+    input_path = Path(args.input).expanduser().resolve()
+    if not input_path.exists():
+        print(f"[metrics-cli] input not found: {input_path}", file=sys.stderr)
+        return 2
+
+    run_id = args.run_id or input_path.stem
+    schema_path = Path(args.schema).expanduser().resolve() if args.schema else None
+    if schema_path is not None:
+        try:
+            _validate_with_jsonschema(input_path, schema_path)
+        except ValueError as exc:
+            print(f"[metrics-cli] {exc}", file=sys.stderr)
+            return 3
+
+    rows = _flatten_records(_iter_ndjson(input_path), run_id=run_id)
+    out_csv = Path(args.out_csv).expanduser().resolve()
+    written = _write_csv(rows, out_csv)
+
+    parquet_path: Path | None = None
+    if args.out_parquet:
+        candidate = Path(args.out_parquet).expanduser().resolve()
+        if _try_write_parquet(out_csv, candidate):
+            parquet_path = candidate
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "rows": written,
+                "csv": out_csv.as_posix(),
+                "parquet": parquet_path.as_posix() if parquet_path else None,
+            }
+        )
+    )
+    return 0
+
+
+def _summarize(path: Path) -> dict[str, Any]:
+    last_by_key: dict[str, Any] = {}
+    min_by_key: dict[str, float] = {}
+    max_by_key: dict[str, float] = {}
+    epochs: set[int] = set()
+
+    for record in _iter_ndjson(path):
+        if "epoch" in record:
+            try:
+                epochs.add(int(record["epoch"]))
+            except Exception:
+                pass
+        for key, value in record.items():
+            if key == "epoch":
+                continue
+            last_by_key[key] = value
+            if isinstance(value, (int, float)):
+                min_by_key[key] = value if key not in min_by_key else min(min_by_key[key], value)
+                max_by_key[key] = value if key not in max_by_key else max(max_by_key[key], value)
+
+    return {
+        "epochs": sorted(epochs),
+        "last": last_by_key,
+        "min": min_by_key,
+        "max": max_by_key,
+    }
+
+
+def cmd_summary(args: argparse.Namespace) -> int:
+    input_path = Path(args.input).expanduser().resolve()
+    if not input_path.exists():
+        print(f"[metrics-cli] input not found: {input_path}", file=sys.stderr)
+        return 2
+
+    summary = _summarize(input_path)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="codex metrics", description="Metrics NDJSON utilities")
+    sub = parser.add_subparsers(dest="subcommand", required=True)
+
+    ingest = sub.add_parser("ingest", help="Ingest NDJSON into tidy CSV rows (optional Parquet)")
+    ingest.add_argument("--input", required=True, help="Path to NDJSON (one JSON per line)")
+    ingest.add_argument("--out-csv", required=True, help="Output CSV file path")
+    ingest.add_argument(
+        "--out-parquet",
+        help="Optional Parquet file path (requires pandas with pyarrow or fastparquet)",
+    )
+    ingest.add_argument("--run-id", help="Run identifier (defaults to input stem)")
+    ingest.add_argument("--schema", help="Optional JSON Schema file for validation")
+    ingest.set_defaults(func=cmd_ingest)
+
+    summary = sub.add_parser("summary", help="Print quick statistics from NDJSON")
+    summary.add_argument("--input", required=True, help="Path to NDJSON metrics file")
+    summary.set_defaults(func=cmd_summary)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/cli/test_metrics_ingest.py
+++ b/tests/cli/test_metrics_ingest.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_ndjson(path: Path) -> None:
+    records = [
+        {"epoch": 0, "loss": 2.0, "acc": 0.30},
+        {"epoch": 1, "loss": 1.5, "acc": 0.35},
+    ]
+    with path.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record) + "\n")
+
+
+def test_ingest_to_csv_and_summary(tmp_path: Path) -> None:
+    ndjson_path = tmp_path / "metrics.ndjson"
+    _write_ndjson(ndjson_path)
+
+    csv_path = tmp_path / "metrics.csv"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "codex_ml.cli",
+            "metrics",
+            "ingest",
+            "--input",
+            str(ndjson_path),
+            "--out-csv",
+            str(csv_path),
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    payload = json.loads(proc.stdout)
+    assert payload["ok"] is True
+    assert payload["rows"] == 4
+    assert Path(payload["csv"]).exists()
+
+    proc_summary = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "codex_ml.cli",
+            "metrics",
+            "summary",
+            "--input",
+            str(ndjson_path),
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    summary = json.loads(proc_summary.stdout)
+    assert summary["last"]["acc"] == 0.35
+    assert summary["min"]["loss"] == 1.5
+    assert summary["epochs"] == [0, 1]


### PR DESCRIPTION
## Summary
- add a metrics-focused CLI module that ingests NDJSON into tidy CSV/optional Parquet output and provides summary stats
- document the workflow with new Diátaxis-friendly how-to/reference pages and link them from the docs index
- add Python security Semgrep rules and wire them into a local optional pre-commit hook

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/cli/test_metrics_ingest.py
- ruff check src/codex_ml/cli/metrics_cli.py tests/cli/test_metrics_ingest.py

------
https://chatgpt.com/codex/tasks/task_e_68e7051bebd08331a33aecbbb3d05aac