### PR TITLE
Add release persistence for packed releases

### DIFF
--- a/docs/crm/admin-runbooks/release.md
+++ b/docs/crm/admin-runbooks/release.md
@@ -43,3 +43,14 @@ Every PACK/VERIFY/UNPACK appends JSONL to:
 - **No scripts executed** during unpack unless `--allow-scripts` is passed (not recommended).
 - Template variables perform **pure string substitution** in text-like files (.json/.txt/.md/.yml/.yaml/.env).
 - Use consolidation + archival to pin canonical components before release packing.
+
+## (Optional) Persist release rows (SQLite-first)
+`release pack` will attempt to write release metadata to the archive if the backend supports it:
+
+- `release_meta(release_id, version, created_at, actor, metadata)`
+- `release_component(release_id → release_meta.id, item_id?, tombstone, dest_path, mode, template_vars)`
+
+Backends:
+
+- **SQLite**: implemented.
+- **Postgres/MariaDB**: stubs available; implement the DAL methods in `src/codex/archive/dal.py` to enable.

--- a/tests/release/test_release_dal.py
+++ b/tests/release/test_release_dal.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from codex.archive.api import store
+from codex.archive.dal import ArchiveDAL
+from codex.release.api import pack_release
+
+
+def test_release_persist_rows(tmp_path, monkeypatch):
+    root = tmp_path
+    (root / "dist").mkdir(parents=True, exist_ok=True)
+    (root / "work" / "release_staging").mkdir(parents=True, exist_ok=True)
+    (root / ".codex" / "evidence").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("CODEX_ARCHIVE_BACKEND", "sqlite")
+    monkeypatch.setenv(
+        "CODEX_ARCHIVE_URL",
+        f"sqlite:///{(root / '.codex' / 'archive.sqlite').as_posix()}",
+    )
+    monkeypatch.setenv("CODEX_EVIDENCE_DIR", (root / ".codex" / "evidence").as_posix())
+    out = store(
+        repo="_codex_",
+        path="bin/codex-cli",
+        by="tester",
+        reason="release_component",
+        commit_sha="HEAD",
+        bytes_in=b"#!/bin/sh\necho codex\n",
+        mime="text/x-shellscript",
+        lang="shell",
+    )
+    manifest = {
+        "release_id": "codex-it-r01",
+        "version": "v1",
+        "created_at": "2025-10-13T00:00:00Z",
+        "actor": "tester",
+        "target": {"platforms": ["linux/amd64"]},
+        "components": [
+            {
+                "tombstone": out["tombstone"],
+                "dest_path": "bin/codex-cli",
+                "mode": "0755",
+                "type": "file",
+            }
+        ],
+        "symlinks": [],
+        "post_unpack_commands": [],
+        "checks": {"sha256_manifest": "<filled at pack time>"},
+    }
+    manifest_path = root / "release.manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    bundle, _ = pack_release(
+        manifest_path,
+        root / "work" / "release_staging",
+        root / "dist" / "codex-release.tar.gz",
+    )
+    assert bundle.exists()
+
+    dal = ArchiveDAL.from_env()
+    meta = dal.get_release_meta_by_release_id(release_id="codex-it-r01")
+    assert meta is not None
+    conn = sqlite3.connect((root / ".codex" / "archive.sqlite").as_posix())
+    conn.row_factory = sqlite3.Row
+    rows = list(
+        conn.execute(
+            "SELECT * FROM release_component WHERE release_id = ?",
+            (meta["id"],),
+        )
+    )
+    assert len(rows) == 1
+    assert rows[0]["tombstone"] == out["tombstone"]
+    conn.close()


### PR DESCRIPTION
## Summary
- add DAL methods for release metadata and component persistence, including sqlite implementations and placeholders for postgres/mariadb
- persist release metadata and component entries when packing releases, emitting evidence on success or failure
- cover the workflow with a sqlite-backed test and document optional release row persistence in the runbook

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/release -k release_dal

------
https://chatgpt.com/codex/tasks/task_e_68ecc4557de083319b473a652433dbf7