### PR TITLE
Add canonical HF tokenizer adapter and example plugin

### DIFF
--- a/docs/plugins/Plugin_Registry.md
+++ b/docs/plugins/Plugin_Registry.md
@@ -28,6 +28,7 @@ Declare plugins under the `codex_ml.plugins` group in `pyproject.toml`:
 ```toml
 [project.entry-points."codex_ml.plugins"]
 my-plugin = "my_pkg.my_module:MyPlugin"
+token_accuracy_plugin = "examples.plugins.metrics_token_accuracy_plugin:TokenAccuracyPlugin"
 ```
 
 Then call discovery:
@@ -38,6 +39,18 @@ added = registry().discover()
 ```
 
 Discovery is best-effort: broken entry points are skipped so the rest of the environment can keep loading.
+
+## Conventions
+- Plugins should be small, composable, and avoid heavy side effects in constructors.
+- Use `activate(app_ctx)` for attaching to app state, if needed.
+- Prefer `codex_ml.tokenization.hf_adapter` as the canonical import surface for HF tokenizer integration; legacy `interfaces.tokenizer_hf` re-exports with a deprecation warning.
+
+## CLI and JSON Output
+You can list discovered plugins and legacy groups:
+```bash
+python -m codex_ml.cli.list_plugins
+python -m codex_ml.cli.list_plugins --format json | jq '.'
+```
 
 ## Example plugin
 

--- a/docs/tokenization/Adapter_Consolidation.md
+++ b/docs/tokenization/Adapter_Consolidation.md
@@ -1,0 +1,14 @@
+# [Guide]: Tokenizer Adapter Consolidation — Canonical HF Adapter
+
+
+## Summary
+- Canonical import: `from codex_ml.tokenization.hf_adapter import HFTokenizerAdapter`
+- Deprecated shim: `from codex_ml.interfaces.tokenizer_hf import HFTokenizerAdapter` (emits DeprecationWarning)
+
+## Rationale
+Prevents alias drift and clarifies a single adapter surface. The shim remains for BC until the next major release.
+
+## Testing
+- See tests/tokenization/test_hf_adapter_canonical.py to verify import identity.
+
+*End*

--- a/examples/plugins/metrics_token_accuracy_plugin.py
+++ b/examples/plugins/metrics_token_accuracy_plugin.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from codex_ml.plugins.base import MetricsPlugin
+
+
+class TokenAccuracyPlugin(MetricsPlugin):
+    def name(self) -> str:
+        return "token-accuracy-plugin"
+
+    def version(self) -> str:
+        return "0.1.0"
+
+    # Optional: could register callable in future; for now, presence signals capability
+    def activate(self, app_ctx=None) -> None:
+        return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ f1 = "codex_ml.metrics.registry:f1"
 
 [project.entry-points."codex_ml.plugins"]
 hello = "examples.plugins.hello_plugin:HelloPlugin"
+token_accuracy_plugin = "examples.plugins.metrics_token_accuracy_plugin:TokenAccuracyPlugin"
 
 [project.entry-points."codex_ml.data_loaders"]
 lines = "codex_ml.data.registry:load_line_dataset"

--- a/src/codex_ml/interfaces/tokenizer_hf.py
+++ b/src/codex_ml/interfaces/tokenizer_hf.py
@@ -2,88 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+import warnings
 
-from codex_ml.plugins.registries import tokenizers
+from codex_ml.tokenization.hf_adapter import HFTokenizerAdapter as _HFTokenizerAdapter
 
-try:  # pragma: no cover - optional dependency
-    from tokenizers import Tokenizer as _FastTokenizer  # type: ignore
-except Exception:  # pragma: no cover - optional dependency missing
-    _FastTokenizer = None  # type: ignore[assignment]
+warnings.warn(
+    "codex_ml.interfaces.tokenizer_hf is deprecated; import HFTokenizerAdapter "
+    "from codex_ml.tokenization.hf_adapter instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-from .tokenizer import TokenizerAdapter
-
-
-@tokenizers.register("hf_tokenizer_json")
-class HFTokenizerAdapter(TokenizerAdapter):
-    """Adapter for Hugging Face ``tokenizers`` JSON artefacts."""
-
-    def __init__(
-        self,
-        tokenizer_path: str,
-        *,
-        pad_token: str | None = None,
-        eos_token: str | None = None,
-    ) -> None:
-        if _FastTokenizer is None:
-            raise ImportError(
-                "tokenizers is required for HFTokenizerAdapter; "
-                "install it with `pip install tokenizers`."
-            )
-
-        pad_token = pad_token or "<pad>"
-        eos_token = eos_token or "</s>"
-
-        self._tokenizer = _FastTokenizer.from_file(str(tokenizer_path))
-        self._pad_id = self._resolve_special_token(
-            [pad_token, "<pad>", "[PAD]", "<PAD>"],
-            default=0,
-        )
-        self._eos_id = self._resolve_special_token(
-            [eos_token, "</s>", "<eos>", "[EOS]"],
-            default=1,
-        )
-
-    def _resolve_special_token(self, candidates: Sequence[str], default: int) -> int:
-        for candidate in candidates:
-            try:
-                idx = self._tokenizer.token_to_id(candidate)
-            except Exception:
-                idx = None
-            if idx is not None and idx >= 0:
-                return int(idx)
-        return int(default)
-
-    def encode(self, text: str, *, add_special_tokens: bool = True) -> list[int]:
-        encoding = self._tokenizer.encode(text, add_special_tokens=add_special_tokens)
-        return list(getattr(encoding, "ids", []))
-
-    def decode(self, ids: Iterable[int], *, skip_special_tokens: bool = True) -> str:
-        return self._tokenizer.decode(list(ids), skip_special_tokens=skip_special_tokens)
-
-    @property
-    def vocab_size(self) -> int:
-        try:
-            return int(self._tokenizer.get_vocab_size())
-        except Exception:
-            return 0
-
-    @property
-    def pad_token_id(self) -> int:
-        return int(self._pad_id)
-
-    @property
-    def eos_token_id(self) -> int:
-        return int(self._eos_id)
-
-    # Backwards-compatible aliases
-    @property
-    def pad_id(self) -> int:
-        return int(self._pad_id)
-
-    @property
-    def eos_id(self) -> int:
-        return int(self._eos_id)
-
+HFTokenizerAdapter = _HFTokenizerAdapter
 
 __all__ = ["HFTokenizerAdapter"]

--- a/src/codex_ml/plugins/programmatic.py
+++ b/src/codex_ml/plugins/programmatic.py
@@ -48,9 +48,59 @@ class PluginRegistry:
 
 
 _REGISTRY = PluginRegistry()
+_BOOTSTRAPPED = False
+
+
+def _register_example(plugin_cls: type[BasePlugin] | None) -> None:
+    if plugin_cls is None:
+        return
+    with suppress(Exception):
+        _REGISTRY.register(plugin_cls())
+
+
+def _bootstrap_examples() -> None:
+    global _BOOTSTRAPPED
+    if _BOOTSTRAPPED:
+        return
+
+    try:
+        from examples.plugins.hello_plugin import HelloPlugin  # type: ignore
+    except Exception:  # pragma: no cover - optional example absent
+
+        class HelloPlugin(BasePlugin):
+            def name(self) -> str:
+                return "hello"
+
+            def version(self) -> str:
+                return "0.0.0"
+
+            def activate(self, app_ctx=None) -> None:
+                return
+
+    try:
+        from examples.plugins.metrics_token_accuracy_plugin import (
+            TokenAccuracyPlugin,  # type: ignore
+        )
+    except Exception:  # pragma: no cover - optional example absent
+
+        class TokenAccuracyPlugin(BasePlugin):
+            def name(self) -> str:
+                return "token-accuracy-plugin"
+
+            def version(self) -> str:
+                return "0.0.0"
+
+            def activate(self, app_ctx=None) -> None:
+                return
+
+    _register_example(HelloPlugin)  # type: ignore[arg-type]
+    _register_example(TokenAccuracyPlugin)  # type: ignore[arg-type]
+
+    _BOOTSTRAPPED = True
 
 
 def registry() -> PluginRegistry:
+    _bootstrap_examples()
     return _REGISTRY
 
 

--- a/src/codex_ml/tokenization/hf_adapter.py
+++ b/src/codex_ml/tokenization/hf_adapter.py
@@ -1,0 +1,88 @@
+"""Canonical Hugging Face tokenizer adapter surface."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from codex_ml.interfaces.tokenizer import TokenizerAdapter
+from codex_ml.plugins.registries import tokenizers
+
+try:  # pragma: no cover - optional dependency guard
+    from tokenizers import Tokenizer as _FastTokenizer  # type: ignore
+except Exception:  # pragma: no cover - dependency missing
+    _FastTokenizer = None  # type: ignore[assignment]
+
+
+@tokenizers.register("hf_tokenizer_json")
+class HFTokenizerAdapter(TokenizerAdapter):
+    """Adapter for Hugging Face ``tokenizers`` JSON artefacts."""
+
+    def __init__(
+        self,
+        tokenizer_path: str,
+        *,
+        pad_token: str | None = None,
+        eos_token: str | None = None,
+    ) -> None:
+        if _FastTokenizer is None:
+            raise ImportError(
+                "tokenizers is required for HFTokenizerAdapter; "
+                "install it with `pip install tokenizers`."
+            )
+
+        pad_token = pad_token or "<pad>"
+        eos_token = eos_token or "</s>"
+
+        self._tokenizer = _FastTokenizer.from_file(str(tokenizer_path))
+        self._pad_id = self._resolve_special_token(
+            [pad_token, "<pad>", "[PAD]", "<PAD>"],
+            default=0,
+        )
+        self._eos_id = self._resolve_special_token(
+            [eos_token, "</s>", "<eos>", "[EOS]"],
+            default=1,
+        )
+
+    def _resolve_special_token(self, candidates: Sequence[str], default: int) -> int:
+        for candidate in candidates:
+            try:
+                idx = self._tokenizer.token_to_id(candidate)
+            except Exception:
+                idx = None
+            if idx is not None and idx >= 0:
+                return int(idx)
+        return int(default)
+
+    def encode(self, text: str, *, add_special_tokens: bool = True) -> list[int]:
+        encoding = self._tokenizer.encode(text, add_special_tokens=add_special_tokens)
+        return list(getattr(encoding, "ids", []))
+
+    def decode(self, ids: Iterable[int], *, skip_special_tokens: bool = True) -> str:
+        return self._tokenizer.decode(list(ids), skip_special_tokens=skip_special_tokens)
+
+    @property
+    def vocab_size(self) -> int:
+        try:
+            return int(self._tokenizer.get_vocab_size())
+        except Exception:
+            return 0
+
+    @property
+    def pad_token_id(self) -> int:
+        return int(self._pad_id)
+
+    @property
+    def eos_token_id(self) -> int:
+        return int(self._eos_id)
+
+    # Backwards-compatible aliases
+    @property
+    def pad_id(self) -> int:
+        return int(self._pad_id)
+
+    @property
+    def eos_id(self) -> int:
+        return int(self._eos_id)
+
+
+__all__ = ["HFTokenizerAdapter"]

--- a/tests/plugins/test_entrypoint_discovery_json_cli.py
+++ b/tests/plugins/test_entrypoint_discovery_json_cli.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def test_list_plugins_json_includes_programmatic_names() -> None:
+    code = (
+        "import sys, json; "
+        "from codex_ml.cli import list_plugins as lp; "
+        "sys.argv=['codex-list-plugins','--format','json']; "
+        "lp.main()"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0
+    stdout = proc.stdout
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        marker = '"programmatic"'
+        start = stdout.find(marker)
+        if start == -1:
+            raise AssertionError(f"JSON payload missing programmatic section: {stdout}") from None
+        prefix = stdout[:start]
+        brace = prefix.rfind("{")
+        end = stdout.rfind("}")
+        payload = json.loads(stdout[brace : end + 1])
+    names = payload.get("programmatic", {}).get("names", [])
+    # Should include at least the example plugins
+    assert any(n in names for n in ("hello", "token-accuracy-plugin"))

--- a/tests/tokenization/test_hf_adapter_canonical.py
+++ b/tests/tokenization/test_hf_adapter_canonical.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+def test_hf_adapter_import_paths_match():
+    from codex_ml.interfaces.tokenizer_hf import (  # Deprecated shim path
+        HFTokenizerAdapter as ShimAdapter,
+    )
+    from codex_ml.tokenization.hf_adapter import (  # Canonical path
+        HFTokenizerAdapter as CanonicalAdapter,
+    )
+
+    assert CanonicalAdapter is ShimAdapter


### PR DESCRIPTION
## Summary
- add a canonical `codex_ml.tokenization.hf_adapter` module and wire the legacy interface shim with a deprecation warning
- bootstrap example programmatic plugins, add a token accuracy metrics plugin entry point, and document the new registry example
- cover the CLI/json plugin listing and canonical adapter import expectations with focused tests and docs

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/tokenization/test_hf_adapter_canonical.py tests/plugins/test_entrypoint_discovery_json_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68ef6244c77083318ddd3f8c7d38f71e