### PR TITLE
chore(audit): add workflow config and traversal docs

### DIFF
--- a/.copilot-space/workflow.yaml
+++ b/.copilot-space/workflow.yaml
@@ -1,0 +1,56 @@
+version: 1.1.0
+stages:
+  - id: index
+    script: scripts/space_traversal/audit_runner.py
+    entry: stage
+    args: ["S1"]
+  - id: facets
+    script: scripts/space_traversal/audit_runner.py
+    entry: stage
+    args: ["S2"]
+  - id: capabilities
+    script: scripts/space_traversal/audit_runner.py
+    entry: stage
+    args: ["S3"]
+  - id: scoring
+    script: scripts/space_traversal/audit_runner.py
+    entry: stage
+    args: ["S4"]
+  - id: gaps
+    script: scripts/space_traversal/audit_runner.py
+    entry: stage
+    args: ["S5"]
+  - id: render
+    script: scripts/space_traversal/audit_runner.py
+    entry: stage
+    args: ["S6"]
+  - id: manifest
+    script: scripts/space_traversal/audit_runner.py
+    entry: stage
+    args: ["S7"]
+
+weights:
+  functionality: 0.25
+  consistency: 0.20
+  tests: 0.25
+  safeguards: 0.15
+  documentation: 0.15
+
+scoring:
+  thresholds:
+    low: 0.70
+    medium: 0.85
+
+capability_map:
+  overrides:
+    training-engine: ["train_loop", "functional_training"]
+  dynamic: true
+
+output:
+  reports_dir: reports
+  artifacts_dir: audit_artifacts
+  matrix_template: templates/audit/capability_matrix.md.j2
+
+options:
+  fail_on_score_regression: true
+  regression_delta_threshold: 0.02

--- a/docs/Traversal_Workflow.md
+++ b/docs/Traversal_Workflow.md
@@ -1,0 +1,51 @@
+# [Doc]: Copilot Space Traversal Workflow (v1.1.0)
+> Generated: 2025-10-10 01:58:00 UTC | Author: mbaetiong
+Roles: [Knowledge Ops], [ML Platform Auditor]  Energy: 5
+
+## 1) Objective
+Codify a reproducible, explainable capability maturity assessment pipeline with deterministic outputs.
+
+## 2) Flow
+```text
+FILES → (S1 Index) → FACETS → (S2 Regex cluster) → CAPABILITIES_RAW
+→ (S3 Detectors) → CAPABILITIES_SCORED → (S4 Weights) → GAPS
+→ (S5 Threshold) → REPORT (S6 Jinja) → MANIFEST (S7 Integrity)
+```
+
+## 3) Score Formula
+score = Σ_i weight_i * clamp(component_i, 0..1) (weights normalized if Σ≠1)
+
+| Component | Computation |
+|-----------|-------------|
+| functionality | Hits / Required Patterns |
+| consistency | 1 − duplication_ratio(evidence_files) |
+| tests | (# test-linked files) / (# evidence files) |
+| safeguards | (# safeguard keywords with ≥1 hit) / total keywords |
+| documentation | doc token hits / scaled corpus |
+
+## 4) Safeguard Keywords
+sha256, checksum, rng, seed, offline, WANDB_MODE (see audit_runner.py)
+
+## 5) Determinism Guards
+- Sorted traversal, truncated safe reads (200KB)
+- Template fingerprint embedded (SHA of all .j2)
+- Manifest includes repo_root_sha and per-artifact SHA
+
+## 6) Detectors
+Place under scripts/space_traversal/detectors/*.py with:
+```python
+def detect(file_index: dict) -> dict:
+    return {"id":"new-cap","evidence_files":[],"found_patterns":[],"required_patterns":[],"meta":{}}
+```
+
+## 7) Diff / Explain
+```bash
+python scripts/space_traversal/audit_runner.py diff --old A --new B
+python scripts/space_traversal/audit_runner.py explain checkpointing
+```
+
+## 8) Policy Gates
+- Fail build if any score < low threshold
+- Optional regression fail via options in workflow.yaml
+
+*End of Workflow Doc*

--- a/docs/Usage_Guide.md
+++ b/docs/Usage_Guide.md
@@ -1,0 +1,41 @@
+# [Guide]: Copilot Space Audit Usage (v1.1.0)
+> Generated: 2025-10-10 01:58:00 UTC | Author: mbaetiong
+Roles: [Workflow Steward], [Reliability Analyst]  Energy: 5
+
+## Quick Run
+```bash
+python scripts/space_traversal/audit_runner.py run
+```
+
+## Single Stage
+```bash
+python scripts/space_traversal/audit_runner.py stage S4
+```
+
+## Explain Score
+```bash
+python scripts/space_traversal/audit_runner.py explain checkpointing
+```
+
+## Update Weights then Rerun S4–S7
+```bash
+python scripts/space_traversal/audit_runner.py stage S4
+python scripts/space_traversal/audit_runner.py stage S5
+python scripts/space_traversal/audit_runner.py stage S6
+python scripts/space_traversal/audit_runner.py stage S7
+```
+
+## CI (Optional)
+```bash
+python scripts/space_traversal/audit_runner.py run
+python scripts/space_traversal/audit_runner.py diff --old baseline/capabilities_scored.json --new audit_artifacts/capabilities_scored.json
+```
+
+## Red Flags & Mitigations
+| Symptom | Cause | Action |
+|---------|-------|--------|
+| Sudden score drop | Deleted/renamed evidence | Restore or adjust detectors |
+| Zero safeguards | Stale keyword set | Update SAFEGUARD_KEYWORDS |
+| High duplication penalty | Broad facet regex | Narrow patterns |
+
+*End of Guide*

--- a/docs/prompts/codex_run_prompt_0D_base_.md
+++ b/docs/prompts/codex_run_prompt_0D_base_.md
@@ -1,0 +1,33 @@
+@codex implement plan
+title: "Run 0D_base_ audit and commit artifacts"
+on_conflict: "prefer-upstream"
+steps:
+  - sh: |
+      # Offline-first environment
+      export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+      # Optional (non-fatal) tools for spec tests
+      pip -q install pyyaml jinja2 jsonschema z3-solver || true
+  - sh: |
+      # Full audit pipeline (S1–S7)
+      python scripts/space_traversal/audit_runner.py run
+  - sh: |
+      # Quick validation subset (offline)
+      pytest -q tests/specs/test_cli_normalization.py || true
+      pytest -q tests/specs/test_regex_props.py || true
+  - sh: |
+      # Stage outputs snapshot
+      ls -l audit_artifacts || true
+      test -f audit_run_manifest.json && jq '.repo_root_sha, .template_hash' audit_run_manifest.json || true
+  - commit: |
+      chore(audit): add audit artifacts & manifest (0D_base_)
+    add: |
+      audit_artifacts/context_index.json
+      audit_artifacts/facets.json
+      audit_artifacts/capabilities_raw.json
+      audit_artifacts/capabilities_scored.json
+      audit_artifacts/gaps.json
+      audit_run_manifest.json
+    message: |
+      chore(audit): add audit artifacts & manifest (0D_base_)
+      - Deterministic outputs (S1–S7)
+      - Include manifest chain (repo_root_sha, per-artifact SHA, template_hash)

--- a/scripts/space_traversal/capability_scoring.py
+++ b/scripts/space_traversal/capability_scoring.py
@@ -1,0 +1,53 @@
+"""
+Capability Scoring Utilities (v1.1.0)
+
+Provides:
+  - normalize_weights(weights) -> dict
+  - score_capability(components, weights) -> float
+  - explain_score(capability, weights) -> dict
+  - aggregate_scores(capabilities, weights) -> list (with contributions)
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def normalize_weights(weights: Dict[str, float]) -> Dict[str, float]:
+    total = float(sum(weights.values()))
+    if total <= 0:
+        raise ValueError("Weights must sum > 0")
+    return {k: v / total for k, v in weights.items()}
+
+
+def score_capability(components: Dict[str, float], weights: Dict[str, float]) -> float:
+    w = normalize_weights(weights)
+    return sum(max(0.0, min(1.0, components.get(k, 0.0))) * w[k] for k in w)
+
+
+def explain_score(capability: dict, weights: Dict[str, float]) -> dict:
+    components = capability.get("components", {})
+    w_norm = normalize_weights(weights)
+    partials = {}
+    for k in w_norm:
+        val = max(0.0, min(1.0, components.get(k, 0.0)))
+        partials[k] = {
+            "component_value": val,
+            "weight": w_norm[k],
+            "contribution": val * w_norm[k],
+        }
+    score = round(sum(v["contribution"] for v in partials.values()), 4)
+    return {
+        "id": capability.get("id"),
+        "score": score,
+        "partials": partials,
+    }
+
+
+def aggregate_scores(capabilities: List[dict], weights: Dict[str, float]) -> List[dict]:
+    w_norm = normalize_weights(weights)
+    enriched = []
+    for cap in capabilities:
+        explanation = explain_score(cap, w_norm)
+        enriched.append(explanation)
+    return enriched


### PR DESCRIPTION
## Summary
- add a Copilot Space workflow configuration covering the S1–S7 audit stages
- document the traversal workflow, usage guide, and operator run prompt for 0D_base_
- provide a reusable capability scoring helper for audit automation scripts

## Testing
- python -m compileall scripts/space_traversal/capability_scoring.py

------
https://chatgpt.com/codex/tasks/task_e_68e867ef067c83318d045053e3c6fcdf