### PR TITLE
Add import contract summary tooling and security refresh docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,3 +449,10 @@ check-tabs:
 	@awk 'inrule && $$0 ~ /^ {/ { print "SPACE recipe at line " NR ": " $$0 } /^[-_A-Za-z0-9]+:/{inrule=1; next} /^$$/{inrule=0}' Makefile || true
 	@echo "[check-tabs] Also check included makefiles if any (e.g., codex.mk, space.mk)."
 	@echo "[check-tabs] Done. Use a tab (\t) to indent recipe commands."
+# --- Security & Rules Refresh (advisory) ---
+.PHONY: security-refresh
+security-refresh:
+@echo "[security-refresh] Ensure semgrep_rules/ and bandit.yaml reflect the latest local policy."
+@echo "[security-refresh] This target is advisory and offline; update rules from your internal mirror as appropriate."
+@ls -1 semgrep_rules || true
+@test -f bandit.yaml && echo "[security-refresh] bandit.yaml present." || echo "[security-refresh] bandit.yaml missing."

--- a/docs/ops/Security_Artifacts.md
+++ b/docs/ops/Security_Artifacts.md
@@ -28,5 +28,6 @@ CODEX_AUDIT=1 CODEX_IMAGE=codex:local make docker-trivy
 - Tools must be installed locally (see docs/ops/Local_Tooling_Prereqs.md).
 - semgrep runs only if semgrep_rules/ exists.
 - pip-audit runs only when CODEX_AUDIT=1 to avoid surprises.
+- Refresh cadence (advisory): run `make security-refresh` monthly to review semgrep_rules/ and bandit.yaml against your internal baseline.
 
 *End*

--- a/noxfile.py
+++ b/noxfile.py
@@ -298,6 +298,12 @@ def lint(session: nox.Session) -> None:
             str(import_linter_config),
             success_codes=[0, 1],
         )
+        # Print an advisory summary for trend tracking
+        session.run(
+            "python",
+            "tools/import_contracts_summary.py",
+            external=True,
+        )
 
 
 @nox.session(python=DEFAULT_PYTHON)

--- a/tools/import_contracts_summary.py
+++ b/tools/import_contracts_summary.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def main() -> None:
+    """Summarize import-linter contract results in advisory mode."""
+
+    try:
+        proc = subprocess.run(
+            ["lint-imports"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        print(
+            "[import-contracts] lint-imports not found; skipping summary",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    output = proc.stdout + "\n" + proc.stderr
+    broken = 0
+    contracts = 0
+
+    for line in output.splitlines():
+        if "Contract" in line and ":" in line:
+            contracts += 1
+        if "BROKEN" in line or "broken" in line:
+            broken += 1
+
+    print(
+        f"[import-contracts] contracts={contracts} "
+        f"broken={broken} exit={proc.returncode}"
+    )
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add an advisory helper that summarizes import-linter contract status
- integrate the summary into the lint nox session and expose an advisory Makefile target
- document the new security refresh cadence in the security artifacts guide

## Testing
- python tools/import_contracts_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68ef6827b57483318038715d5d52f648