### PR TITLE
Update Hydra CLI usage to rely on config path/name flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ codex-gates:
 .PHONY: hydra-sweep
 hydra-sweep:
 @echo "[hydra-sweep] Example multirun:"
-@echo "python -m codex_ml.cli.hydra_main --multirun +defaults=@configs/default.yaml learning_rate=1e-5,3e-5,5e-5 batch_size=2,4"
+@echo "python -m codex_ml.cli.hydra_main --multirun --config-path configs --config-name default learning_rate=1e-5,3e-5,5e-5 batch_size=2,4"
 
 .PHONY: repo-admin-dry-run repo-admin-apply
 

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,5 +1,5 @@
 # Safe baseline defaults for Codex ML Hydra runs (offline-friendly)
-# Apply with: python -m codex_ml.cli.hydra_main +defaults=@configs/default.yaml
+# Apply with: python -m codex_ml.cli.hydra_main --config-path configs --config-name default
 model_name: "sshleifer/tiny-gpt2"
 dataset_path: "data/tiny_corpus.txt"
 epochs: 1

--- a/docs/configuration/hydra_quickstart.md
+++ b/docs/configuration/hydra_quickstart.md
@@ -6,20 +6,20 @@
 - Config file: configs/default.yaml (safe, offline)
 - Example:
 ```bash
-python -m codex_ml.cli.hydra_main +defaults=@configs/default.yaml
+python -m codex_ml.cli.hydra_main --config-path configs --config-name default
 ```
 
 ## Override examples
 - Change learning rate and epochs:
 ```bash
-python -m codex_ml.cli.hydra_main +defaults=@configs/default.yaml learning_rate=3e-5 epochs=2
+python -m codex_ml.cli.hydra_main --config-path configs --config-name default learning_rate=3e-5 epochs=2
 ```
 
 ## Multirun (sweep) examples
 - Sweep learning rate and batch size (offline):
 ```bash
 python -m codex_ml.cli.hydra_main --multirun \
-  +defaults=@configs/default.yaml \
+  --config-path configs --config-name default \
   learning_rate=1e-5,3e-5,5e-5 \
   batch_size=2,4
 ```
@@ -27,7 +27,7 @@ python -m codex_ml.cli.hydra_main --multirun \
 - Sweep LoRA flags (if PEFT available; otherwise ignored gracefully):
 ```bash
 python -m codex_ml.cli.hydra_main --multirun \
-  +defaults=@configs/default.yaml \
+  --config-path configs --config-name default \
   use_lora=true,false \
   lora_rank=4,8
 ```


### PR DESCRIPTION
## Summary
- update the baseline Hydra config comment to show the --config-path/--config-name invocation
- align the Hydra quickstart guide and Makefile helper text with the updated CLI syntax

## Testing
- git commit

------
https://chatgpt.com/codex/tasks/task_e_68ef09c40a4483319404330ca6cd556d