### PR TITLE
fix: harden zendesk tooling and validations

### DIFF
--- a/data/zendesk_docs_manifest.json
+++ b/data/zendesk_docs_manifest.json
@@ -29,6 +29,9 @@
     "forms": [
       "https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_forms/"
     ],
+    "groups": [
+      "https://developer.zendesk.com/api-reference/ticketing/groups/groups/"
+    ],
     "macros": [
       "https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/"
     ],

--- a/docs/zendesk_api_catalog_generated.md
+++ b/docs/zendesk_api_catalog_generated.md
@@ -24,6 +24,8 @@
 - https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_fields/
 ### Forms
 - https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_forms/
+### Groups
+- https://developer.zendesk.com/api-reference/ticketing/groups/groups/
 ### Macros
 - https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/
 ### Triggers

--- a/scripts/zendesk_docs_catalog.py
+++ b/scripts/zendesk_docs_catalog.py
@@ -21,7 +21,8 @@ def main() -> int:
             for url in urls:
                 lines.append(f"- {url}")
         lines.append("")
-    OUT_MD.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    content = "\n".join(lines).rstrip() + "\n"
+    OUT_MD.write_text(content, encoding="utf-8")
     print(f"Wrote {OUT_MD.relative_to(ROOT)}")
     return 0
 

--- a/src/codex/zendesk/plan/validators.py
+++ b/src/codex/zendesk/plan/validators.py
@@ -1,0 +1,32 @@
+"""Pydantic models for validating Zendesk plan payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class Operation(BaseModel):
+    """A single plan operation to apply to a Zendesk resource."""
+
+    op: Literal["create", "update", "delete"]
+    id: int | None = Field(default=None)
+    payload: dict = Field(default_factory=dict)
+
+
+class Plan(BaseModel):
+    """Top-level plan payload for a Zendesk resource."""
+
+    resource: str
+    operations: Sequence[Operation]
+
+
+def validate_plan(plan_data: dict) -> Plan:
+    """Validate and coerce an arbitrary plan payload into the canonical model."""
+
+    return Plan.model_validate(plan_data)
+
+
+__all__ = ["Operation", "Plan", "validate_plan"]

--- a/tests/test_zendesk_validators.py
+++ b/tests/test_zendesk_validators.py
@@ -1,0 +1,22 @@
+import pytest
+from pydantic import ValidationError
+
+from codex.zendesk.plan.validators import validate_plan
+
+
+def test_validate_minimal_plan() -> None:
+    plan = validate_plan(
+        {
+            "resource": "fields",
+            "operations": [
+                {"op": "create", "payload": {"title": "New Field"}},
+            ],
+        }
+    )
+    assert plan.resource == "fields"
+    assert plan.operations[0].op == "create"
+
+
+def test_reject_scalar_plan() -> None:
+    with pytest.raises(ValidationError):
+        validate_plan({"resource": "views", "operations": "oops"})  # type: ignore[arg-type]

--- a/tools/python_shim.py
+++ b/tools/python_shim.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Invoke the first available Python interpreter, preferring `python`."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from collections.abc import Sequence
+from typing import NoReturn
+
+
+def _find_python(candidates: Sequence[str]) -> str:
+    for candidate in candidates:
+        path = shutil.which(candidate)
+        if path:
+            return path
+    raise SystemExit(
+        "Unable to locate a Python interpreter from candidates: " + ", ".join(candidates)
+    )
+
+
+def main(argv: list[str]) -> NoReturn:
+    interpreter = _find_python(("python", "python3"))
+    os.execv(interpreter, [interpreter, *argv])  # noqa: S606 - deterministic hand-off
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- add a python shim for local hooks and ensure Zendesk CLI docs commands proxy subprocess output cleanly
- validate Zendesk plans with new Pydantic models, expand the docs manifest/catalog, and add focused tests
- stabilize the Nox test matrix across supported Python versions and harden the Zendesk docs fetch retry logic

## Testing
- python3 -m pre_commit run --files tools/python_shim.py src/codex/cli_zendesk.py src/codex/zendesk/plan/validators.py scripts/zendesk_docs_fetch.py scripts/zendesk_docs_catalog.py data/zendesk_docs_manifest.json noxfile.py tests/test_zendesk_validators.py
- python3 -m nox -s tests
- PYTHONPATH=src python3 -m codex.cli_zendesk docs-sync --dry-run
- PYTHONPATH=src python3 -m codex.cli_zendesk docs-catalog
- PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_zendesk_validators.py -q
- ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68ebeb8dcc248331b46112c70e297cb2