### PR TITLE
Add CLI JSON schema tests and resilience utilities

### DIFF
--- a/docs/developer/Patch_Debris_Guard.md
+++ b/docs/developer/Patch_Debris_Guard.md
@@ -1,0 +1,13 @@
+# Patch Debris Guard
+
+The `patch_debris` nox session scans the working tree for stray diff markers such as `*** Begin Patch` or `diff --git`. Use it before committing patches assembled manually.
+
+## Usage
+
+```bash
+nox -s patch_debris
+```
+
+The task is offline-friendly and only inspects text-like files (Python, Markdown, JSON, YAML, TOML, shell, Makefiles). Build caches, hidden directories, and `patches/` are automatically excluded.
+
+If any markers are detected the session fails and prints the offending paths; otherwise it logs a success message.

--- a/docs/ops/CLI_JSON_Schemas.md
+++ b/docs/ops/CLI_JSON_Schemas.md
@@ -1,0 +1,27 @@
+# CLI JSON Schemas
+
+Two CLIs surface machine-readable JSON and are validated against schemas stored in `schemas/cli/`:
+
+- `python -m codex_ml.cli.list_plugins --format json`
+- `python tools/github/gh_api.py --json-envelope ...`
+
+## Validating Locally
+
+Install `jsonschema` in your environment and run:
+
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/cli/test_cli_schemas.py
+```
+
+This suite verifies that stdout contains exactly one JSON document and matches the corresponding schema.
+
+## Envelope Mode
+
+`tools/github/gh_api.py` supports `--json-envelope`, which wraps stdout in a normalized envelope:
+
+```json
+{ "ok": true, "data": <payload> }
+{ "ok": false, "error": "message" }
+```
+
+This keeps stderr free for diagnostics while downstream tools consume predictable JSON.

--- a/schemas/cli/gh_api_envelope.schema.json
+++ b/schemas/cli/gh_api_envelope.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "additionalProperties": true,
+      "properties": {
+        "data": {},
+        "ok": {
+          "const": true
+        }
+      },
+      "required": [
+        "ok",
+        "data"
+      ]
+    },
+    {
+      "additionalProperties": true,
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "ok": {
+          "const": false
+        }
+      },
+      "required": [
+        "ok",
+        "error"
+      ]
+    }
+  ],
+  "required": [
+    "ok"
+  ],
+  "title": "GitHub API CLI envelope",
+  "type": "object"
+}

--- a/schemas/cli/list_plugins.schema.json
+++ b/schemas/cli/list_plugins.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "legacy": {
+      "additionalProperties": true,
+      "properties": {
+        "datasets": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "metrics": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "models": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "reward_models": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "rl_agents": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "tokenizers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "trainers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "programmatic": {
+      "additionalProperties": true,
+      "properties": {
+        "discovered": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "discovered",
+        "names"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "programmatic",
+    "legacy"
+  ],
+  "title": "codex list_plugins JSON",
+  "type": "object"
+}

--- a/src/codex_ml/logging/structured.py
+++ b/src/codex_ml/logging/structured.py
@@ -1,0 +1,50 @@
+"""Lightweight structured logging helpers for CLIs."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from codex_ml.utils.jsonio import print_error_json
+
+
+def init_logger(
+    level: str = "WARNING", *, json_mode: bool = False, name: str = "codex"
+) -> logging.Logger:
+    """Initialise a stderr logger with optional terse formatting for JSON CLIs."""
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        if json_mode:
+            formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+        else:
+            formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    logger.setLevel(getattr(logging, level.upper(), logging.WARNING))
+    logger.propagate = False
+    return logger
+
+
+@contextmanager
+def capture_exceptions(
+    *, exit_code: int = 2, emit_json: bool = False, errmsg: str = "error"
+) -> Iterator[None]:
+    """Capture unexpected exceptions and exit cleanly with optional JSON."""
+
+    try:
+        yield
+    except SystemExit:
+        raise
+    except Exception as exc:  # pragma: no cover - exercised via CLI integration tests
+        if emit_json:
+            print_error_json(f"{errmsg}: {exc}")
+        else:
+            sys.stderr.write(f"{errmsg}: {exc}\n")
+        raise SystemExit(exit_code) from None
+
+
+__all__ = ["init_logger", "capture_exceptions"]

--- a/src/codex_ml/utils/checkpoint_core.py
+++ b/src/codex_ml/utils/checkpoint_core.py
@@ -57,6 +57,8 @@ except Exception:  # pragma: no cover - optional dependency
         return None
 
 
+from .runmeta import collect_run_meta
+
 # NOTE: _atomic_write is an internal primitive. Do not call it outside this module.
 # All callers must use save_checkpoint(), which enriches metadata integrity and rewrites safely.
 __all__ = ["save_checkpoint"]  # explicitly export only the public API
@@ -478,8 +480,17 @@ def save_checkpoint(
     _write_index(root, idx)
 
     try:
-        run_meta = collect_run_metadata()
-        write_run_manifest(root, run_meta)
+        manifest = dict(collect_run_metadata())
+    except Exception:
+        manifest = {}
+    try:
+        provenance = collect_run_meta()
+        if provenance:
+            manifest.setdefault("provenance", {}).update(provenance)
+    except Exception:
+        pass
+    try:
+        write_run_manifest(root, manifest)
     except Exception:
         pass
 

--- a/src/codex_ml/utils/jsonio.py
+++ b/src/codex_ml/utils/jsonio.py
@@ -1,0 +1,37 @@
+"""Helpers for CLI JSON stdout discipline."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping
+from typing import Any
+
+
+def _ensure_newline(text: str) -> str:
+    return text if text.endswith("\n") else text + "\n"
+
+
+def print_json(payload: Any) -> None:
+    """Emit exactly one JSON document to stdout followed by a newline."""
+
+    sys.stdout.write(_ensure_newline(json.dumps(payload)))
+
+
+def print_error_json(
+    message: str,
+    *,
+    code: int | None = None,
+    details: Mapping[str, Any] | None = None,
+) -> None:
+    """Emit a normalized error envelope suitable for CLI consumption."""
+
+    output: dict[str, Any] = {"ok": False, "error": str(message)}
+    if code is not None:
+        output["code"] = int(code)
+    if details:
+        output["details"] = dict(details)
+    print_json(output)
+
+
+__all__ = ["print_json", "print_error_json"]

--- a/src/codex_ml/utils/runmeta.py
+++ b/src/codex_ml/utils/runmeta.py
@@ -1,0 +1,90 @@
+"""Helpers to capture minimal run metadata for checkpoint sidecars."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+
+def python_version() -> str:
+    return ".".join(map(str, sys.version_info[:3]))
+
+
+def _git_rev_parse() -> str | None:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        )
+    except Exception:
+        return None
+    return out.decode("utf-8").strip()
+
+
+def _git_read_head(repo: Path) -> str | None:
+    head = repo / ".git" / "HEAD"
+    if not head.exists():
+        return None
+    try:
+        ref = head.read_text(encoding="utf-8").strip()
+    except Exception:
+        return None
+    if ref.startswith("ref:"):
+        _, ref_path = ref.split(":", 1)
+        ref_file = repo / ".git" / ref_path.strip()
+        if ref_file.exists():
+            try:
+                return ref_file.read_text(encoding="utf-8").strip()
+            except Exception:
+                return None
+        return None
+    return ref or None
+
+
+def git_sha(repo: str | Path = ".") -> str:
+    repo_path = Path(repo)
+    return _git_rev_parse() or _git_read_head(repo_path) or ""
+
+
+def _sha256_file(path: Path) -> str | None:
+    try:
+        hasher = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1 << 16), b""):
+                hasher.update(chunk)
+        return hasher.hexdigest()
+    except Exception:
+        return None
+
+
+_LOCK_CANDIDATES = ("uv.lock", "requirements.lock", "poetry.lock", "Pipfile.lock")
+
+
+def lock_digest(root: str | Path = ".") -> str:
+    base = Path(root)
+    for candidate in _LOCK_CANDIDATES:
+        lock_path = base / candidate
+        if lock_path.exists():
+            digest = _sha256_file(lock_path)
+            if digest:
+                return digest
+    return ""
+
+
+def collect_run_meta(extra: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "python": python_version(),
+        "git": git_sha(),
+        "lock_sha256": lock_digest(),
+    }
+    if extra:
+        payload.update(dict(extra))
+    return payload
+
+
+__all__ = ["python_version", "git_sha", "lock_digest", "collect_run_meta"]

--- a/tests/checkpoint/test_runmeta_enrichment.py
+++ b/tests/checkpoint/test_runmeta_enrichment.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import codex_ml.utils.checkpoint_core as checkpoint_core
+
+
+def test_run_manifest_includes_provenance(tmp_path: Path) -> None:
+    ckpt_dir = tmp_path / "artifacts"
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    state = {"weights": [1, 2, 3]}
+    checkpoint_core.save_checkpoint(str(ckpt_dir), state)
+    manifest_path = ckpt_dir / "run_manifest.json"
+    assert manifest_path.exists()
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    provenance = payload.get("provenance")
+    assert isinstance(provenance, dict)
+    assert "python" in provenance
+    assert "git" in provenance
+    assert "lock_sha256" in provenance

--- a/tests/cli/test_cli_schemas.py
+++ b/tests/cli/test_cli_schemas.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    import jsonschema  # type: ignore
+except Exception:  # pragma: no cover - optional dependency not installed
+    jsonschema = None  # type: ignore[assignment]
+    pytestmark = pytest.mark.skip(reason="jsonschema not installed")
+
+SCHEMAS = Path("schemas/cli")
+
+
+def _load_schema(name: str) -> dict:
+    return json.loads((SCHEMAS / name).read_text(encoding="utf-8"))
+
+
+def test_list_plugins_matches_schema():
+    schema = _load_schema("list_plugins.schema.json")
+    proc = subprocess.run(
+        [sys.executable, "-m", "codex_ml.cli.list_plugins", "--format", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout or "{}")
+    jsonschema.validate(instance=payload, schema=schema)
+
+
+def test_gh_api_envelope_schema(monkeypatch, capsys):
+    schema = _load_schema("gh_api_envelope.schema.json")
+    import tools.github.gh_api as gh
+
+    monkeypatch.setenv("GH_TOKEN", "dummy-token")
+
+    def _stub_request(method, url, token, scheme, body):
+        return 200, json.dumps([{"name": "branch"}]), {}
+
+    monkeypatch.setattr(gh, "_request", _stub_request)
+    rc = gh.main(
+        [
+            "--method",
+            "GET",
+            "--path",
+            "/repos/owner/repo/branches",
+            "--json-envelope",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    jsonschema.validate(instance=payload, schema=schema)
+    assert payload["ok"] is True

--- a/tests/interfaces/test_registry_degradation.py
+++ b/tests/interfaces/test_registry_degradation.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+
+import codex_ml.cli.list_plugins as list_plugins
+
+
+def test_programmatic_registry_failure_degrades_to_legacy(monkeypatch, capsys):
+    def _boom():
+        raise RuntimeError("registry unavailable")
+
+    fake_module = types.SimpleNamespace(registry=_boom)
+    monkeypatch.setitem(sys.modules, "codex_ml.plugins.programmatic", fake_module)
+    plugins_spec = importlib.util.find_spec("codex_ml.plugins")
+    if plugins_spec is not None:
+        plugins_pkg = importlib.import_module("codex_ml.plugins")
+        monkeypatch.setattr(plugins_pkg, "programmatic", fake_module, raising=False)
+
+    rc = list_plugins.main(["--format", "json"])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert "legacy" in payload
+    assert isinstance(payload["legacy"], dict)
+    assert payload["programmatic"]["names"] == []

--- a/tests/monitoring/test_system_metrics_cpu_fallback.py
+++ b/tests/monitoring/test_system_metrics_cpu_fallback.py
@@ -23,5 +23,29 @@ def test_collect_without_nvml(monkeypatch):
     # CPU-only fallback should provide stable GPU keys with numeric values.
     assert "gpu0_util" in metrics
     assert "gpu0_mem" in metrics
-    assert isinstance(metrics["gpu0_util"], (int, float))
-    assert isinstance(metrics["gpu0_mem"], (int, float))
+    assert isinstance(metrics["gpu0_util"], (int, float))  # noqa: UP038
+    assert isinstance(metrics["gpu0_mem"], (int, float))  # noqa: UP038
+
+
+def test_runtime_nvml_failure_advisory(monkeypatch):
+    """Runtime NVML initialisation failures should still provide CPU fallbacks."""
+
+    mod = importlib.import_module("codex_ml.callbacks.system_metrics")
+
+    class _FakeNVML:
+        class NVMLError(Exception):
+            ...
+
+        def nvmlInit(self):  # type: ignore  # noqa: N802
+            raise RuntimeError("NVML init failed")
+
+        def nvmlDeviceGetCount(self):  # type: ignore  # noqa: N802
+            return 0
+
+    monkeypatch.setattr(mod, "pynvml", _FakeNVML(), raising=True)
+
+    callback = mod.SystemMetricsCallback()
+    metrics: dict[str, float] = {}
+    callback.on_epoch_end(epoch=0, metrics=metrics, state={})
+    assert "gpu0_util" in metrics
+    assert "gpu0_mem" in metrics

--- a/tests/train/test_hydra_degrade.py
+++ b/tests/train/test_hydra_degrade.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import codex_ml.cli.hydra_main as hydra_main
+
+
+def test_hydra_missing_module_degrades(monkeypatch, capsys):
+    monkeypatch.setattr(hydra_main, "hydra", None, raising=False)
+    monkeypatch.setattr(hydra_main, "_hydra_entry", None, raising=False)
+    rc = hydra_main.main([])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "hydra-core is required" in captured.err


### PR DESCRIPTION
## Summary
- add JSON schema helpers and structured logging utilities for CLI outputs
- update GitHub API CLI to support JSON envelopes, structured logging, and cache fixes
- introduce schema-based CLI tests, optional dependency degradation coverage, and run metadata capture
- document new patch debris guard, CLI schema usage, and add nox guard session

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/github/test_gh_api_pagination_cache.py
- CODEX_CLI_LIGHTWEIGHT=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/monitoring/test_system_metrics_cpu_fallback.py tests/interfaces/test_registry_degradation.py tests/train/test_hydra_degrade.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/checkpoint/test_runmeta_enrichment.py
- n/a (pre-commit hooks run via git commit)


------
https://chatgpt.com/codex/tasks/task_e_68efe344bba88331b377e4ddcd073842