### PR TITLE
Fix MLflow offline guard remote URI whitespace handling

### DIFF
--- a/src/codex_ml/tracking/guards.py
+++ b/src/codex_ml/tracking/guards.py
@@ -171,7 +171,10 @@ def decide_mlflow_tracking_uri(
     # Enforce offline
     if offline:
         # Remote -> rewrite to local
-        if mlflow_uri and _is_remote_uri(mlflow_uri):
+        normalized_for_remote_check = mlflow_uri_norm
+        if not normalized_for_remote_check and mlflow_uri is not None:
+            normalized_for_remote_check = mlflow_uri.strip()
+        if normalized_for_remote_check and _is_remote_uri(normalized_for_remote_check):
             local_uri = _local_runs_uri_from_env(e)
             return TrackingDecision(
                 uri=local_uri,


### PR DESCRIPTION
## Summary
- ensure the offline MLflow guard checks remote URIs using the normalized value
- trim the raw tracking URI as a fallback so whitespace-padded remote endpoints are still blocked in offline mode

## Testing
- no automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8731d79948331a50f473e2f0e5054