### PR TITLE
chore(audit): round-3 — improve docs scoring, add primary_deficit, detectors scaffold, docs/spec fixes

### DIFF
--- a/.github/docs/Space_TraversalWorkflow_Copilot.md
+++ b/.github/docs/Space_TraversalWorkflow_Copilot.md
@@ -1,5 +1,5 @@
 # [Copilot Space Spec]: Traversal & Capability Audit Workflow (v1.1.0)
-> Generated: 2025-10-10 03:27:51 UTC | Author: mbaetiong
+> Generated: 2025-10-10 04:02:13 UTC | Author: mbaetiong
 
 Roles: [Primary: Audit Orchestrator], [Secondary: Capability Cartographer]  Energy: 5
 
@@ -41,14 +41,14 @@ Define a deterministic, introspectable, extensible audit workflow for this Copil
 | Fast Feedback | Single-stage invocations for iterative tuning |
 
 ## 5. Directory Layout
-| Path | Description |
-|------|-------------|
-| `scripts/space_traversal/` | Orchestration, scoring, detectors |
-| `scripts/space_traversal/detectors/` | Drop-in capability detectors |
-| `templates/audit/` | Jinja2 templates |
-| `audit_artifacts/` | Intermediate JSON outputs |
-| `reports/` | Published markdown matrices |
-| `.copilot-space/workflow.yaml` | Declarative pipeline config |
+| Path | Description | Added In |
+|------|-------------|----------|
+| `scripts/space_traversal/` | Orchestration, scoring, detectors | v1.0 |
+| `scripts/space_traversal/detectors/` | Drop-in capability detectors | v1.1 |
+| `templates/audit/` | Jinja2 templates | v1.0 |
+| `audit_artifacts/` | Intermediate JSON outputs | v1.0 |
+| `reports/` | Published markdown matrices | v1.0 |
+| `.copilot-space/workflow.yaml` | Declarative pipeline config | v1.0 |
 
 ## 6. Scoring Components (Weights Default)
 | Component | Weight | Definition | Signals |
@@ -59,7 +59,49 @@ Define a deterministic, introspectable, extensible audit workflow for this Copil
 | safeguards | 0.15 | Integrity, reproducibility, offline gating | Keyword presence map |
 | documentation | 0.15 | Clear doc references | Doc corpus incidence |
 
-## 7. Integrity Chain (Manifest)
+Weights must sum to 1.0; normalization occurs if drift detected (manifest notes warning).
+
+## 7. Duplicate Implementation Heuristic
+| Criterion | Rule |
+|----------|------|
+| File Stem Overlap | Same stem appears >1 time inside capability evidence |
+| Adjusted Dup Ratio | `(duplicate_instances) / total_evidence_files` (clamped) |
+| Similarity Path Check (future) | Planned introduction of token-level similarity (Phase II) |
+
+## 8. Safeguard Signals
+| Keyword | Category | Example |
+|---------|----------|---------|
+| `sha256` | Integrity | Checkpoint hashing |
+| `checksum` | Integrity | Dataset manifest |
+| `rng` | Repro | RNG state persistence |
+| `seed` | Repro | Deterministic seeding |
+| `offline` | Network guard | W&B / MLflow offline |
+| `WANDB_MODE` | Network guard | Force offline mode |
+
+## 9. Execution Entrypoints
+| Command | Function |
+|---------|----------|
+| `python scripts/space_traversal/audit_runner.py run` | Full pipeline S1→S7 |
+| `python scripts/space_traversal/audit_runner.py stage S4` | Run single stage |
+| `python scripts/space_traversal/audit_runner.py diff --old A --new B` | Compare two reports / score JSON |
+| `python scripts/space_traversal/audit_runner.py explain <cap_id>` | Print component breakdown |
+| `make space-audit` | Convenience wrapper |
+| `make space-audit-fast` | Minimal subset (S1,S3,S4,S6) |
+
+## 10. YAML Configuration Keys
+| Path | Type | Example | Description |
+|------|------|---------|-------------|
+| `version` | semver | `1.1.0` | Workflow spec version |
+| `stages` | list | IDs S1..S7 | Execution ordering |
+| `weights` | map | component weights | Overrides defaults |
+| `scoring.thresholds.low` | float | `0.70` | Low maturity gating |
+| `scoring.thresholds.medium` | float | `0.85` | Higher maturity label |
+| `capability_map.overrides` | map | merge arrays | ID merging / aliasing |
+| `capability_map.dynamic` | bool | `true` | Enable detector discovery |
+| `output.reports_dir` | str | `reports` | Where matrix saved |
+| `output.artifacts_dir` | str | `audit_artifacts` | Intermediates location |
+
+## 11. Integrity Chain (Manifest)
 | Field | Meaning |
 |-------|---------|
 | `repo_root_sha` | SHA256 of sorted file listing |
@@ -68,7 +110,7 @@ Define a deterministic, introspectable, extensible audit workflow for this Copil
 | `weights` | Effective normalized weights |
 | `warnings` | Normalization / missing stage notes |
 
-## 8. Extending with a Detector
+## 12. Extending with a Detector
 | Step | Action |
 |------|--------|
 | 1 | Create `scripts/space_traversal/detectors/<id>.py` |
@@ -76,5 +118,77 @@ Define a deterministic, introspectable, extensible audit workflow for this Copil
 | 3 | Ensure unique `id`, include `required_patterns` list |
 | 4 | Re-run S3 (auto-load) |
 | 5 | Validate presence in `capabilities_raw.json` then final matrix |
+
+Detector Return Contract:
+```python
+{
+  "id": "inference-serving",
+  "evidence_files": ["src/.../server.py"],
+  "found_patterns": ["fastapi"],
+  "required_patterns": ["server", "fastapi"],
+  "meta": {"layer":"serving"}
+}
+```
+
+## 13. Failure Mode Radar
+| Symptom | Stage | Root Cause | Remediation |
+|---------|-------|-----------|-------------|
+| Missing capability in matrix | S3 | Detector not loaded / dynamic disabled | Enable `capability_map.dynamic` or fix import error |
+| Score = 0 unexpectedly | S4 | Patterns mismatched or renamed | Adjust `required_patterns` / update detector |
+| Template hash mismatch | S7 | Template edited post-run | Re-run full pipeline |
+| High duplication inflation | S4 | Broad facet pattern capturing unrelated files | Refine regex domain patterns |
+| No low maturity flagged but expected | S5 | Threshold too low | Adjust `scoring.thresholds.low` |
+
+## 14. Quality Gates (Optional Policy)
+| Gate | Condition | Action |
+|------|-----------|--------|
+| Fail Build (Low) | Any capability < low threshold | Exit non-zero |
+| Warn Drift | >5% delta vs last manifest | Print diff summary |
+| Warn Weight Normalize | Provided weights sum != 1 | Log normalization warning |
+| Fail Missing Detector | Detector referenced but not loaded | Exit non-zero |
+
+## 15. Prompt Hints (Copilot Space)
+| Intent | Prompt |
+|--------|--------|
+| Regenerate audit | "Run the space audit workflow now." |
+| List weak areas | "List all capabilities below threshold." |
+| Show provenance | "Display manifest integrity chain." |
+| Explain score | "Explain capability checkpointing score." |
+
+## 16. Security & Offline Policy
+| Concern | Measure |
+|---------|---------|
+| Network avoidance | No external imports beyond installed libs |
+| Hash tamper detection | Manifest + template hash chain |
+| Controlled writes | Paths restricted to configured output dirs |
+| Execution isolation | Stage-specific invocation possible |
+
+## 17. Determinism Validation Steps
+1. Run full pipeline twice with no code changes.
+2. Compare JSON artifact hashes (excluding timestamp).
+3. Expect identical `repo_root_sha` & identical `capabilities_scored.json` content.
+4. If diverged → inspect nondeterministic detector logic (e.g., random ordering).
+
+## 18. Maintenance Cadence
+| Interval | Tasks |
+|----------|-------|
+| Weekly | Run audit; review deltas; commit if material |
+| Monthly | Rebalance weights; refine detectors |
+| Quarterly | Validate duplication heuristic vs manual review; rotate safeguard keywords |
+
+## 19. Upgrade Path (Future)
+| Version | Planned Feature |
+|---------|-----------------|
+| 1.2.x | Token-level similarity duplicate heuristic |
+| 1.3.x | Coverage XML ingestion for real test depth |
+| 1.4.x | Multi-report trend aggregation & sparkline rendering |
+| 2.0.0 | Multi-repo federated capability indexing |
+
+## 20. Pre-Commit Checklist
+- [ ] All stages S1–S7 succeeded
+- [ ] Weight normalization produced no warnings (or justified)
+- [ ] Manifest integrity chain verified
+- [ ] Diff summary appended in commit message
+- [ ] New detectors documented in Appendix (if added)
 
 *End of Spec*

--- a/docs/Traversal_Workflow.md
+++ b/docs/Traversal_Workflow.md
@@ -1,6 +1,6 @@
 # [Doc]: Copilot Space Traversal Workflow (v1.1.0)
-> Generated: 2025-10-10 02:53:25 UTC | Author: mbaetiong
-Roles: [Knowledge Ops], [ML Platform Auditor]  Energy: 5
+> Generated: 2025-10-10 04:02:13 UTC | Author: mbaetiong
+Roles: [Primary: Knowledge Ops], [Secondary: ML Platform Auditor]  Energy: 5
 
 ## 1. Objective
 Codify a reproducible, explainable capability maturity assessment pipeline with deterministic outputs.

--- a/docs/Usage_Guide.md
+++ b/docs/Usage_Guide.md
@@ -1,6 +1,6 @@
 # [Guide]: Copilot Space Audit Usage (v1.1.0)
-> Generated: 2025-10-10 02:53:25 UTC | Author: mbaetiong
-Roles: [Workflow Steward], [Reliability Analyst]  Energy: 5
+> Generated: 2025-10-10 04:02:13 UTC | Author: mbaetiong
+Roles: [Primary: Workflow Steward], [Secondary: Reliability Analyst]  Energy: 5
 
 ## 1. Quick Run
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,5 +10,5 @@
 - [How-to: Bootstrap Self‑Hosted Runner](how-to/bootstrap_runner.md)
 - [Ops: Rulesets vs Protection](ops/repo_rulesets_vs_protection.md)
 - [How-to: Run Audit on 0D_base_](how-to/run_audit_0D_base_.md)
- - [Traversal Workflow](Traversal_Workflow.md)
- - [Usage Guide](Usage_Guide.md)
+  - [Traversal Workflow](Traversal_Workflow.md)
+  - [Usage Guide](Usage_Guide.md)

--- a/scripts/space_traversal/detectors/README.md
+++ b/scripts/space_traversal/detectors/README.md
@@ -1,5 +1,5 @@
 # Detectors — Dynamic Capability Extraction
-> Generated: 2025-10-10 03:27:51 UTC | Author: mbaetiong
+> Generated: 2025-10-10 04:02:13 UTC | Author: mbaetiong
 
 Purpose
 - Add pluggable capability detectors without editing the core audit runner.

--- a/templates/audit/capability_matrix.md.j2
+++ b/templates/audit/capability_matrix.md.j2
@@ -18,8 +18,7 @@ Low Maturity (< {{ (weights.functionality + weights.consistency) | round(2) }} h
 | ID | Score | Primary Deficit |
 |----|-------|-----------------|
 {% for g in gaps -%}
-{% set comp = (g.components|dictsort(false, 'value'))[0][0] %}
-| {{ g.id }} | {{ "%.2f"|format(g.score) }} | {{ comp }} |
+| {{ g.id }} | {{ "%.2f"|format(g.score) }} | {{ g.primary_deficit | default("n/a") }} |
 {% endfor %}
 {% else %}
 All capabilities meet minimum thresholds.


### PR DESCRIPTION
## Summary
- enhance audit runner docs scoring with capability keywords, add perplexity to evaluation metrics, and surface primary deficit in gap analysis
- render new primary_deficit in the capability matrix, refresh documentation headers/indentation, and expand traversal spec guidance
- document detectors scaffold and streamline capability scoring aggregation

## Testing
- python -m pyflakes scripts/space_traversal/audit_runner.py
- python -m pyflakes scripts/space_traversal/capability_scoring.py
- python - <<'PY'
import yaml, json, os
p=".copilot-space/workflow.yaml"
if os.path.exists(p):
    with open(p, 'r', encoding='utf-8') as fh:
        cfg=yaml.safe_load(fh)
    print(json.dumps({"ok": True, "keys": list(cfg.keys())}, indent=2))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e886895f048331aed62e85d0054c33