### PR TITLE
fix: ignore diff headers in evidence check

### DIFF
--- a/.github/workflows/archive-gates.yml.disabled
+++ b/.github/workflows/archive-gates.yml.disabled
@@ -51,7 +51,9 @@ jobs:
               echo "::error ::Evidence log changed but no additions detected"; exit 1;
             fi
             # Basic JSON line check (id/path/sha256/provenance)
-            git diff "origin/${base}...HEAD" -- "${file}" | sed -n 's/^+//p' > /tmp/evidence_added.jsonl
+            git diff "origin/${base}...HEAD" -- "${file}" \
+              | grep -E '^\+[^+]' \
+              | sed 's/^+//' > /tmp/evidence_added.jsonl
             python3 - <<'PY'
 import sys, json
 rc=0


### PR DESCRIPTION
## Summary
- filter diff metadata lines before stripping the leading plus sign in the evidence gate

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f19d9251bc8331a88a14aa21cd32ea