### PR TITLE
Enhance CLI plugin listing and checkpoint metadata

### DIFF
--- a/docs/training/Evaluation_CLI.md
+++ b/docs/training/Evaluation_CLI.md
@@ -17,6 +17,17 @@ codex-eval --dry-run   # smoke test without running evaluation
 
 Downstream modules handle their own arguments (datasets, models, metrics).
 
+### Environment override
+Use `CODEX_EVAL_ENTRY` to direct the CLI to a specific evaluator. The value accepts either
+`module:function` or a bare module name (which is executed via `python -m`).
+
+```bash
+export CODEX_EVAL_ENTRY="codex_ml.training.eval:main"
+# or execute a module directly
+export CODEX_EVAL_ENTRY="codex_ml.eval.evaluator"
+codex-eval -- some --custom --args
+```
+
 ## Notes
 - Offline-first: no network calls are introduced by this wrapper.
 - Determinism: relies on evaluation code seeding and dataset determinism.

--- a/src/codex_ml/cli/hydra_main.py
+++ b/src/codex_ml/cli/hydra_main.py
@@ -111,6 +111,10 @@ if hydra is not None:  # pragma: no cover - executed when hydra available
             result = None
             try:
                 initialized = bool(init_distributed_if_needed())
+                if not initialized:
+                    sys.stderr.write(
+                        "[codex-ddp] disabled (env not set or torch.distributed unavailable)\n"
+                    )
                 result = run_functional_training(resolved)
             finally:
                 if initialized:

--- a/src/codex_ml/cli/list_plugins.py
+++ b/src/codex_ml/cli/list_plugins.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import argparse
+import json
 import sys
 from collections.abc import Iterable, Sequence
 from contextlib import suppress
@@ -14,10 +16,49 @@ from codex_ml.codex_structured_logging import (
     log_event,
     run_cmd,
 )
-from codex_ml.data.registry import list_datasets
-from codex_ml.registry import list_models, list_tokenizers
 
 _ = run_cmd
+
+_JSON_EPILOG = (
+    "JSON schema:\n"
+    "{\n"
+    '  "programmatic": {"discovered": [<str>...], "names": [<str>...]},\n'
+    '  "legacy": {"models": [<str>...], "tokenizers": [<str>...], "datasets": [<str>...] }\n'
+    "}\n"
+)
+
+
+def _list_models_safe() -> list[str]:
+    try:
+        from codex_ml.registry import list_models  # type: ignore
+    except Exception:
+        return []
+    try:
+        return sorted(str(name) for name in list_models())
+    except Exception:
+        return []
+
+
+def _list_tokenizers_safe() -> list[str]:
+    try:
+        from codex_ml.registry import list_tokenizers  # type: ignore
+    except Exception:
+        return []
+    try:
+        return sorted(str(name) for name in list_tokenizers())
+    except Exception:
+        return []
+
+
+def _list_datasets_safe() -> list[str]:
+    try:
+        from codex_ml.data.registry import list_datasets  # type: ignore
+    except Exception:
+        return []
+    try:
+        return sorted(str(name) for name in list_datasets())
+    except Exception:
+        return []
 
 
 def _print_lines(header: str, items: Iterable[str]) -> None:
@@ -26,7 +67,7 @@ def _print_lines(header: str, items: Iterable[str]) -> None:
         print(f"  - {item}")
 
 
-def _programmatic_registry_snapshot() -> dict[str, Any] | None:
+def _programmatic_registry_snapshot(*, discover: bool = True) -> dict[str, Any] | None:
     try:
         from codex_ml.plugins import registry as programmatic_registry  # type: ignore[attr-defined]
     except Exception:
@@ -37,17 +78,18 @@ def _programmatic_registry_snapshot() -> dict[str, Any] | None:
         return None
 
     snapshot: dict[str, Any] = {"names": [], "discovered": []}
-    try:
-        discovered = registry.discover()
-    except Exception:
-        discovered = []
-    else:
-        if isinstance(discovered, dict):
-            snapshot["discovered"] = sorted(str(key) for key in discovered)
-        elif isinstance(discovered, (list | tuple | set)):
-            snapshot["discovered"] = sorted(str(item) for item in discovered)
-        elif discovered:
-            snapshot["discovered"] = [str(discovered)]
+    if discover:
+        try:
+            discovered = registry.discover()
+        except Exception:
+            discovered = []
+        else:
+            if isinstance(discovered, dict):
+                snapshot["discovered"] = sorted(str(key) for key in discovered)
+            elif isinstance(discovered, (list | tuple | set)):
+                snapshot["discovered"] = sorted(str(item) for item in discovered)
+            elif discovered:
+                snapshot["discovered"] = [str(discovered)]
 
     names: list[str] = []
     try:
@@ -83,11 +125,26 @@ def _print_programmatic(snapshot: dict[str, Any] | None) -> None:
 
 def main(argv: Sequence[str] | None = None) -> int:
     logger = init_json_logging()
-    parser = ArgparseJSONParser(description="List Codex ML plugin registries")
+    parser = ArgparseJSONParser(
+        description="List Codex ML plugin registries",
+        epilog=_JSON_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument(
         "--section",
         choices=["models", "tokenizers", "datasets", "programmatic", "all"],
         default="all",
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
+    parser.add_argument(
+        "--names-only",
+        action="store_true",
+        help="Print only programmatic plugin names (text mode)",
+    )
+    parser.add_argument(
+        "--no-discover",
+        action="store_true",
+        help="Skip entry-point discovery for speed",
     )
     arg_list: list[str] = list(argv) if argv is not None else sys.argv[1:]
 
@@ -95,33 +152,68 @@ def main(argv: Sequence[str] | None = None) -> int:
         args = parser.parse_args(arg_list)
         log_event(logger, "cli.start", prog=parser.prog, args=arg_list)
 
-        summary: dict[str, Any] = {"section": args.section}
+        summary: dict[str, Any] = {
+            "section": args.section,
+            "format": args.format,
+            "names_only": args.names_only,
+            "discover": not args.no_discover,
+        }
 
         models: list[str] | None = None
-        if args.section in {"models", "all"}:
-            models = list(list_models())
-            _print_lines("Models", models)
-        summary["models"] = len(models) if models is not None else None
-
         tokenizers: list[str] | None = None
-        if args.section in {"tokenizers", "all"}:
-            tokenizers = list(list_tokenizers())
-            _print_lines("Tokenizers", tokenizers)
-        summary["tokenizers"] = len(tokenizers) if tokenizers is not None else None
-
         datasets: list[str] | None = None
-        if args.section in {"datasets", "all"}:
-            datasets = list(list_datasets())
-            _print_lines("Datasets", datasets)
-        summary["datasets"] = len(datasets) if datasets is not None else None
-
         programmatic_snapshot = None
-        if args.section in {"programmatic", "all"}:
-            programmatic_snapshot = _programmatic_registry_snapshot()
-            _print_programmatic(programmatic_snapshot)
-        summary["programmatic"] = (
-            len(programmatic_snapshot.get("names", [])) if programmatic_snapshot else None
+
+        include_programmatic = (
+            args.section in {"programmatic", "all"} or args.names_only or args.format == "json"
         )
+        include_models = args.section in {"models", "all"} or args.format == "json"
+        include_tokenizers = args.section in {"tokenizers", "all"} or args.format == "json"
+        include_datasets = args.section in {"datasets", "all"} or args.format == "json"
+
+        if include_models:
+            models = _list_models_safe()
+        if include_tokenizers:
+            tokenizers = _list_tokenizers_safe()
+        if include_datasets:
+            datasets = _list_datasets_safe()
+        if include_programmatic:
+            programmatic_snapshot = _programmatic_registry_snapshot(discover=not args.no_discover)
+
+        summary.update(
+            {
+                "models": len(models) if models is not None else None,
+                "tokenizers": len(tokenizers) if tokenizers is not None else None,
+                "datasets": len(datasets) if datasets is not None else None,
+                "programmatic": (
+                    len(programmatic_snapshot.get("names", [])) if programmatic_snapshot else None
+                ),
+            }
+        )
+
+        if args.format == "json":
+            payload = {
+                "programmatic": programmatic_snapshot or {"names": [], "discovered": []},
+                "legacy": {
+                    "models": sorted(models or []),
+                    "tokenizers": sorted(tokenizers or []),
+                    "datasets": sorted(datasets or []),
+                },
+            }
+            print(json.dumps(payload, indent=2))
+        else:
+            if args.names_only:
+                names = (programmatic_snapshot or {}).get("names", [])
+                print("\n".join(names))
+            else:
+                if include_models and models is not None:
+                    _print_lines("Models", models)
+                if include_tokenizers and tokenizers is not None:
+                    _print_lines("Tokenizers", tokenizers)
+                if include_datasets and datasets is not None:
+                    _print_lines("Datasets", datasets)
+                if include_programmatic:
+                    _print_programmatic(programmatic_snapshot)
 
         log_event(
             logger,

--- a/tests/checkpoint/test_checkpoint_integrity_tolerant.py
+++ b/tests/checkpoint/test_checkpoint_integrity_tolerant.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_save_checkpoint_tolerates_integrity_fail(monkeypatch, tmp_path: Path):
+    import importlib
+
+    core = importlib.import_module("codex_ml.utils.checkpoint_core")
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("integrity failure")
+
+    monkeypatch.setattr(core, "attach_integrity", _boom, raising=True)
+
+    ckpt_dir = tmp_path / "ckpts"
+    ckpt_path, meta = core.save_checkpoint(str(ckpt_dir), {"w": 1})
+
+    assert ckpt_path.exists()
+    index = json.loads((ckpt_dir / "index.json").read_text(encoding="utf-8"))
+    assert index.get("entries")
+    assert meta.sha256

--- a/tests/eval/test_eval_cli_passthrough.py
+++ b/tests/eval/test_eval_cli_passthrough.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+
+
+def test_eval_cli_env_override_and_passthrough(monkeypatch):
+    dummy = types.ModuleType("dummy_eval")
+
+    def _main():
+        assert "--foo" in sys.argv and "bar" in sys.argv
+        return 0
+
+    dummy.main = _main  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "dummy_eval", dummy)
+
+    code = (
+        "import os, sys; "
+        "os.environ['CODEX_EVAL_ENTRY']='dummy_eval:main'; "
+        "import codex_ml.cli.entrypoints as E; "
+        "sys.argv=['codex-eval','--','--foo','bar']; "
+        "sys.exit(E.eval_main())"
+    )
+    proc = subprocess.run([sys.executable, "-c", code])
+    assert proc.returncode == 0

--- a/tests/plugins/test_list_plugins_cli_smoke.py
+++ b/tests/plugins/test_list_plugins_cli_smoke.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def test_list_plugins_json_smoke():
+    code = (
+        "import sys, json; "
+        "import codex_ml.cli.list_plugins as L; "
+        "sys.argv=['list-plugins','--format','json']; "
+        "rc=L.main(); "
+        "sys.exit(rc)"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert "programmatic" in data and "legacy" in data
+    assert isinstance(data["programmatic"].get("names", []), list)
+
+
+def test_list_plugins_names_only_smoke():
+    code = (
+        "import sys; "
+        "import codex_ml.cli.list_plugins as L; "
+        "sys.argv=['list-plugins','--names-only']; "
+        "sys.exit(L.main())"
+    )
+    proc = subprocess.run([sys.executable, "-c", code])
+    assert proc.returncode == 0
+
+
+def test_list_plugins_no_discover_smoke():
+    code = (
+        "import sys; "
+        "import codex_ml.cli.list_plugins as L; "
+        "sys.argv=['list-plugins','--no-discover','--format','json']; "
+        "sys.exit(L.main())"
+    )
+    proc = subprocess.run([sys.executable, "-c", code])
+    assert proc.returncode == 0


### PR DESCRIPTION
This pull request introduces several improvements and new features to the CLI utilities and supporting infrastructure, focusing on enhanced flexibility, robustness, and usability. The most significant changes are the addition of an environment variable override for the evaluation CLI, major enhancements to the `list-plugins` CLI (including new output formats and improved error handling), and improved checkpoint integrity tracking. The updates are complemented by new and expanded test coverage to ensure reliability.

**CLI Enhancements**

* Added support for overriding the evaluation entrypoint in the `codex-eval` CLI using the `CODEX_EVAL_ENTRY` environment variable, allowing users to specify a custom module or function to execute. This is documented in `Evaluation_CLI.md` and implemented in `entrypoints.py`. [[1]](diffhunk://#diff-07eedd2e2594af1d87ecef52e490b72570ac512580be72d923069f0ee447082aR20-R30) [[2]](diffhunk://#diff-914b1c1e21eea96a11ea74d178b16e4100374d2deec92add9bd35062096a5305R73-R91) [[3]](diffhunk://#diff-914b1c1e21eea96a11ea74d178b16e4100374d2deec92add9bd35062096a5305R138-R145) [[4]](diffhunk://#diff-914b1c1e21eea96a11ea74d178b16e4100374d2deec92add9bd35062096a5305R4) [[5]](diffhunk://#diff-d19963065e7db567e9f8f19ac98d45e9c8cf06b6593e31f4c974a6bc67725816R1-R26)
* Significantly expanded the `list-plugins` CLI with new options: `--format` (text or JSON output), `--names-only`, and `--no-discover`. The command now safely handles missing or broken registries and provides a JSON schema for output. [[1]](diffhunk://#diff-d0eeb8c0a3a2c5f24f2ec2a32e0ff09e19feb45809fb4372c30e555fb563d923R5-R6) [[2]](diffhunk://#diff-d0eeb8c0a3a2c5f24f2ec2a32e0ff09e19feb45809fb4372c30e555fb563d923L17-R70) [[3]](diffhunk://#diff-d0eeb8c0a3a2c5f24f2ec2a32e0ff09e19feb45809fb4372c30e555fb563d923R81) [[4]](diffhunk://#diff-d0eeb8c0a3a2c5f24f2ec2a32e0ff09e19feb45809fb4372c30e555fb563d923L86-R217) [[5]](diffhunk://#diff-73c6bc72e171ab52ea72b6f838fd8b06cb042c839c96d3db7de012001414b19bR1-R42)

**Robustness and Error Handling**

* Improved checkpoint integrity tracking by attaching the current Git SHA (if available via environment or git command) to checkpoint metadata, aiding reproducibility and traceability. [[1]](diffhunk://#diff-8114c89b4cf46b5897b417f6ecd11d022eedecd71e7b596897bd6233339a839bR12-R13) [[2]](diffhunk://#diff-8114c89b4cf46b5897b417f6ecd11d022eedecd71e7b596897bd6233339a839bR30-R41) [[3]](diffhunk://#diff-8114c89b4cf46b5897b417f6ecd11d022eedecd71e7b596897bd6233339a839bR91-R94)
* Enhanced distributed training initialization to provide clearer feedback when distributed mode is unavailable, writing a message to `stderr` if not enabled.

**Testing Improvements**

* Added new tests for checkpoint saving behavior in the presence of integrity check failures, ensuring tolerant and robust handling.
* Added smoke tests for the new `list-plugins` CLI options and for the `codex-eval` CLI environment override and argument passthrough. [[1]](diffhunk://#diff-73c6bc72e171ab52ea72b6f838fd8b06cb042c839c96d3db7de012001414b19bR1-R42) [[2]](diffhunk://#diff-d19963065e7db567e9f8f19ac98d45e9c8cf06b6593e31f4c974a6bc67725816R1-R26)


------
## Summary
- extend `codex-plugins` CLI with JSON schema help plus `--names-only`/`--no-discover` options while hardening registry fallbacks
- add `CODEX_EVAL_ENTRY` override support and docs, and surface DDP skip diagnostics alongside checkpoint git SHA capture
- cover the new behaviors with smoke tests for plugin/eval CLIs and tolerant checkpoint save scenarios

## Testing
- `python -m codex_ml.cli.list_plugins --format json | python -m json.tool | head`
- `python -m codex_ml.cli.list_plugins --names-only | head`
- `python -m codex_ml.cli.list_plugins --no-discover | head`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/plugins/test_list_plugins_cli_smoke.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/eval/test_eval_cli_passthrough.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/checkpoint/test_checkpoint_integrity_tolerant.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/checkpoint/test_checkpoint_integrity_wiring.py`
- `python -c "import codex_ml.cli.hydra_main as h; import sys; sys.exit(h.main())" || true`


------
https://chatgpt.com/codex/tasks/task_e_68ef390bc25c8331947e66fddc3ee1bd