### PR TITLE
chore(audit): round-5 — docs token variants, minimal tests, scoring util tidy, docs/spec touch-ups

### DIFF
--- a/docs/Traversal_Workflow.md
+++ b/docs/Traversal_Workflow.md
@@ -1,5 +1,5 @@
 # [Doc]: Copilot Space Traversal Workflow (v1.1.0)
-> Generated: 2025-10-10 04:31:26 UTC | Author: mbaetiong
+> Generated: 2025-10-10 05:06:10 UTC | Author: mbaetiong
 Roles: [Primary: Knowledge Ops], [Secondary: ML Platform Auditor]  Energy: 5
 
 ## 1. Objective
@@ -35,7 +35,7 @@ Weights normalized if Σ != 1.0 (warning added to manifest).
 | safeguards | (# safeguard keywords with ≥1 hit) / (total safeguard keywords) |
 | documentation | (# doc files containing capability token) / scaled corpus |
 
-Note on doc scoring: tokens include capability keywords plus simple synonyms per capability (see DOCS_SYNONYMS_MAP in audit_runner.py).
+Note on doc scoring: tokens include capability keywords plus simple synonyms and naive plural/singular variants per capability (see `DOCS_SYNONYMS_MAP` in `audit_runner.py`).
 
 ## 4. Evidence Prioritization Heuristics
 | Signal | Priority | Notes |

--- a/docs/Usage_Guide.md
+++ b/docs/Usage_Guide.md
@@ -1,5 +1,5 @@
 # [Guide]: Copilot Space Audit Usage (v1.1.0)
-> Generated: 2025-10-10 04:31:26 UTC | Author: mbaetiong
+> Generated: 2025-10-10 05:06:10 UTC | Author: mbaetiong
 Roles: [Primary: Workflow Steward], [Secondary: Reliability Analyst]  Energy: 5
 
 ## 1. Quick Run
@@ -54,5 +54,8 @@ Two sequential runs (no source changes) must produce identical:
 | Can I disable a stage? | Remove from `stages` array (ensure dependencies satisfied) |
 | How to isolate a regression? | Re-run stages sequentially; compare JSON artifacts |
 | Where to add synonyms? | Edit `DOCS_SYNONYMS_MAP` in scripts/space_traversal/audit_runner.py or add `docs_keywords` in BASE_CAPABILITY_RULES |
+
+## 16. Component Caps (Optional)
+Add caps under `scoring.component_caps` in `.copilot-space/workflow.yaml` to bound component influence (e.g., documentation: 0.90).
 
 *End of Guide*

--- a/tests/specs/test_detector_inference_serving.py
+++ b/tests/specs/test_detector_inference_serving.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from scripts.space_traversal.detectors.inference_serving import detect
+
+
+def test_inference_serving_detector_basic_path_signals():
+    file_index = {
+        "files": [
+            {"path": "src/api/server_fastapi.py"},
+            {"path": "src/training/train_loop.py"},
+        ]
+    }
+    result = detect(file_index)
+    assert result["id"] == "inference-serving"
+    assert any("server" in p for p in result["evidence_files"])
+    # signals detected from filename tokens
+    assert "server" in result["found_patterns"]
+    assert "fastapi" in result["found_patterns"]
+    # required patterns declared
+    assert set(result["required_patterns"]) == {"server", "fastapi"}

--- a/tests/specs/test_docs_score_synonyms.py
+++ b/tests/specs/test_docs_score_synonyms.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+# Minimal tests for docs scoring synonyms/variants (offline-safe)
+from scripts.space_traversal.audit_runner import _docs_score, _expand_doc_tokens
+
+
+def test_expand_tokens_variants_include_synonyms():
+    toks = _expand_doc_tokens("tokenization", ["token"])
+    # Expect base token and known synonym variants
+    assert "token" in toks
+    assert "sentencepiece" in toks
+    # naive pluralization present
+    assert "tokens" in toks
+
+
+def test_docs_score_hits_synonym_in_doc():
+    cache = {
+        "docs/tokenization.md": "We integrate SentencePiece for subword models.",
+        "README.md": "Setup instructions",
+    }
+    score = _docs_score("tokenization", cache, ["token"])
+    # one doc hit among small corpus => positive score
+    assert score > 0.0
+
+
+def test_docs_score_variants_plural_checkpoint():
+    cache = {"docs/checkpoints.md": "How to manage checkpoints safely."}
+    score = _docs_score("checkpointing", cache, ["checkpoint"])
+    assert score > 0.0


### PR DESCRIPTION
## Summary
- add a doc token expansion helper to include capability keywords, synonyms, and simple plural/singular variants in scoring
- cover doc scoring expansion and the inference serving detector with lightweight specs
- document the doc token behavior and mention optional component caps in the workflow guide

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/specs/test_docs_score_synonyms.py tests/specs/test_detector_inference_serving.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e8956e4b38833196f7112c1d0a452d