### PR TITLE
feat: add logging and evaluation helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   - Rationale: improve offline determinism, enable resilient checkpoint resume, and validate local experiment tracking without network services.
   - Risks: optional `torch`/`mlflow` dependencies require `pytest.importorskip`; best-K retention removes files matching the checkpoint glob; CUDA RNG restore only runs when GPUs are present.
   - Rollback: drop the new trainer/checkpoint helpers and tests, delete the MLflow nox session, and remove the MLflow dev dependency.
+- feat(logging): extend `logging_utils` with safe MLflow context manager, TensorBoard scalar helper, and lightweight system metrics snapshotting.
+- feat(eval): add NDJSON/CSV writers and baseline metric helpers under `src/evaluation/`.
+- tests: introduce coverage for logging helpers (MLflow/TensorBoard/system metrics) and evaluation writers.
+- docs: add LOGGING.md and README pointers covering offline MLflow/TensorBoard usage and NDJSON conventions.
 - Captured the October gap→risk→resolution tracker and refreshed high-signal/open-question reports to prioritise outstanding modeling, security, and deployment work from the latest status update.【F:reports/gap_risk_resolution.md†L1-L15】【F:reports/high_signal_findings.md†L1-L6】【F:OPEN_QUESTIONS.md†L1-L18】
 
 ## Unreleased - 2025-09-22

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,39 @@
 
-.PHONY: format
-.PHONY: install package clean
+.PHONY: help setup fmt lint type test cover sast track cli clean format install package
+
+help:
+	@echo "Targets: setup fmt lint type test cover sast track cli clean"
+
+setup:
+	pip install -r requirements.txt -r requirements-dev.txt
+
+fmt:
+	black src tests
+	isort src tests
+
+lint:
+	ruff src tests
+	flake8 src tests
+
+type:
+	mypy src
+
+test:
+	pytest -q
+
+cover:
+	pytest -q --cov=src --cov-report=term-missing
+
+sast:
+	bandit -q -r src
+	semgrep scan --config=p/ci src
+	pip-audit -r requirements.txt || true
+
+track:
+	nox -s tracking_smoke
+
+cli:
+	nox -s cli
 
 install:
 	@pip install -e .
@@ -13,7 +46,7 @@ package:
 	fi
 
 clean:
-	rm -rf build dist .nox *.egg-info artifacts/coverage.xml .pytest_cache
+	rm -rf build dist .nox *.egg-info artifacts/coverage.xml .pytest_cache mlruns .checkpoints artifacts coverage.xml
 
 # --- Metrics utilities ---
 metrics-csv:

--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ codex repo-map
 - [Checkpoint retention notes](docs/CHECKPOINTS.md)
 - [Manifest Integrity](docs/manifest_integrity.md)
 
+## Logging & Tracking
+
+All helper utilities default to **local/offline** backends:
+
+- **MLflow** uses the file store under `./mlruns` (configurable via `MLFLOW_TRACKING_URI`).
+- **TensorBoard** writes event files consumable with `tensorboard --logdir <dir>`.
+
+See [`docs/LOGGING.md`](docs/LOGGING.md) for configuration notes and references.
+
 ### Repo admin bootstrap (no workflows)
 ```bash
 # dry-run

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -1,0 +1,37 @@
+# Local Logging & Tracking
+
+This repository uses **local-only** logging utilities to keep smoke tests hermetic.
+
+## MLflow (file backend)
+
+- Default: the helpers in `src/logging_utils.py` set `MLFLOW_TRACKING_URI` to `file:./mlruns` when `offline=True`.
+- Customize the directory by exporting an absolute path:
+
+```bash
+export MLFLOW_TRACKING_URI="file:/absolute/path/to/mlruns"
+```
+
+References: MLflow tracking URIs and the file store backend.[^mlflow]
+
+## TensorBoard
+
+Use PyTorch's `SummaryWriter` to emit event files locally:
+
+```python
+from torch.utils.tensorboard import SummaryWriter
+
+writer = SummaryWriter("./runs")
+writer.add_scalar("loss", 0.123, 1)
+```
+
+Reference: PyTorch TensorBoard utilities.[^tensorboard]
+
+## NDJSON & CSV outputs
+
+- **NDJSON**: emit one JSON object per line; prefer the `.ndjson` extension for clarity.[^ndjson]
+- **CSV**: use Python's `csv.DictWriter` for schema-aware tabular exports.[^csv]
+
+[^mlflow]: https://mlflow.org/docs/latest/tracking.html#file-store
+[^tensorboard]: https://pytorch.org/docs/stable/tensorboard.html
+[^ndjson]: https://github.com/ndjson/ndjson-spec
+[^csv]: https://docs.python.org/3/library/csv.html

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ mypy
 pytest>=8.0
 pytest-randomly>=4.0
 pytest-cov==7.0.0
+tensorboard>=2.14
 bandit
 defusedxml
 semgrep

--- a/src/evaluation/__init__.py
+++ b/src/evaluation/__init__.py
@@ -1,0 +1,14 @@
+"""Evaluation helpers (metrics, writers)."""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+__all__ = ["metrics", "writers"]
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name in __all__:
+        return importlib.import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/evaluation/metrics.py
+++ b/src/evaluation/metrics.py
@@ -1,0 +1,27 @@
+"""Basic evaluation metrics used in training/evaluation loops."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as functional
+
+
+def accuracy(logits: torch.Tensor, targets: torch.Tensor) -> float:
+    """Return top-1 accuracy for classification logits."""
+
+    preds = torch.argmax(logits, dim=-1)
+    return float((preds == targets).float().mean().item())
+
+
+def cross_entropy(logits: torch.Tensor, targets: torch.Tensor) -> float:
+    """Compute mean cross-entropy loss."""
+
+    return float(functional.cross_entropy(logits, targets).item())
+
+
+def perplexity(loss: float) -> float:
+    """Convert an average loss value into perplexity."""
+
+    return float(math.exp(min(50.0, max(-50.0, loss))))

--- a/src/evaluation/writers.py
+++ b/src/evaluation/writers.py
@@ -1,0 +1,38 @@
+"""Utilities to persist evaluation artefacts (NDJSON, CSV)."""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+
+
+def write_ndjson(records: Iterable[Mapping[str, object]], path: str | Path) -> None:
+    """Write records to ``path`` as newline-delimited JSON."""
+
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", encoding="utf-8", newline="\n") as handle:
+        for record in records:
+            handle.write(json.dumps(dict(record), ensure_ascii=False))
+            handle.write("\n")
+
+
+def write_csv(records: Sequence[Mapping[str, object]], path: str | Path) -> None:
+    """Write records to CSV, merging keys across all rows for the header."""
+
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    fieldnames: list[str] = []
+    for record in records:
+        for key in record:
+            if key not in fieldnames:
+                fieldnames.append(key)
+
+    with destination.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for record in records:
+            writer.writerow({key: record.get(key) for key in fieldnames})

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, MutableMapping
+import os
+import time
+from collections.abc import Iterator, Mapping, MutableMapping
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 LOGGER = logging.getLogger(__name__)
 
@@ -18,6 +22,16 @@ try:  # pragma: no cover - MLflow is optional for offline smoke tests
     import mlflow
 except Exception:  # pragma: no cover - guard offline runs that skip mlflow install
     mlflow = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional runtime dependency
+    import psutil
+except Exception:  # pragma: no cover - allow execution without psutil
+    psutil = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional GPU metrics dependency
+    import pynvml
+except Exception:  # pragma: no cover - allow execution without NVML bindings
+    pynvml = None  # type: ignore[assignment]
 
 
 @dataclass(slots=True)
@@ -36,23 +50,32 @@ class LoggingSession:
     mlflow_active: bool
 
 
-def _create_tensorboard_writer(log_dir: str) -> SummaryWriter | None:
+@dataclass(slots=True)
+class LogHandles:
+    """Lightweight container for optional logging backends."""
+
+    tb: SummaryWriter | None = None
+    mlflow_run_active: bool = False
+
+
+def _create_tensorboard_writer(log_dir: str | Path) -> SummaryWriter | None:
     if SummaryWriter is None:
         LOGGER.info("TensorBoard unavailable; skipping SummaryWriter initialisation")
         return None
     try:
-        Path(log_dir).mkdir(parents=True, exist_ok=True)
+        path = Path(log_dir)
+        path.mkdir(parents=True, exist_ok=True)
     except Exception as exc:  # pragma: no cover - propagate context
         LOGGER.warning("Unable to create TensorBoard log directory '%s': %s", log_dir, exc)
         return None
     try:
-        return SummaryWriter(log_dir)
+        return SummaryWriter(str(path))
     except Exception as exc:  # pragma: no cover - e.g. tensorboard not installed
         LOGGER.warning("Failed to initialise TensorBoard writer: %s", exc)
         return None
 
 
-def init_tensorboard(log_dir: str) -> SummaryWriter | None:
+def init_tensorboard(log_dir: str | Path) -> SummaryWriter | None:
     """Compatibility wrapper returning a TensorBoard writer when available."""
 
     # The legacy API exposed ``init_tensorboard`` directly; delegate to the new helper
@@ -159,12 +182,131 @@ def shutdown_logging(session: LoggingSession) -> None:
             LOGGER.debug("Failed to end MLflow run cleanly: %s", exc)
 
 
+@contextmanager
+def mlflow_run(
+    run_name: str = "run",
+    *,
+    offline: bool = True,
+    tracking_dir: str | Path = "./mlruns",
+) -> Iterator[None]:
+    """Context manager that starts an MLflow run if MLflow is available."""
+
+    if mlflow is None:
+        yield
+        return
+
+    tracking_path = Path(tracking_dir)
+    if offline:
+        os.environ.setdefault("MLFLOW_TRACKING_URI", f"file:{tracking_path.resolve()}")
+        with suppress(Exception):  # pragma: no cover - directory creation best-effort
+            tracking_path.mkdir(parents=True, exist_ok=True)
+
+    mlflow.start_run(run_name=run_name)
+    try:
+        yield
+    finally:
+        try:
+            mlflow.end_run()
+        except Exception:  # pragma: no cover - best-effort shutdown
+            LOGGER.debug("Failed to end MLflow run via context manager", exc_info=True)
+
+
+def log_scalar_tb(writer: SummaryWriter | None, tag: str, value: float, step: int) -> None:
+    """Log a scalar metric to TensorBoard when a writer is provided."""
+
+    if writer is None:
+        return
+    try:
+        writer.add_scalar(tag, value, global_step=step)
+    except Exception:  # pragma: no cover - robustness guard
+        LOGGER.debug("TensorBoard scalar logging failed", exc_info=True)
+
+
+def log_params_mlflow(params: Mapping[str, Any]) -> None:
+    """Log parameters to MLflow, coercing unsupported value types to strings."""
+
+    if mlflow is None or not params:
+        return
+    try:
+        mlflow.log_params(
+            {
+                key: value if isinstance(value, int | float | str) else str(value)
+                for key, value in params.items()
+            }
+        )
+    except Exception:  # pragma: no cover - robustness guard
+        LOGGER.debug("MLflow parameter logging failed", exc_info=True)
+
+
+def log_metrics_mlflow(metrics: Mapping[str, float], step: int | None = None) -> None:
+    """Log metrics to MLflow if available."""
+
+    if mlflow is None or not metrics:
+        return
+    try:
+        mlflow.log_metrics({k: float(v) for k, v in metrics.items()}, step=step)
+    except Exception:  # pragma: no cover - robustness guard
+        LOGGER.debug("MLflow metric logging failed", exc_info=True)
+
+
+def system_metrics() -> dict[str, Any]:
+    """Return a lightweight snapshot of CPU, RAM, and optional GPU utilisation."""
+
+    snapshot: dict[str, Any] = {"ts": time.time()}
+
+    if psutil is not None:
+        try:
+            cpu_percent = psutil.cpu_percent(interval=None)
+            memory = psutil.virtual_memory()
+            snapshot.update(
+                {
+                    "cpu_percent": float(cpu_percent),
+                    "ram_used_bytes": int(memory.used),
+                    "ram_total_bytes": int(memory.total),
+                }
+            )
+        except Exception:  # pragma: no cover - psutil metrics best-effort
+            LOGGER.debug("psutil metrics collection failed", exc_info=True)
+
+    if pynvml is not None:
+        try:
+            pynvml.nvmlInit()
+            device_count = pynvml.nvmlDeviceGetCount()
+            gpus: list[dict[str, Any]] = []
+            for idx in range(device_count):
+                handle = pynvml.nvmlDeviceGetHandleByIndex(idx)
+                memory_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                gpus.append(
+                    {
+                        "index": idx,
+                        "mem_used_bytes": int(memory_info.used),
+                        "mem_total_bytes": int(memory_info.total),
+                    }
+                )
+            snapshot["gpus"] = gpus
+        except Exception:  # pragma: no cover - NVML metrics best-effort
+            LOGGER.debug("NVML metrics collection failed", exc_info=True)
+        finally:
+            try:
+                pynvml.nvmlShutdown()
+            except Exception:  # pragma: no cover - best-effort shutdown
+                LOGGER.debug("NVML shutdown failed", exc_info=True)
+
+    return snapshot
+
+
 __all__ = [
     "init_mlflow",
     "init_tensorboard",
     "LoggingConfig",
     "LoggingSession",
+    "LogHandles",
     "log_metrics",
+    "log_metrics_mlflow",
+    "log_params_mlflow",
+    "log_scalar_tb",
     "setup_logging",
     "shutdown_logging",
+    "system_metrics",
+    "mlflow_run",
 ]

--- a/tests/test_eval_writers.py
+++ b/tests/test_eval_writers.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+from src.evaluation.writers import write_csv, write_ndjson
+
+
+def test_write_ndjson(tmp_path: Path):
+    path = tmp_path / "rows.ndjson"
+    rows = [{"a": 1}, {"a": 2, "b": "x"}]
+    write_ndjson(rows, path)
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["a"] == 1
+    assert json.loads(lines[1])["b"] == "x"
+
+
+def test_write_csv(tmp_path: Path):
+    path = tmp_path / "rows.csv"
+    rows = [{"a": 1}, {"a": 2, "b": "x"}]
+    write_csv(rows, path)
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = list(csv.DictReader(handle))
+    assert reader[0]["a"] == "1"
+    assert reader[1]["b"] == "x"

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.logging_utils import (
+    init_tensorboard,
+    log_metrics_mlflow,
+    log_params_mlflow,
+    log_scalar_tb,
+    mlflow_run,
+    system_metrics,
+)
+
+
+def test_tb_writer_creates_eventfiles(tmp_path: Path):
+    writer = init_tensorboard(tmp_path / "tb")
+    if writer is None:
+        pytest.skip("tensorboard not available")
+    log_scalar_tb(writer, "loss", 0.123, step=1)
+    writer.flush()
+    assert any((tmp_path / "tb").glob("events.*"))
+
+
+def test_mlflow_offline_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip("mlflow", reason="mlflow not installed")
+    uri = f"file:{tmp_path / 'mlruns'}"
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", uri)
+    with mlflow_run(run_name="smoke", offline=True, tracking_dir=tmp_path / "mlruns"):
+        log_params_mlflow({"p": 1})
+        log_metrics_mlflow({"m": 0.123}, step=1)
+    assert any((tmp_path / "mlruns").glob("**/meta.yaml"))
+
+
+def test_system_metrics_has_keys():
+    metrics = system_metrics()
+    assert "ts" in metrics
+    assert isinstance(metrics["ts"], float)
+    if "cpu_percent" in metrics:
+        assert 0.0 <= metrics["cpu_percent"] <= 100.0


### PR DESCRIPTION
## Summary
- add TensorBoard/MLflow helper APIs and system metrics snapshotting in `logging_utils`
- introduce evaluation metrics and NDJSON/CSV writer utilities with package init
- expand docs with offline logging guide and extend Makefile/requirements for local tracking

## Testing
- pytest tests/test_logging_utils.py tests/test_eval_writers.py --override-ini addopts= -q

------
https://chatgpt.com/codex/tasks/task_e_68f05b635b248331be866cedc46aa08a