### PR TITLE
Add multi-entry archive plan test and broaden provenance hints

### DIFF
--- a/src/tools/archive_pr_checklist.py
+++ b/src/tools/archive_pr_checklist.py
@@ -5,6 +5,21 @@ the governance artefacts our policy requires: an ADR, changelog entry,
 evidence log update, and provenance material.  The helper can operate on
 the staged git diff or on an explicit list of paths, making it easy to
 use from tests and CI automation alike.
+
+Recognised provenance artefacts
+-------------------------------
+Paths that contain any of the following substrings are treated as
+provenance evidence when the referenced files exist relative to the
+repository root:
+
+* ``provenance`` - legacy directory layout.
+* ``attest`` or ``attestation`` - generic attestations.
+* ``intoto`` or ``in-toto`` - in-toto statements and bundles.
+* ``slsa`` - SLSA provenance materials (JSON/JSONL, statements, etc.).
+
+The detection is case-insensitive and applies to full paths, so both
+``artifacts/intoto/archive.intoto.jsonl`` and
+``artifacts/slsa/provenance.json`` satisfy the provenance requirement.
 """
 
 from __future__ import annotations
@@ -19,7 +34,7 @@ from pathlib import Path
 ADR_PREFIX = "docs/arch/"
 CHANGELOG_PATH = "CHANGELOG.md"
 EVIDENCE_PATH = ".codex/evidence/archive_ops.jsonl"
-PROVENANCE_HINTS = ("provenance", "attest", "attestation")
+PROVENANCE_HINTS = ("provenance", "attest", "attestation", "intoto", "in-toto", "slsa")
 
 
 @dataclass(slots=True)

--- a/tests/archive/test_archive_plan_apply.py
+++ b/tests/archive/test_archive_plan_apply.py
@@ -103,3 +103,96 @@ def test_apply_plan_then_restore(tmp_path: Path, monkeypatch) -> None:
     assert restore_events, "RESTORE event missing from evidence log"
 
     assert plan_apply_events[0]["tombstone"] == restore_events[0]["tombstone"]
+
+
+def test_apply_plan_multiple_entries(tmp_path: Path, monkeypatch) -> None:
+    evidence_dir = tmp_path / ".codex" / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    db_path = tmp_path / ".codex" / "archive.sqlite"
+
+    monkeypatch.setenv("CODEX_EVIDENCE_DIR", evidence_dir.as_posix())
+    monkeypatch.setenv("CODEX_ARCHIVE_BACKEND", "sqlite")
+    monkeypatch.setenv("CODEX_ARCHIVE_URL", f"sqlite:///{db_path.as_posix()}")
+    monkeypatch.setenv("CODEX_ACTOR", "cli-test")
+    monkeypatch.chdir(tmp_path)
+
+    cli_archive, archive_api = _reload_archive_cli()
+
+    targets = {
+        tmp_path / "legacy_one.py": "print('legacy-one')\n",
+        tmp_path / "pkg" / "legacy_two.py": "value = 42\n",
+    }
+
+    for path, contents in targets.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+
+    original_bytes = {path: path.read_bytes() for path in targets}
+
+    plan_data = {
+        "entries": [
+            {
+                "path": path.as_posix(),
+                "reason": "cleanup",
+                "commit_sha": f"deadbeef{i}",
+            }
+            for i, path in enumerate(targets, start=1)
+        ]
+    }
+    plan_file = tmp_path / "artifacts" / "archive_plan.json"
+    plan_file.parent.mkdir(parents=True, exist_ok=True)
+    plan_file.write_text(json.dumps(plan_data), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_archive.app,
+        [
+            "apply-plan",
+            plan_file.as_posix(),
+            "--repo",
+            "demo-repo",
+            "--by",
+            "cli-test",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.stdout)
+    applied_paths = {item["path"] for item in payload["applied"]}
+    assert applied_paths == {path.as_posix() for path in targets}
+
+    tombstone_by_path: dict[str, str] = {}
+    sha_by_path: dict[str, str] = {}
+    for item in payload["applied"]:
+        tombstone_by_path[item["path"]] = item["tombstone"]
+        sha_by_path[item["path"]] = item["sha256"]
+
+    for path, _ in targets.items():
+        stub_text = path.read_text(encoding="utf-8")
+        path_key = path.as_posix()
+        assert f"# Tombstone: {tombstone_by_path[path_key]}" in stub_text
+        assert f"# SHA256: {sha_by_path[path_key]}" in stub_text
+
+    evidence_file = evidence_dir / "archive_ops.jsonl"
+    assert evidence_file.exists(), "expected evidence log to exist"
+    events = [json.loads(line) for line in evidence_file.read_text(encoding="utf-8").splitlines()]
+
+    for path in targets:
+        path_key = path.as_posix()
+        tombstone = tombstone_by_path[path_key]
+        plan_events = [
+            event
+            for event in events
+            if event.get("action") == "PLAN_APPLY" and event.get("tombstone") == tombstone
+        ]
+        archive_events = [
+            event
+            for event in events
+            if event.get("action") == "ARCHIVE" and event.get("tombstone") == tombstone
+        ]
+        assert plan_events, f"PLAN_APPLY event missing for {path_key}"
+        assert archive_events, f"ARCHIVE event missing for {path_key}"
+
+    for path, contents in original_bytes.items():
+        restored = archive_api.restore(tombstone_by_path[path.as_posix()])
+        assert restored["bytes"] == contents

--- a/tests/ops/test_archive_pr_checklist.py
+++ b/tests/ops/test_archive_pr_checklist.py
@@ -19,10 +19,10 @@ def compliant_repo(tmp_path: Path) -> Path:
     (repo / "docs" / "arch" / "adr-999.md").write_text("# ADR 999", encoding="utf-8")
     (repo / "CHANGELOG.md").write_text("- Added archive entry", encoding="utf-8")
     (repo / ".codex" / "evidence" / "archive_ops.jsonl").write_text(
-        "{\"change\": \"archive\"}\n", encoding="utf-8"
+        '{"change": "archive"}\n', encoding="utf-8"
     )
     (repo / "artifacts" / "provenance" / "attestation.json").write_text(
-        "{\"attested\": true}\n", encoding="utf-8"
+        '{"attested": true}\n', encoding="utf-8"
     )
 
     return repo
@@ -67,7 +67,10 @@ def test_evaluate_archive_pr_all_requirements_present(compliant_repo: Path) -> N
     [
         ("docs/arch/adr-999.md", "ADR in docs/arch/"),
         ("CHANGELOG.md", "CHANGELOG.md update"),
-        (".codex/evidence/archive_ops.jsonl", "Evidence log delta (.codex/evidence/archive_ops.jsonl)"),
+        (
+            ".codex/evidence/archive_ops.jsonl",
+            "Evidence log delta (.codex/evidence/archive_ops.jsonl)",
+        ),
         ("artifacts/provenance/attestation.json", "Provenance artifact"),
     ],
 )
@@ -102,3 +105,44 @@ def test_evaluate_archive_pr_reports_all_missing(non_compliant_repo: Path) -> No
     assert "ADR in docs/arch/" in result.missing
     assert "Evidence log delta (.codex/evidence/archive_ops.jsonl)" in result.missing
     assert "Provenance artifact" in result.missing
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "artifacts/intoto/archive.intoto.jsonl",
+        "artifacts/in-toto/statement.json",
+        "artifacts/slsa/provenance.json",
+    ],
+)
+def test_provenance_hints_detect_common_patterns(compliant_repo: Path, relative_path: str) -> None:
+    target = compliant_repo / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("{}", encoding="utf-8")
+
+    result = evaluate_archive_pr(
+        compliant_repo,
+        changed_files=[relative_path],
+    )
+
+    assert result.has_provenance is True
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "artifacts/logs/archive.txt",
+        "docs/archived/readme.md",
+    ],
+)
+def test_provenance_hints_ignore_unrelated_paths(compliant_repo: Path, relative_path: str) -> None:
+    target = compliant_repo / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("{}", encoding="utf-8")
+
+    result = evaluate_archive_pr(
+        compliant_repo,
+        changed_files=[relative_path],
+    )
+
+    assert result.has_provenance is False


### PR DESCRIPTION
## Summary
- add a regression test that applies an archive plan with multiple entries, checks tombstone stubs, evidence logging, and restoration
- expand the archive checklist provenance hints and document the recognised naming patterns
- extend the archive checklist tests to validate new provenance patterns and ensure unrelated paths are ignored

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest --override-ini=addopts= tests/archive/test_archive_plan_apply.py::test_apply_plan_multiple_entries -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest --override-ini=addopts= tests/ops/test_archive_pr_checklist.py -q


------
https://chatgpt.com/codex/tasks/task_e_68f1d38afc948331b0b9ef5a20b8397d