### PR TITLE
Preserve archive CLI runtime configuration

### DIFF
--- a/src/codex/archive/cli.py
+++ b/src/codex/archive/cli.py
@@ -29,8 +29,7 @@ def _service(
     app_config: ArchiveAppConfig | None = None,
 ) -> ArchiveService:
     runtime = app_config or _load_config()
-    backend_config = runtime.to_backend_config()
-    return ArchiveService(backend_config, apply_schema=apply_schema)
+    return ArchiveService(runtime, apply_schema=apply_schema)
 
 
 def _setup_logger(app_config: ArchiveAppConfig) -> logging.Logger:

--- a/src/codex/archive/service.py
+++ b/src/codex/archive/service.py
@@ -7,7 +7,7 @@ import mimetypes
 import os
 import subprocess
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -319,9 +319,9 @@ class ArchiveService:
             return SettingsArchiveConfig.load()
         if isinstance(config, SettingsArchiveConfig):
             return config
-        return SettingsArchiveConfig(
-            backend=SettingsBackendConfig(backend=config.backend, url=config.url)
-        )
+        base_settings = SettingsArchiveConfig.load()
+        backend_settings = SettingsBackendConfig(backend=config.backend, url=config.url)
+        return replace(base_settings, backend=backend_settings)
 
     def _record_restore_failure(
         self,


### PR DESCRIPTION
## Summary
- ensure ArchiveService merges backend-only configurations with the composed runtime settings so non-backend overrides persist
- pass the full ArchiveAppConfig from the CLI to ArchiveService so env and config-file options influence runtime behaviour

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/archive -q --override-ini addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68f270ca07108331b056c944b2507006