### PR TITLE
feat: repo admin bootstrap v2 with shared auth helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,18 +57,13 @@ include codex.mk
 codex-gates:
 @bash scripts/codex_local_gates.sh
 
-.PHONY: repo-admin-dryrun
-repo-admin-dryrun:
-	@python scripts/ops/codex_repo_admin_bootstrap.py \
-	  --owner Aries-Serpent --repo _codex_ \
-	  --labels-json docs/reference/labels_preset.json \
-	  --codeowners .github/CODEOWNERS \
-	  --status-check "ruff" --status-check "pytest"
+.PHONY: repo-admin-dry-run repo-admin-apply
 
-.PHONY: repo-admin-apply
+repo-admin-dry-run:
+	python -m scripts.ops.codex_repo_admin_bootstrap --owner $(owner) --repo $(repo) --detect-default-branch
+
 repo-admin-apply:
-	@CODEX_NET_MODE=online_allowlist CODEX_ALLOWLIST_HOSTS=api.github.com \
-	@python scripts/ops/codex_repo_admin_bootstrap.py --owner Aries-Serpent --repo _codex_ --apply
+	python -m scripts.ops.codex_repo_admin_bootstrap --owner $(owner) --repo $(repo) --apply --detect-default-branch --dependabot-updates
 
 wheelhouse:
 	@tools/bootstrap_wheelhouse.sh

--- a/README.md
+++ b/README.md
@@ -33,8 +33,15 @@ Artifacts are written under `.codex/` (metrics, checkpoints, provenance).
 - [Checkpoint Schema v2](docs/checkpoint_schema_v2.md)
 - [Manifest Integrity](docs/manifest_integrity.md)
 
-### Repo Admin Bootstrap (local)
-See [docs/how-to/repo_admin_bootstrap.md](docs/how-to/repo_admin_bootstrap.md) for labels, CODEOWNERS, branch protection and security toggles via CLI.
+### Repo admin bootstrap (no workflows)
+```bash
+# dry-run
+make repo-admin-dry-run owner=Aries-Serpent repo=_codex_
+# apply (PAT or App creds from env; network allowlisted)
+make repo-admin-apply owner=Aries-Serpent repo=_codex_
+```
+
+See [docs/how-to/repo_admin_bootstrap.md](docs/how-to/repo_admin_bootstrap.md) for flag details and endpoint references.
 
 ## LoRA fine-tuning (minimal example)
 

--- a/docs/how-to/repo_admin_bootstrap.md
+++ b/docs/how-to/repo_admin_bootstrap.md
@@ -7,27 +7,80 @@ This guide hardens a repository **without GitHub Actions** using local scripts:
 - Branch protection on default branch: required PR reviews, **code owner reviews**, conversation resolution, status checks
 - Repo security toggles: **secret scanning**, **push protection**, **Dependabot security updates**
 
-## Usage
+## 1) Quickstart
 
 ```bash
-# Dry-run (prints plan as JSON)
-python scripts/ops/codex_repo_admin_bootstrap.py \
-  --owner Aries-Serpent --repo _codex_ \
-  --labels-json docs/reference/labels_preset.json \
-  --codeowners .github/CODEOWNERS \
-  --status-check "ruff" --status-check "pytest"
+# Dry-run (detect branch locally, no network calls)
+python -m scripts.ops.codex_repo_admin_bootstrap --owner <org> --repo <name> --detect-default-branch
 
-# Apply (requires env allowlist + token)
+# Apply (requires network allowlist + auth env)
 export CODEX_NET_MODE=online_allowlist
 export CODEX_ALLOWLIST_HOSTS=api.github.com
-export GITHUB_APP_INSTALLATION_TOKEN=<token>  # or GITHUB_TOKEN
-python scripts/ops/codex_repo_admin_bootstrap.py --owner Aries-Serpent --repo _codex_ --apply
+# Prefer GitHub App credentials; PAT fallback supported
+export GITHUB_APP_ID=<app id>
+export GITHUB_APP_INSTALLATION_ID=<installation id>
+export GITHUB_APP_PRIVATE_KEY_PATH=/path/to/private-key.pem
+# or: export GITHUB_TOKEN=<fine-grained PAT>
+python -m scripts.ops.codex_repo_admin_bootstrap --owner <org> --repo <name> --apply --detect-default-branch --dependabot-updates
 ```
 
-## Notes
-* Uses `PATCH /repos/{owner}/{repo}` to enable `security_and_analysis` (secret scanning + push protection).
-* Uses `PUT /repos/{owner}/{repo}/branches/{branch}/protection` to enforce code owner reviews and conversation resolution.
-* Uses `PUT /repos/{owner}/{repo}/contents/.github/CODEOWNERS` to upsert CODEOWNERS via Contents API.
-* Uses `/labels` POST/PATCH to upsert labels.
+## 2) Prerequisites
 
-See script docstring for endpoint references.
+| Item | Value |
+|---|---|
+| Online policy | `CODEX_NET_MODE=online_allowlist`; `CODEX_ALLOWLIST_HOSTS=api.github.com` |
+| GitHub App | `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY_PATH` or `GITHUB_APP_PRIVATE_KEY_PEM` |
+| Scope | Repo admin for target repository (via App installation) |
+| Alt auth | `GITHUB_TOKEN` (PAT) fallback supported |
+
+> ⚠️ Online calls require the host to be present in the allowlist guard. The script exits fast when the mode/hosts are missing.
+
+## 3) Flags at a Glance
+
+| Flag | Purpose |
+|---|---|
+| `--preset` | Merge policy toggles (`default`, `strict`, `relaxed`) |
+| `--status-check` | Repeatable flag for required status checks |
+| `--required-approvals` | Number of PR approvals enforced in branch protection |
+| `--detect-default-branch` | REST lookup for repo default branch (used when `--branch` omitted) |
+| `--dependabot-updates` | Enables Dependabot security updates (best-effort) |
+| `--labels-json` | Path to labels JSON (created/updated) |
+| `--codeowners` | Path to CODEOWNERS template committed via Contents API |
+
+## 4) Dry-Run Output
+
+Dry-run mode prints the planned operations without contacting GitHub:
+
+```json
+{
+  "dry_run": true,
+  "plan": {
+    "target": {"owner": "o", "repo": "r", "branch": "main"},
+    "repo_settings": {...},
+    "branch_protection": {...},
+    "labels": [...],
+    "files": [...]
+  }
+}
+```
+
+Use this to verify presets and required checks before enabling `--apply`.
+
+## 5) What's Applied (Endpoints)
+
+| Area | Endpoint | Notes |
+|---|---|---|
+| Repo settings | `PATCH /repos/{owner}/{repo}` | Merge settings; `security_and_analysis` best-effort (plan dependent) |
+| Vulnerability alerts | `PUT /repos/{owner}/{repo}/vulnerability-alerts` | `204/202` OK; `403/404` skipped |
+| Dependabot updates | `PUT /repos/{owner}/{repo}/automated-security-fixes` | Best-effort enable; `204/202` OK; `403/404` skipped |
+| Branch protection | `PUT /repos/{owner}/{repo}/branches/{branch}/protection` | Approvals, CODEOWNERS reviews |
+| Labels | `GET/POST/PATCH /repos/{owner}/{repo}/labels` | Create missing; update color/description |
+| Hygiene files | `PUT /repos/{owner}/{repo}/contents/{path}` | Base64 contents; skip if exists |
+
+> References: Update repository, labels, contents, branch protection, vulnerability alerts, and automated security fixes endpoints (see GitHub REST docs).
+
+## 6) Cautions
+
+- **Best-effort security features:** GitHub may return `403/404` when the plan is not available (e.g., Free tier). The script reports "skipped" for those cases.
+- **No workflow changes:** Scripts intentionally avoid workflow YAML creation/modification.
+- **Verbose logs:** Add `--verbose` to surface masked auth headers and target branch detection.

--- a/scripts/ops/codex_repo_admin_bootstrap.py
+++ b/scripts/ops/codex_repo_admin_bootstrap.py
@@ -1,188 +1,204 @@
 #!/usr/bin/env python3
-"""
-codex_repo_admin_bootstrap.py
-
-Purpose:
-  Bootstrap a repository to sane defaults:
-    - Create/update standard labels from JSON
-    - Ensure CODEOWNERS exists/updated (via Contents API)
-    - Harden default branch protection (reviews, code-owner reviews, status checks, conversation resolution)
-    - Enable repo security features via PATCH /repos (secret scanning, push protection, dependabot updates)
-
-Defaults to DRY-RUN to avoid accidental network calls. Explicit --apply required.
-
-Environment (strongly recommended):
-  CODEX_NET_MODE=online_allowlist
-  CODEX_ALLOWLIST_HOSTS=api.github.com
-  GITHUB_APP_INSTALLATION_TOKEN=<short-lived token>  # or GITHUB_TOKEN (PAT fine-grained)
-  GITHUB_API_BASE=https://api.github.com
-
-Docs:
-  - Update a repository (security_and_analysis toggles)
-  - Create/Update file contents (CODEOWNERS)
-  - Branch protection update (require code owner reviews, conversation resolution)
-  - Labels API (create/update)
-"""
+"""Harden a GitHub repository without touching workflows."""
 
 from __future__ import annotations
+
 import argparse
 import base64
+import importlib.util
 import json
 import os
 import sys
-from functools import lru_cache
+import types
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+from urllib.parse import quote as _url_quote
 
-API = os.getenv("GITHUB_API_BASE", "https://api.github.com").rstrip("/")
+from src.integrations.github_app_auth import assert_online_allowlisted, build_auth_header_from_env
 
+_requests_spec = importlib.util.find_spec("requests")
+if _requests_spec is None:
 
-@lru_cache(maxsize=1)
-def _requests():
-    import requests  # type: ignore
-
-    return requests
-
-
-def _auth_headers() -> Dict[str, str]:
-    token = os.getenv("GITHUB_APP_INSTALLATION_TOKEN") or os.getenv("GITHUB_TOKEN")
-    if not token:
-        raise SystemExit("Provide GITHUB_APP_INSTALLATION_TOKEN or GITHUB_TOKEN")
-    return {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-
-
-def _allowlisted() -> None:
-    mode = os.getenv("CODEX_NET_MODE", "offline")
-    allow = {h.strip() for h in os.getenv("CODEX_ALLOWLIST_HOSTS", "").split(",") if h.strip()}
-    if mode != "online_allowlist" or "api.github.com" not in allow:
-        raise SystemExit(
-            "Online mode not permitted (set CODEX_NET_MODE=online_allowlist and add api.github.com to CODEX_ALLOWLIST_HOSTS)."
+    def _missing(*args, **kwargs):  # type: ignore[unused-arg]
+        raise RuntimeError(
+            "requests library not available; install requests to enable network calls"
         )
 
-
-def _req(method: str, url: str, *, json_body: Any | None = None):
-    requests = _requests()
-    r = requests.request(method, url, headers=_auth_headers(), json=json_body, timeout=20)
-    if r.status_code >= 400:
-        raise SystemExit(f"{method} {url} failed: {r.status_code} {r.text}")
-    return r
-
-
-# -------------------------
-# Labels
-# -------------------------
-
-
-def plan_labels(
-    owner: str, repo: str, labels: List[Dict[str, Any]]
-) -> List[Tuple[str, Dict[str, Any]]]:
-    """Return a list of ('create'|'update', payload) operations. When applied, POST/PATCH label endpoints are used."""
-    ops: List[Tuple[str, Dict[str, Any]]] = []
-    for lb in labels:
-        name = lb["name"]
-        payload = {
-            "name": name,
-            "color": lb.get("color", "ededed").lstrip("#"),
-            "description": lb.get("description", ""),
-        }
-        # In 'apply' we will check existence and swap endpoint to PATCH as needed.
-        ops.append(("upsert", payload))
-    return ops
+    requests = types.SimpleNamespace(  # type: ignore[assignment]
+        request=_missing,
+        post=_missing,
+        get=_missing,
+        put=_missing,
+        patch=_missing,
+        Session=lambda: types.SimpleNamespace(request=_missing, close=lambda: None),
+        utils=types.SimpleNamespace(quote=_url_quote),
+    )
+else:  # pragma: no cover - exercised in integration
+    import requests  # type: ignore
 
 
-def apply_labels(owner: str, repo: str, labels: List[Dict[str, Any]]) -> None:
-    # list existing labels (best-effort); fallback to creating all
-    existing = {}
-    try:
-        r = _req("GET", f"{API}/repos/{owner}/{repo}/labels")
-        for item in r.json():
-            existing[item["name"].lower()] = item
-    except SystemExit:
-        existing = {}
-    for lb in labels:
-        name = lb["name"]
-        payload = {
-            "name": name,
-            "color": lb.get("color", "ededed").lstrip("#"),
-            "description": lb.get("description", ""),
-        }
-        if name.lower() in existing:
-            requests = _requests()
-            _req(
-                "PATCH",
-                f"{API}/repos/{owner}/{repo}/labels/{requests.utils.quote(name, safe='')}",
-                json_body={"new_name": name, **payload},
+API_VERSION = os.getenv("GITHUB_API_VERSION", "2022-11-28")
+DEFAULT_API_BASE = os.getenv("GITHUB_API_BASE", "https://api.github.com")
+USER_AGENT = "codex-ops-repo-admin-bootstrap/2.0"
+
+
+def _mask(secret: str, keep: int = 4) -> str:
+    if not secret:
+        return "<empty>"
+    s = secret.strip()
+    if len(s) <= keep:
+        return "*" * len(s)
+    return f"{'*' * (len(s) - keep)}{s[-keep:]}"
+
+
+@dataclass
+class GitHubSession:
+    """Small wrapper around :mod:`requests` with default headers."""
+
+    auth_header: str
+    api_base: str = DEFAULT_API_BASE
+
+    def __post_init__(self) -> None:
+        if not self.auth_header:
+            raise ValueError("auth_header is required")
+        if not self.auth_header.lower().startswith(("token ", "bearer ", "basic ")):
+            self.auth_header = f"token {self.auth_header}"
+        session_factory = getattr(requests, "Session", None)
+        self._session = session_factory() if callable(session_factory) else None
+
+    def __enter__(self) -> "GitHubSession":  # pragma: no cover - trivial
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
+        self.close()
+
+    def close(self) -> None:
+        if self._session and hasattr(self._session, "close"):
+            self._session.close()
+
+    # Methods that tests can patch
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, object] | None = None,
+        json_body: Mapping[str, object] | None = None,
+        data: object | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: float = 15,
+    ):
+        url = self._url(path)
+        hdrs = self._headers(headers)
+        if self._session is not None:
+            return self._session.request(
+                method,
+                url,
+                params=params,
+                json=json_body,
+                data=data,
+                headers=hdrs,
+                timeout=timeout,
             )
-        else:
-            _req("POST", f"{API}/repos/{owner}/{repo}/labels", json_body=payload)
+        return requests.request(
+            method,
+            url,
+            params=params,
+            json=json_body,
+            data=data,
+            headers=hdrs,
+            timeout=timeout,
+        )
+
+    def _headers(self, extra: Mapping[str, str] | None = None) -> Mapping[str, str]:
+        base = {
+            "Authorization": self.auth_header,
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": API_VERSION,
+            "User-Agent": USER_AGENT,
+        }
+        if extra:
+            merged = dict(base)
+            merged.update(extra)
+            return merged
+        return base
+
+    def _url(self, path: str) -> str:
+        if path.startswith("http://") or path.startswith("https://"):
+            return path
+        return f"{self.api_base.rstrip('/')}/{path.lstrip('/')}"
+
+    def get(self, path: str, *, params: Mapping[str, object] | None = None, timeout: float = 15):
+        return self._request("GET", path, params=params, timeout=timeout)
+
+    def put(
+        self,
+        path: str,
+        *,
+        json: Mapping[str, object] | None = None,
+        data: object | None = None,
+        timeout: float = 15,
+    ):
+        return self._request("PUT", path, json_body=json, data=data, timeout=timeout)
+
+    def post(
+        self,
+        path: str,
+        *,
+        json: Mapping[str, object] | None = None,
+        data: object | None = None,
+        timeout: float = 15,
+    ):
+        return self._request("POST", path, json_body=json, data=data, timeout=timeout)
+
+    def patch(
+        self,
+        path: str,
+        *,
+        json: Mapping[str, object] | None = None,
+        data: object | None = None,
+        timeout: float = 15,
+    ):
+        return self._request("PATCH", path, json_body=json, data=data, timeout=timeout)
 
 
-# -------------------------
-# CODEOWNERS
-# -------------------------
-
-
-def upsert_codeowners(owner: str, repo: str, branch: str, content: str, message: str) -> None:
-    """PUT contents API to .github/CODEOWNERS on default branch."""
-    path = ".github/CODEOWNERS"
-    # fetch current sha (if exists)
-    sha = None
-    url = f"{API}/repos/{owner}/{repo}/contents/{path}"
-    requests = _requests()
-    r = requests.get(url, headers=_auth_headers(), timeout=20, params={"ref": branch})
-    if r.status_code == 200:
-        sha = r.json().get("sha")
-    elif r.status_code != 404:
-        raise SystemExit(f"GET {url} failed: {r.status_code} {r.text}")
-    body = {
-        "message": message,
-        "content": base64.b64encode(content.encode("utf-8")).decode("ascii"),
-        "branch": branch,
-    }
-    if sha:
-        body["sha"] = sha
-    _req("PUT", url, json_body=body)
-
-
-# -------------------------
-# Repo settings + security
-# -------------------------
-
-
-def patch_repo_settings(owner: str, repo: str) -> None:
-    payload = {
-        "allow_squash_merge": True,
-        "allow_merge_commit": False,
-        "allow_rebase_merge": False,
-        "allow_auto_merge": True,
+def _default_repo_settings(preset: str = "default") -> Dict[str, object]:
+    squash_only = True if preset in {"default", "strict"} else True
+    allow_auto_merge = True if preset == "default" else False
+    return {
+        "allow_squash_merge": squash_only,
+        "allow_merge_commit": not squash_only and preset != "strict",
+        "allow_rebase_merge": False if preset != "relaxed" else True,
         "delete_branch_on_merge": True,
-        # security_and_analysis toggles (Advanced Security features / push protection)
+        "allow_auto_merge": allow_auto_merge,
+        "squash_merge_commit_message": "PR_BODY",
+        "squash_merge_commit_title": "PR_TITLE",
+        # Best-effort features (eligible plans only)
         "security_and_analysis": {
+            "advanced_security": {"status": "enabled"},
             "secret_scanning": {"status": "enabled"},
             "secret_scanning_push_protection": {"status": "enabled"},
-            "dependabot_security_updates": {"status": "enabled"},
         },
     }
-    _req("PATCH", f"{API}/repos/{owner}/{repo}", json_body=payload)
 
 
-# -------------------------
-# Branch protection
-# -------------------------
-
-
-def put_branch_protection(owner: str, repo: str, branch: str, checks: List[str]) -> None:
-    payload = {
-        "required_status_checks": {"strict": True, "contexts": checks},
+def _branch_protection_template(
+    branch: str,
+    required_approvals: int,
+    status_checks: Sequence[str],
+) -> Dict[str, object]:
+    return {
+        "branch": branch,
+        "required_status_checks": {
+            "strict": True,
+            "contexts": list(status_checks),
+        },
         "enforce_admins": True,
         "required_pull_request_reviews": {
             "dismiss_stale_reviews": True,
             "require_code_owner_reviews": True,
-            "required_approving_review_count": 2,
+            "required_approving_review_count": max(required_approvals, 0),
             "require_last_push_approval": True,
         },
         "restrictions": None,
@@ -194,80 +210,325 @@ def put_branch_protection(owner: str, repo: str, branch: str, checks: List[str])
         "lock_branch": False,
         "allow_fork_syncing": False,
     }
-    _req("PUT", f"{API}/repos/{owner}/{repo}/branches/{branch}/protection", json_body=payload)
 
 
-# -------------------------
-# CLI
-# -------------------------
+def plan_labels(
+    owner: str, repo: str, labels: Sequence[Mapping[str, Any]]
+) -> List[Tuple[str, Dict[str, Any]]]:
+    ops: List[Tuple[str, Dict[str, Any]]] = []
+    for label in labels:
+        name = label["name"]
+        payload = {
+            "name": name,
+            "color": label.get("color", "ededed").lstrip("#"),
+            "description": label.get("description", ""),
+        }
+        ops.append(("upsert", payload))
+    return ops
 
 
-def main(argv: Optional[List[str]] = None) -> int:
-    p = argparse.ArgumentParser(
-        description="Bootstrap a repository to sane defaults (dry-run by default)."
+def apply_repo_settings(
+    session: GitHubSession, owner: str, repo: str, payload: Mapping[str, Any]
+) -> None:
+    resp = session.patch(f"/repos/{owner}/{repo}", json=payload)
+    if resp.status_code // 100 != 2:
+        if resp.status_code in (403, 404):
+            raise SystemExit(f"Repo settings update forbidden: {resp.status_code} {resp.text}")
+        raise SystemExit(f"Repo settings update failed: {resp.status_code} {resp.text}")
+
+
+def enable_vulnerability_alerts(session: GitHubSession, owner: str, repo: str) -> str:
+    resp = session.put(f"/repos/{owner}/{repo}/vulnerability-alerts")
+    if resp.status_code in (204, 202):
+        return "enabled"
+    if resp.status_code in (403, 404):
+        return "skipped"
+    raise SystemExit(f"Enable vulnerability-alerts failed: {resp.status_code} {resp.text}")
+
+
+def set_automated_security_fixes(
+    session: GitHubSession, owner: str, repo: str, enable: bool
+) -> str:
+    path = f"/repos/{owner}/{repo}/automated-security-fixes"
+    resp = session.put(path) if enable else session._request("DELETE", path)
+    if resp.status_code in (204, 202):
+        return "enabled" if enable else "disabled"
+    if resp.status_code in (403, 404):
+        return "skipped"
+    raise SystemExit(
+        f"{'Enable' if enable else 'Disable'} automated-security-fixes failed: {resp.status_code} {resp.text}"
     )
-    p.add_argument("--owner", required=True)
-    p.add_argument("--repo", required=True)
-    p.add_argument("--default-branch", default="main")
-    p.add_argument("--labels-json", type=Path, help="Path to labels.json (optional)")
-    p.add_argument("--codeowners", type=Path, help="Path to CODEOWNERS template (optional)")
-    p.add_argument(
+
+
+def get_default_branch(session: GitHubSession, owner: str, repo: str) -> str:
+    resp = session.get(f"/repos/{owner}/{repo}")
+    if resp.status_code != 200:
+        alt = session._request("GET", f"/repos/{owner}")
+        if alt.status_code == 200:
+            resp = alt
+        else:
+            raise SystemExit(f"Get repository failed: {resp.status_code} {resp.text}")
+    data = resp.json()
+    return data.get("default_branch") or "main"
+
+
+def apply_branch_protection(
+    session: GitHubSession,
+    owner: str,
+    repo: str,
+    branch: str,
+    config: Mapping[str, Any],
+) -> None:
+    payload = dict(config)
+    payload.pop("branch", None)
+    resp = session.put(f"/repos/{owner}/{repo}/branches/{branch}/protection", json=payload)
+    if resp.status_code // 100 != 2:
+        raise SystemExit(f"Branch protection failed: {resp.status_code} {resp.text}")
+
+
+def _list_labels(
+    session: GitHubSession, owner: str, repo: str
+) -> MutableMapping[str, Mapping[str, Any]]:
+    resp = session.get(f"/repos/{owner}/{repo}/labels")
+    if resp.status_code == 200:
+        return {item["name"].lower(): item for item in resp.json()}
+    if resp.status_code // 100 == 2:
+        return {}
+    if resp.status_code in (403, 404):
+        return {}
+    raise SystemExit(f"List labels failed: {resp.status_code} {resp.text}")
+
+
+def ensure_labels(
+    session: GitHubSession,
+    owner: str,
+    repo: str,
+    labels: Sequence[Mapping[str, Any]],
+) -> List[Mapping[str, object]]:
+    existing = _list_labels(session, owner, repo)
+    results: List[Mapping[str, object]] = []
+    for label in labels:
+        name = label["name"]
+        payload = {
+            "name": name,
+            "color": label.get("color", "ededed").lstrip("#"),
+            "description": label.get("description", ""),
+        }
+        if name.lower() in existing:
+            resp = session.patch(
+                f"/repos/{owner}/{repo}/labels/{_url_quote(name, safe='')}",
+                json={"new_name": name, **payload},
+            )
+            if resp.status_code // 100 != 2:
+                raise SystemExit(f"Update label {name} failed: {resp.status_code} {resp.text}")
+            results.append({"name": name, "status": "updated"})
+        else:
+            resp = session.post(f"/repos/{owner}/{repo}/labels", json=payload)
+            if resp.status_code // 100 != 2:
+                raise SystemExit(f"Create label {name} failed: {resp.status_code} {resp.text}")
+            results.append({"name": name, "status": "created"})
+    return results
+
+
+def ensure_files(
+    session: GitHubSession,
+    owner: str,
+    repo: str,
+    files: Sequence[Mapping[str, Any]],
+    *,
+    branch: str,
+    author: str,
+) -> List[Mapping[str, object]]:
+    results: List[Mapping[str, object]] = []
+    for file in files:
+        path = file["path"]
+        message = file.get("message", f"chore: ensure {path} present")
+        content = file["content"]
+        url = f"/repos/{owner}/{repo}/contents/{path}"
+        resp = session.get(url, params={"ref": branch})
+        sha: Optional[str]
+        if resp.status_code == 200:
+            sha = resp.json().get("sha")
+        elif resp.status_code == 404:
+            sha = None
+        else:
+            raise SystemExit(f"Fetch contents {path} failed: {resp.status_code} {resp.text}")
+        body: Dict[str, Any] = {
+            "message": message,
+            "content": base64.b64encode(content.encode("utf-8")).decode("ascii"),
+            "branch": branch,
+            "committer": {"name": author, "email": "ops@codex.local"},
+        }
+        if sha:
+            body["sha"] = sha
+        resp = session.put(url, json=body)
+        if resp.status_code not in (200, 201):
+            raise SystemExit(f"Upsert contents {path} failed: {resp.status_code} {resp.text}")
+        results.append({"path": path, "status": "updated" if sha else "created"})
+    return results
+
+
+def _load_labels(path: Optional[Path]) -> List[Mapping[str, Any]]:
+    if path and path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return []
+
+
+def _load_codeowners(path: Optional[Path]) -> List[Mapping[str, Any]]:
+    if path and path.exists():
+        return [
+            {
+                "path": ".github/CODEOWNERS",
+                "message": "chore: ensure CODEOWNERS present",
+                "content": path.read_text(encoding="utf-8"),
+            }
+        ]
+    return []
+
+
+def _build_plan(args: argparse.Namespace) -> Dict[str, Any]:
+    branch = args.branch or "main"
+    labels = _load_labels(args.labels_json)
+    files = _load_codeowners(args.codeowners)
+    plan: Dict[str, Any] = {
+        "target": {"owner": args.owner, "repo": args.repo, "branch": branch},
+        "preset": args.preset,
+        "repo_settings": _default_repo_settings(args.preset),
+        "branch_protection": _branch_protection_template(
+            branch, args.required_approvals, args.status_check
+        ),
+        "labels": labels,
+        "files": files,
+    }
+    return plan
+
+
+def _assert_online_allowed() -> None:
+    assert_online_allowlisted()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Standardize GitHub repo settings (no workflows). Dry-run by default."
+    )
+    parser.add_argument("--owner", required=True, help="Repository owner/org")
+    parser.add_argument("--repo", required=True, help="Repository name")
+    parser.add_argument("--branch", help="Protected branch (if omitted, detect from repo default)")
+    parser.add_argument(
+        "--detect-default-branch",
+        action="store_true",
+        help="Auto-detect default branch via REST API",
+    )
+    parser.add_argument(
+        "--preset",
+        default="default",
+        choices=["default", "strict", "relaxed"],
+        help="Policy preset toggling merge behavior and auto-merge",
+    )
+    parser.add_argument(
+        "--required-approvals",
+        type=int,
+        default=1,
+        help="Required PR approvals (branch protection)",
+    )
+    parser.add_argument(
         "--status-check",
         action="append",
         default=[],
         help="Required status check context (repeatable)",
     )
-    p.add_argument(
-        "--apply", action="store_true", help="Execute calls (network). Default is dry-run."
+    parser.add_argument(
+        "--labels-json",
+        type=Path,
+        help="Path to labels.json (optional)",
     )
-    args = p.parse_args(argv)
+    parser.add_argument(
+        "--codeowners",
+        type=Path,
+        help="Path to CODEOWNERS template (optional)",
+    )
+    parser.add_argument(
+        "--author",
+        default="Codex Admin Bot",
+        help="Commit author for hygiene files",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Execute changes (omit to print plan only)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Verbose logs (masked token tails + status)",
+    )
+    parser.add_argument(
+        "--dependabot-updates",
+        action="store_true",
+        help="Enable Dependabot security updates (best-effort)",
+    )
+    return parser
 
-    # Always require allowlist when applying
-    if args.apply:
-        _allowlisted()
 
-    plan = {
-        "owner": args.owner,
-        "repo": args.repo,
-        "default_branch": args.default_branch,
-        "ops": [],
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    plan = _build_plan(args)
+    if not args.apply:
+        print(json.dumps({"dry_run": True, "plan": plan}, indent=2, ensure_ascii=False))
+        return 0
+
+    _assert_online_allowed()
+    auth_header = build_auth_header_from_env()
+    if args.verbose:
+        print(f"[auth] Using header: {_mask(auth_header)}", file=sys.stderr)
+
+    with GitHubSession(auth_header=auth_header) as gh:
+        branch = args.branch
+        if args.detect_default_branch and not branch:
+            branch = get_default_branch(gh, args.owner, args.repo)
+        branch = branch or plan["target"]["branch"]
+        plan["target"]["branch"] = branch
+        plan["branch_protection"]["branch"] = branch
+        if args.verbose:
+            print(f"[info] target branch: {branch}", file=sys.stderr)
+
+        apply_repo_settings(gh, args.owner, args.repo, plan["repo_settings"])
+
+        va_state = enable_vulnerability_alerts(gh, args.owner, args.repo)
+        dep_state = "skipped"
+        if args.dependabot_updates:
+            dep_state = set_automated_security_fixes(gh, args.owner, args.repo, enable=True)
+
+        apply_branch_protection(
+            gh,
+            args.owner,
+            args.repo,
+            branch,
+            plan["branch_protection"],
+        )
+
+        labels_result = ensure_labels(gh, args.owner, args.repo, plan["labels"])
+        files_result = ensure_files(
+            gh,
+            args.owner,
+            args.repo,
+            plan["files"],
+            branch=branch,
+            author=args.author,
+        )
+
+    result = {
+        "applied": True,
+        "vulnerability_alerts": va_state,
+        "dependabot_security_updates": dep_state,
+        "labels": labels_result,
+        "files": files_result,
     }
-
-    if args.labels_json and args.labels_json.exists():
-        labels = json.loads(args.labels_json.read_text(encoding="utf-8"))
-        plan["ops"].append({"labels": labels})
-        if args.apply:
-            apply_labels(args.owner, args.repo, labels)
-
-    if args.codeowners and args.codeowners.exists():
-        content = args.codeowners.read_text(encoding="utf-8")
-        plan["ops"].append({"codeowners": ".github/CODEOWNERS"})
-        if args.apply:
-            upsert_codeowners(
-                args.owner,
-                args.repo,
-                args.default_branch,
-                content,
-                "chore: ensure CODEOWNERS present",
-            )
-
-    # Repo settings + security
-    plan["ops"].append({"repo_settings": True, "security_and_analysis": True})
-    if args.apply:
-        patch_repo_settings(args.owner, args.repo)
-
-    # Branch protection
-    plan["ops"].append(
-        {"branch_protection": {"branch": args.default_branch, "checks": args.status_check}}
-    )
-    if args.apply:
-        put_branch_protection(args.owner, args.repo, args.default_branch, args.status_check)
-
-    print(json.dumps({"ok": True, "dry_run": not args.apply, "plan": plan}, indent=2))
+    print(json.dumps(result, indent=2, ensure_ascii=False))
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI
     try:
         sys.exit(main())
     except KeyboardInterrupt:

--- a/src/integrations/github_app_auth.py
+++ b/src/integrations/github_app_auth.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import os
+import re
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+API_VERSION = os.getenv("GITHUB_API_VERSION", "2022-11-28")
+DEFAULT_API_BASE = os.getenv("GITHUB_API_BASE", "https://api.github.com")
+
+
+def _host_from_base(base: str) -> str:
+    match = re.match(r"^https?://([^/]+)/?", base)
+    return match.group(1) if match else ""
+
+
+def assert_online_allowlisted() -> None:
+    mode = os.getenv("CODEX_NET_MODE", "offline")
+    allow = {h.strip() for h in os.getenv("CODEX_ALLOWLIST_HOSTS", "").split(",") if h.strip()}
+    host = _host_from_base(DEFAULT_API_BASE)
+    if mode != "online_allowlist" or host not in allow:
+        raise SystemExit(
+            "Online mode not permitted. "
+            "Set CODEX_NET_MODE=online_allowlist and include api.github.com (or your host) in CODEX_ALLOWLIST_HOSTS."
+        )
+
+
+def _read_app_private_key() -> str:
+    pem_inline = os.getenv("GITHUB_APP_PRIVATE_KEY_PEM")
+    if pem_inline:
+        return pem_inline.replace("\\n", "\n")
+    pem_path = os.getenv("GITHUB_APP_PRIVATE_KEY_PATH")
+    if pem_path and Path(pem_path).exists():
+        return Path(pem_path).read_text(encoding="utf-8")
+    raise SystemExit(
+        "Missing app private key (GITHUB_APP_PRIVATE_KEY_PEM or GITHUB_APP_PRIVATE_KEY_PATH)."
+    )
+
+
+def mint_app_jwt(app_id: str | int, ttl: int = 540) -> str:
+    import jwt  # type: ignore
+
+    now = int(time.time())
+    payload = {"iat": now - 60, "exp": now + ttl, "iss": str(app_id)}
+    token = jwt.encode(payload, _read_app_private_key(), algorithm="RS256")
+    return token if isinstance(token, str) else token.decode("utf-8")
+
+
+def exchange_installation_token(
+    app_jwt: str, installation_id: str | int
+) -> Tuple[str, Optional[str]]:
+    import requests
+
+    url = f"{DEFAULT_API_BASE}/app/installations/{installation_id}/access_tokens"
+    headers = {
+        "Authorization": f"Bearer {app_jwt}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": API_VERSION,
+    }
+    response = requests.post(url, headers=headers, timeout=15)
+    if response.status_code != 201:
+        raise SystemExit(
+            f"Installation token exchange failed: {response.status_code} {response.text}"
+        )
+    data = response.json()
+    return data["token"], data.get("expires_at")
+
+
+def build_auth_header_from_env() -> str:
+    """Prefer GitHub App flow when available; fall back to GITHUB_TOKEN."""
+
+    app_id = os.getenv("GITHUB_APP_ID")
+    inst_id = os.getenv("GITHUB_APP_INSTALLATION_ID")
+    pat = os.getenv("GITHUB_TOKEN")
+    if app_id and inst_id:
+        assert_online_allowlisted()
+        jwt_token = mint_app_jwt(app_id)
+        inst_token, _ = exchange_installation_token(jwt_token, inst_id)
+        return f"token {inst_token}"
+    if pat:
+        assert_online_allowlisted()
+        return f"token {pat}"
+    raise SystemExit(
+        "No auth: set App creds (GITHUB_APP_ID + GITHUB_APP_INSTALLATION_ID + key) or GITHUB_TOKEN."
+    )

--- a/tests/ops/test_repo_admin_bootstrap_v2.py
+++ b/tests/ops/test_repo_admin_bootstrap_v2.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from importlib import import_module
+
+
+def _m():
+    return import_module("scripts.ops.codex_repo_admin_bootstrap")
+
+
+def test_dry_run_shape_and_flags(capsys):
+    m = _m()
+    rc = m.main(["--owner", "o", "--repo", "r"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["dry_run"] is True
+    plan = out["plan"]
+    assert plan["target"]["owner"] == "o"
+    assert plan["target"]["repo"] == "r"
+    assert isinstance(plan["repo_settings"], dict)
+    assert isinstance(plan["branch_protection"], dict)
+    assert isinstance(plan["labels"], list)
+
+
+def test_detect_default_branch_in_apply_mode(monkeypatch):
+    m = _m()
+
+    class FakeResp:
+        def __init__(self, status, json_data=None):
+            self.status_code = status
+            self._json = json_data or {}
+            self.text = json.dumps(self._json)
+
+        def json(self):
+            return self._json
+
+    calls = {"get_repo": 0}
+
+    def fake_request(self, method, path, **kwargs):
+        if method == "GET" and path.startswith("/repos/") and path.count("/") == 2:
+            calls["get_repo"] += 1
+            return FakeResp(200, {"default_branch": "trunk"})
+        return FakeResp(202, {})
+
+    import scripts.ops.codex_repo_admin_bootstrap as mod
+
+    monkeypatch.setenv("CODEX_NET_MODE", "online_allowlist")
+    monkeypatch.setenv("CODEX_ALLOWLIST_HOSTS", "api.github.com")
+    monkeypatch.setenv("GITHUB_TOKEN", "x" * 40)
+
+    mod.GitHubSession._request = fake_request  # type: ignore[method-assign]
+
+    rc = m.main(["--owner", "o", "--repo", "r", "--apply", "--detect-default-branch"])
+    assert rc == 0
+    assert calls["get_repo"] == 1


### PR DESCRIPTION
## Summary
- add reusable GitHub App authentication helpers that enforce the allowlist guard and mint installation tokens on demand
- refactor the repo admin bootstrap script for PAT fallback, default-branch detection, Dependabot security updates, and safer API session handling
- document the new flow, add focused tests, and expose make targets/README quickstart for the bootstrap tooling

## Testing
- `ruff check && ruff format --check` *(fails: pre-existing lint issues in unrelated files)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ops/test_repo_admin_bootstrap_v2.py`
- `python -m py_compile scripts/ops/codex_repo_admin_bootstrap.py src/integrations/github_app_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_68e7c9ee8b888331a0e5bb5d43c00390