### PR TITLE
Add 0D_base_ audit report and runbook

### DIFF
--- a/docs/how-to/run_audit_0D_base_.md
+++ b/docs/how-to/run_audit_0D_base_.md
@@ -1,0 +1,42 @@
+# [How-to]: Run the Deterministic Audit on 0D_base_
+> Generated: 2025-10-10 01:27:43 UTC | Author: mbaetiong
+Roles: [Audit Orchestrator], [Capability Cartographer]  Energy: 5
+
+Purpose
+- Produce canonical, hash-stamped maturity artifacts (S1–S7) for branch 0D_base_.
+
+Prereqs
+- Python 3.10+ environment; install pyyaml and jinja2 for rendering:
+  - pip install pyyaml jinja2
+
+Commands
+- Full pipeline (S1–S7)
+  - python scripts/space_traversal/audit_runner.py run
+- Fast path (S1, S3, S4, S6)
+  - make space-audit-fast
+- Explain a capability’s score
+  - python scripts/space_traversal/audit_runner.py explain checkpointing
+- Diff two runs
+  - python scripts/space_traversal/audit_runner.py diff --old <old.json|md> --new <new.json|md>
+
+Outputs (deterministic)
+- audit_artifacts/context_index.json (S1)
+- audit_artifacts/facets.json (S2)
+- audit_artifacts/capabilities_raw.json (S3)
+- audit_artifacts/capabilities_scored.json (S4)
+- audit_artifacts/gaps.json (S5)
+- reports/capability_matrix_<timestamp>.md (S6)
+- audit_run_manifest.json (S7)
+
+Determinism guard
+- Run twice unchanged; expect identical repo_root_sha and identical capabilities_scored.json (ignoring timestamp fields). On mismatch, audit detectors for ordering or file filters.
+
+Quality gates (optional)
+- Configure low threshold and regression delta in .copilot-space/workflow.yaml.
+- Use “diff” exit codes to fail builds on score regression if enabled.
+
+Notes
+- The pipeline is offline-first; no network calls are made.
+- Template_hash is embedded in the matrix for tamper detection.
+
+*End of Runbook*

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,3 +9,4 @@
 - [How-to: Admin Bootstrap](how-to/admin_bootstrap.md)
 - [How-to: Bootstrap Self‑Hosted Runner](how-to/bootstrap_runner.md)
 - [Ops: Rulesets vs Protection](ops/repo_rulesets_vs_protection.md)
+- [How-to: Run Audit on 0D_base_](how-to/run_audit_0D_base_.md)

--- a/reports/_codex_status_update-0D_base_-2025-10-10.md
+++ b/reports/_codex_status_update-0D_base_-2025-10-10.md
@@ -1,0 +1,110 @@
+# [Audit]: _codex_ Status Update — Branch 0D_base_
+> Generated: 2025-10-10 01:27:43 UTC | Author: mbaetiong
+Roles: [Audit Orchestrator], [Capability Cartographer]  Energy: 5
+
+Note on scope and provenance
+- Repository: Aries-Serpent/_codex_
+- Focus branch: 0D_base_ (latest baseline in the series)
+- Method: deterministic, offline-first review leveraging existing repo structure and prior audit artifacts; canonical, hash-stamped outputs should be generated locally via the S1–S7 pipeline (see runbook).
+
+## 1) Repo Map (high-level)
+Top-level directories (representative, not exhaustive)
+- .codex, .github, LICENSES, _codex, agents, analysis, archive, artifacts, codex_addons, codex_digest
+- codex_ml, codex_utils, conf, configs, copilot, data, db, deploy, docs, documentation, examples, experiments
+- hydra, interfaces, logs, mcp, monitoring, notebooks, nox_sessions, omegaconf, ops, patches, reports, requirements
+- schemas, scripts, semgrep_rules, services, src, temp, tests, tokenization, tools, torch, training, typer, yaml
+
+Key files (span)
+- pyproject.toml, noxfile.py, pytest.ini, requirements.lock, uv.lock, Dockerfile, README.md
+- scripts/space_traversal/audit_runner.py (S1–S7 audit pipeline; offline)
+- templates/audit/capability_matrix.md.j2 (matrix renderer)
+- schemas/metrics-ndjson-v0.3.json (metrics schema; JSON Schema 2020-12)
+
+New or reinforced primitives (since earlier baselines)
+- src/codex_ml/utils/atomic_io.py (tmpfile→fsync→os.replace)
+- src/codex_ml/utils/checkpoint_core.py (metadata + sha256 + best‑k index)
+- src/codex_utils/tracking/guards.py (MLflow file://, WANDB offline)
+- src/data/manifest.py (per-shard sha256)
+- src/tokenization/api.py (migration shim, DeprecationWarning)
+- src/tools/codeowners_validate.py (offline CODEOWNERS validator)
+- src/integrations/github_app_auth.py; scripts/ops/bootstrap_self_hosted_runner.py (opt‑in Admin bootstrap)
+
+## 2) Capability Audit Table (summary snapshot)
+| Capability | Status | Evidence (examples) | Gaps |
+|---|---|---|---|
+| Checkpointing & Resume | Hardened | src/codex_ml/utils/checkpoint_core.py; tests/training/test_checkpoint_integrity.py | Windows fsync semantics unverified; extend GPU RNG restore tests when GPU present |
+| Logging & Tracking (offline-first) | Implemented | src/codex_utils/tracking/guards.py; docs/how-to/offline_tracking.md | Add guard unit for remote allowlist regression |
+| Data Handling & Manifests | Implemented | src/data/manifest.py; tests/data/test_shard_integrity.py | Optional repair hooks (mirror) deferred |
+| Tokenization (migration) | Implemented | src/tokenization/api.py; tests/tokenization/test_deprecation.py | Document deprecation timeline in README |
+| Evaluation & Metrics | Implemented | schemas/metrics-ndjson-v0.3.json; tests/specs/test_metrics_schema.py | Expand streaming summary examples in docs |
+| Internal CI/Test (local) | Implemented | pytest.ini; noxfile.py; tests/specs/* | Tag a fast subset marker for laptops |
+| Security & Safety (regex/SMT) | Implemented (spec-level) | tests/specs/test_regex_props.py; tools/smt/policy_constraints.smt2 | Optional: add secrets/entropy scan docs |
+| Admin Bootstrap (opt‑in) | Available | src/integrations/github_app_auth.py; scripts/ops/bootstrap_self_hosted_runner.py; docs/how-to/admin_bootstrap.md | Confirm org rulesets policy; add rulesets example JSON |
+
+Scoring note
+- To produce canonical scores, run the S1–S7 audit pipeline locally; this report mirrors status by inspection and added tests/docs.
+
+## 3) High-Signal Findings
+- Atomic IO and integrity: Checkpoints now embed sha256 and verify on load; writes are atomic with directory fsync to guard rename persistence.
+- Determinism: RNG snapshot/restore path captured (python/numpy/torch where available); added a CPU-only RNG restore smoke test.
+- Offline tracking: MLflow coerced to file:// store unless host allowlisted; W&B defaults to WANDB_MODE=offline; behavior covered by tests.
+- Dataset integrity: Per‑shard sha256 manifest enforced; rejects mismatches; pure-stdlib design.
+- Spec hardening: ReDoS-safe regex tests; JSON Schema for metrics; SMT policy constraints for network/admin gating (tests skip without z3).
+- Governance hygiene: Offline CODEOWNERS validator and how‑to; Admin bootstrap scripts and runbooks for GitHub App + runner token flows (opt‑in).
+
+## 4) Minimal Atomic Diffs (landed or queued)
+- Atomic IO helper (safe_write_bytes/text) to standardize durable writes.
+- Checkpoint core with metadata, best‑k retention (index.json), and checksum verification.
+- Tracking guards for MLflow/W&B with allowlist; docs and tests.
+- Dataset manifest build/verify; docs and tests.
+- Tokenizer migration shim with DeprecationWarning and tests.
+- CODEOWNERS validator tool and how‑to.
+- Admin bootstrap runner script and GitHub App auth helper; runbooks.
+
+Rollback notes
+- All changes are additive; remove new files or bypass via feature flags (e.g., not invoking guards) to revert to prior behavior.
+
+## 5) Local Tests & Gates (fast, offline)
+Recommended quick subset
+- pytest -q tests/training/test_checkpoint_integrity.py::test_roundtrip_and_integrity
+- pytest -q tests/training/test_checkpoint_integrity.py::test_best_k_retention
+- pytest -q tests/training/test_checkpoint_rng_restore.py
+- pytest -q tests/tracking/test_tracking_guards.py
+- pytest -q tests/data/test_shard_integrity.py
+- pytest -q tests/tokenization/test_deprecation.py
+- pytest -q tests/specs/test_cli_normalization.py
+- pytest -q tests/specs/test_regex_props.py
+
+Optional (if deps installed)
+- pytest -q tests/specs/test_metrics_schema.py  # needs jsonschema
+- pytest -q tests/specs/test_smt_policy.py      # needs z3-solver
+
+## 6) Reproducibility Checklist
+- Seeds & RNG: python/numpy/torch captured in checkpoint metadata; restore guard present.
+- Integrity: sha256 for checkpoints; per‑shard sha256 in dataset manifest; IO via atomic replace.
+- Offline policy: MLflow file:// enforced; WANDB offline by default; allowlist required for remote hosts.
+- Manifesting: audit pipeline S7 emits repo_root_sha and artifact hashes; template_hash baked into matrix render.
+- Docs: quick how‑tos for offline tracking, dataset manifest, checkpoint metadata, admin bootstrap, tokenizer migration.
+
+## 7) Deferred Items
+- Expand Windows filesystem coverage for fsync/replace edge cases.
+- Add GPU RNG resume coverage on CUDA hosts (skip on CPU CI).
+- Optional: introduce rulesets guidance with example payloads to complement classic branch protection.
+
+## 8) Error Capture Template
+```text
+Question for Codex (0D_base_) YYYY-MM-DDTHH:MM:SSZ:
+While performing [STEP_NUMBER:STEP_DESCRIPTION], encountered the following error:
+[ERROR_MESSAGE]
+Context: [BRIEF_CONTEXT]
+What are the possible causes, and how can this be resolved while preserving intended functionality?
+```
+
+## 9) Provenance & Next Steps
+- For canonical numbers, run the audit pipeline on 0D_base_:
+  - make space-audit     # full S1–S7
+  - make space-audit-fast # S1, S3, S4, S6
+- Commit artifacts: audit_artifacts/*.json, reports/capability_matrix_*.md, audit_run_manifest.json
+- Optional: use “diff” and “explain” commands to track maturity movements and justify deltas.
+
+*End of Status Update*


### PR DESCRIPTION
## Summary
- add a status update report for the 0D_base_ baseline in the reports catalog
- document how to execute the deterministic 0D_base_ audit pipeline and surface it from the docs index

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/specs/test_cli_normalization.py

------
https://chatgpt.com/codex/tasks/task_e_68e865b5ba0c83318e62c687f4f5115c