### PR TITLE
Add patch completeness review record and update traversal docs metadata

### DIFF
--- a/.github/docs/Space_TraversalWorkflow_Copilot.md
+++ b/.github/docs/Space_TraversalWorkflow_Copilot.md
@@ -1,4 +1,5 @@
 # [Copilot Space Spec]: Traversal & Capability Audit Workflow (v1.1.0)
+> Generated: 2025-10-18 09:19:02 UTC | Author: mbaetiong
 
  Roles: [Primary: Audit Orchestrator], [Secondary: Capability Cartographer]  Energy: 5
 

--- a/docs/validation/Patch_Completeness_Review_2025-10-18.md
+++ b/docs/validation/Patch_Completeness_Review_2025-10-18.md
@@ -1,0 +1,40 @@
+# [Review]: Space Audit Patch Completeness (v1.1.0)
+> Generated: 2025-10-18 09:19:02 UTC | Author: mbaetiong
+
+Roles: [Audit Orchestrator], [Capability Cartographer]  Energy: 5
+
+
+Summary
+- This review validates whether additional files are required beyond the previously proposed patch set.
+- Core changes delivered:
+  - S3→S4 meta propagation
+  - Optional component caps (scoring.component_caps)
+  - Optional duplication heuristic switch (scoring.dup.heuristic with token_similarity scaffold)
+  - Template renders Meta when present
+  - Docs (Workflow, Usage, Spec) updated
+  - Tests for meta rendering, caps clamp, and dup heuristic fallback
+
+Decision
+- No additional code files are required for feature completeness of this iteration.
+- Two documentation headers updated below to align with Space formatting (Generated + Physics).
+
+Delivered/Updated Files (recap)
+| Path | Type | Status |
+|------|------|--------|
+| .copilot-space/workflow.yaml | Config | Updated: added component_caps, dup.heuristic |
+| scripts/space_traversal/audit_runner.py | Code | Updated: meta propagation, caps clamp, heuristic switch |
+| scripts/space_traversal/dup_similarity.py | Code | New: token similarity scaffold (Jaccard over stem tokens) |
+| templates/audit/capability_matrix.md.j2 | Template | Updated: Meta rendering |
+| docs/validation/Traversal_Workflow.md | Doc | Updated: caps formula, heuristic switch |
+| docs/validation/Usage_Guide.md | Doc | Updated: sample YAML + usage |
+| .github/docs/Space_TraversalWorkflow_Copilot.md | Doc | Updated: spec adds for caps/meta/dup |
+| tests/specs/test_audit_meta_in_report.py | Test | New: meta propagates and renders |
+| tests/specs/test_component_caps_clamp.py | Test | New: caps clamp behavior |
+| tests/specs/test_dup_similarity.py | Test | New: heuristic fallback behavior |
+
+Notes
+- Determinism preserved (sorted traversal, truncated reads).
+- Offline-only operations maintained; dup_similarity uses stem tokens (no file content).
+- Future work (not in scope): v1.2 token similarity refinement (content-aware), coverage XML ingestion.
+
+*End of Review*

--- a/docs/validation/Traversal_Workflow.md
+++ b/docs/validation/Traversal_Workflow.md
@@ -1,4 +1,5 @@
 # [Doc]: Copilot Space Traversal Workflow (v1.1.0)
+> Generated: 2025-10-18 09:19:02 UTC | Author: mbaetiong
 
  Roles: [Primary: Knowledge Ops], [Secondary: ML Platform Auditor]  Energy: 5
 


### PR DESCRIPTION
## Summary
- add the Space audit patch completeness review for v1.1.0
- annotate the traversal workflow docs with generated metadata headers for consistency

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f361907c6c8331a6c19961833fd10c