### PR TITLE
fix: infer GPT-2 compatible LoRA targets

### DIFF
--- a/tests/unit/test_peft_utils.py
+++ b/tests/unit/test_peft_utils.py
@@ -5,14 +5,14 @@ import pytest
 
 def test_imports_exist():
     try:
-        from hhg_logistics.model.peft_utils import load_hf_llm, apply_lora, freeze_base_weights  # noqa: F401
+        from hhg_logistics.model.peft_utils import apply_lora, freeze_base_weights, load_hf_llm
     except Exception:
         pytest.skip("transformers/peft not installed in this environment")
 
 
 def test_freeze_counts():
     try:
-        from hhg_logistics.model.peft_utils import load_hf_llm, apply_lora, freeze_base_weights
+        from hhg_logistics.model.peft_utils import apply_lora, freeze_base_weights, load_hf_llm
     except Exception:
         pytest.skip("transformers/peft not installed")
     try:
@@ -21,4 +21,4 @@ def test_freeze_counts():
         pytest.skip("model weights not available offline")
     model = apply_lora(bundle.model, r=4, alpha=8, dropout=0.0)
     trainable = freeze_base_weights(model)
-    assert trainable >= 0
+    assert trainable > 0


### PR DESCRIPTION
## Summary
- infer default LoRA target modules from the model type so GPT-2 receives compatible adapters
- fail fast when targets cannot be inferred instead of silently training nothing
- tighten the tiny GPT-2 regression test to verify LoRA leaves trainable parameters

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 CODEX_ALLOW_MISSING_HYDRA_EXTRA=1 pytest -q tests/unit/test_peft_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68eb4074fb788331833e965c0f6d1eaa