### PR TITLE
feat: extend zendesk tooling and add qa scaffolds

### DIFF
--- a/src/codex/cli_zendesk.py
+++ b/src/codex/cli_zendesk.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import importlib
 import json
+import os
 import subprocess
 import sys
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -18,6 +20,8 @@ from codex.zendesk.model import (
     Group,
     GuideThemeRef,
     Macro,
+    RoutingRule,
+    SLAPolicy,
     TemplatePatch,
     TicketField,
     TicketForm,
@@ -33,6 +37,8 @@ from codex.zendesk.plan.diff_engine import (
     diff_groups,
     diff_guide,
     diff_macros,
+    diff_routing,
+    diff_slas,
     diff_triggers,
     diff_views,
     diff_webhooks,
@@ -54,6 +60,8 @@ _RESOURCE_CONFIG: dict[str, ResourceConfig] = {
     "views": (View, diff_views),
     "webhooks": (Webhook, diff_webhooks),
     "apps": (App, diff_apps),
+    "routing": (RoutingRule, diff_routing),
+    "slas": (SLAPolicy, diff_slas),
 }
 RESOURCE_TYPES = (
     "apps",
@@ -63,6 +71,7 @@ RESOURCE_TYPES = (
     "guide",
     "macros",
     "routing",
+    "slas",
     "talk",
     "triggers",
     "views",
@@ -72,7 +81,7 @@ RESOURCE_TYPES = (
 APPLY_RESOURCE_HELP = "Resource type of the plan (" + ", ".join(RESOURCE_TYPES) + ")"
 SUPPORTED_RESOURCES = tuple(sorted((*_RESOURCE_CONFIG.keys(), "guide")))
 
-_APPLY_HANDLERS: dict[str, Callable[[Any, str], None]] = {
+_APPLY_HANDLERS: dict[str, Callable[[Any, str, bool], None]] = {
     "apps": apply_module.apply_apps,
     "fields": apply_module.apply_fields,
     "forms": apply_module.apply_forms,
@@ -80,6 +89,7 @@ _APPLY_HANDLERS: dict[str, Callable[[Any, str], None]] = {
     "guide": apply_module.apply_guide,
     "macros": apply_module.apply_macros,
     "routing": apply_module.apply_routing,
+    "slas": apply_module.apply_slas,
     "talk": apply_module.apply_talk,
     "triggers": apply_module.apply_triggers,
     "views": apply_module.apply_views,
@@ -105,6 +115,9 @@ PLAN_DIFF_ARGUMENT = typer.Argument(
 PLAN_OUTPUT_OPTION = typer.Option(None, help="Optional file path to store the plan JSON.")
 PLAN_FILE_ARGUMENT = typer.Argument(..., exists=True, readable=True, help="Plan JSON to apply.")
 ENVIRONMENT_OPTION = typer.Option(..., help="Zendesk environment identifier.")
+SNAPSHOT_OUTPUT_OPTION = typer.Option(
+    None, "--output", "-o", help="Output file path for snapshot JSON"
+)
 
 
 @app.command("docs-sync")
@@ -147,10 +160,23 @@ def docs_catalog() -> None:
 
 
 @app.command()
-def snapshot(env: str = ENVIRONMENT_OPTION) -> None:
-    """Placeholder command that will eventually export the active configuration."""
+def snapshot(
+    env: str = ENVIRONMENT_OPTION,
+    output: Path | None = SNAPSHOT_OUTPUT_OPTION,
+) -> None:
+    """Export the active Zendesk configuration for the given environment."""
 
-    typer.echo(f"Snapshotting Zendesk configuration for '{env}' is not yet implemented.")
+    try:
+        data = _export_zendesk_config(env)
+    except Exception as exc:  # pragma: no cover - depends on Zenpy availability
+        raise typer.BadParameter(str(exc)) from exc
+
+    snapshot_json = json.dumps(data, indent=2)
+    if output:
+        output.write_text(snapshot_json, encoding="utf-8")
+        typer.echo(f"Snapshot written to {output}")
+    else:
+        typer.echo(snapshot_json)
 
 
 @app.command()
@@ -170,12 +196,21 @@ def diff(
         current_models = _load_models(current_file, resource, model_cls)
         diffs = diff_fn(desired_models, current_models)
 
-    diff_payload = json.dumps(diffs, indent=2, sort_keys=True)
+    result = {resource: diffs}
+    diff_text = json.dumps(result, indent=2, sort_keys=True)
     if output is not None:
-        output.write_text(diff_payload, encoding="utf-8")
+        output.write_text(diff_text, encoding="utf-8")
         typer.echo(f"Diff written to {output}")
     else:
-        typer.echo(diff_payload)
+        adds = sum(1 for d in diffs if isinstance(d, Mapping) and d.get("op") == "add")
+        updates = sum(
+            1 for d in diffs if isinstance(d, Mapping) and d.get("op") in {"patch", "update"}
+        )
+        removes = sum(1 for d in diffs if isinstance(d, Mapping) and d.get("op") == "remove")
+        typer.echo(
+            f"{resource.capitalize()} diff: {adds} additions, {updates} changes, {removes} removals"
+        )
+        typer.echo(diff_text)
 
 
 @app.command()
@@ -185,12 +220,31 @@ def plan(
 ) -> None:
     """Emit a plan from a previously generated diff."""
 
-    payload = diff_file.read_text(encoding="utf-8")
+    diff_data = _read_structured_file(diff_file)
+
+    plan_ops: list[dict[str, Any]] = []
+    if isinstance(diff_data, Mapping):
+        for resource_name, changes in diff_data.items():
+            if not isinstance(changes, Sequence):
+                continue
+            for entry in changes:
+                if not isinstance(entry, Mapping):
+                    continue
+                plan_ops.extend(_plan_operations_from_entry(resource_name, entry))
+    elif isinstance(diff_data, Sequence):
+        inferred_resource = _infer_resource_from_entries(diff_data)
+        for entry in diff_data:
+            if not isinstance(entry, Mapping):
+                continue
+            plan_ops.extend(_plan_operations_from_entry(inferred_resource, entry))
+
+    plan_payload = {"operations": plan_ops}
+    plan_json = json.dumps(plan_payload, indent=2)
     if output is not None:
-        output.write_text(payload, encoding="utf-8")
+        output.write_text(plan_json, encoding="utf-8")
         typer.echo(f"Plan written to {output}")
     else:
-        typer.echo(payload)
+        typer.echo(plan_json)
 
 
 @app.command()
@@ -198,6 +252,7 @@ def apply(
     resource: str = typer.Argument(..., help=APPLY_RESOURCE_HELP),
     plan_file: Path = PLAN_FILE_ARGUMENT,
     env: str = ENVIRONMENT_OPTION,
+    dry_run: bool = typer.Option(False, "--dry-run", help="Simulate apply without making changes"),
 ) -> None:
     """Apply a previously generated plan for a specific Zendesk resource."""
 
@@ -216,31 +271,81 @@ def apply(
     except ValidationError as exc:
         raise typer.BadParameter(f"Invalid plan for resource '{resource}': {exc}") from exc
 
-    handlers = {
-        "apps": apply_module.apply_apps,
-        "fields": apply_module.apply_fields,
-        "forms": apply_module.apply_forms,
-        "groups": apply_module.apply_groups,
-        "guide": apply_module.apply_guide,
-        "macros": apply_module.apply_macros,
-        "routing": apply_module.apply_routing,
-        "talk": apply_module.apply_talk,
-        "triggers": apply_module.apply_triggers,
-        "views": apply_module.apply_views,
-        "webhooks": apply_module.apply_webhooks,
-        "widgets": apply_module.apply_widgets,
-    }
+    handlers = _APPLY_HANDLERS
     if resource not in handlers:
         valid = ", ".join(RESOURCE_TYPES)
         message = f"Unsupported resource '{resource}'. Valid options: {valid}."
         raise typer.BadParameter(message)
 
     try:
-        handlers[resource](plan_payload, env)
+        handlers[resource](plan_payload, env, dry_run=dry_run)
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
 
     typer.echo("ok")
+
+
+def _plan_operations_from_entry(resource: str, entry: Mapping[str, Any]) -> list[dict[str, Any]]:
+    op_type = entry.get("op") or entry.get("action")
+    name = _extract_name(entry)
+    operations: list[dict[str, Any]] = []
+    if op_type in {"add", "create"}:
+        value = entry.get("value") if "value" in entry else entry.get("data", {})
+        if value is None:
+            value = entry.get("data", {})
+        operations.append(
+            {
+                "action": "create",
+                "resource": resource,
+                "name": name,
+                "data": value,
+            }
+        )
+    elif op_type in {"remove", "delete"}:
+        operations.append(
+            {
+                "action": "delete",
+                "resource": resource,
+                "name": name,
+            }
+        )
+    elif op_type in {"patch", "update"}:
+        changes = entry.get("patches") if "patches" in entry else entry.get("changes", [])
+        operations.append(
+            {
+                "action": "update",
+                "resource": resource,
+                "name": name,
+                "changes": changes,
+            }
+        )
+    return operations
+
+
+def _extract_name(entry: Mapping[str, Any]) -> str:
+    path = entry.get("path", "")
+    if isinstance(path, str) and path:
+        segment = path.rstrip("/").split("/")[-1]
+        if segment:
+            return segment
+    name = entry.get("name")
+    if isinstance(name, str):
+        return name
+    return ""
+
+
+def _infer_resource_from_entries(entries: Sequence[object]) -> str:
+    for entry in entries:
+        if isinstance(entry, Mapping):
+            resource = entry.get("resource")
+            if isinstance(resource, str) and resource:
+                return resource
+            path = entry.get("path")
+            if isinstance(path, str) and path:
+                stripped = path.lstrip("/")
+                if stripped:
+                    return stripped.split("/", 1)[0]
+    return "resource"
 
 
 @app.command()
@@ -347,6 +452,132 @@ def _read_structured_file(path: Path) -> object:
         return json.loads(text)
     except json.JSONDecodeError as exc:
         raise typer.BadParameter(f"Failed to parse {path}: {exc}") from exc
+
+
+def _get_zendesk_client(env: str):
+    module_spec = importlib.util.find_spec("zenpy")
+    if module_spec is None:
+        raise RuntimeError("Zenpy is required to connect to Zendesk.")
+    zenpy_module = importlib.import_module("zenpy")
+    zenpy_client = getattr(zenpy_module, "Zenpy", None)
+    if zenpy_client is None:
+        raise RuntimeError("Zenpy client is unavailable.")
+
+    prefix = f"ZENDESK_{env.upper()}_"
+    subdomain = os.getenv(f"{prefix}SUBDOMAIN")
+    email = os.getenv(f"{prefix}EMAIL")
+    token = os.getenv(f"{prefix}TOKEN")
+    if not subdomain or not email or not token:
+        raise RuntimeError(f"Missing Zendesk credentials for environment '{env}'.")
+
+    return zenpy_client(subdomain=subdomain, email=email, token=token)
+
+
+def _collect_objects(client: object, attribute: str) -> list[Any]:
+    collection = getattr(client, attribute, None)
+    if collection is None:
+        return []
+    result = collection() if callable(collection) else collection
+    if result is None:
+        return []
+    if isinstance(result, list):
+        return result
+    try:
+        return list(result)
+    except TypeError:
+        return []
+
+
+def _export_zendesk_config(env: str) -> dict[str, Any]:
+    client = _get_zendesk_client(env)
+    snapshot: dict[str, Any] = {}
+
+    snapshot["triggers"] = [
+        (
+            trigger.to_dict()
+            if hasattr(trigger, "to_dict")
+            else {
+                "name": getattr(trigger, "title", None)
+                or getattr(trigger, "name", None)
+                or getattr(trigger, "id", None),
+                "active": getattr(trigger, "active", None),
+                "category": getattr(trigger, "category", None),
+                "conditions": getattr(trigger, "conditions", None),
+                "actions": getattr(trigger, "actions", None),
+                "position": getattr(trigger, "position", None),
+            }
+        )
+        for trigger in _collect_objects(client, "triggers")
+    ]
+
+    snapshot["fields"] = [
+        {
+            "name": getattr(field, "title", None) or getattr(field, "id", None),
+            "type": getattr(field, "type", None),
+            "options": [
+                getattr(opt, "value", opt)
+                for opt in getattr(field, "custom_field_options", []) or []
+            ],
+            "active": getattr(field, "active", None),
+            "description": getattr(field, "description", None),
+        }
+        for field in _collect_objects(client, "ticket_fields")
+    ]
+
+    snapshot["forms"] = [
+        {
+            "name": getattr(form, "name", None) or getattr(form, "id", None),
+            "fields": list(getattr(form, "ticket_field_ids", []) or []),
+            "active": getattr(form, "active", None),
+        }
+        for form in _collect_objects(client, "ticket_forms")
+    ]
+
+    snapshot["groups"] = [
+        {
+            "name": getattr(group, "name", None) or getattr(group, "id", None),
+            "description": getattr(group, "description", None),
+            "memberships": [],
+        }
+        for group in _collect_objects(client, "groups")
+    ]
+
+    snapshot["macros"] = [
+        {
+            "name": getattr(macro, "title", None)
+            or getattr(macro, "name", None)
+            or getattr(macro, "id", None),
+            "actions": [
+                {"field": getattr(action, "field", None), "value": getattr(action, "value", None)}
+                for action in getattr(macro, "actions", []) or []
+            ],
+            "active": getattr(macro, "active", None),
+        }
+        for macro in _collect_objects(client, "macros")
+    ]
+
+    snapshot["views"] = [
+        {
+            "name": getattr(view, "title", None)
+            or getattr(view, "name", None)
+            or getattr(view, "id", None),
+            "filters": getattr(view, "conditions", None) or {},
+            "columns": list(getattr(view, "columns", []) or []),
+            "sort": getattr(view, "execution", None) or {},
+        }
+        for view in _collect_objects(client, "views")
+    ]
+
+    snapshot["webhooks"] = [
+        {
+            "name": getattr(webhook, "name", None) or getattr(webhook, "id", None),
+            "endpoint": getattr(webhook, "endpoint", None),
+            "status": getattr(webhook, "status", None),
+        }
+        for webhook in _collect_objects(client, "webhooks")
+    ]
+
+    return snapshot
 
 
 __all__ = ["app"]

--- a/src/codex/dynamics/__init__.py
+++ b/src/codex/dynamics/__init__.py
@@ -1,0 +1,5 @@
+"""Dynamics 365 integration namespace for Codex."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/codex/dynamics/model/__init__.py
+++ b/src/codex/dynamics/model/__init__.py
@@ -1,0 +1,8 @@
+"""Data models for Dynamics 365 resources."""
+
+from __future__ import annotations
+
+from .choice import ChoiceSet
+from .role import DynamicsPrivilege, DynamicsRole
+
+__all__ = ["DynamicsPrivilege", "DynamicsRole", "ChoiceSet"]

--- a/src/codex/dynamics/model/choice.py
+++ b/src/codex/dynamics/model/choice.py
@@ -1,0 +1,35 @@
+"""Models describing Dynamics 365 choice (picklist) metadata."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ChoiceOption(BaseModel):
+    """An option in a global choice set."""
+
+    value: int
+    label: str
+
+
+class ChoiceSet(BaseModel):
+    """Definition of a global choice set with multiple options."""
+
+    name: str
+    options: list[ChoiceOption] = Field(default_factory=list)
+
+    def diff(self, other: ChoiceSet) -> list[dict[str, Any]]:
+        patches: list[dict[str, Any]] = []
+        self_options = {(opt.value, opt.label) for opt in self.options}
+        other_options = {(opt.value, opt.label) for opt in other.options}
+        if self_options != other_options:
+            patches.append(
+                {
+                    "op": "replace",
+                    "path": "/options",
+                    "value": [opt.model_dump() for opt in self.options],
+                }
+            )
+        return patches

--- a/src/codex/dynamics/model/role.py
+++ b/src/codex/dynamics/model/role.py
@@ -1,0 +1,36 @@
+"""Dynamics 365 role and privilege models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class DynamicsPrivilege(BaseModel):
+    """A privilege entry in a Dynamics 365 role (entity-level permission)."""
+
+    entity: str
+    privilege: str
+    level: str
+
+
+class DynamicsRole(BaseModel):
+    """Dynamics 365 security role with a set of privileges."""
+
+    name: str
+    privileges: list[DynamicsPrivilege] = Field(default_factory=list)
+
+    def diff(self, other: DynamicsRole) -> list[dict[str, Any]]:
+        patches: list[dict[str, Any]] = []
+        self_set = {(p.entity, p.privilege, p.level) for p in self.privileges}
+        other_set = {(p.entity, p.privilege, p.level) for p in other.privileges}
+        if self_set != other_set:
+            patches.append(
+                {
+                    "op": "replace",
+                    "path": "/privileges",
+                    "value": [priv.model_dump() for priv in self.privileges],
+                }
+            )
+        return patches

--- a/src/codex/dynamics/role_matrix.py
+++ b/src/codex/dynamics/role_matrix.py
@@ -1,0 +1,35 @@
+"""Utilities for aligning Zendesk and Dynamics role permissions."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from codex.dynamics.model.role import DynamicsRole
+from codex.zendesk.model.role import Role as ZendeskRole
+
+
+def build_role_matrix(
+    zendesk_roles: Iterable[ZendeskRole],
+    dynamics_roles: Iterable[DynamicsRole],
+) -> dict[str, dict[str, bool]]:
+    """Build a permission category matrix across Zendesk and Dynamics roles."""
+
+    category_map = {
+        "Ticket Management": ("tickets", "incident"),
+        "User Management": ("users", "account"),
+    }
+    matrix: dict[str, dict[str, bool]] = {category: {} for category in category_map}
+
+    for role in zendesk_roles:
+        for category, (zendesk_flag, _) in category_map.items():
+            has_permission = getattr(role.permissions, zendesk_flag, False)
+            matrix[category][role.name] = bool(has_permission)
+
+    for role in dynamics_roles:
+        for category, (_, dynamics_entity) in category_map.items():
+            has_privilege = any(
+                privilege.entity.lower() == dynamics_entity.lower() for privilege in role.privileges
+            )
+            matrix[category][role.name] = bool(has_privilege)
+
+    return matrix

--- a/src/codex/qa/__init__.py
+++ b/src/codex/qa/__init__.py
@@ -1,0 +1,5 @@
+"""Quality Assurance utilities for offline evaluation."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/codex/qa/rubric.py
+++ b/src/codex/qa/rubric.py
@@ -1,0 +1,75 @@
+"""Offline QA rubric definition and scoring utilities."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RubricCriterion(BaseModel):
+    """A single evaluation criterion in a QA rubric."""
+
+    id: str
+    description: str
+    max_score: float
+
+
+class QARubric(BaseModel):
+    """A QA rubric composed of multiple criteria."""
+
+    name: str
+    criteria: list[RubricCriterion] = Field(default_factory=list)
+
+
+def load_rubric(path: Path) -> QARubric:
+    """Load a QA rubric definition from CSV or JSON."""
+
+    if path.suffix.lower() == ".csv":
+        criteria: list[RubricCriterion] = []
+        with path.open("r", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            for row in reader:
+                if not row:
+                    continue
+                criteria.append(
+                    RubricCriterion(
+                        id=(row.get("id") or "").strip(),
+                        description=(row.get("description") or "").strip(),
+                        max_score=float(row.get("max_score") or 0),
+                    )
+                )
+        return QARubric(name=path.stem, criteria=criteria)
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return QARubric(**data)
+
+
+def generate_scores(input_path: Path, rubric: QARubric, output_path: Path) -> None:
+    """Generate a JSONL score file for the provided rubric."""
+
+    with (
+        input_path.open("r", encoding="utf-8") as fin,
+        output_path.open("w", encoding="utf-8") as fout,
+    ):
+        reader = csv.DictReader(fin)
+        for row in reader:
+            if not row:
+                continue
+            record_id = row.get("id") or row.get("record_id") or ""
+            scores: dict[str, Any] = {}
+            total_score = 0.0
+            for criterion in rubric.criteria:
+                raw_value = row.get(criterion.id)
+                try:
+                    value = float(raw_value) if raw_value not in (None, "") else None
+                except ValueError:
+                    value = None
+                scores[criterion.id] = value
+                if value is not None:
+                    total_score += value
+            payload = {"id": record_id, "scores": scores, "total_score": total_score}
+            fout.write(json.dumps(payload) + "\n")

--- a/src/codex/versioning.py
+++ b/src/codex/versioning.py
@@ -1,0 +1,79 @@
+"""Utilities for semantic versioning of Codex artifacts."""
+
+from __future__ import annotations
+
+import datetime
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+
+class SemanticVersion:
+    """Simple semantic version representation and manipulator."""
+
+    def __init__(self, version: str):
+        parts = version.split(".")
+        self.major = int(parts[0]) if len(parts) > 0 and parts[0].isdigit() else 0
+        self.minor = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 0
+        self.patch = int(parts[2]) if len(parts) > 2 and parts[2].isdigit() else 0
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    def bump(self, level: str = "patch") -> None:
+        if level == "major":
+            self.major += 1
+            self.minor = 0
+            self.patch = 0
+        elif level == "minor":
+            self.minor += 1
+            self.patch = 0
+        else:
+            self.patch += 1
+
+
+def determine_bump(diff_entries: list[Mapping[str, Any]] | list[dict[str, Any]]) -> str:
+    """Determine the semantic version bump level based on diff operations."""
+
+    level = "patch"
+    for entry in diff_entries:
+        op = entry.get("op") or entry.get("action")
+        if op in {"remove", "delete"}:
+            return "major"
+        if op in {"add", "create"} and level != "major":
+            level = "minor"
+    return level
+
+
+def update_artifact_version(
+    artifact_name: str,
+    diff: list[Mapping[str, Any]] | list[dict[str, Any]],
+    version_file: Path = Path("artifact_versions.json"),
+    changelog_file: Path = Path("CHANGELOG.md"),
+) -> str:
+    """Update the artifact version file and changelog based on diff operations."""
+
+    bump_level = determine_bump(diff)
+    versions: dict[str, str]
+    if version_file.exists():
+        try:
+            versions = json.loads(version_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            versions = {}
+    else:
+        versions = {}
+
+    current_version = versions.get(artifact_name, "0.0.0")
+    semver = SemanticVersion(current_version)
+    semver.bump(bump_level)
+    new_version = str(semver)
+    versions[artifact_name] = new_version
+    version_file.write_text(json.dumps(versions, indent=2), encoding="utf-8")
+
+    timestamp = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%SZ")
+    entry = f"{timestamp} - {artifact_name} updated to v{new_version} ({bump_level} change)\n"
+    with changelog_file.open("a", encoding="utf-8") as handle:
+        handle.write(entry)
+
+    return new_version

--- a/src/codex/zendesk/__init__.py
+++ b/src/codex/zendesk/__init__.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from .model import Action, Condition, Group, Membership, TicketField, TicketForm, Trigger
+from .model import Action, Condition, Group, Membership, Role, TicketField, TicketForm, Trigger
 
 __all__ = [
     "Action",
     "Condition",
     "Group",
     "Membership",
+    "Role",
     "TicketField",
     "TicketForm",
     "Trigger",

--- a/src/codex/zendesk/apply.py
+++ b/src/codex/zendesk/apply.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
+import os
 from collections.abc import Iterable, Mapping, Sequence
+from types import ModuleType
 from typing import Any
 
 from codex.zendesk.monitoring.zendesk_metrics import metrics as _metrics
@@ -11,6 +14,207 @@ from codex.zendesk.monitoring.zendesk_metrics import metrics as _metrics
 LOGGER = logging.getLogger(__name__)
 
 PlanOperations = Iterable[Mapping[str, Any]]
+
+_API_OBJECTS_MODULE: ModuleType | None = None
+
+_RESOURCE_ENDPOINTS: dict[str, tuple[str, str]] = {
+    "triggers": ("triggers", "Trigger"),
+    "fields": ("ticket_fields", "TicketField"),
+    "forms": ("ticket_forms", "TicketForm"),
+    "groups": ("groups", "Group"),
+    "macros": ("macros", "Macro"),
+    "views": ("views", "View"),
+    "webhooks": ("webhooks", "Webhook"),
+    "slas": ("sla_policies", "SLAPolicy"),
+}
+
+_RESOURCE_NAME_FIELDS: dict[str, tuple[str, ...]] = {
+    "triggers": ("title", "name", "id"),
+    "fields": ("title", "name", "id"),
+    "forms": ("name", "title", "id"),
+    "groups": ("name", "id"),
+    "macros": ("title", "name", "id"),
+    "views": ("title", "name", "id"),
+    "webhooks": ("name", "id"),
+    "slas": ("title", "name", "id"),
+}
+
+
+def _get_client(env: str):
+    module_spec = importlib.util.find_spec("zenpy")
+    if module_spec is None:
+        LOGGER.error("Zenpy package is not installed; cannot apply changes.")
+        return None
+    zenpy_module = importlib.import_module("zenpy")
+    zenpy_client = getattr(zenpy_module, "Zenpy", None)
+    if zenpy_client is None:
+        LOGGER.error("Zenpy client class is unavailable; cannot apply changes.")
+        return None
+
+    prefix = f"ZENDESK_{env.upper()}_"
+    subdomain = os.getenv(f"{prefix}SUBDOMAIN")
+    email = os.getenv(f"{prefix}EMAIL")
+    token = os.getenv(f"{prefix}TOKEN")
+    if not subdomain or not email or not token:
+        LOGGER.error("Missing Zendesk credentials for environment '%s'.", env)
+        return None
+
+    return zenpy_client(subdomain=subdomain, email=email, token=token)
+
+
+def _load_api_objects_module() -> ModuleType | None:
+    global _API_OBJECTS_MODULE
+    if _API_OBJECTS_MODULE is None:
+        module_spec = importlib.util.find_spec("zenpy.lib.api_objects")
+        if module_spec is None:
+            return None
+        _API_OBJECTS_MODULE = importlib.import_module("zenpy.lib.api_objects")
+    return _API_OBJECTS_MODULE
+
+
+def _get_api_class(class_name: str):
+    module = _load_api_objects_module()
+    if module is None:
+        return None
+    return getattr(module, class_name, None)
+
+
+def _list_existing(endpoint: Any) -> list[Any]:
+    if endpoint is None:
+        return []
+    try:
+        if callable(endpoint):
+            result = endpoint()
+        elif hasattr(endpoint, "list") and callable(endpoint.list):
+            result = endpoint.list()
+        else:
+            return []
+        if result is None:
+            return []
+        if isinstance(result, list):
+            return result
+        return list(result)
+    except Exception as exc:  # pragma: no cover - network interactions mocked in tests
+        LOGGER.debug("Unable to enumerate existing resources: %s", exc)
+        return []
+
+
+def _operation_name(resource: str, entry: Mapping[str, Any], data: Mapping[str, Any]) -> str:
+    name = entry.get("name")
+    if isinstance(name, str) and name:
+        return name
+    for field in _RESOURCE_NAME_FIELDS.get(resource, ("name", "title", "id")):
+        value = data.get(field)
+        if isinstance(value, str) and value:
+            return value
+        if value is not None:
+            return str(value)
+    path = entry.get("path")
+    if isinstance(path, str) and path:
+        segment = path.rstrip("/").split("/")[-1]
+        if segment:
+            return segment
+    return ""
+
+
+def _find_existing(existing: list[Any], resource: str, name: str):
+    if not name:
+        return None
+    for item in existing:
+        for field in _RESOURCE_NAME_FIELDS.get(resource, ("name", "title", "id")):
+            value = getattr(item, field, None)
+            if value is None:
+                continue
+            if str(value) == name:
+                return item
+    return None
+
+
+def _apply_patch_set(target: Any, patches: Sequence[Mapping[str, Any]]) -> None:
+    for patch in patches:
+        path = patch.get("path")
+        if not isinstance(path, str):
+            continue
+        attr = path.lstrip("/").split("/", 1)[0]
+        if not attr:
+            continue
+        if "value" in patch:
+            setattr(target, attr, patch.get("value"))
+
+
+def _apply_named_resource(
+    resource: str,
+    plan_data: Any,
+    env: str,
+    dry_run: bool,
+) -> None:
+    endpoint_attr, class_name = _RESOURCE_ENDPOINTS[resource]
+    operations = _extract_operations(plan_data, resource)
+    _log_pending(resource, operations, env)
+    if not operations:
+        return
+    if dry_run:
+        LOGGER.info("Dry-run enabled; skipping apply for resource '%s'.", resource)
+        return
+
+    client = _get_client(env)
+    if client is None:
+        return
+    endpoint = getattr(client, endpoint_attr, None)
+    if endpoint is None:
+        LOGGER.error(
+            "Zendesk client does not expose endpoint '%s' for resource '%s'.",
+            endpoint_attr,
+            resource,
+        )
+        return
+
+    api_class = _get_api_class(class_name)
+    if api_class is None:
+        LOGGER.error("Zenpy API object '%s' not found; cannot apply %s.", class_name, resource)
+        return
+
+    existing_items = _list_existing(endpoint)
+    create_fn = getattr(endpoint, "create", None)
+    update_fn = getattr(endpoint, "update", None)
+    delete_fn = getattr(endpoint, "delete", None)
+
+    for entry in operations:
+        action = entry.get("action") or entry.get("op")
+        payload = entry.get("data") or entry.get("value") or {}
+        if hasattr(payload, "model_dump"):
+            payload = payload.model_dump()
+        if not isinstance(payload, Mapping):
+            payload = {}
+        name = _operation_name(resource, entry, payload)
+
+        if action in {"add", "create"}:
+            if not callable(create_fn):
+                LOGGER.error("Create operation not supported for resource '%s'.", resource)
+                continue
+            instance = api_class(**payload)
+            create_fn(instance)
+        elif action in {"remove", "delete"}:
+            if not callable(delete_fn):
+                LOGGER.error("Delete operation not supported for resource '%s'.", resource)
+                continue
+            target = _find_existing(existing_items, resource, name)
+            if target is None:
+                LOGGER.warning("Resource '%s' named '%s' not found for deletion.", resource, name)
+                continue
+            delete_fn(target)
+        elif action in {"patch", "update"}:
+            if not callable(update_fn):
+                LOGGER.error("Update operation not supported for resource '%s'.", resource)
+                continue
+            target = _find_existing(existing_items, resource, name)
+            if target is None:
+                LOGGER.warning("Resource '%s' named '%s' not found for update.", resource, name)
+                continue
+            changes = entry.get("changes") or entry.get("patches") or []
+            if isinstance(changes, Sequence):
+                _apply_patch_set(target, changes)
+            update_fn(target)
 
 
 def _extract_operations(plan_data: Any, resource: str) -> list[Mapping[str, Any]]:
@@ -42,6 +246,9 @@ def _extract_operations(plan_data: Any, resource: str) -> list[Mapping[str, Any]
                 f"Plan for {resource} must contain mapping entries; item {index} is "
                 f"{entry_type}."
             )
+        entry_resource = entry.get("resource")
+        if entry_resource is not None and entry_resource != resource:
+            continue
         operations.append(entry)
     return operations
 
@@ -69,76 +276,107 @@ def _log_pending(resource: str, operations: PlanOperations, env: str) -> None:
         LOGGER.debug("Metrics emit skipped for resource '%s'.", resource)
 
 
-def apply_triggers(plan_data: Any, env: str) -> None:
+def apply_triggers(plan_data: Any, env: str, dry_run: bool = False) -> None:
     """Apply trigger operations to the given Zendesk environment."""
 
-    _log_pending("triggers", _extract_operations(plan_data, "triggers"), env)
+    _apply_named_resource("triggers", plan_data, env, dry_run)
 
 
-def apply_fields(plan_data: Any, env: str) -> None:
+def apply_fields(plan_data: Any, env: str, dry_run: bool = False) -> None:
     """Apply ticket field operations to the given Zendesk environment."""
 
-    _log_pending("fields", _extract_operations(plan_data, "fields"), env)
+    _apply_named_resource("fields", plan_data, env, dry_run)
 
 
-def apply_forms(plan_data: Any, env: str) -> None:
+def apply_forms(plan_data: Any, env: str, dry_run: bool = False) -> None:
     """Apply ticket form operations to the given Zendesk environment."""
 
-    _log_pending("forms", _extract_operations(plan_data, "forms"), env)
+    _apply_named_resource("forms", plan_data, env, dry_run)
 
 
-def apply_groups(plan_data: Any, env: str) -> None:
+def apply_groups(plan_data: Any, env: str, dry_run: bool = False) -> None:
     """Apply group operations to the given Zendesk environment."""
 
-    _log_pending("groups", _extract_operations(plan_data, "groups"), env)
+    _apply_named_resource("groups", plan_data, env, dry_run)
 
 
-def apply_macros(plan_data: Any, env: str) -> None:
+def apply_macros(plan_data: Any, env: str, dry_run: bool = False) -> None:
     """Apply macro operations to the given Zendesk environment."""
 
-    _log_pending("macros", _extract_operations(plan_data, "macros"), env)
+    _apply_named_resource("macros", plan_data, env, dry_run)
 
 
-def apply_views(plan_data: Any, env: str) -> None:
+def apply_views(plan_data: Any, env: str, dry_run: bool = False) -> None:
     """Apply view operations to the given Zendesk environment."""
 
-    _log_pending("views", _extract_operations(plan_data, "views"), env)
+    _apply_named_resource("views", plan_data, env, dry_run)
 
 
-def apply_webhooks(plan_data: Any, env: str) -> None:
+def apply_webhooks(plan_data: Any, env: str, dry_run: bool = False) -> None:
     """Apply webhook operations to the given Zendesk environment."""
 
-    _log_pending("webhooks", _extract_operations(plan_data, "webhooks"), env)
+    _apply_named_resource("webhooks", plan_data, env, dry_run)
 
 
-def apply_apps(plan_data: Any, env: str) -> None:
+def apply_apps(plan_data: Any, env: str, dry_run: bool = False) -> None:
     """Apply app operations to the given Zendesk environment."""
 
-    _log_pending("apps", _extract_operations(plan_data, "apps"), env)
+    operations = _extract_operations(plan_data, "apps")
+    _log_pending("apps", operations, env)
+    if dry_run:
+        LOGGER.info("Dry-run enabled; skipping apply for resource 'apps'.")
+        return
+    LOGGER.info("App apply logic is not yet implemented; operations logged only.")
 
 
-def apply_guide(plan_data: Any, env: str) -> None:
+def apply_guide(plan_data: Any, env: str, dry_run: bool = False) -> None:
     """Apply guide (themes/templates) operations to the given Zendesk environment."""
 
-    _log_pending("guide", _extract_operations(plan_data, "guide"), env)
+    operations = _extract_operations(plan_data, "guide")
+    _log_pending("guide", operations, env)
+    if dry_run:
+        LOGGER.info("Dry-run enabled; skipping apply for resource 'guide'.")
+        return
+    LOGGER.info("Guide apply logic is not yet implemented; operations logged only.")
 
 
-def apply_talk(plan_data: Any, env: str) -> None:
+def apply_talk(plan_data: Any, env: str, dry_run: bool = False) -> None:
     """Apply Talk (IVR, greetings, number bindings) operations to the given environment."""
 
-    _log_pending("talk", _extract_operations(plan_data, "talk"), env)
+    operations = _extract_operations(plan_data, "talk")
+    _log_pending("talk", operations, env)
+    if dry_run:
+        LOGGER.info("Dry-run enabled; skipping apply for resource 'talk'.")
+        return
+    LOGGER.info("Talk apply logic is not yet implemented; operations logged only.")
 
 
-def apply_routing(plan_data: Any, env: str) -> None:
+def apply_routing(plan_data: Any, env: str, dry_run: bool = False) -> None:
     """Apply skills-based routing operations to the given environment."""
 
-    _log_pending("routing", _extract_operations(plan_data, "routing"), env)
+    operations = _extract_operations(plan_data, "routing")
+    _log_pending("routing", operations, env)
+    if dry_run:
+        LOGGER.info("Dry-run enabled; skipping apply for resource 'routing'.")
+        return
+    LOGGER.info("Routing apply logic is not yet implemented; operations logged only.")
 
 
-def apply_widgets(plan_data: Any, env: str) -> None:
+def apply_widgets(plan_data: Any, env: str, dry_run: bool = False) -> None:
     """Apply web widget operations to the given Zendesk environment."""
 
-    _log_pending("widgets", _extract_operations(plan_data, "widgets"), env)
+    operations = _extract_operations(plan_data, "widgets")
+    _log_pending("widgets", operations, env)
+    if dry_run:
+        LOGGER.info("Dry-run enabled; skipping apply for resource 'widgets'.")
+        return
+    LOGGER.info("Widget apply logic is not yet implemented; operations logged only.")
+
+
+def apply_slas(plan_data: Any, env: str, dry_run: bool = False) -> None:
+    """Apply SLA policy operations to the given Zendesk environment."""
+
+    _apply_named_resource("slas", plan_data, env, dry_run)
 
 
 __all__ = [
@@ -148,6 +386,7 @@ __all__ = [
     "apply_groups",
     "apply_guide",
     "apply_macros",
+    "apply_slas",
     "apply_routing",
     "apply_talk",
     "apply_triggers",

--- a/src/codex/zendesk/model/__init__.py
+++ b/src/codex/zendesk/model/__init__.py
@@ -5,7 +5,9 @@ from .field import TicketField, TicketForm
 from .group import Group, Membership
 from .guide import GuideThemeRef, TemplatePatch
 from .macro import Macro
-from .routing import AgentSkills, Attribute, SkillValue, TicketSkillsPolicy
+from .role import Role, ZendeskRolePermissions
+from .routing import AgentSkills, Attribute, RoutingRule, SkillValue, TicketSkillsPolicy
+from .sla import SLAPolicy
 from .talk import Greeting, IVRMenu, IVRRoute, PhoneNumberBinding
 from .trigger import Action, Condition, Trigger
 from .view import View
@@ -25,7 +27,10 @@ __all__ = [
     "IVRRoute",
     "Macro",
     "Membership",
+    "Role",
     "PhoneNumberBinding",
+    "RoutingRule",
+    "SLAPolicy",
     "SkillValue",
     "TemplatePatch",
     "TicketField",
@@ -35,5 +40,5 @@ __all__ = [
     "View",
     "Webhook",
     "WidgetConfig",
+    "ZendeskRolePermissions",
 ]
-

--- a/src/codex/zendesk/model/role.py
+++ b/src/codex/zendesk/model/role.py
@@ -1,0 +1,35 @@
+"""Models for Zendesk custom roles and permissions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from .trigger import _ZendeskBaseModel
+
+
+class ZendeskRolePermissions(_ZendeskBaseModel):
+    """Simplified permissions flags for a Zendesk role."""
+
+    tickets: bool = Field(False, description="Permission to manage tickets")
+    users: bool = Field(False, description="Permission to manage end-users")
+
+
+class Role(_ZendeskBaseModel):
+    """Zendesk custom role with assigned permissions."""
+
+    name: str
+    permissions: ZendeskRolePermissions
+
+    def diff(self, other: Role) -> list[dict[str, Any]]:
+        patches: list[dict[str, Any]] = []
+        if self.permissions != other.permissions:
+            patches.append(
+                {
+                    "op": "replace",
+                    "path": "/permissions",
+                    "value": self.permissions.model_dump(),
+                }
+            )
+        return patches

--- a/src/codex/zendesk/model/routing.py
+++ b/src/codex/zendesk/model/routing.py
@@ -42,3 +42,19 @@ class TicketSkillsPolicy(_ZendeskBaseModel):
         if self.optional != other.optional:
             patches.append({"op": "replace", "path": "/optional", "value": self.optional})
         return patches
+
+
+class RoutingRule(_ZendeskBaseModel):
+    """A skills-based or queue routing rule for ticket assignment."""
+
+    name: str
+    conditions: dict[str, object] = Field(default_factory=dict)
+    destination: str
+
+    def diff(self, other: "RoutingRule") -> list[dict[str, object]]:
+        patches: list[dict[str, object]] = []
+        if self.conditions != other.conditions:
+            patches.append({"op": "replace", "path": "/conditions", "value": self.conditions})
+        if self.destination != other.destination:
+            patches.append({"op": "replace", "path": "/destination", "value": self.destination})
+        return patches

--- a/src/codex/zendesk/model/sla.py
+++ b/src/codex/zendesk/model/sla.py
@@ -1,0 +1,40 @@
+"""Models describing Zendesk SLA policies."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from .trigger import _ZendeskBaseModel
+
+
+class SLAPolicy(_ZendeskBaseModel):
+    """Zendesk SLA policy settings."""
+
+    name: str
+    description: str | None = None
+    targets: dict[str, int] = Field(
+        default_factory=dict,
+        description="Target times (minutes) for SLA metrics",
+    )
+
+    def diff(self, other: SLAPolicy) -> list[dict[str, Any]]:
+        patches: list[dict[str, Any]] = []
+        if self.targets != other.targets:
+            patches.append(
+                {
+                    "op": "replace",
+                    "path": "/targets",
+                    "value": dict(self.targets),
+                }
+            )
+        if self.description != other.description:
+            patches.append(
+                {
+                    "op": "replace",
+                    "path": "/description",
+                    "value": self.description,
+                }
+            )
+        return patches

--- a/src/codex/zendesk/plan/diff_engine.py
+++ b/src/codex/zendesk/plan/diff_engine.py
@@ -12,6 +12,8 @@ from codex.zendesk.model import (
     Group,
     GuideThemeRef,
     Macro,
+    RoutingRule,
+    SLAPolicy,
     TemplatePatch,
     TicketField,
     TicketForm,
@@ -102,6 +104,24 @@ def diff_guide(
         )
     )
     return diffs
+
+
+def diff_slas(
+    desired_policies: Iterable[ModelInput],
+    actual_policies: Iterable[ModelInput],
+) -> list[dict[str, Any]]:
+    """Compute JSON patch differences for SLA policies."""
+
+    return _diff_named_resources(desired_policies, actual_policies, SLAPolicy, base_path="/slas")
+
+
+def diff_routing(
+    desired_rules: Iterable[ModelInput],
+    actual_rules: Iterable[ModelInput],
+) -> list[dict[str, Any]]:
+    """Compute JSON patch differences for routing rules."""
+
+    return _diff_named_resources(desired_rules, actual_rules, RoutingRule, base_path="/routing")
 
 
 def _diff_named_resources(
@@ -202,6 +222,8 @@ __all__ = [
     "diff_guide",
     "diff_groups",
     "diff_macros",
+    "diff_routing",
+    "diff_slas",
     "diff_triggers",
     "diff_views",
     "diff_webhooks",


### PR DESCRIPTION
## Summary
- extend the Zendesk CLI with snapshot export, resource-aware diff planning, and dry-run aware apply orchestration for new routing and SLA resources
- integrate Zenpy-backed apply handlers with dry-run guardrails and add SLA and role models to the Zendesk diff engine
- scaffold Dynamics role/choice models with a cross-system role matrix, provide QA rubric scoring helpers, and add artifact versioning utilities

## Testing
- python -m compileall src/codex/cli_zendesk.py src/codex/zendesk/apply.py src/codex/versioning.py src/codex/dynamics src/codex/qa
- ruff check src/codex/cli_zendesk.py src/codex/qa/rubric.py src/codex/dynamics/role_matrix.py src/codex/zendesk/model/sla.py

------
https://chatgpt.com/codex/tasks/task_e_68ec3ea22d608331bc01949d894f2acc