### PR TITLE
feat: bootstrap repo admin automation tooling and docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
-* @Aries-Serpent
+# Default owners
+* @Aries-Serpent/owners
+
+# ML core
+src/codex_ml/** @Aries-Serpent/ml-core
+
+# Docs
+docs/** @Aries-Serpent/docs

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,20 @@ include codex.mk
 
 ## Run local gates with the exact same entrypoint humans and bots use
 codex-gates:
-	@bash scripts/codex_local_gates.sh
+@bash scripts/codex_local_gates.sh
+
+.PHONY: repo-admin-dryrun
+repo-admin-dryrun:
+	@python scripts/ops/codex_repo_admin_bootstrap.py \
+	  --owner Aries-Serpent --repo _codex_ \
+	  --labels-json docs/reference/labels_preset.json \
+	  --codeowners .github/CODEOWNERS \
+	  --status-check "ruff" --status-check "pytest"
+
+.PHONY: repo-admin-apply
+repo-admin-apply:
+	@CODEX_NET_MODE=online_allowlist CODEX_ALLOWLIST_HOSTS=api.github.com \
+	@python scripts/ops/codex_repo_admin_bootstrap.py --owner Aries-Serpent --repo _codex_ --apply
 
 wheelhouse:
 	@tools/bootstrap_wheelhouse.sh
@@ -162,4 +175,3 @@ hooks-prewarm:
 # Run manual-stage hooks (security scanners, etc.) across the repo
 hooks-manual:
 	@pre-commit run --hook-stage manual --all-files
-

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Artifacts are written under `.codex/` (metrics, checkpoints, provenance).
 - [Checkpoint Schema v2](docs/checkpoint_schema_v2.md)
 - [Manifest Integrity](docs/manifest_integrity.md)
 
+### Repo Admin Bootstrap (local)
+See [docs/how-to/repo_admin_bootstrap.md](docs/how-to/repo_admin_bootstrap.md) for labels, CODEOWNERS, branch protection and security toggles via CLI.
+
 ## LoRA fine-tuning (minimal example)
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ Welcome! This site covers **Getting Started (Ubuntu)**, **Concepts**, **API Refe
 * [Metrics: Validate, Tail & Badge](how-to/metrics_validate_tail_badge.md)
 * [Hydra sweeps & defaults](how-to/hydra_sweeps.md)
 * [Offline tracking (MLflow & W&B)](how-to/offline_tracking.md)
+* [Repo Admin Bootstrap](how-to/repo_admin_bootstrap.md)
 
 ## Reference
 

--- a/docs/reference/labels_preset.json
+++ b/docs/reference/labels_preset.json
@@ -1,0 +1,47 @@
+[
+  {
+    "color": "b60205",
+    "description": "Must fix now",
+    "name": "priority: P0"
+  },
+  {
+    "color": "d93f0b",
+    "description": "High priority",
+    "name": "priority: P1"
+  },
+  {
+    "color": "fbca04",
+    "description": "Normal priority",
+    "name": "priority: P2"
+  },
+  {
+    "color": "d73a4a",
+    "description": "Bug",
+    "name": "type: bug"
+  },
+  {
+    "color": "0e8a16",
+    "description": "Feature",
+    "name": "type: feat"
+  },
+  {
+    "color": "0366d6",
+    "description": "Documentation",
+    "name": "type: docs"
+  },
+  {
+    "color": "0e8a16",
+    "description": "Ready to pick",
+    "name": "status: ready"
+  },
+  {
+    "color": "5319e7",
+    "description": "Blocked",
+    "name": "status: blocked"
+  },
+  {
+    "color": "1d76db",
+    "description": "ML Core area",
+    "name": "A: ml-core"
+  }
+]

--- a/scripts/ops/codex_repo_admin_bootstrap.py
+++ b/scripts/ops/codex_repo_admin_bootstrap.py
@@ -1,276 +1,275 @@
+#!/usr/bin/env python3
 """
-Codex Repo Admin Bootstrap
- - Standardize GitHub repo settings without enabling any workflows.
- - Idempotent; defaults are safe; dry-run by default.
+codex_repo_admin_bootstrap.py
 
-Requires:
+Purpose:
+  Bootstrap a repository to sane defaults:
+    - Create/update standard labels from JSON
+    - Ensure CODEOWNERS exists/updated (via Contents API)
+    - Harden default branch protection (reviews, code-owner reviews, status checks, conversation resolution)
+    - Enable repo security features via PATCH /repos (secret scanning, push protection, dependabot updates)
+
+Defaults to DRY-RUN to avoid accidental network calls. Explicit --apply required.
+
+Environment (strongly recommended):
   CODEX_NET_MODE=online_allowlist
   CODEX_ALLOWLIST_HOSTS=api.github.com
-  GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and App private key (see mint script).
+  GITHUB_APP_INSTALLATION_TOKEN=<short-lived token>  # or GITHUB_TOKEN (PAT fine-grained)
+  GITHUB_API_BASE=https://api.github.com
+
+Docs:
+  - Update a repository (security_and_analysis toggles)
+  - Create/Update file contents (CODEOWNERS)
+  - Branch protection update (require code owner reviews, conversation resolution)
+  - Labels API (create/update)
 """
 
 from __future__ import annotations
-
 import argparse
 import base64
 import json
 import os
+import sys
+from functools import lru_cache
 from pathlib import Path
-from typing import Iterable, Mapping
+from typing import Any, Dict, List, Optional, Tuple
 
-from scripts.ops.codex_mint_tokens_per_run import (  # type: ignore
-    _assert_online_allowed,
-    _mint_app_jwt,
-    TokenScope,
-    GitHubSession,
-    create_installation_access_token,
-)
-
-ROOT = Path(__file__).resolve().parents[2]
-TEMPLATES = ROOT / "templates" / "github_repo_baseline"
+API = os.getenv("GITHUB_API_BASE", "https://api.github.com").rstrip("/")
 
 
-def _default_repo_settings() -> dict:
-    # Conservative, squash-only, delete merged branches, enable security knobs when available.
+@lru_cache(maxsize=1)
+def _requests():
+    import requests  # type: ignore
+
+    return requests
+
+
+def _auth_headers() -> Dict[str, str]:
+    token = os.getenv("GITHUB_APP_INSTALLATION_TOKEN") or os.getenv("GITHUB_TOKEN")
+    if not token:
+        raise SystemExit("Provide GITHUB_APP_INSTALLATION_TOKEN or GITHUB_TOKEN")
     return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def _allowlisted() -> None:
+    mode = os.getenv("CODEX_NET_MODE", "offline")
+    allow = {h.strip() for h in os.getenv("CODEX_ALLOWLIST_HOSTS", "").split(",") if h.strip()}
+    if mode != "online_allowlist" or "api.github.com" not in allow:
+        raise SystemExit(
+            "Online mode not permitted (set CODEX_NET_MODE=online_allowlist and add api.github.com to CODEX_ALLOWLIST_HOSTS)."
+        )
+
+
+def _req(method: str, url: str, *, json_body: Any | None = None):
+    requests = _requests()
+    r = requests.request(method, url, headers=_auth_headers(), json=json_body, timeout=20)
+    if r.status_code >= 400:
+        raise SystemExit(f"{method} {url} failed: {r.status_code} {r.text}")
+    return r
+
+
+# -------------------------
+# Labels
+# -------------------------
+
+
+def plan_labels(
+    owner: str, repo: str, labels: List[Dict[str, Any]]
+) -> List[Tuple[str, Dict[str, Any]]]:
+    """Return a list of ('create'|'update', payload) operations. When applied, POST/PATCH label endpoints are used."""
+    ops: List[Tuple[str, Dict[str, Any]]] = []
+    for lb in labels:
+        name = lb["name"]
+        payload = {
+            "name": name,
+            "color": lb.get("color", "ededed").lstrip("#"),
+            "description": lb.get("description", ""),
+        }
+        # In 'apply' we will check existence and swap endpoint to PATCH as needed.
+        ops.append(("upsert", payload))
+    return ops
+
+
+def apply_labels(owner: str, repo: str, labels: List[Dict[str, Any]]) -> None:
+    # list existing labels (best-effort); fallback to creating all
+    existing = {}
+    try:
+        r = _req("GET", f"{API}/repos/{owner}/{repo}/labels")
+        for item in r.json():
+            existing[item["name"].lower()] = item
+    except SystemExit:
+        existing = {}
+    for lb in labels:
+        name = lb["name"]
+        payload = {
+            "name": name,
+            "color": lb.get("color", "ededed").lstrip("#"),
+            "description": lb.get("description", ""),
+        }
+        if name.lower() in existing:
+            requests = _requests()
+            _req(
+                "PATCH",
+                f"{API}/repos/{owner}/{repo}/labels/{requests.utils.quote(name, safe='')}",
+                json_body={"new_name": name, **payload},
+            )
+        else:
+            _req("POST", f"{API}/repos/{owner}/{repo}/labels", json_body=payload)
+
+
+# -------------------------
+# CODEOWNERS
+# -------------------------
+
+
+def upsert_codeowners(owner: str, repo: str, branch: str, content: str, message: str) -> None:
+    """PUT contents API to .github/CODEOWNERS on default branch."""
+    path = ".github/CODEOWNERS"
+    # fetch current sha (if exists)
+    sha = None
+    url = f"{API}/repos/{owner}/{repo}/contents/{path}"
+    requests = _requests()
+    r = requests.get(url, headers=_auth_headers(), timeout=20, params={"ref": branch})
+    if r.status_code == 200:
+        sha = r.json().get("sha")
+    elif r.status_code != 404:
+        raise SystemExit(f"GET {url} failed: {r.status_code} {r.text}")
+    body = {
+        "message": message,
+        "content": base64.b64encode(content.encode("utf-8")).decode("ascii"),
+        "branch": branch,
+    }
+    if sha:
+        body["sha"] = sha
+    _req("PUT", url, json_body=body)
+
+
+# -------------------------
+# Repo settings + security
+# -------------------------
+
+
+def patch_repo_settings(owner: str, repo: str) -> None:
+    payload = {
         "allow_squash_merge": True,
         "allow_merge_commit": False,
         "allow_rebase_merge": False,
-        "delete_branch_on_merge": True,
         "allow_auto_merge": True,
-        "squash_merge_commit_message": "PR_BODY",
-        "squash_merge_commit_title": "PR_TITLE",
+        "delete_branch_on_merge": True,
+        # security_and_analysis toggles (Advanced Security features / push protection)
         "security_and_analysis": {
-            "advanced_security": {"status": "enabled"},
             "secret_scanning": {"status": "enabled"},
             "secret_scanning_push_protection": {"status": "enabled"},
-            # vulnerability alerts are separate, see _enable_repo_feature()
+            "dependabot_security_updates": {"status": "enabled"},
         },
     }
+    _req("PATCH", f"{API}/repos/{owner}/{repo}", json_body=payload)
 
 
-def _default_branch_protection() -> dict:
-    # Minimal, safe protection for 'main' (no required status checks by default).
-    return {
-        "required_status_checks": None,  # or {"strict": False, "contexts": []}
+# -------------------------
+# Branch protection
+# -------------------------
+
+
+def put_branch_protection(owner: str, repo: str, branch: str, checks: List[str]) -> None:
+    payload = {
+        "required_status_checks": {"strict": True, "contexts": checks},
         "enforce_admins": True,
         "required_pull_request_reviews": {
-            "required_approvals": 1,
             "dismiss_stale_reviews": True,
             "require_code_owner_reviews": True,
+            "required_approving_review_count": 2,
+            "require_last_push_approval": True,
         },
         "restrictions": None,
+        "required_linear_history": True,
+        "allow_force_pushes": False,
+        "allow_deletions": False,
+        "block_creations": True,
         "required_conversation_resolution": True,
-        # Note: required signatures & linear history have separate endpoints; omitted by default.
+        "lock_branch": False,
+        "allow_fork_syncing": False,
     }
+    _req("PUT", f"{API}/repos/{owner}/{repo}/branches/{branch}/protection", json_body=payload)
 
 
-def _default_labels() -> list[dict]:
-    return [
-        {"name": "type:bug", "color": "d73a4a", "description": "Something isn't working"},
-        {"name": "type:feature", "color": "a2eeef", "description": "New feature or request"},
-        {"name": "type:docs", "color": "0075ca", "description": "Documentation updates"},
-        {"name": "prio:high", "color": "b60205", "description": "High priority"},
-        {"name": "good first issue", "color": "7057ff", "description": "Good for newcomers"},
-    ]
+# -------------------------
+# CLI
+# -------------------------
 
 
-def _plan_templates() -> dict[str, Path]:
-    files: dict[str, Path] = {}
-    for p in TEMPLATES.rglob("*"):
-        if p.is_file():
-            rel = p.relative_to(TEMPLATES)
-            # map to repository path (.github/*)
-            repo_path = Path(".github") / rel
-            files[str(repo_path)] = p
-    return files
-
-
-def _put_json(
-    session: GitHubSession, url: str, payload: Mapping[str, object], expected: int = 200
-) -> dict:
-    resp = session.request("PUT", url, json=payload)
-    if resp.status_code != expected:
-        raise SystemExit(f"PUT {url} failed: {resp.status_code} {resp.text}")
-    return resp.json() if resp.text else {}
-
-
-def _patch_json(
-    session: GitHubSession, url: str, payload: Mapping[str, object], ok: set[int] = {200}
-) -> dict:
-    resp = session.request("PATCH", url, json=payload)
-    if resp.status_code not in ok:
-        raise SystemExit(f"PATCH {url} failed: {resp.status_code} {resp.text}")
-    return resp.json() if resp.text else {}
-
-
-def _enable_repo_feature(session: GitHubSession, owner: str, repo: str, feature: str) -> None:
-    # vulnerability alerts on: PUT /repos/{owner}/{repo}/vulnerability-alerts
-    url = f"/repos/{owner}/{repo}/{feature}"
-    resp = session.put(url)
-    if resp.status_code not in (204, 202):  # 202 for async enable on some hosts
-        # Best-effort: ignore 404/403 if not available for the plan/org tier.
-        if resp.status_code not in (403, 404):
-            raise SystemExit(f"Enable {feature} failed: {resp.status_code} {resp.text}")
-
-
-def apply_repo_settings(
-    session: GitHubSession, owner: str, repo: str, settings: Mapping[str, object]
-) -> dict:
-    return _patch_json(session, f"/repos/{owner}/{repo}", settings)
-
-
-def apply_branch_protection(
-    session: GitHubSession, owner: str, repo: str, branch: str, rules: Mapping[str, object]
-) -> dict:
-    return _put_json(
-        session, f"/repos/{owner}/{repo}/branches/{branch}/protection", rules, expected=200
-    )
-
-
-def ensure_labels(
-    session: GitHubSession, owner: str, repo: str, labels: Iterable[Mapping[str, str]]
-) -> dict:
-    # Build a plan by diffing existing labels; create missing, update mismatched colors/descriptions.
-    existing = session.get(f"/repos/{owner}/{repo}/labels").json()
-    by_name = {l["name"].lower(): l for l in (existing or [])}
-    plan: dict[str, list] = {"create": [], "update": []}
-    for label in labels:
-        name = label["name"]
-        cur = by_name.get(name.lower())
-        if not cur:
-            plan["create"].append(label)
-        else:
-            needs = {}
-            if cur.get("color", "").lower() != label["color"].lower():
-                needs["color"] = label["color"]
-            if (cur.get("description") or "") != label.get("description", ""):
-                needs["description"] = label.get("description", "")
-            if needs:
-                plan["update"].append({"name": name, **needs})
-    # Apply
-    for lbl in plan["create"]:
-        resp = session.post(f"/repos/{owner}/{repo}/labels", json=lbl)
-        if resp.status_code not in (201, 200):
-            raise SystemExit(f"Create label {lbl['name']} failed: {resp.status_code} {resp.text}")
-    for upd in plan["update"]:
-        name = upd.pop("name")
-        resp = session.patch(f"/repos/{owner}/{repo}/labels/{name}", json=upd)
-        if resp.status_code != 200:
-            raise SystemExit(f"Update label {name} failed: {resp.status_code} {resp.text}")
-    return plan
-
-
-def ensure_repo_files(
-    session: GitHubSession,
-    owner: str,
-    repo: str,
-    files: dict[str, Path],
-    branch: str,
-    author: str,
-) -> dict:
-    # Uses "Create or update file contents" API; creates missing files only.
-    plan = {"create": [], "skip": []}
-    for repo_path, src in files.items():
-        # stat if exists
-        stat = session.get(f"/repos/{owner}/{repo}/contents/{repo_path}?ref={branch}")
-        if stat.status_code == 200:
-            plan["skip"].append(repo_path)
-            continue
-        if stat.status_code not in (404, 200):
-            raise SystemExit(f"Probe {repo_path} failed: {stat.status_code} {stat.text}")
-        content = base64.b64encode(src.read_bytes()).decode("ascii")
-        payload = {
-            "message": f"codex: bootstrap {repo_path}",
-            "content": content,
-            "branch": branch,
-            "committer": {"name": author, "email": "codex@example"},
-        }
-        resp = session.put(f"/repos/{owner}/{repo}/contents/{repo_path}", json=payload)
-        if resp.status_code not in (201, 200):
-            raise SystemExit(f"Create {repo_path} failed: {resp.status_code} {resp.text}")
-        plan["create"].append(repo_path)
-    return plan
-
-
-def build_parser() -> argparse.ArgumentParser:
+def main(argv: Optional[List[str]] = None) -> int:
     p = argparse.ArgumentParser(
-        description="Standardize GitHub repo settings (no workflows). Dry-run by default."
+        description="Bootstrap a repository to sane defaults (dry-run by default)."
     )
     p.add_argument("--owner", required=True)
     p.add_argument("--repo", required=True)
-    p.add_argument("--branch", default="main")
+    p.add_argument("--default-branch", default="main")
+    p.add_argument("--labels-json", type=Path, help="Path to labels.json (optional)")
+    p.add_argument("--codeowners", type=Path, help="Path to CODEOWNERS template (optional)")
     p.add_argument(
-        "--apply", action="store_true", help="Execute changes. Omit to just print the plan."
+        "--status-check",
+        action="append",
+        default=[],
+        help="Required status check context (repeatable)",
     )
     p.add_argument(
-        "--with-templates",
-        action="store_true",
-        help="Also push CODEOWNERS + PR/Issue templates (.github).",
+        "--apply", action="store_true", help="Execute calls (network). Default is dry-run."
     )
-    p.add_argument(
-        "--codeowners", default="@Aries-Serpent/codex-admins", help="Default CODEOWNERS entry."
-    )
-    p.add_argument("--author", default="Codex Admin Bot", help="Commit author for hygiene files.")
-    return p
+    args = p.parse_args(argv)
 
+    # Always require allowlist when applying
+    if args.apply:
+        _allowlisted()
 
-def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
-    owner, repo, branch = args.owner, args.repo, args.branch
-
-    # Plan
     plan = {
-        "repo_settings": _default_repo_settings(),
-        "branch_protection": _default_branch_protection(),
-        "labels": _default_labels(),
-        "templates": list(_plan_templates().keys()) if args.with_templates else [],
-        "target": {"owner": owner, "repo": repo, "branch": branch},
-        "apply": bool(args.apply),
+        "owner": args.owner,
+        "repo": args.repo,
+        "default_branch": args.default_branch,
+        "ops": [],
     }
 
-    if not args.apply:
-        print(json.dumps({"dry_run": True, "plan": plan}, indent=2, ensure_ascii=False))
-        return 0
+    if args.labels_json and args.labels_json.exists():
+        labels = json.loads(args.labels_json.read_text(encoding="utf-8"))
+        plan["ops"].append({"labels": labels})
+        if args.apply:
+            apply_labels(args.owner, args.repo, labels)
 
-    _assert_online_allowed()
-    app_id = os.getenv("GITHUB_APP_ID")
-    inst_id = os.getenv("GITHUB_APP_INSTALLATION_ID")
-    if not app_id or not inst_id:
-        raise SystemExit("Missing GITHUB_APP_ID / GITHUB_APP_INSTALLATION_ID")
+    if args.codeowners and args.codeowners.exists():
+        content = args.codeowners.read_text(encoding="utf-8")
+        plan["ops"].append({"codeowners": ".github/CODEOWNERS"})
+        if args.apply:
+            upsert_codeowners(
+                args.owner,
+                args.repo,
+                args.default_branch,
+                content,
+                "chore: ensure CODEOWNERS present",
+            )
 
-    # Mint JWT -> Installation token
-    app_jwt = _mint_app_jwt(app_id)
-    with GitHubSession(f"Bearer {app_jwt}") as app_session:
-        token_data = create_installation_access_token(app_session, inst_id, TokenScope(tuple(), {}))
-    installation_token = token_data.get("token", "")
-    if not installation_token:
-        raise SystemExit("No installation token minted.")
+    # Repo settings + security
+    plan["ops"].append({"repo_settings": True, "security_and_analysis": True})
+    if args.apply:
+        patch_repo_settings(args.owner, args.repo)
 
-    # Apply via Installation token
-    with GitHubSession(f"token {installation_token}") as gh:
-        apply_repo_settings(gh, owner, repo, plan["repo_settings"])
-        # Best-effort security toggles that require special endpoints
-        _enable_repo_feature(gh, owner, repo, "vulnerability-alerts")
-        apply_branch_protection(gh, owner, repo, branch, plan["branch_protection"])
-        label_result = ensure_labels(gh, owner, repo, plan["labels"])
-        file_result = {}
-        if args.with_templates:
-            # Prepare CODEOWNERS file dynamically if absent in template set.
-            codeowners = TEMPLATES / "CODEOWNERS"
-            if not codeowners.exists():
-                codeowners.write_text(f"* {args.codeowners}\n", encoding="utf-8")
-            file_result = ensure_repo_files(gh, owner, repo, _plan_templates(), branch, args.author)
-
-    print(
-        json.dumps(
-            {"applied": True, "labels": label_result, "files": file_result},
-            indent=2,
-            ensure_ascii=False,
-        )
+    # Branch protection
+    plan["ops"].append(
+        {"branch_protection": {"branch": args.default_branch, "checks": args.status_check}}
     )
+    if args.apply:
+        put_branch_protection(args.owner, args.repo, args.default_branch, args.status_check)
+
+    print(json.dumps({"ok": True, "dry_run": not args.apply, "plan": plan}, indent=2))
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("\nAborted by user.", file=sys.stderr)
+        sys.exit(130)

--- a/tests/ops/test_repo_admin_bootstrap.py
+++ b/tests/ops/test_repo_admin_bootstrap.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from scripts.ops.codex_repo_admin_bootstrap import plan_labels
+
+
+def test_plan_labels_upserts() -> None:
+    labels = [{"name": "type: bug", "color": "#ff0000", "description": "Bug"}]
+    ops = plan_labels("o", "r", labels)
+    assert ops and ops[0][0] == "upsert"
+    payload = ops[0][1]
+    assert payload["name"] == "type: bug"
+    assert payload["color"] == "ff0000"


### PR DESCRIPTION
## Summary
- add a dry-run-first repo admin bootstrap CLI to manage labels, CODEOWNERS, branch protection, and security toggles
- document usage and provide presets for labels plus CODEOWNERS defaults
- add make targets and a unit test to exercise the planning helpers

## Testing
- python -m py_compile scripts/ops/codex_repo_admin_bootstrap.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ops/test_repo_admin_bootstrap.py
- ruff check scripts/ops/codex_repo_admin_bootstrap.py
- mypy scripts/ops/codex_repo_admin_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68e7bd17fcd883318fa2307b13bf8e88