### PR TITLE
chore(audit): finalize traversal workflow v1.1.0 rollout

### DIFF
--- a/docs/Traversal_Workflow.md
+++ b/docs/Traversal_Workflow.md
@@ -1,51 +1,88 @@
 # [Doc]: Copilot Space Traversal Workflow (v1.1.0)
-> Generated: 2025-10-10 01:58:00 UTC | Author: mbaetiong
+> Generated: 2025-10-10 02:53:25 UTC | Author: mbaetiong
 Roles: [Knowledge Ops], [ML Platform Auditor]  Energy: 5
 
-## 1) Objective
+## 1. Objective
 Codify a reproducible, explainable capability maturity assessment pipeline with deterministic outputs.
 
-## 2) Flow
+## 2. Flow (Conceptual)
 ```text
-FILES → (S1 Index) → FACETS → (S2 Regex cluster) → CAPABILITIES_RAW
-→ (S3 Detectors) → CAPABILITIES_SCORED → (S4 Weights) → GAPS
-→ (S5 Threshold) → REPORT (S6 Jinja) → MANIFEST (S7 Integrity)
+FILES
+  ↓ (S1 Index: enumerate + hash)
+FACETS
+  ↓ (S2 Regex cluster)
+CAPABILITIES_RAW
+  ↓ (S3 Static + dynamic detectors)
+CAPABILITIES_SCORED
+  ↓ (S4 Component weighting)
+GAPS
+  ↓ (S5 Threshold segmentation)
+REPORT (Markdown)
+  ↓ (S6 Jinja rendering)
+MANIFEST
+  ↓ (S7 Integrity chain)
 ```
 
-## 3) Score Formula
-score = Σ_i weight_i * clamp(component_i, 0..1) (weights normalized if Σ≠1)
+## 3. Component Score Formula
+`score = Σ_i ( weight_i * clamp(component_i, 0, 1) )`
+Weights normalized if Σ != 1.0 (warning added to manifest).
 
 | Component | Computation |
 |-----------|-------------|
 | functionality | Hits / Required Patterns |
-| consistency | 1 − duplication_ratio(evidence_files) |
-| tests | (# test-linked files) / (# evidence files) |
-| safeguards | (# safeguard keywords with ≥1 hit) / total keywords |
-| documentation | doc token hits / scaled corpus |
+| consistency | 1 - duplication_ratio(evidence_files) |
+| tests | (# test-linked files) / (# evidence files) (clamped) |
+| safeguards | (# safeguard keywords with ≥1 hit) / (total safeguard keywords) |
+| documentation | (# doc files containing capability token) / scaled corpus |
 
-## 4) Safeguard Keywords
-sha256, checksum, rng, seed, offline, WANDB_MODE (see audit_runner.py)
+## 4. Evidence Prioritization Heuristics
+| Signal | Priority | Notes |
+|--------|----------|-------|
+| Direct pattern hit | High | Immediately increases functionality |
+| Keyword variant (pluralization) | Medium | Future enhancement |
+| Detector meta (e.g., layer tags) | Informational | Not scored yet |
 
-## 5) Determinism Guards
-- Sorted traversal, truncated safe reads (200KB)
-- Template fingerprint embedded (SHA of all .j2)
-- Manifest includes repo_root_sha and per-artifact SHA
+## 5. Safeguard Keywords (Current Set)
+`sha256`, `checksum`, `rng`, `seed`, `offline`, `WANDB_MODE`
 
-## 6) Detectors
-Place under scripts/space_traversal/detectors/*.py with:
-```python
-def detect(file_index: dict) -> dict:
-    return {"id":"new-cap","evidence_files":[],"found_patterns":[],"required_patterns":[],"meta":{}}
-```
+## 6. Adding a Dynamic Detector
+1) Place file under `scripts/space_traversal/detectors/`.
+2) Implement `detect(file_index: dict) -> dict`.
+3) Return contract MUST include: `id`, `evidence_files`, `found_patterns`, `required_patterns`.
+4) Re-run: `python scripts/space_traversal/audit_runner.py stage S3`.
 
-## 7) Diff / Explain
+## 7. Determinism Guard Rails
+| Guard | Implementation |
+|-------|----------------|
+| Sorted traversal | Use `sorted(Path.rglob())` |
+| Read truncation | Cap file read length (200KB) |
+| Hash chain | Manifest collects per-artifact SHA |
+| Template fingerprint | Concatenate `.j2` files → SHA |
+| Weight normalization | Auto-correct + record warning |
+
+## 8. Diff & Explain
 ```bash
-python scripts/space_traversal/audit_runner.py diff --old A --new B
+python scripts/space_traversal/audit_runner.py diff --old reports/capability_matrix_A.md --new reports/capability_matrix_B.md
 python scripts/space_traversal/audit_runner.py explain checkpointing
 ```
 
-## 8) Policy Gates
-- Fail build if any score < low threshold
-- Optional regression fail via options in workflow.yaml
+## 9. Failure Mode Reference
+| Issue | Likely Root | Mitigation |
+|-------|-------------|------------|
+| Missing capability ID | Detector file syntax error | Run S3 & inspect stderr |
+| Score suppression | Required pattern rename | Update pattern list |
+| High duplication ratio | Over-broad facet regex | Narrow facet patterns |
+| Zero docs score | No doc token mention | Add docs anchor or synonyms list |
+
+## 10. Manifest Anatomy (Excerpt)
+```json
+{
+  "repo_root_sha": "<sha>",
+  "artifacts": [{"name":"context_index.json","sha":"<sha>"}],
+  "template_hash": "<sha>",
+  "weights": {"functionality":0.25,"consistency":0.2,"tests":0.25,"safeguards":0.15,"documentation":0.15},
+  "warnings": []
+}
+```
 
 *End of Workflow Doc*

--- a/docs/Usage_Guide.md
+++ b/docs/Usage_Guide.md
@@ -1,23 +1,24 @@
 # [Guide]: Copilot Space Audit Usage (v1.1.0)
-> Generated: 2025-10-10 01:58:00 UTC | Author: mbaetiong
+> Generated: 2025-10-10 02:53:25 UTC | Author: mbaetiong
 Roles: [Workflow Steward], [Reliability Analyst]  Energy: 5
 
-## Quick Run
+## 1. Quick Run
 ```bash
 python scripts/space_traversal/audit_runner.py run
 ```
 
-## Single Stage
+## 2. Single Stage Invocation
 ```bash
 python scripts/space_traversal/audit_runner.py stage S4
 ```
 
-## Explain Score
+## 3. Explain a Capability Score
 ```bash
 python scripts/space_traversal/audit_runner.py explain checkpointing
 ```
 
-## Update Weights then Rerun S4–S7
+## 4. Update Weights
+Edit `.copilot-space/workflow.yaml` → rerun S4–S7:
 ```bash
 python scripts/space_traversal/audit_runner.py stage S4
 python scripts/space_traversal/audit_runner.py stage S5
@@ -25,17 +26,18 @@ python scripts/space_traversal/audit_runner.py stage S6
 python scripts/space_traversal/audit_runner.py stage S7
 ```
 
-## CI (Optional)
-```bash
-python scripts/space_traversal/audit_runner.py run
-python scripts/space_traversal/audit_runner.py diff --old baseline/capabilities_scored.json --new audit_artifacts/capabilities_scored.json
-```
+## 5. Add a New Capability
+| Step | Action |
+|------|--------|
+| 1 | Create detector in `scripts/space_traversal/detectors/` |
+| 2 | Implement `detect()` contract |
+| 3 | Run `stage S3` or full `run` |
+| 4 | Inspect `capabilities_raw.json` |
+| 5 | Confirm matrix entry |
 
-## Red Flags & Mitigations
-| Symptom | Cause | Action |
-|---------|-------|--------|
-| Sudden score drop | Deleted/renamed evidence | Restore or adjust detectors |
-| Zero safeguards | Stale keyword set | Update SAFEGUARD_KEYWORDS |
-| High duplication penalty | Broad facet regex | Narrow patterns |
+## 6. Determinism Validation
+Two sequential runs (no source changes) must produce identical:
+- `repo_root_sha`
+- `capabilities_scored.json` (excluding timestamp)
 
 *End of Guide*

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,3 +10,5 @@
 - [How-to: Bootstrap Self‑Hosted Runner](how-to/bootstrap_runner.md)
 - [Ops: Rulesets vs Protection](ops/repo_rulesets_vs_protection.md)
 - [How-to: Run Audit on 0D_base_](how-to/run_audit_0D_base_.md)
+- [Traversal Workflow](../Traversal_Workflow.md)
+- [Usage Guide](../Usage_Guide.md)

--- a/scripts/space_traversal/capability_scoring.py
+++ b/scripts/space_traversal/capability_scoring.py
@@ -1,16 +1,16 @@
-"""
-Capability Scoring Utilities (v1.1.0)
-
-Provides:
-  - normalize_weights(weights) -> dict
-  - score_capability(components, weights) -> float
-  - explain_score(capability, weights) -> dict
-  - aggregate_scores(capabilities, weights) -> list (with contributions)
-"""
+"""Capability scoring utilities for the traversal workflow (v1.1.0)."""
 
 from __future__ import annotations
 
 from typing import Dict, List
+
+
+__all__ = [
+    "aggregate_scores",
+    "explain_score",
+    "normalize_weights",
+    "score_capability",
+]
 
 
 def normalize_weights(weights: Dict[str, float]) -> Dict[str, float]:
@@ -31,23 +31,12 @@ def explain_score(capability: dict, weights: Dict[str, float]) -> dict:
     partials = {}
     for k in w_norm:
         val = max(0.0, min(1.0, components.get(k, 0.0)))
-        partials[k] = {
-            "component_value": val,
-            "weight": w_norm[k],
-            "contribution": val * w_norm[k],
-        }
+        partials[k] = {"component_value": val, "weight": w_norm[k], "contribution": val * w_norm[k]}
+
     score = round(sum(v["contribution"] for v in partials.values()), 4)
-    return {
-        "id": capability.get("id"),
-        "score": score,
-        "partials": partials,
-    }
+    return {"id": capability.get("id"), "score": score, "partials": partials}
 
 
 def aggregate_scores(capabilities: List[dict], weights: Dict[str, float]) -> List[dict]:
     w_norm = normalize_weights(weights)
-    enriched = []
-    for cap in capabilities:
-        explanation = explain_score(cap, w_norm)
-        enriched.append(explanation)
-    return enriched
+    return [explain_score(cap, w_norm) for cap in capabilities]

--- a/space.mk
+++ b/space.mk
@@ -1,0 +1,29 @@
+# Copilot Space Audit Workflow Makefile (v1.1.0)
+
+SPACE_PY ?= python
+RUNNER ?= scripts/space_traversal/audit_runner.py
+
+.PHONY: space-audit
+space-audit:
+$(SPACE_PY) $(RUNNER) run
+
+.PHONY: space-audit-fast
+space-audit-fast:
+$(SPACE_PY) $(RUNNER) stage S1
+$(SPACE_PY) $(RUNNER) stage S3
+$(SPACE_PY) $(RUNNER) stage S4
+$(SPACE_PY) $(RUNNER) stage S6
+
+.PHONY: space-explain
+space-explain:
+@if [ -z "$(cap)" ]; then echo "Usage: make -f space.mk space-explain cap=<capability_id>"; exit 2; fi
+$(SPACE_PY) $(RUNNER) explain $(cap)
+
+.PHONY: space-diff
+space-diff:
+@if [ -z "$(old)" ] || [ -z "$(new)" ]; then echo "Usage: make -f space.mk space-diff old=<old> new=<new>"; exit 2; fi
+$(SPACE_PY) $(RUNNER) diff --old $(old) --new $(new)
+
+.PHONY: space-clean
+space-clean:
+rm -rf audit_artifacts audit_run_manifest.json reports/capability_matrix_*.md

--- a/templates/audit/capability_matrix.md.j2
+++ b/templates/audit/capability_matrix.md.j2
@@ -1,0 +1,66 @@
+# [Report]: Capability Matrix
+> Generated: {{ timestamp }} | Author: audit_system
+ Roles: [Primary: Automated Auditor], [Secondary: Provenance Engine]  Energy: 5
+
+## 1. Summary
+Total Capabilities: {{ capabilities|length }}
+Low Maturity (< {{ (weights.functionality + weights.consistency) | round(2) }} heuristic): {{ gaps|length }}
+
+## 2. Capability Scores
+| ID | Score | Functionality | Consistency | Tests | Safeguards | Docs | Evidence Count |
+|----|-------|--------------:|------------:|------:|-----------:|-----:|---------------:|
+{% for cap in capabilities -%}
+| {{ cap.id }} | {{ "%.2f"|format(cap.score) }} | {{ "%.2f"|format(cap.components.functionality) }} | {{ "%.2f"|format(cap.components.consistency) }} | {{ "%.2f"|format(cap.components.tests) }} | {{ "%.2f"|format(cap.components.safeguards) }} | {{ "%.2f"|format(cap.components.documentation) }} | {{ cap.evidence_files|length }} |
+{% endfor %}
+
+## 3. Low Maturity Focus
+{% if gaps %}
+| ID | Score | Primary Deficit |
+|----|-------|-----------------|
+{% for g in gaps -%}
+{% set comp = (g.components|dictsort(false, 'value'))[0][0] %}
+| {{ g.id }} | {{ "%.2f"|format(g.score) }} | {{ comp }} |
+{% endfor %}
+{% else %}
+All capabilities meet minimum thresholds.
+{% endif %}
+
+## 4. Weight Reference
+| Component | Weight |
+|-----------|-------:|
+{% for k,v in weights.items() -%}
+| {{ k }} | {{ "%.2f"|format(v) }} |
+{% endfor %}
+
+## 5. Capability Details
+{% for cap in capabilities %}
+### {{ cap.id }}
+Score: {{ "%.4f"|format(cap.score) }}
+
+Components:
+- Functionality: {{ cap.components.functionality }}
+- Consistency: {{ cap.components.consistency }}
+- Tests: {{ cap.components.tests }}
+- Safeguards: {{ cap.components.safeguards }}
+- Documentation: {{ cap.components.documentation }}
+
+Patterns Found: {{ cap.found_patterns|join(", ") if cap.found_patterns else "None" }}
+
+Evidence Files (first 10):
+```
+{% for f in cap.evidence_files[:10] -%}
+{{ f }}
+{% endfor %}
+```
+{% endfor %}
+
+## 6. Appendix
+| Field | Description |
+|-------|-------------|
+| template_hash | Hash of concatenated Jinja templates |
+| generation_strategy | Weighted component aggregation |
+| scoring_components | functionality, consistency, tests, safeguards, documentation |
+
+Embedded Template SHA256: {{ template_hash|default("UNKNOWN") }}
+
+*End of Matrix*


### PR DESCRIPTION
## Summary
- document the Copilot Space traversal workflow and operator usage guidance
- add capability scoring utilities, update the audit runner to v1.1.0, and introduce a reusable Makefile helper
- ship the capability matrix template and link the new resources from the docs index

## Testing
- python -m pyflakes scripts/space_traversal/audit_runner.py
- ruff check scripts/space_traversal/audit_runner.py scripts/space_traversal/capability_scoring.py
- mypy scripts/space_traversal/audit_runner.py scripts/space_traversal/capability_scoring.py

------
https://chatgpt.com/codex/tasks/task_e_68e877016e2c833180883bf2dc24b0c0