### PR TITLE
feat(packaging): add local build tooling and plugin registry scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ metrics-csv:
 mlflow-ui:
 	. .venv/bin/activate && mlflow ui --backend-store-uri file:./mlruns
 
-.PHONY: lint tests test build type setup venv env-info codex-gates wheelhouse fast-tests sys-tests ssp-tests sec-scan sec-audit lock-refresh ci-local coverage gates lint-policy lint-ruff lint-hybrid lint-auto quality fix-shebangs hooks integrity space-audit space-audit-fast space-explain space-diff space-clean data-pull data-push pipeline dvc-repro
+.PHONY: lint tests test build wheel sdist install-local type setup venv env-info codex-gates wheelhouse fast-tests sys-tests ssp-tests sec-scan sec-audit lock-refresh ci-local coverage gates lint-policy lint-ruff lint-hybrid lint-auto quality fix-shebangs hooks integrity space-audit space-audit-fast space-explain space-diff space-clean data-pull data-push pipeline dvc-repro
 
 format:
 	pre-commit run --all-files
@@ -80,8 +80,24 @@ quality:
 	pre-commit run --all-files
 	pytest
 
+# --- Packaging (local-first) ---
 build:
-	python -m build
+	@python -m pip install --upgrade build >/dev/null 2>&1 || true
+	@python -m build
+	@ls -lh dist || true
+
+wheel:
+	@python -m pip install --upgrade build >/dev/null 2>&1 || true
+	@python -m build --wheel
+	@ls -lh dist || true
+
+sdist:
+	@python -m pip install --upgrade build >/dev/null 2>&1 || true
+	@python -m build --sdist
+	@ls -lh dist || true
+
+install-local:
+	@python -m pip install -e ".[dev,test]"
 
 type:
 	mypy src

--- a/docs/packaging/Packaging_and_Release.md
+++ b/docs/packaging/Packaging_and_Release.md
@@ -1,0 +1,44 @@
+# Packaging & Release (Local-First)
+
+This guide covers the local packaging workflow introduced for week 3.
+
+## Build artifacts
+
+```bash
+make build    # build wheel + sdist under ./dist/
+make wheel    # wheel only
+make sdist    # sdist only
+```
+
+Each target installs `build` on demand and prints a short listing of the `dist/` directory for quick inspection.
+
+## Local installation
+
+```bash
+pip install dist/<artifact>.whl
+# or for editable development installs
+make install-local
+```
+
+`install-local` installs the project in editable mode together with the `dev` and `test` extras so linters and tests are ready to run.
+
+## CLI entry points
+
+The CLI scripts now flow through safe wrappers:
+
+```bash
+codex-train --help
+python -m codex_ml  # continues to dispatch to the Hydra entrypoint
+```
+
+An evaluation CLI stub (`codex-eval`) is present and exits with a helpful message until the implementation lands.
+
+## Optional extras
+
+New optional dependency groups:
+
+- `plugins` – metadata shim for Python < 3.10.
+- `dist` – `torch` CPU/CUDA meta-package for distributed helpers.
+- `tokenizers` – installs the `tokenizers` library when needed.
+
+These join the existing extras to keep installations explicit and modular.

--- a/docs/plugins/Plugin_Registry.md
+++ b/docs/plugins/Plugin_Registry.md
@@ -1,0 +1,44 @@
+# Plugin Registry
+
+The Codex ML plugin surface is intentionally small. A single registry keeps track of
+`BasePlugin` instances and can populate itself from Python entry points.
+
+## Programmatic registration
+
+```python
+from codex_ml.plugins import BasePlugin, registry
+
+class MyPlugin(BasePlugin):
+    def name(self) -> str:
+        return "my-plugin"
+
+    def version(self) -> str:
+        return "0.1.0"
+
+registry().register(MyPlugin())
+```
+
+The registry is global within the process, so repeated calls return the same instance.
+Use `override=True` when you intentionally want to replace an existing plugin implementation.
+
+## Entry-point discovery
+
+Declare plugins under the `codex_ml.plugins` group in `pyproject.toml`:
+
+```toml
+[project.entry-points."codex_ml.plugins"]
+my-plugin = "my_pkg.my_module:MyPlugin"
+```
+
+Then call discovery:
+
+```python
+from codex_ml.plugins import registry
+added = registry().discover()
+```
+
+Discovery is best-effort: broken entry points are skipped so the rest of the environment can keep loading.
+
+## Example plugin
+
+`examples/plugins/hello_plugin.py` is bundled for smoke tests and demonstrates the minimum viable plugin implementation.

--- a/docs/training/Distributed_Minimal_Hooks.md
+++ b/docs/training/Distributed_Minimal_Hooks.md
@@ -1,0 +1,41 @@
+# Minimal Distributed Hooks
+
+The `codex_ml.distributed.minimal` module offers safe helper functions that do nothing
+when `torch.distributed` is unavailable. This keeps local development and CI workflows fast
+while enabling opt-in DDP runs.
+
+## Quick start
+
+```python
+from codex_ml.distributed import (
+    barrier,
+    cleanup,
+    get_rank,
+    get_world_size,
+    init_distributed_if_needed,
+)
+
+init_distributed_if_needed()  # gated by CODEX_DDP=1
+rank = get_rank()
+world = get_world_size()
+# ... training loop ...
+barrier()
+cleanup()
+```
+
+## Enabling distributed mode
+
+```bash
+export CODEX_DDP=1
+python -m codex_ml.cli.hydra_main --config-path configs --config-name default
+```
+
+The helper defaults to the NCCL backend but automatically falls back to `gloo` when CUDA is
+unavailable. All functions return sensible defaults (`rank=0`, `world_size=1`) if the process
+group was never initialised.
+
+## Failure handling
+
+`init_distributed_if_needed` catches and suppresses errors thrown during initialisation so
+single-process workflows stay usable even in partially configured environments (e.g., missing
+hostfile or incorrect backend).

--- a/examples/plugins/hello_plugin.py
+++ b/examples/plugins/hello_plugin.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from codex_ml.plugins import BasePlugin
+
+
+class HelloPlugin(BasePlugin):
+    def name(self) -> str:
+        return "hello"
+
+    def version(self) -> str:
+        return "0.1.0"
+
+    def activate(self, app_ctx=None) -> None:
+        # No-op activation; example plugin only.
+        return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,15 @@ monitoring = ["psutil>=5.9"]
 gpu = ["nvidia-ml-py3>=7.352.0"]
 perf = ["numpy>=1.24; python_version<'3.13'", "mlflow>=2.0"]
 ops = ["requests>=2.31", "PyJWT>=2.8"]
+plugins = [
+  "importlib-metadata; python_version < '3.10'"
+]
+dist = [
+  "torch>=2.1; platform_system != 'Windows'"
+]
+tokenizers = [
+  "tokenizers>=0.15"
+]
 dev = [
   "pytest>=7.4",
   "pytest-cov>=4.1",
@@ -99,7 +108,8 @@ codex = "codex.cli:cli"
 codex-import-ndjson = "codex.logging.import_ndjson:main"
 codex-ml-cli = "codex_ml.cli.main:cli"
 codex-cli = "codex_ml.cli.simple_cli:main"
-codex-train = "codex_ml.cli.hydra_main:main"
+codex-train = "codex_ml.cli.entrypoints:train_main"
+codex-eval = "codex_ml.cli.entrypoints:eval_main"
 hhg-train = "hhg_logistics.main:main"
 ndjson-to-csv = "common.ndjson_tools:cli_ndjson_to_csv"
 codex-tokenizer = "tokenization.cli:app"
@@ -129,6 +139,9 @@ token_accuracy = "codex_ml.metrics.registry:token_accuracy"
 ppl = "codex_ml.metrics.registry:perplexity"
 exact_match = "codex_ml.metrics.registry:exact_match"
 f1 = "codex_ml.metrics.registry:f1"
+
+[project.entry-points."codex_ml.plugins"]
+hello = "examples.plugins.hello_plugin:HelloPlugin"
 
 [project.entry-points."codex_ml.data_loaders"]
 lines = "codex_ml.data.registry:load_line_dataset"

--- a/src/codex_ml/cli/entrypoints.py
+++ b/src/codex_ml/cli/entrypoints.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import runpy
+import sys
+from typing import NoReturn
+
+
+def _die(msg: str, code: int = 2) -> NoReturn:
+    sys.stderr.write(msg + "\n")
+    raise SystemExit(code)
+
+
+def train_main() -> int:
+    """Delegate to the Hydra training entrypoint while staying import-safe."""
+    try:
+        from . import hydra_main
+    except Exception as exc:  # pragma: no cover - defensive
+        _die(f"[codex-train] hydra_main not available: {exc}")
+    try:
+        main = getattr(hydra_main, "main", None)  # type: ignore[name-defined]
+        if callable(main):
+            return int(main())
+        runpy.run_module("codex_ml.cli.hydra_main", run_name="__main__")
+        return 0
+    except SystemExit as exc:  # propagate exit codes cleanly
+        return int(getattr(exc, "code", 0) or 0)
+
+
+def eval_main() -> int:
+    """Placeholder for future evaluation CLI."""
+    _die("[codex-eval] not yet implemented; use evaluation modules directly for now.")

--- a/src/codex_ml/distributed/__init__.py
+++ b/src/codex_ml/distributed/__init__.py
@@ -1,0 +1,17 @@
+from .minimal import (
+    barrier,
+    cleanup,
+    get_rank,
+    get_world_size,
+    init_distributed_if_needed,
+    is_distributed_available,
+)
+
+__all__ = [
+    "barrier",
+    "cleanup",
+    "get_rank",
+    "get_world_size",
+    "init_distributed_if_needed",
+    "is_distributed_available",
+]

--- a/src/codex_ml/distributed/minimal.py
+++ b/src/codex_ml/distributed/minimal.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+
+try:  # pragma: no cover - torch is optional
+    import torch  # type: ignore
+    import torch.distributed as dist  # type: ignore
+except Exception:  # pragma: no cover - execution environments without torch
+    torch = None  # type: ignore[assignment]
+    dist = None  # type: ignore[assignment]
+
+
+def _dist_available() -> bool:
+    return bool(dist is not None and getattr(dist, "is_available", lambda: False)())
+
+
+def is_distributed_available() -> bool:
+    """Return True when torch.distributed APIs are importable and available."""
+    return _dist_available()
+
+
+def init_distributed_if_needed(backend: str = "nccl", env_flag: str = "CODEX_DDP") -> bool:
+    """Best-effort initialization gated by an environment flag.
+
+    Returns True if the process group is initialized after the call, False otherwise.
+    """
+    if not _dist_available() or os.environ.get(env_flag, "0") not in {"1", "true", "TRUE"}:
+        return False
+    if dist is None:  # pragma: no cover - defensive
+        return False
+    if dist.is_initialized():
+        return True
+
+    chosen_backend = backend
+    if backend == "nccl":
+        cuda_available = bool(torch and getattr(torch.cuda, "is_available", lambda: False)())
+        if not cuda_available:
+            chosen_backend = "gloo"
+    try:
+        dist.init_process_group(backend=chosen_backend)
+        return True
+    except Exception:
+        return False
+
+
+def get_rank() -> int:
+    if dist is None or not getattr(dist, "is_initialized", lambda: False)():
+        return 0
+    return int(dist.get_rank())  # type: ignore[call-arg]
+
+
+def get_world_size() -> int:
+    if dist is None or not getattr(dist, "is_initialized", lambda: False)():
+        return 1
+    return int(dist.get_world_size())  # type: ignore[call-arg]
+
+
+def barrier() -> None:
+    if dist is not None and getattr(dist, "is_initialized", lambda: False)():
+        dist.barrier()
+
+
+def cleanup() -> None:
+    if dist is not None and getattr(dist, "is_initialized", lambda: False)():
+        dist.destroy_process_group()

--- a/src/codex_ml/plugins/__init__.py
+++ b/src/codex_ml/plugins/__init__.py
@@ -1,6 +1,8 @@
 """Plugin registry utilities for codex_ml."""
 
+from .base import BasePlugin, MetricsPlugin, ModelPlugin, TokenizerPlugin
 from .loader import load_plugins
+from .programmatic import PluginRegistry, registry
 from .registries import (
     datasets,
     load_dataset_entry_points,
@@ -34,4 +36,10 @@ __all__ = [
     "load_reward_model_entry_points",
     "load_rl_agent_entry_points",
     "load_plugins",
+    "BasePlugin",
+    "MetricsPlugin",
+    "ModelPlugin",
+    "TokenizerPlugin",
+    "PluginRegistry",
+    "registry",
 ]

--- a/src/codex_ml/plugins/base.py
+++ b/src/codex_ml/plugins/base.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BasePlugin(ABC):
+    """Minimal plugin interface for Codex ML."""
+
+    @abstractmethod
+    def name(self) -> str:
+        """Unique plugin name."""
+
+    @abstractmethod
+    def version(self) -> str:
+        """Semantic version string for the plugin implementation."""
+
+    def activate(self, app_ctx: dict[str, Any] | None = None) -> None:
+        """Optional activation hook executed once the plugin is registered."""
+        return
+
+
+class TokenizerPlugin(BasePlugin):
+    """Marker interface for tokenizer plugins."""
+
+
+class MetricsPlugin(BasePlugin):
+    """Marker interface for metrics/logging plugins."""
+
+
+class ModelPlugin(BasePlugin):
+    """Marker interface for model provider plugins."""
+
+
+__all__ = [
+    "BasePlugin",
+    "TokenizerPlugin",
+    "MetricsPlugin",
+    "ModelPlugin",
+]

--- a/src/codex_ml/plugins/programmatic.py
+++ b/src/codex_ml/plugins/programmatic.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from dataclasses import dataclass, field
+
+from .base import BasePlugin
+from .registry import DEFAULT_GROUP, _activate_editable_distribution, _iter_entry_points
+
+
+@dataclass
+class PluginRegistry:
+    """Minimal instance-based registry for plugin objects."""
+
+    _by_name: dict[str, BasePlugin] = field(default_factory=dict)
+
+    def register(self, plugin: BasePlugin, *, override: bool = False) -> None:
+        key = plugin.name().lower()
+        if not override and key in self._by_name:
+            raise ValueError(f"plugin already registered: {key}")
+        self._by_name[key] = plugin
+
+    def get(self, name: str) -> BasePlugin | None:
+        return self._by_name.get(name.lower())
+
+    def all(self) -> list[BasePlugin]:
+        return list(self._by_name.values())
+
+    def discover(self, group: str = DEFAULT_GROUP) -> int:
+        """Discover entry-point plugins and register them."""
+
+        count = 0
+        for ep in _iter_entry_points(group):
+            plugin: BasePlugin | None = None
+            with suppress(Exception):  # pragma: no cover - best effort
+                _activate_editable_distribution(ep)
+                candidate = ep.load()
+                resolved = candidate() if isinstance(candidate, type) else candidate
+                if isinstance(resolved, BasePlugin):
+                    plugin = resolved
+            if plugin is None:
+                continue
+            try:
+                self.register(plugin)
+            except ValueError:
+                continue
+            count += 1
+        return count
+
+
+_REGISTRY = PluginRegistry()
+
+
+def registry() -> PluginRegistry:
+    return _REGISTRY
+
+
+__all__ = ["PluginRegistry", "registry"]

--- a/tests/distributed/test_minimal_distributed.py
+++ b/tests/distributed/test_minimal_distributed.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from codex_ml.distributed import (
+    barrier,
+    cleanup,
+    get_rank,
+    get_world_size,
+    init_distributed_if_needed,
+    is_distributed_available,
+)
+
+
+def test_minimal_distributed_noop_paths(monkeypatch):
+    monkeypatch.delenv("CODEX_DDP", raising=False)
+    _ = is_distributed_available()
+    assert init_distributed_if_needed() is False
+    assert get_rank() == 0
+    assert get_world_size() == 1
+    barrier()
+    cleanup()

--- a/tests/plugins/test_registry_programmatic.py
+++ b/tests/plugins/test_registry_programmatic.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from codex_ml.plugins import BasePlugin, registry
+
+
+class _DummyPlugin(BasePlugin):
+    def name(self) -> str:
+        return "dummy"
+
+    def version(self) -> str:
+        return "0.0.1"
+
+
+def test_programmatic_register_and_get():
+    reg = registry()
+    plugin = _DummyPlugin()
+    reg.register(plugin, override=True)
+    assert reg.get("dummy") is plugin
+    names = {p.name() for p in reg.all()}
+    assert "dummy" in names


### PR DESCRIPTION
## Summary
- add local build helpers, CLI wrappers, and example plugin wiring for entry-point discovery
- introduce programmatic plugin registry primitives with unit tests and documentation
- add minimal distributed utility module, optional extras, and reference docs for packaging and DDP hooks

## Testing
- ⚠️ `make build` *(fails: existing Makefile recipes rely on space-prefixed commands)*
- ✅ `python -m build`
- ✅ `python -m pip install --no-deps dist/codex_ml-0.1.0-py3-none-any.whl`
- ✅ `python -m codex_ml`
- ✅ `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/plugins/test_registry_programmatic.py`
- ✅ `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/distributed/test_minimal_distributed.py`

------
https://chatgpt.com/codex/tasks/task_e_68ef10ec25c4833188c43bfd460009c5