### PR TITLE
Add release packaging workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,17 @@ archive-plan:
 archive-apply:
 	@python -m codex.cli archive apply-plan artifacts/archive_plan.json --repo _codex_ --by "$${USER:-codex}"
 
+# --- Release helpers (offline) ---
+.PHONY: release-pack release-verify release-unpack
+release-pack:
+	@python -m codex.cli release pack --staging work/release_staging --out dist/codex-release.tar.gz
+
+release-verify:
+	@python -m codex.cli release verify dist/codex-release.tar.gz
+
+release-unpack:
+	@python -m codex.cli release unpack dist/codex-release.tar.gz --dest /opt/codex/app
+
 quality:
 	pre-commit run --all-files
 	pytest

--- a/db/migrations/mariadb/002_release.sql
+++ b/db/migrations/mariadb/002_release.sql
@@ -1,0 +1,20 @@
+-- Release tracking tables (MariaDB)
+CREATE TABLE IF NOT EXISTS release_meta (
+  id          CHAR(36) PRIMARY KEY,
+  release_id  VARCHAR(191) NOT NULL,
+  version     VARCHAR(191) NOT NULL,
+  created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  actor       VARCHAR(256) NOT NULL,
+  metadata    JSON NOT NULL
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS release_component (
+  id            CHAR(36) PRIMARY KEY,
+  release_id    CHAR(36) NOT NULL,
+  item_id       CHAR(36) NULL,
+  tombstone     VARCHAR(191) NOT NULL,
+  dest_path     VARCHAR(2048) NOT NULL,
+  mode          VARCHAR(8) NOT NULL DEFAULT '0644',
+  template_vars JSON NOT NULL,
+  FOREIGN KEY (release_id) REFERENCES release_meta(id) ON DELETE CASCADE
+) ENGINE=InnoDB;

--- a/db/migrations/postgres/002_release.sql
+++ b/db/migrations/postgres/002_release.sql
@@ -1,0 +1,18 @@
+-- Release tracking tables (PostgreSQL)
+CREATE TABLE IF NOT EXISTS release_meta (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  release_id  TEXT NOT NULL,
+  version     TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL,
+  actor       TEXT NOT NULL,
+  metadata    JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE TABLE IF NOT EXISTS release_component (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  release_id    UUID NOT NULL REFERENCES release_meta(id) ON DELETE CASCADE,
+  item_id       UUID, -- optional link to archive.item
+  tombstone     TEXT NOT NULL,
+  dest_path     TEXT NOT NULL,
+  mode          TEXT NOT NULL DEFAULT '0644',
+  template_vars JSONB NOT NULL DEFAULT '{}'::jsonb
+);

--- a/db/migrations/sqlite/002_release.sql
+++ b/db/migrations/sqlite/002_release.sql
@@ -1,0 +1,18 @@
+-- Release tracking tables (optional; offline-friendly)
+CREATE TABLE IF NOT EXISTS release_meta (
+  id            TEXT PRIMARY KEY,
+  release_id    TEXT NOT NULL,
+  version       TEXT NOT NULL,
+  created_at    TEXT NOT NULL,
+  actor         TEXT NOT NULL,
+  metadata      TEXT NOT NULL DEFAULT '{}'
+);
+CREATE TABLE IF NOT EXISTS release_component (
+  id            TEXT PRIMARY KEY,
+  release_id    TEXT NOT NULL,
+  item_id       TEXT,             -- optional, if resolvable
+  tombstone     TEXT NOT NULL,
+  dest_path     TEXT NOT NULL,
+  mode          TEXT NOT NULL DEFAULT '0644',
+  template_vars TEXT NOT NULL DEFAULT '{}'
+);

--- a/docs/crm/admin-runbooks/release.md
+++ b/docs/crm/admin-runbooks/release.md
@@ -1,0 +1,45 @@
+# Codex Release (Offline Pack → Verify → Unpack)
+
+**Goal:** deterministically "roll up" a release from archived tombstones and materialize it on a target host—**offline**, **append-only evidence**, **never hard-delete**.
+
+## Prereqs
+```bash
+export CODEX_ARCHIVE_BACKEND=sqlite
+export CODEX_ARCHIVE_URL=sqlite:///./.codex/archive.sqlite
+export CODEX_EVIDENCE_DIR=.codex/evidence
+export CODEX_ACTOR="$USER"
+mkdir -p "$CODEX_EVIDENCE_DIR" dist/ work/
+```
+
+## Create a manifest
+```bash
+python -m codex.cli release init-manifest
+# edit release.manifest.json (set tombstones, paths, modes, template_vars)
+```
+
+## Pack
+```bash
+python -m codex.cli release pack --staging work/release_staging --out dist/codex-release.tar.gz
+# emits dist/release.manifest.lock.json (sha256-locked)
+```
+
+## Verify
+```bash
+python -m codex.cli release verify dist/codex-release.tar.gz
+```
+
+## Unpack (target)
+```bash
+python -m codex.cli release unpack dist/codex-release.tar.gz --dest /opt/codex/app
+```
+
+### Evidence
+Every PACK/VERIFY/UNPACK appends JSONL to:
+```text
+.codex/evidence/archive_ops.jsonl
+```
+
+## Notes & Guardrails
+- **No scripts executed** during unpack unless `--allow-scripts` is passed (not recommended).
+- Template variables perform **pure string substitution** in text-like files (.json/.txt/.md/.yml/.yaml/.env).
+- Use consolidation + archival to pin canonical components before release packing.

--- a/noxfile.py
+++ b/noxfile.py
@@ -285,6 +285,7 @@ def crm_gates(session: nox.Session) -> None:
     )
     session.run("pytest", "-q", "tests/d365")
     session.run("pytest", "-q", "tests/archive")
+    session.run("pytest", "-q", "tests/release")
 
 
 @nox.session(name="diagram_check", python=DEFAULT_PYTHON)

--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -613,6 +613,13 @@ def _register_external_cli() -> None:
     )
     _register_typer_app(
         cli,
+        "release",
+        "codex.cli_release",
+        "app",
+        help_text="Offline release pack/verify/unpack.",
+    )
+    _register_typer_app(
+        cli,
         "validate",
         "codex_ml.cli.validate",
         "app",

--- a/src/codex/cli_release.py
+++ b/src/codex/cli_release.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from codex.release.api import pack_release, unpack_bundle, verify_bundle
+
+DEFAULT_MANIFEST = Path("release.manifest.json")
+DEFAULT_STAGING = Path("work/release_staging")
+DEFAULT_BUNDLE = Path("dist/codex-release.tar.gz")
+DEFAULT_DEST = Path("/opt/codex/app")
+
+app = typer.Typer(help="Codex Release (offline pack/verify/unpack)")
+
+
+@app.command("init-manifest")
+def cmd_init_manifest(
+    out: Annotated[Path, typer.Argument()] = DEFAULT_MANIFEST,
+) -> None:
+    out.write_text(
+        json.dumps(
+            {
+                "release_id": "codex-YYYY.MM.DD-r01",
+                "version": "vYYYY.MM.DD",
+                "created_at": "YYYY-MM-DDTHH:MM:SSZ",
+                "actor": "marc",
+                "target": {"platforms": ["linux/amd64"], "apps": []},
+                "components": [
+                    {
+                        "tombstone": "<uuid>",
+                        "dest_path": "bin/codex-cli",
+                        "mode": "0755",
+                        "type": "file",
+                    },
+                ],
+                "symlinks": [],
+                "post_unpack_commands": [],
+                "checks": {"sha256_manifest": "<filled at pack time>"},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    typer.echo(out.as_posix())
+
+
+@app.command("pack")
+def cmd_pack(
+    manifest: Annotated[Path, typer.Argument(exists=True)] = DEFAULT_MANIFEST,
+    staging: Annotated[Path, typer.Option("--staging")] = DEFAULT_STAGING,
+    out_bundle: Annotated[Path, typer.Option("--out")] = DEFAULT_BUNDLE,
+) -> None:
+    bundle, locked = pack_release(manifest, staging, out_bundle)
+    typer.echo(
+        json.dumps(
+            {
+                "bundle": bundle.as_posix(),
+                "locked": {"sha256_manifest": locked["checks"]["sha256_manifest"]},
+            },
+            indent=2,
+        )
+    )
+
+
+@app.command("verify")
+def cmd_verify(
+    bundle: Annotated[Path, typer.Argument(exists=True)] = DEFAULT_BUNDLE,
+) -> None:
+    res = verify_bundle(bundle)
+    typer.echo(json.dumps(res, indent=2))
+
+
+@app.command("unpack")
+def cmd_unpack(
+    bundle: Annotated[Path, typer.Argument(exists=True)] = DEFAULT_BUNDLE,
+    dest: Annotated[Path, typer.Option("--dest")] = DEFAULT_DEST,
+    allow_scripts: Annotated[bool, typer.Option("--allow-scripts/--no-allow-scripts")] = False,
+) -> None:
+    d = unpack_bundle(bundle, dest, allow_scripts=allow_scripts)
+    typer.echo(json.dumps({"dest": d.as_posix()}, indent=2))

--- a/src/codex/release/__init__.py
+++ b/src/codex/release/__init__.py
@@ -1,0 +1,6 @@
+"""Release packaging helpers."""
+
+__all__ = [
+    "manifest",
+    "api",
+]

--- a/src/codex/release/api.py
+++ b/src/codex/release/api.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import os
+import tarfile
+from pathlib import Path
+
+from codex.archive.api import restore
+from codex.archive.dal import ArchiveDAL
+from codex.archive.util import append_evidence
+from codex.release.manifest import dump_manifest_locked, load_manifest
+
+
+def _set_mode(path: Path, mode_str: str) -> None:
+    mode = int(mode_str, 8)
+    os.chmod(path, (path.stat().st_mode & ~0o777) | mode)
+
+
+def _templated_bytes(data: bytes, vars: dict) -> bytes:
+    if not vars:
+        return data
+    try:
+        s = data.decode("utf-8", "ignore")
+    except Exception:
+        return data
+    for k, v in vars.items():
+        s = s.replace("{{" + str(k) + "}}", str(v))
+    return s.encode("utf-8")
+
+
+def _tar_add_bytes(tar: tarfile.TarFile, arcname: str, b: bytes, mode: int = 0o644) -> None:
+    ti = tarfile.TarInfo(arcname)
+    ti.size = len(b)
+    ti.mtime = 0
+    ti.uid = ti.gid = 0
+    ti.uname = ti.gname = ""
+    ti.mode = mode
+    tar.addfile(ti, io.BytesIO(b))
+
+
+def _tar_add_symlink(tar: tarfile.TarFile, linkname: str, target: str) -> None:
+    ti = tarfile.TarInfo(linkname)
+    ti.mtime = 0
+    ti.uid = ti.gid = 0
+    ti.uname = ti.gname = ""
+    ti.type = tarfile.SYMTYPE
+    ti.linkname = target
+    ti.mode = 0o777
+    tar.addfile(ti)
+
+
+def _is_safe_member(member: tarfile.TarInfo) -> bool:
+    name = Path(member.name)
+    return not name.is_absolute() and ".." not in name.parts
+
+
+def _safe_extract(tar: tarfile.TarFile, dest: Path) -> None:
+    for member in tar.getmembers():
+        if not _is_safe_member(member):
+            raise ValueError(f"unsafe path in archive: {member.name}")
+        target = dest / member.name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tar.extract(member, dest.as_posix())
+
+
+def pack_release(manifest_path: Path, staging_dir: Path, bundle_path: Path) -> tuple[Path, dict]:
+    """
+    Build a deterministic tar.gz bundle from a manifest referencing archive tombstones.
+    Returns (bundle_path, locked_manifest_dict).
+    """
+
+    m = load_manifest(manifest_path)
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    # hydrate components
+    for c in m.components:
+        obj = restore(c.tombstone)
+        outp = staging_dir / c.dest_path
+        outp.parent.mkdir(parents=True, exist_ok=True)
+        data = _templated_bytes(obj["bytes"], c.template_vars or {})
+        outp.write_bytes(data)
+        _set_mode(outp, c.mode)
+    # symlinks
+    for s in m.symlinks:
+        p = staging_dir / s.link_path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        if p.exists() or p.is_symlink():
+            with contextlib.suppress(OSError):
+                p.unlink()
+        os.symlink(s.target, p)
+    # lock manifest with sha256 of canonical JSON
+    manifest_dict = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest_for_hash = json.loads(json.dumps(manifest_dict))
+    checks = manifest_for_hash.get("checks", {})
+    if isinstance(checks, dict) and "sha256_manifest" in checks:
+        checks = dict(checks)
+        checks.pop("sha256_manifest", None)
+        if checks:
+            manifest_for_hash["checks"] = checks
+        else:
+            manifest_for_hash.pop("checks", None)
+    manifest_bytes = json.dumps(manifest_for_hash, sort_keys=True, separators=(",", ":")).encode()
+    sha = hashlib.sha256(manifest_bytes).hexdigest()
+    manifest_dict.setdefault("checks", {})["sha256_manifest"] = sha
+    dump_manifest_locked(manifest_dict, Path("dist/release.manifest.lock.json"))
+    # build deterministic tar.gz
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(
+        bundle_path.as_posix(), "w:gz", compresslevel=9, format=tarfile.GNU_FORMAT
+    ) as tar:
+        # embed staged files
+        for f in sorted(staging_dir.rglob("*")):
+            if f == staging_dir:
+                continue
+            arc = f.relative_to(staging_dir).as_posix()
+            if f.is_symlink():
+                _tar_add_symlink(tar, arc, os.readlink(f))
+            elif f.is_file():
+                b = f.read_bytes()
+                mode = f.stat().st_mode & 0o777
+                _tar_add_bytes(tar, arc, b, mode)
+        # embed locked manifest as well
+        locked = Path("dist/release.manifest.lock.json")
+        _tar_add_bytes(tar, "release.manifest.lock.json", locked.read_bytes(), 0o644)
+    append_evidence(
+        {
+            "action": "PACK",
+            "release_id": m.release_id,
+            "version": m.version,
+            "bundle": bundle_path.as_posix(),
+        }
+    )
+    # optional: record release rows (best-effort)
+    with contextlib.suppress(Exception):
+        _dal = ArchiveDAL.from_env()
+        # Minimal write: release row with metadata JSON in referent table not implemented
+        # here for portability. Full SQL persistence added via migrations 002_*.sql (optional
+        # hookup to DAL extensions).
+    return bundle_path, manifest_dict
+
+
+def verify_bundle(bundle_path: Path) -> dict:
+    import json
+    import tarfile
+
+    with tarfile.open(bundle_path.as_posix(), "r:gz") as tar:
+        extracted = tar.extractfile("release.manifest.lock.json")
+        if extracted is None:
+            raise FileNotFoundError("release.manifest.lock.json missing from bundle")
+        manifest_bytes = extracted.read()
+        locked_manifest = json.loads(manifest_bytes)
+        stored = locked_manifest.get("checks", {}).get("sha256_manifest")
+        manifest_for_hash = json.loads(json.dumps(locked_manifest))
+        checks = manifest_for_hash.get("checks", {})
+        if isinstance(checks, dict):
+            checks = dict(checks)
+            checks.pop("sha256_manifest", None)
+            if checks:
+                manifest_for_hash["checks"] = checks
+            else:
+                manifest_for_hash.pop("checks", None)
+        canonical_bytes = json.dumps(
+            manifest_for_hash, sort_keys=True, separators=(",", ":")
+        ).encode()
+        recomputed = hashlib.sha256(canonical_bytes).hexdigest()
+        ok = stored == recomputed
+    append_evidence({"action": "VERIFY", "bundle": bundle_path.as_posix(), "ok": ok})
+    if not ok:
+        raise RuntimeError("manifest sha mismatch")
+    return {"ok": ok, "sha256_manifest": stored}
+
+
+def unpack_bundle(bundle_path: Path, dest_dir: Path, allow_scripts: bool = False) -> Path:
+    import tarfile
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(bundle_path.as_posix(), "r:gz") as tar:
+        _safe_extract(tar, dest_dir)
+        # Do not execute any scripts by default; a future flag can explicitly allow it.
+        if not allow_scripts:
+            # noop
+            pass
+    append_evidence(
+        {"action": "UNPACK", "bundle": bundle_path.as_posix(), "dest": dest_dir.as_posix()}
+    )
+    return dest_dir

--- a/src/codex/release/manifest.py
+++ b/src/codex/release/manifest.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{2,}$", re.I)
+
+
+@dataclass
+class Component:
+    tombstone: str
+    dest_path: str
+    mode: str = "0644"
+    type: str = "file"  # file only in this scaffold
+    template_vars: dict[str, Any] | None = None
+
+
+@dataclass
+class Symlink:
+    link_path: str
+    target: str
+
+
+@dataclass
+class Manifest:
+    release_id: str
+    version: str
+    created_at: str
+    actor: str
+    target: dict[str, Any]
+    components: list[Component]
+    symlinks: list[Symlink]
+    post_unpack_commands: list[str]
+    checks: dict[str, Any]
+
+
+def _require(cond: bool, msg: str) -> None:
+    if not cond:
+        raise ValueError(msg)
+
+
+def _is_rel_safe(path: str) -> bool:
+    # Disallow abs paths and path traversal
+    return not (path.startswith("/") or ".." in Path(path).parts)
+
+
+def load_manifest(p: Path) -> Manifest:
+    data = json.loads(p.read_text(encoding="utf-8"))
+    _require(
+        "release_id" in data and bool(_ID_RE.match(data["release_id"] or "")),
+        "invalid or missing release_id",
+    )
+    _require("version" in data and data["version"], "missing version")
+    _require("created_at" in data and data["created_at"], "missing created_at")
+    _require("actor" in data and data["actor"], "missing actor")
+    _require(
+        "components" in data and isinstance(data["components"], list) and bool(data["components"]),
+        "missing components[]",
+    )
+    components: list[Component] = []
+    for c in data["components"]:
+        _require("tombstone" in c and c["tombstone"], "component missing tombstone")
+        _require("dest_path" in c and c["dest_path"], "component missing dest_path")
+        _require(_is_rel_safe(c["dest_path"]), f"unsafe dest_path: {c['dest_path']}")
+        components.append(
+            Component(
+                tombstone=c["tombstone"],
+                dest_path=c["dest_path"],
+                mode=c.get("mode", "0644"),
+                type=c.get("type", "file"),
+                template_vars=c.get("template_vars"),
+            )
+        )
+    symlinks: list[Symlink] = []
+    for s in data.get("symlinks", []):
+        _require("link_path" in s and s["link_path"], "symlink missing link_path")
+        _require("target" in s and s["target"], "symlink missing target")
+        _require(_is_rel_safe(s["link_path"]), f"unsafe link_path: {s['link_path']}")
+        symlinks.append(Symlink(link_path=s["link_path"], target=s["target"]))
+    return Manifest(
+        release_id=data["release_id"],
+        version=data["version"],
+        created_at=data["created_at"],
+        actor=data["actor"],
+        target=data.get("target", {}),
+        components=components,
+        symlinks=symlinks,
+        post_unpack_commands=data.get("post_unpack_commands", []),
+        checks=data.get("checks", {}),
+    )
+
+
+def dump_manifest_locked(m: dict[str, Any], out: Path) -> None:
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(m, indent=2), encoding="utf-8")

--- a/tests/release/test_release_pack_verify.py
+++ b/tests/release/test_release_pack_verify.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+
+from codex.archive.api import store
+from codex.release.api import pack_release, verify_bundle
+
+
+def test_pack_and_verify(tmp_path, monkeypatch):
+    root = tmp_path
+    (root / "dist").mkdir()
+    (root / "work" / "release_staging").mkdir(parents=True, exist_ok=True)
+    # Configure archive (SQLite)
+    monkeypatch.setenv("CODEX_ARCHIVE_BACKEND", "sqlite")
+    monkeypatch.setenv(
+        "CODEX_ARCHIVE_URL",
+        f"sqlite:///{(root / '.codex' / 'archive.sqlite').as_posix()}",
+    )
+    monkeypatch.setenv("CODEX_EVIDENCE_DIR", (root / ".codex" / "evidence").as_posix())
+    (root / ".codex" / "evidence").mkdir(parents=True, exist_ok=True)
+    # Store an artifact → tombstone
+    src_bytes = b'{"hello":"world"}\n'
+    out = store(
+        repo="_codex_",
+        path="configs/sample.json",
+        by="tester",
+        reason="release_component",
+        commit_sha="HEAD",
+        bytes_in=src_bytes,
+        mime="application/json",
+        lang="json",
+    )
+    # Manifest
+    manifest = {
+        "release_id": "codex-test-r01",
+        "version": "v0",
+        "created_at": "2025-10-13T00:00:00Z",
+        "actor": "tester",
+        "target": {"platforms": ["linux/amd64"], "apps": []},
+        "components": [
+            {
+                "tombstone": out["tombstone"],
+                "dest_path": "configs/sample.json",
+                "mode": "0644",
+                "type": "file",
+            }
+        ],
+        "symlinks": [],
+        "post_unpack_commands": [],
+        "checks": {"sha256_manifest": "<filled at pack time>"},
+    }
+    (root / "release.manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    # Pack
+    bundle, locked = pack_release(
+        root / "release.manifest.json",
+        root / "work" / "release_staging",
+        root / "dist" / "codex-release.tar.gz",
+    )
+    assert bundle.exists()
+    assert "sha256_manifest" in locked["checks"]
+    # Verify
+    verification = verify_bundle(bundle)
+    assert verification["ok"] is True
+    assert verification["sha256_manifest"] == locked["checks"]["sha256_manifest"]

--- a/tests/release/test_release_unpack.py
+++ b/tests/release/test_release_unpack.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+
+from codex.archive.api import store
+from codex.release.api import pack_release, unpack_bundle
+
+
+def test_unpack(tmp_path, monkeypatch):
+    root = tmp_path
+    (root / "dist").mkdir()
+    (root / "work" / "release_staging").mkdir(parents=True, exist_ok=True)
+    # Configure archive (SQLite)
+    monkeypatch.setenv("CODEX_ARCHIVE_BACKEND", "sqlite")
+    monkeypatch.setenv(
+        "CODEX_ARCHIVE_URL",
+        f"sqlite:///{(root / '.codex' / 'archive.sqlite').as_posix()}",
+    )
+    monkeypatch.setenv("CODEX_EVIDENCE_DIR", (root / ".codex" / "evidence").as_posix())
+    (root / ".codex" / "evidence").mkdir(parents=True, exist_ok=True)
+    # Store artifacts
+    tombstone_bin = store(
+        repo="_codex_",
+        path="bin/codex-cli",
+        by="tester",
+        reason="release_component",
+        commit_sha="HEAD",
+        bytes_in=b"#!/bin/sh\necho codex\n",
+        mime="text/x-shellscript",
+        lang="shell",
+    )
+    tombstone_cfg = store(
+        repo="_codex_",
+        path="configs/app.json",
+        by="tester",
+        reason="release_component",
+        commit_sha="HEAD",
+        bytes_in=b'{"name":"{{app}}"}\n',
+        mime="application/json",
+        lang="json",
+    )
+    manifest = {
+        "release_id": "codex-test-r02",
+        "version": "v0",
+        "created_at": "2025-10-13T00:00:00Z",
+        "actor": "tester",
+        "target": {},
+        "components": [
+            {
+                "tombstone": tombstone_bin["tombstone"],
+                "dest_path": "bin/codex-cli",
+                "mode": "0755",
+                "type": "file",
+            },
+            {
+                "tombstone": tombstone_cfg["tombstone"],
+                "dest_path": "configs/app.json",
+                "mode": "0644",
+                "type": "file",
+                "template_vars": {"app": "codex"},
+            },
+        ],
+        "symlinks": [{"link_path": "bin/codex", "target": "bin/codex-cli"}],
+        "post_unpack_commands": [],
+        "checks": {"sha256_manifest": "<filled at pack time>"},
+    }
+    (root / "release.manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    bundle, _ = pack_release(
+        root / "release.manifest.json",
+        root / "work" / "release_staging",
+        root / "dist" / "codex-release.tar.gz",
+    )
+    dest = root / "unpacked"
+    unpack_bundle(bundle, dest, allow_scripts=False)
+    assert (dest / "bin" / "codex-cli").exists()
+    assert (dest / "bin" / "codex").is_symlink()
+    assert (dest / "configs" / "app.json").read_text(encoding="utf-8").strip() == '{"name":"codex"}'


### PR DESCRIPTION
## Summary
- add release manifest dataclasses and packaging helpers for deterministic tarball builds
- wire a new Typer-based `codex release` CLI along with docs, Makefile targets, and database migrations for release tracking
- cover the flow with release pack/verify/unpack tests and include them in the CRM gates session

## Testing
- pytest -q tests/release
- mypy --ignore-missing-imports --follow-imports=skip src/codex/release src/codex/cli_release.py

------
https://chatgpt.com/codex/tasks/task_e_68ecc012c8088331bea55101e278ba79