### PR TITLE
Handle binary single-logit inputs in precision_recall_f1

### DIFF
--- a/src/evaluation/metrics.py
+++ b/src/evaluation/metrics.py
@@ -18,9 +18,23 @@ def precision_recall_f1(logits: torch.Tensor, targets: torch.Tensor) -> tuple[fl
     The metrics are computed for the positive class (label ``1``). When there are
     no predicted or true positives, the corresponding metric is reported as
     ``0.0`` to avoid division errors.
+
+    Binary classifiers sometimes emit a single logit or probability per example
+    (``(batch,)`` or ``(batch, 1)`` shaped tensors). In those cases we predict the
+    positive class when the value is at least ``0`` for logits or ``0.5`` for
+    probabilities. For multi-class logits we fall back to ``argmax`` based
+    predictions.
     """
 
-    preds = torch.argmax(logits, dim=-1)
+    if logits.ndim == 1 or (logits.ndim > 1 and logits.shape[-1] == 1):
+        logits_1d = logits.squeeze(-1)
+
+        if logits_1d.dtype.is_floating_point and torch.all((0.0 <= logits_1d) & (logits_1d <= 1.0)):
+            preds = (logits_1d >= 0.5).to(targets.dtype)
+        else:
+            preds = (logits_1d >= 0).to(targets.dtype)
+    else:
+        preds = torch.argmax(logits, dim=-1)
 
     positives = targets == 1
     predicted_positives = preds == 1

--- a/tests/evaluation/test_metrics.py
+++ b/tests/evaluation/test_metrics.py
@@ -50,6 +50,32 @@ def test_precision_recall_f1_handles_missing_predictions() -> None:
     assert f1 == pytest.approx(0.0)
 
 
+def test_precision_recall_f1_accepts_single_logit_binary_logits() -> None:
+    torch, metrics_module = _require_metrics_module()
+
+    logits = torch.tensor([2.0, -1.0, 0.1, -0.2], dtype=torch.float32)
+    targets = torch.tensor([1, 0, 1, 0], dtype=torch.long)
+
+    precision, recall, f1 = metrics_module.precision_recall_f1(logits, targets)
+
+    assert precision == pytest.approx(1.0)
+    assert recall == pytest.approx(1.0)
+    assert f1 == pytest.approx(1.0)
+
+
+def test_precision_recall_f1_accepts_single_logit_probabilities() -> None:
+    torch, metrics_module = _require_metrics_module()
+
+    logits = torch.tensor([0.8, 0.6, 0.4, 0.2], dtype=torch.float32)
+    targets = torch.tensor([1, 1, 0, 0], dtype=torch.long)
+
+    precision, recall, f1 = metrics_module.precision_recall_f1(logits, targets)
+
+    assert precision == pytest.approx(1.0)
+    assert recall == pytest.approx(1.0)
+    assert f1 == pytest.approx(1.0)
+
+
 def test_metrics_aggregator_combines_metrics() -> None:
     torch, metrics_module = _require_metrics_module()
 


### PR DESCRIPTION
## Summary
- handle binary metrics inputs that provide a single logit or probability per example by thresholding
- expand the precision/recall/F1 tests to cover raw logits and probability vectors

## Testing
- pytest --override-ini addopts="--disable-plugin-autoload -q" tests/evaluation/test_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68f51fe970948331b44653075b132bcd