### PR TITLE
Improve eval CLI override, plugin listing, and checkpoint resilience

### DIFF
--- a/tests/checkpoint/test_checkpoint_integrity_tolerant.py
+++ b/tests/checkpoint/test_checkpoint_integrity_tolerant.py
@@ -1,25 +1,26 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
-from codex_ml.utils import checkpoint_core
 
+def test_save_checkpoint_tolerates_integrity_fail(monkeypatch, tmp_path: Path) -> None:
+    import importlib
 
-def test_save_checkpoint_integrity_failure_is_tolerated(monkeypatch, tmp_path: Path) -> None:
+    core = importlib.import_module("codex_ml.utils.checkpoint_core")
+
     def _boom(*_args, **_kwargs):
         raise RuntimeError("integrity failure")
 
-    monkeypatch.setattr(checkpoint_core, "attach_integrity", _boom, raising=False)
+    monkeypatch.setattr(core, "attach_integrity", _boom, raising=True)
 
-    checkpoint_dir = tmp_path / "outputs"
-    checkpoint_dir.mkdir()
-
-    ckpt_path, meta = checkpoint_core.save_checkpoint(
-        checkpoint_dir,
-        state={"weights": [1]},
-        config={"model": "tiny"},
-        metric_value=None,
-    )
+    ckpt_dir = tmp_path / "ckpts"
+    ckpt_path, meta = core.save_checkpoint(str(ckpt_dir), {"w": 1})
 
     assert ckpt_path.exists()
-    assert meta.sha256 is not None
+
+    index_path = ckpt_dir / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    assert index.get("entries")
+
+    assert getattr(meta, "sha256", None)

--- a/tests/eval/test_eval_cli_passthrough.py
+++ b/tests/eval/test_eval_cli_passthrough.py
@@ -1,26 +1,23 @@
 from __future__ import annotations
 
-import subprocess
 import sys
 import types
 
+from codex_ml.cli.entrypoints import eval_main
 
-def test_eval_cli_env_override_and_passthrough(monkeypatch):
+
+def test_eval_cli_env_override_and_passthrough(monkeypatch) -> None:
     dummy = types.ModuleType("dummy_eval")
 
-    def _main():
-        assert "--foo" in sys.argv and "bar" in sys.argv
-        return 0
+    def _main() -> int:
+        print("PASSTHROUGH")
+        return 123
 
     dummy.main = _main  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "dummy_eval", dummy)
+    monkeypatch.setenv("CODEX_EVAL_ENTRY", "dummy_eval:main")
+    monkeypatch.setattr(sys, "argv", ["codex-eval"])
 
-    code = (
-        "import os, sys; "
-        "os.environ['CODEX_EVAL_ENTRY']='dummy_eval:main'; "
-        "import codex_ml.cli.entrypoints as E; "
-        "sys.argv=['codex-eval','--','--foo','bar']; "
-        "sys.exit(E.eval_main())"
-    )
-    proc = subprocess.run([sys.executable, "-c", code])
-    assert proc.returncode == 0
+    rc = eval_main()
+
+    assert rc == 123

--- a/tests/plugins/test_list_plugins_cli_smoke.py
+++ b/tests/plugins/test_list_plugins_cli_smoke.py
@@ -5,38 +5,57 @@ import subprocess
 import sys
 
 
-def test_list_plugins_json_smoke():
+def test_list_plugins_json_smoke() -> None:
     code = (
         "import sys, json; "
-        "import codex_ml.cli.list_plugins as L; "
-        "sys.argv=['list-plugins','--format','json']; "
-        "rc=L.main(); "
+        "import codex_ml.cli.list_plugins as cli; "
+        "sys.argv = ['list-plugins', '--format', 'json']; "
+        "rc = cli.main(); "
         "sys.exit(rc)"
     )
-    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
     assert proc.returncode == 0
-    data = json.loads(proc.stdout)
-    assert "programmatic" in data and "legacy" in data
-    assert isinstance(data["programmatic"].get("names", []), list)
+    payload = json.loads(proc.stdout)
+    assert "legacy" in payload and "programmatic" in payload
 
 
-def test_list_plugins_names_only_smoke():
+def test_list_plugins_names_only_contains_known_plugin() -> None:
     code = (
         "import sys; "
-        "import codex_ml.cli.list_plugins as L; "
-        "sys.argv=['list-plugins','--names-only']; "
-        "sys.exit(L.main())"
+        "import codex_ml.cli.list_plugins as cli; "
+        "sys.argv = ['list-plugins', '--names-only']; "
+        "rc = cli.main(); "
+        "sys.exit(rc)"
     )
-    proc = subprocess.run([sys.executable, "-c", code])
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
     assert proc.returncode == 0
+    assert "whitespace" in proc.stdout
 
 
-def test_list_plugins_no_discover_smoke():
+def test_list_plugins_no_discover_lists_tokenizers() -> None:
     code = (
         "import sys; "
-        "import codex_ml.cli.list_plugins as L; "
-        "sys.argv=['list-plugins','--no-discover','--format','json']; "
-        "sys.exit(L.main())"
+        "import codex_ml.cli.list_plugins as cli; "
+        "sys.argv = ['list-plugins', '--no-discover']; "
+        "rc = cli.main(); "
+        "sys.exit(rc)"
     )
-    proc = subprocess.run([sys.executable, "-c", code])
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
     assert proc.returncode == 0
+    assert "Tokenizers:" in proc.stdout
+    assert "whitespace" in proc.stdout


### PR DESCRIPTION
## Summary
- refactor the `list-plugins` CLI to use structured logging, safe registry accessors, and richer output controls
- avoid invoking git when capturing checkpoint integrity metadata and tolerate integrity sidecar failures
- add targeted tests covering the eval CLI override path and plugin listing behaviours

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/plugins/test_list_plugins_cli_smoke.py tests/eval/test_eval_cli_passthrough.py tests/checkpoint/test_checkpoint_integrity_tolerant.py

------
https://chatgpt.com/codex/tasks/task_e_68ef5d0c1c608331b702249415c6e257