### PR TITLE
Add GitHub API pagination and caching support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,13 +147,24 @@ gh-api-curl:
 	@GH_TOKEN=$${GH_TOKEN:?} python tools/github/gh_api.py \
 		--method GET \
 		--path /repos/Aries-Serpent/_codex_/branches \
+		--param per_page=100 \
+		--paginate \
 		--print-curl
 
 # Perform the actual API call (requires network)
 gh-api-call:
 	@GH_TOKEN=$${GH_TOKEN:?} python tools/github/gh_api.py \
 		--method GET \
-		--path /repos/Aries-Serpent/_codex_/branches
+		--path /repos/Aries-Serpent/_codex_/branches \
+		--param per_page=100 \
+		--paginate \
+		--cache-dir .gh_cache
+
+.PHONY: gh-branches gh-branches-curl
+gh-branches:
+	@$(MAKE) gh-api-call
+gh-branches-curl:
+	@$(MAKE) gh-api-curl
 
 # Unregister a self-hosted runner (DRY_RUN supported)
 runner-unregister:

--- a/docs/ops/GitHub_App_Integration.md
+++ b/docs/ops/GitHub_App_Integration.md
@@ -76,12 +76,26 @@ The wrapper emits a sanitized curl for review or performs the request:
 GH_TOKEN=xxxxx python tools/github/gh_api.py \
   --method GET \
   --path /repos/Aries-Serpent/_codex_/branches \
+  --param per_page=100 \
+  --paginate \
   --print-curl
 
 # Actual call (prints JSON to stdout)
 GH_TOKEN=$INSTALLATION_TOKEN python tools/github/gh_api.py \
   --method GET \
-  --path /repos/Aries-Serpent/_codex_/branches
+  --path /repos/Aries-Serpent/_codex_/branches \
+  --param per_page=100 \
+  --paginate \
+  --cache-dir .gh_cache
+
+## Caching
+- Enable cache with `--cache-dir .gh_cache` (or set `GH_API_CACHE_DIR`).
+- Serve from cache only with `--use-cache-only` (no network attempt).
+- Force a re-fetch with `--refresh-cache`.
+
+## Pagination
+- Use `--paginate` to follow `Link: ... rel="next"` until exhausted.
+- Control page size with `--per-page 100` and bound traversal with `--max-pages`.
 ```
 Use `--param key=value` to add query params, `--data/--data-file` for JSON body, and set `GITHUB_AUTH_SCHEME=Bearer` if you must use a non-default header scheme.
 

--- a/tests/github/test_gh_api_pagination_cache.py
+++ b/tests/github/test_gh_api_pagination_cache.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+
+import tools.github.gh_api as gh
+
+
+def test_pagination_aggregates_arrays(monkeypatch, capsys):
+    calls = {"n": 0}
+
+    def _stub_request(method, url, token, scheme, body):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            headers = {"Link": '<https://api.example/next>; rel="next"'}
+            return 200, json.dumps([{"name": "a"}, {"name": "b"}]), headers
+        headers = {}
+        return 200, json.dumps([{"name": "c"}]), headers
+
+    monkeypatch.setenv("GH_TOKEN", "dummy")
+    monkeypatch.setattr(gh, "_request", _stub_request)
+
+    argv = [
+        "prog",
+        "--method",
+        "GET",
+        "--path",
+        "/repos/o/r/branches",
+        "--paginate",
+        "--max-pages",
+        "10",
+    ]
+    monkeypatch.setattr(
+        gh,
+        "sys",
+        types.SimpleNamespace(argv=argv, stdout=gh.sys.stdout, stderr=gh.sys.stderr),
+    )
+
+    rc = gh.main()
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert isinstance(payload, list)
+    assert [item["name"] for item in payload] == ["a", "b", "c"]
+
+
+def test_cache_write_and_read(monkeypatch, tmp_path: Path, capsys):
+    def _stub_request(method, url, token, scheme, body):
+        return 200, json.dumps({"ok": True}), {}
+
+    monkeypatch.setenv("GH_TOKEN", "dummy")
+    monkeypatch.setattr(gh, "_request", _stub_request)
+    cache_dir = tmp_path / "cache"
+
+    argv1 = [
+        "prog",
+        "--method",
+        "GET",
+        "--path",
+        "/repos/o/r/branches",
+        "--cache-dir",
+        str(cache_dir),
+    ]
+    monkeypatch.setattr(
+        gh,
+        "sys",
+        types.SimpleNamespace(argv=argv1, stdout=gh.sys.stdout, stderr=gh.sys.stderr),
+    )
+    rc1 = gh.main()
+    assert rc1 == 0
+    capsys.readouterr()
+    cached_files = list(cache_dir.glob("*.json"))
+    assert cached_files, "expected a cached JSON file"
+
+    def _boom(*_args, **_kwargs):
+        raise AssertionError("network should not be called in cache-only mode")
+
+    monkeypatch.setattr(gh, "_request", _boom)
+    argv2 = [
+        "prog",
+        "--method",
+        "GET",
+        "--path",
+        "/repos/o/r/branches",
+        "--cache-dir",
+        str(cache_dir),
+        "--use-cache-only",
+    ]
+    monkeypatch.setattr(
+        gh,
+        "sys",
+        types.SimpleNamespace(argv=argv2, stdout=gh.sys.stdout, stderr=gh.sys.stderr),
+    )
+    rc2 = gh.main()
+    assert rc2 == 0
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert payload.get("ok") is True


### PR DESCRIPTION
## Summary
- add pagination support and a filesystem-backed response cache to `tools/github/gh_api.py`
- document the new flags and expose make targets for paginated branch listings
- cover pagination and cache behaviour with offline pytest cases

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/github/test_gh_api_pagination_cache.py

------
https://chatgpt.com/codex/tasks/task_e_68ef77c1f8c88331b0c6b778bb76729d