### PR TITLE
Align distributed opt-in behavior and add tokenization shim coverage

### DIFF
--- a/docs/guides/tokenization.md
+++ b/docs/guides/tokenization.md
@@ -1,23 +1,31 @@
-# Tokenization Guide
-> Generated: 2025-10-17 21:05:18 UTC | Author: mbaetiong
+# Tokenization — Canonical Surfaces and Legacy Shims
 
-Roles: [Audit Orchestrator], [Capability Cartographer]  Energy: 5
+This guide clarifies canonical tokenization imports and the behavior of legacy shims.
 
-## Canonical Modules
-- codex_ml.tokenization.adapter
-- codex_ml.tokenization.hf_adapter
-- codex_ml.tokenization.sentencepiece_adapter
+## Canonical Imports
+| Use case | Import |
+|----------|--------|
+| API | `from codex_ml.tokenization import api` |
+| SentencePiece adapter | `from codex_ml.tokenization import sentencepiece_adapter` |
 
-## Optional Dependencies
-- HuggingFace tokenizers / transformers (optional)
-- sentencepiece (optional)
+These surfaces handle optional dependencies gracefully and are the preferred imports for new code and documentation.
 
-## Legacy Shims (Deprecation)
-The following legacy imports remain for compatibility and emit DeprecationWarning:
-- src.tokenization.api
-- src.tokenization.sentencepiece_adapter
+## Legacy Shims (Deprecated)
+For backward compatibility, the following legacy modules re-export the canonical implementations and emit DeprecationWarning on import:
+- `tokenization.api`
+- `tokenization.sentencepiece_adapter`
 
-Prefer canonical modules for all new code paths.
+Example:
+```python
+# Emits DeprecationWarning, but works
+import tokenization.api as legacy_api
 
-## Fixtures & Offline Training
-- See tools/make_spm_fixture.py for generating deterministic SPM fixtures.
+# Preferred
+from codex_ml.tokenization import api as canonical_api
+```
+
+## Testing Guidance
+- Deprecation warnings are expected when importing legacy shims.
+- No behavior change is introduced by the shims; they only forward to canonical modules.
+
+*End of guide*

--- a/docs/training/Distributed_Minimal_Hooks.md
+++ b/docs/training/Distributed_Minimal_Hooks.md
@@ -10,13 +10,14 @@ This repository includes minimal distributed hooks intended to be environment-ga
 ## Environment Flags
 | Variable | Effect |
 |----------|--------|
-| CODEX_DDP_ENABLE=1 | Opt-in to distributed hooks where available |
+| CODEX_DDP=1 | Opt-in to distributed hooks where available |
 | WORLD_SIZE | Used to determine multi-rank runs |
 | RANK, LOCAL_RANK | Passed through to initialize process group |
 
 ## Behavior
-- If CODEX_DDP_ENABLE is unset or 0, training proceeds as single-process
-- Any initialization errors are caught and surfaced as warnings with guidance
+- If CODEX_DDP is unset or 0, training proceeds as single-process
+- CODEX_DDP_ENABLE remains accepted as a legacy alias for CODEX_DDP
+- Any initialization errors are caught and surfaced as runtime warnings with guidance
 - Hooks avoid altering random seeds unless explicitly instructed
 
 ## Verification

--- a/src/codex_ml/distributed/minimal.py
+++ b/src/codex_ml/distributed/minimal.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import warnings
+from typing import Iterable
 
 try:  # pragma: no cover - torch is optional
     import torch  # type: ignore
@@ -8,6 +10,75 @@ try:  # pragma: no cover - torch is optional
 except Exception:  # pragma: no cover - execution environments without torch
     torch = None  # type: ignore[assignment]
     dist = None  # type: ignore[assignment]
+
+_OPT_IN_VALUES = {"1", "true", "TRUE", "True", "YES", "yes", "on", "ON"}
+_FALLBACK_ENV_FLAGS = ("CODEX_DDP_ENABLE",)
+
+
+def _iter_candidate_flags(primary: str) -> Iterable[str]:
+    yield primary
+    for alias in _FALLBACK_ENV_FLAGS:
+        if alias != primary:
+            yield alias
+
+
+def _env_opted_in(env_flag: str) -> tuple[bool, str | None]:
+    for name in _iter_candidate_flags(env_flag):
+        value = os.environ.get(name)
+        if value is None:
+            continue
+        return value in _OPT_IN_VALUES, name
+    return False, None
+
+
+def _parse_env_int(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        warnings.warn(
+            f"Ignoring {name}={value!r}; expected integer for distributed setup.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return None
+
+
+def _warn_missing_dist(flag_name: str) -> None:
+    warnings.warn(
+        (
+            "Distributed execution requested via "
+            f"{flag_name}, but torch.distributed is unavailable. "
+            "Continuing with single-process semantics."
+        ),
+        RuntimeWarning,
+        stacklevel=2,
+    )
+
+
+def _warn_failed_init(backend: str, flag_name: str, error: Exception) -> None:
+    warnings.warn(
+        (
+            f"Failed to initialize distributed backend '{backend}' after "
+            f"{flag_name} opt-in; falling back to single-process. "
+            f"Error: {error}"
+        ),
+        RuntimeWarning,
+        stacklevel=2,
+    )
+
+
+def _warn_device_set_failed(local_rank: int, error: Exception) -> None:
+    warnings.warn(
+        (
+            f"Unable to set CUDA device for LOCAL_RANK={local_rank}: {error}. "
+            "Continuing without device pinning."
+        ),
+        RuntimeWarning,
+        stacklevel=2,
+    )
 
 
 def _dist_available() -> bool:
@@ -24,7 +95,12 @@ def init_distributed_if_needed(backend: str = "nccl", env_flag: str = "CODEX_DDP
 
     Returns True if the process group is initialized after the call, False otherwise.
     """
-    if not _dist_available() or os.environ.get(env_flag, "0") not in {"1", "true", "TRUE"}:
+    opted_in, flag_used = _env_opted_in(env_flag)
+    if not opted_in:
+        return False
+
+    if not _dist_available():
+        _warn_missing_dist(flag_used or env_flag)
         return False
     if dist is None:  # pragma: no cover - defensive
         return False
@@ -36,10 +112,28 @@ def init_distributed_if_needed(backend: str = "nccl", env_flag: str = "CODEX_DDP
         cuda_available = bool(torch and getattr(torch.cuda, "is_available", lambda: False)())
         if not cuda_available:
             chosen_backend = "gloo"
+    init_kwargs: dict[str, int] = {}
+    world_size = _parse_env_int("WORLD_SIZE")
+    rank = _parse_env_int("RANK")
+    local_rank = _parse_env_int("LOCAL_RANK")
+    if torch is not None and local_rank is not None:
+        cuda = getattr(torch, "cuda", None)
+        if cuda is not None and getattr(cuda, "is_available", lambda: False)():
+            try:
+                cuda.set_device(local_rank)
+            except Exception as exc:  # pragma: no cover - depends on runtime devices
+                _warn_device_set_failed(local_rank, exc)
+    if rank is None and local_rank is not None:
+        rank = local_rank
+    if world_size is not None:
+        init_kwargs["world_size"] = world_size
+    if rank is not None:
+        init_kwargs["rank"] = rank
     try:
-        dist.init_process_group(backend=chosen_backend)
+        dist.init_process_group(backend=chosen_backend, **init_kwargs)
         return True
-    except Exception:
+    except Exception as exc:
+        _warn_failed_init(chosen_backend, flag_used or env_flag, exc)
         return False
 
 

--- a/tests/plugins/test_tokenization_deprecation_shims.py
+++ b/tests/plugins/test_tokenization_deprecation_shims.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import importlib
+import warnings
+
+
+def test_tokenization_api_deprecation_warning():
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always", DeprecationWarning)
+        mod = importlib.import_module("tokenization.api")
+    assert any(
+        isinstance(w.message, DeprecationWarning) for w in rec
+    ), "Importing tokenization.api should emit DeprecationWarning"
+    assert mod is not None
+
+
+def test_sentencepiece_adapter_deprecation_warning():
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always", DeprecationWarning)
+        mod = importlib.import_module("tokenization.sentencepiece_adapter")
+    assert any(
+        isinstance(w.message, DeprecationWarning) for w in rec
+    ), "Importing tokenization.sentencepiece_adapter should emit DeprecationWarning"
+    assert mod is not None

--- a/transformers/__init__.py
+++ b/transformers/__init__.py
@@ -57,5 +57,10 @@ if _real is not None:
 else:  # pragma: no cover - exercised in minimal test envs
     AutoModelForCausalLM = _Stub("transformers.AutoModelForCausalLM")
     AutoTokenizer = _Stub("transformers.AutoTokenizer")
-    __all__ = ["AutoModelForCausalLM", "AutoTokenizer"]
+    PreTrainedTokenizerBase = _Stub("transformers.PreTrainedTokenizerBase")
+    __all__ = [
+        "AutoModelForCausalLM",
+        "AutoTokenizer",
+        "PreTrainedTokenizerBase",
+    ]
     __path__ = []  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
- document canonical tokenization entry points and add regression tests for legacy shim deprecation warnings
- update the distributed minimal hook to honor CODEX_DDP while warning on missing backends and respecting rank metadata
- ensure optional dependency shims stay importable by deferring tokenization submodules and extending the transformers stub

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/plugins/test_tokenization_deprecation_shims.py -o addopts=""
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/distributed -o addopts=""


------
https://chatgpt.com/codex/tasks/task_e_68f332ab0fd88331a1e93b1b185e818c