### PR TITLE
Add CLI probes, structured logging tests, and run metadata sidecar

### DIFF
--- a/docs/ops/runbook_logging.md
+++ b/docs/ops/runbook_logging.md
@@ -47,3 +47,19 @@ stack offline.
   CLI when compiling scorecards.
 * When running headless, forward TensorBoard scalars via `tensorboard --logdir` and
   sync W&B runs manually once connectivity is available (`wandb sync <run-dir>`).
+
+---
+
+## Run Manifest (Checkpoint Provenance)
+
+Each checkpoint save emits a lightweight `run_manifest.json` alongside the artifact.
+The manifest is best-effort (failures are silent) and records:
+
+* `python` — interpreter version used for the save
+* `platform` — host/platform summary from `platform.platform()`
+* `git_sha` — populated from `GIT_SHA` when provided (no subprocess lookups)
+* `lock_sha256` — SHA256 digest of `uv.lock`/`uv.lock.json` if present
+* `env` — selected reproducibility env vars (`PYTHONHASHSEED`, `CODEX_AUDIT`, `CODEX_DDP`)
+
+Treat the manifest as diagnostic metadata to aid reproducibility; its absence must
+not fail training.

--- a/src/codex_ml/utils/run_metadata.py
+++ b/src/codex_ml/utils/run_metadata.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _sha256_file(path: Path) -> str | None:
+    try:
+        hasher = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1 << 16), b""):
+                hasher.update(chunk)
+        return hasher.hexdigest()
+    except Exception:
+        return None
+
+
+def _git_sha() -> str | None:
+    sha = os.environ.get("GIT_SHA")
+    if sha:
+        return sha.strip()
+    return None
+
+
+def _lock_digest(root: Path) -> str | None:
+    for candidate in ("uv.lock", "uv.lock.json"):
+        lock_path = root / candidate
+        if lock_path.exists():
+            return _sha256_file(lock_path)
+    return None
+
+
+def collect_run_metadata(project_root: str | Path | None = None) -> dict[str, Any]:
+    root = Path(project_root or ".").resolve()
+    metadata: dict[str, Any] = {
+        "python": ".".join(map(str, sys.version_info[:3])),
+        "platform": platform.platform(),
+        "git_sha": _git_sha(),
+        "lock_sha256": _lock_digest(root),
+        "env": {
+            "PYTHONHASHSEED": os.environ.get("PYTHONHASHSEED"),
+            "CODEX_AUDIT": os.environ.get("CODEX_AUDIT"),
+            "CODEX_DDP": os.environ.get("CODEX_DDP"),
+        },
+    }
+    return metadata
+
+
+def write_run_manifest(directory: str | Path, payload: dict[str, Any]) -> None:
+    try:
+        target_dir = Path(directory)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        manifest = target_dir / "run_manifest.json"
+        manifest.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except Exception:
+        return

--- a/tests/checkpoint/test_run_metadata_sidecar.py
+++ b/tests/checkpoint/test_run_metadata_sidecar.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_run_manifest_sidecar_written(tmp_path: Path) -> None:
+    import codex_ml.utils.checkpoint_core as checkpoint_core
+
+    ckpt_dir = tmp_path / "artifacts"
+    state = {"weights": [1, 2, 3]}
+    checkpoint_core.save_checkpoint(str(ckpt_dir), state)
+    manifest = ckpt_dir / "run_manifest.json"
+    assert manifest.exists()
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    assert "python" in payload
+    assert "platform" in payload

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,20 +1,22 @@
 import importlib.util
+import os
 
 import pytest
 
-pytest.importorskip("yaml")
-pytest.importorskip("omegaconf")
-pytest.importorskip("hydra")
+if os.environ.get("CODEX_CLI_LIGHTWEIGHT", "0") != "1":
+    pytest.importorskip("yaml")
+    pytest.importorskip("omegaconf")
+    pytest.importorskip("hydra")
 
-spec = importlib.util.find_spec("torch")
-if spec is None:
-    pytest.skip("torch not installed", allow_module_level=True)
+    spec = importlib.util.find_spec("torch")
+    if spec is None:
+        pytest.skip("torch not installed", allow_module_level=True)
 
-try:
-    import torch  # noqa: F401  # ensure torch import succeeds
-    from torch.utils.data import Dataset  # noqa: F401
-except Exception:  # pragma: no cover - incomplete builds
-    pytest.skip(
-        "incomplete torch build (missing torch.utils dependencies)",
-        allow_module_level=True,
-    )
+    try:
+        import torch  # ensure torch import succeeds
+        from torch.utils.data import Dataset
+    except Exception:  # pragma: no cover - incomplete builds
+        pytest.skip(
+            "incomplete torch build (missing torch.utils dependencies)",
+            allow_module_level=True,
+        )

--- a/tests/cli/test_cli_structured_logging.py
+++ b/tests/cli/test_cli_structured_logging.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_eval_override_failure_sets_nonzero_exit() -> None:
+    script = (
+        "import os, sys;"
+        "os.environ['CODEX_EVAL_ENTRY'] = 'nonexistent_mod:missing';"
+        "import codex_ml.cli.entrypoints as entry;"
+        "sys.exit(entry.eval_main())"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert "env override failed" in (proc.stderr or "")
+    assert "override_failed" in (proc.stderr or "")

--- a/tests/cli/test_eval_probe_json_schema.py
+++ b/tests/cli/test_eval_probe_json_schema.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path(__file__).parents[1] / "schemas" / "eval_probe.schema.json"
+SCHEMA = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _validate(payload: dict[str, Any]) -> None:
+    assert isinstance(payload.get("ok"), bool)
+    assert payload.get("component") == "codex-eval"
+    assert isinstance(payload.get("python"), str)
+    assert isinstance(payload.get("platform"), str)
+    details = payload.get("details")
+    assert isinstance(details, dict)
+    assert isinstance(details.get("env_override"), bool)
+
+
+def test_eval_probe_json_output() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import codex_ml.cli.entrypoints as E; import sys; sys.exit(E.eval_main())",
+            "--probe-json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "Traceback" not in (proc.stderr or "")
+    payload = json.loads(proc.stdout)
+    _validate(payload)
+    for required_key in SCHEMA["required"]:
+        assert required_key in payload

--- a/tests/cli/test_hydra_missing_probe_json.py
+++ b/tests/cli/test_hydra_missing_probe_json.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+SCRIPT = """
+import sys
+sys.modules['hydra'] = None
+sys.modules['omegaconf'] = None
+import codex_ml.cli.hydra_main as hydra_main
+result = hydra_main.main(['--probe-json'])
+code = result if isinstance(result, int) else 0
+sys.exit(code)
+"""
+
+
+def test_probe_json_with_hydra_missing() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-c", SCRIPT],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload.get("component") == "codex-train"
+    assert payload.get("ok") in {True, False}
+    assert "Traceback" not in (proc.stderr or "")

--- a/tests/cli/test_train_probe_json_schema.py
+++ b/tests/cli/test_train_probe_json_schema.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_PATH = Path(__file__).parents[1] / "schemas" / "train_probe.schema.json"
+SCHEMA = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _validate(payload: dict[str, Any]) -> None:
+    assert isinstance(payload.get("ok"), bool)
+    assert payload.get("component") == "codex-train"
+    assert isinstance(payload.get("python"), str)
+    assert isinstance(payload.get("platform"), str)
+
+
+def test_train_probe_json_output() -> None:
+    command = (
+        "import codex_ml.cli.hydra_main as H; "
+        "import sys; "
+        "res = H.main(); "
+        "sys.exit(res if isinstance(res, int) else 0)"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", command, "--probe-json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    _validate(payload)
+    for required_key in SCHEMA["required"]:
+        assert required_key in payload
+    assert "Traceback" not in (proc.stderr or "")

--- a/tests/monitoring/test_system_metrics_nvml_missing.py
+++ b/tests/monitoring/test_system_metrics_nvml_missing.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def test_nvml_missing_fallback() -> None:
+    sys.modules.pop("pynvml", None)
+    sys.modules.pop("codex_ml.callbacks.system_metrics", None)
+    module = importlib.import_module("codex_ml.callbacks.system_metrics")
+    callback = module.SystemMetricsCallback()
+    metrics: dict[str, float] = {}
+    callback.on_epoch_end(epoch=0, metrics=metrics, state={})
+    assert "gpu0_util" in metrics
+    assert "gpu0_mem" in metrics
+    assert isinstance(metrics["gpu0_util"], int | float)
+    assert isinstance(metrics["gpu0_mem"], int | float)

--- a/tests/plugins/test_list_plugins_degrade.py
+++ b/tests/plugins/test_list_plugins_degrade.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+
+import codex_ml.cli.list_plugins as cli
+
+
+def test_list_plugins_handles_missing_registry(monkeypatch, capsys) -> None:
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("registry unavailable")
+
+    registry = types.ModuleType("codex_ml.registry")
+    registry.list_models = _raise  # type: ignore[attr-defined]
+    registry.list_tokenizers = _raise  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "codex_ml.registry", registry)
+
+    data_registry = types.ModuleType("codex_ml.data.registry")
+    data_registry.list_datasets = _raise  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "codex_ml.data.registry", data_registry)
+
+    programmatic = types.ModuleType("codex_ml.plugins.programmatic")
+
+    class _BrokenRegistry:
+        def discover(self) -> dict[str, str]:  # pragma: no cover - executed in test
+            raise RuntimeError("discover failed")
+
+        def names(self) -> list[str]:  # pragma: no cover - executed in test
+            raise RuntimeError("names failed")
+
+    programmatic.registry = lambda: _BrokenRegistry()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "codex_ml.plugins.programmatic", programmatic)
+
+    import codex_ml.plugins as plugins_pkg
+
+    plugins_pkg.programmatic = programmatic
+
+    rc = cli.main(["--format", "json"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "Traceback" not in (captured.err or "")
+    payload = json.loads(captured.out)
+    assert payload["legacy"]["models"] == []
+    assert payload["legacy"]["tokenizers"] == []
+    assert payload["legacy"]["datasets"] == []
+    assert payload["programmatic"]["names"] == []
+    assert payload["programmatic"]["discovered"] == []

--- a/tests/schemas/eval_probe.schema.json
+++ b/tests/schemas/eval_probe.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "properties": {
+    "component": {
+      "enum": [
+        "codex-eval"
+      ],
+      "type": "string"
+    },
+    "details": {
+      "additionalProperties": true,
+      "properties": {
+        "env_override": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "env_override"
+      ],
+      "type": "object"
+    },
+    "ok": {
+      "type": "boolean"
+    },
+    "platform": {
+      "type": "string"
+    },
+    "python": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "ok",
+    "component",
+    "python",
+    "platform",
+    "details"
+  ],
+  "title": "codex-eval probe payload",
+  "type": "object"
+}

--- a/tests/schemas/train_probe.schema.json
+++ b/tests/schemas/train_probe.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "properties": {
+    "component": {
+      "enum": [
+        "codex-train"
+      ],
+      "type": "string"
+    },
+    "ok": {
+      "type": "boolean"
+    },
+    "platform": {
+      "type": "string"
+    },
+    "python": {
+      "type": "string"
+    },
+    "reason": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "ok",
+    "component",
+    "python",
+    "platform"
+  ],
+  "title": "codex-train probe payload",
+  "type": "object"
+}


### PR DESCRIPTION
## Summary
- add structured logging fallbacks and a --probe-json mode to the eval and train CLIs
- capture run metadata alongside checkpoints via a run_manifest.json sidecar
- expand offline test coverage, schemas, and the ci nox session for the new probes and degradations

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 CODEX_CLI_LIGHTWEIGHT=1 pytest -q tests/cli/test_eval_probe_json_schema.py tests/cli/test_train_probe_json_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68ef6aece2148331af09532ea94e7940