### PR TITLE
Enhance tokenization CLI and evaluation registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 This repository is intended to help developers customize environments in Codex by providing a similar image that can be pulled and run locally. This is not an identical environment but should help for debugging and development.
 
-<!-- appended by audit rollup -->
 ### Evaluation metrics logging (NDJSON)
 
 Run an evaluation and also append a summary record to an NDJSON file:
@@ -45,15 +44,46 @@ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.lock
+# optional extras for local development
 pip install -e .[ml,logging,dev]
 ```
 
-Run a tiny local training (CPU-only works):
+### Train a tiny run (CPU-friendly)
 
 ```bash
-codex-train training.max_epochs=1 training.batch_size=2 \
-    training.tensorboard=false training.wandb_enable=false
+python -m codex_ml.cli.train \
+  training.trainer.epochs=1 \
+  training.batch_size=2 \
+  training.tensorboard=false \
+  training.wandb_enable=false \
+  training.output_dir=artifacts/runs/quickstart
 ```
+
+### Evaluate a saved checkpoint
+
+```bash
+python -m codex_ml.cli.evaluate \
+  evaluation.dataset_path=data/offline/sample.jsonl \
+  evaluation.metrics='["accuracy"]' \
+  evaluation.output_dir=artifacts/eval/quickstart
+```
+
+### Tokenizer CLI cheatsheet
+
+```bash
+python -m tokenization.cli vocab path/to/tokenizer
+python -m tokenization.cli encode path/to/tokenizer "hello world"
+python -m tokenization.cli decode path/to/tokenizer "1,2,3"
+```
+
+### Offline test session
+
+```bash
+nox -s tests_offline
+```
+
+This session forces `HF_DATASETS_OFFLINE=1` and `WANDB_MODE=offline` so tests run without network access.
 
 Artifacts are written under `.codex/` (metrics, checkpoints, provenance).
 
@@ -207,7 +237,7 @@ flowchart LR
 
 ## Extended training stack (Codex-ready)
 
-The Codex audit added a modular training harness that mirrors the audit diff:
+The modular training harness mirrors the Codex-ready stack and keeps the CLI consistent across environments:
 
 - **Model bootstrap (`src/modeling.py`)** – loads Hugging Face causal language
   models, respects dtype/device hints, and optionally enables LoRA adapters via

--- a/_codex_reports/errors_2025-10-19.md
+++ b/_codex_reports/errors_2025-10-19.md
@@ -1,0 +1,16 @@
+
+:::
+Question for ChatGPT @codex 2025-10-19T22:36:17Z:
+While performing Step 6: run pytest -x -vv, encountered the following error:
+pytest: error: unrecognized arguments: --cov=src --cov-report=term-missing --cov-fail-under=70
+Context: pytest.ini requires pytest-cov but the plugin is unavailable in the current environment.
+What are the possible causes, and how can this be resolved while preserving intended functionality?
+:::
+
+:::
+Question for ChatGPT @codex 2025-10-19T22:36:29+00:00:
+While performing Step 6: run nox -s tests_offline, encountered the following error:
+bash: command not found: nox
+Context: The sandbox image does not include nox; the offline test session cannot run without installing it.
+What are the possible causes, and how can this be resolved while preserving intended functionality?
+:::

--- a/_codex_reports/status_update_2025-10-19.md
+++ b/_codex_reports/status_update_2025-10-19.md
@@ -1,0 +1,14 @@
+# Status Update — 2025-10-19
+
+## Completed
+- Added a Typer-powered tokenizer CLI with `vocab`, `encode`, and `decode` helpers plus graceful fallbacks.
+- Extended the fast tokenizer wrapper with vocabulary utilities and a `build_tokenizer` helper that prefers `transformers` but falls back to local JSON artefacts.
+- Integrated the metrics registry into the evaluation runner and added temporary registration tests.
+- Persisted a `dataset_manifest.json` during evaluation and surfaced the path in the return payload.
+- Introduced offline-aware `tests_offline` nox session semantics and documented usage in the README alongside the new dependency lock flow and CLI quickstart.
+- Logged deferred features and next steps in `docs/deferred.md`.
+
+## Outstanding
+- Broader registry unification (models/datasets) still needs design work before implementation.
+- MLflow UI bootstrap remains deferred pending an offline-friendly activation flow.
+- Extended system metrics sampling (per-process/NVML streaming) is postponed until we can expand the monitoring test matrix.

--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -1,0 +1,27 @@
+# Deferred Enhancements
+
+The following items were intentionally deferred during the Codex-ready hardening. Each entry lists the rationale and a lightweight follow-up plan so future contributors can pick up the work.
+
+## Plugin registry unification
+- **Status**: Deferred.
+- **Rationale**: The metrics registry now supports dynamic registration, but extending the same pattern to models and datasets requires refactoring multiple call sites and introducing new Hydra schemas. This would risk breaking existing training pipelines without a full integration test suite.
+- **Next steps**:
+  1. Catalogue the current entry points under `codex_ml.registry` and identify overlap with Hydra configs.
+  2. Design a shared registry facade that can register models, datasets, and tokenizers with consistent provenance metadata.
+  3. Backfill tests that exercise the registry override path before rolling out to production configs.
+
+## MLflow UI bootstrap
+- **Status**: Deferred.
+- **Rationale**: Launching a bundled MLflow tracking UI requires packaging additional binaries and managing a background process, which conflicts with the offline-only policy for the base image.
+- **Next steps**:
+  1. Provide a documented `make mlflow-ui` target that launches the UI only when explicitly requested.
+  2. Ship a smoke test that verifies metrics are visible via the REST API without requiring a persistent server.
+  3. Evaluate lightweight alternatives (e.g., Rich TUI) for local metric inspection when network access is disabled.
+
+## System metrics expansion
+- **Status**: Deferred.
+- **Rationale**: Extending GPU/CPU sampling to include per-process breakdowns and NVML event streaming would add new optional dependencies and increase test matrix complexity.
+- **Next steps**:
+  1. Prototype an opt-in sampler behind `monitoring.system_metrics.extended=true`.
+  2. Document expected output schemas and update existing monitoring tests to validate them.
+  3. Add alerting hooks only after the sampling layer stabilises.

--- a/noxfile.py
+++ b/noxfile.py
@@ -263,8 +263,11 @@ def tests_offline(session: nox.Session) -> None:
 
     _ensure_pip_cache(session)
     _install(session, "pytest", "pydantic")
+    session.env["HF_DATASETS_OFFLINE"] = "1"
+    session.env["WANDB_MODE"] = "offline"
     _export_env(session)
-    session.run("pytest", "-q", *OFFLINE_TEST_TARGETS)
+    targets = tuple(session.posargs) or OFFLINE_TEST_TARGETS
+    session.run("pytest", "-q", *targets)
 
 
 @nox.session(name="tests_gpu", python=DEFAULT_PYTHON)

--- a/src/codex_ml/config/__init__.py
+++ b/src/codex_ml/config/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass, field, is_dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 try:  # pragma: no cover - optional dependency
     from omegaconf import DictConfig, OmegaConf
@@ -249,9 +249,11 @@ class EvaluationConfig:
     ndjson_filename: str = "records.ndjson"
     metrics_filename: str = "metrics.ndjson"
     model_name: str | None = None
+    dataset_name: str | None = None
     seed: int | None = None
     split: str = "eval"
     run_id: str | None = None
+    write_dataset_manifest: bool = True
 
     def validate(self, path: str = "evaluation") -> None:
         if not self.dataset_path:
@@ -291,6 +293,12 @@ class EvaluationConfig:
             )
         if not isinstance(self.split, str) or not self.split:
             raise ConfigError(f"{path}.split", "must be a non-empty string", self.split)
+        if not isinstance(self.write_dataset_manifest, bool):
+            raise ConfigError(
+                f"{path}.write_dataset_manifest",
+                "must be a boolean",
+                self.write_dataset_manifest,
+            )
 
 
 @dataclass
@@ -585,7 +593,7 @@ class ValidationThresholds:
     perf_ok: float
 
 
-from .settings import AppSettings, EvalRow, eval_row_schema, get_settings
+from .settings import AppSettings, EvalRow, eval_row_schema, get_settings  # noqa: E402,F401
 
 __all__ = sorted(
     set(

--- a/src/codex_ml/eval/runner.py
+++ b/src/codex_ml/eval/runner.py
@@ -11,6 +11,8 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 from codex_ml.config import DataConfig, EvaluationConfig
 from codex_ml.data.loader import CacheManifest
 from codex_ml.eval import metrics
+from codex_ml.metrics.registry import get_metric
+from codex_ml.registry.base import RegistryNotFoundError
 from codex_ml.tracking.writers import NdjsonWriter
 from codex_ml.utils.provenance import export_environment
 from codex_ml.utils.seeding import set_reproducible
@@ -169,6 +171,8 @@ def _compute_metrics(
     results: Dict[str, Any] = {}
     predictions = [rec.get("prediction") for rec in records]
     targets = [rec.get("target") for rec in records]
+    registry_candidates: List[str] = []
+
     for metric_name in metric_names:
         key = metric_name.lower()
         if key == "perplexity":
@@ -178,7 +182,7 @@ def _compute_metrics(
             if not all(value is not None for value in predictions + targets):
                 raise EvaluationError("accuracy requires prediction and target fields")
             results[metric_name] = metrics.accuracy(predictions, targets)
-        elif key == "token_accuracy":
+        elif key in {"token_accuracy", "accuracy@token"}:
             pred_tokens: List[int] = []
             target_tokens: List[int] = []
             for idx, rec in enumerate(records):
@@ -217,7 +221,40 @@ def _compute_metrics(
                 raise EvaluationError("rouge_score package is required for ROUGE-L")
             results[metric_name] = rouge_score["rougeL_f"]
         else:
-            raise EvaluationError(f"Unsupported metric '{metric_name}'")
+            registry_candidates.append(metric_name)
+
+    for metric_name in registry_candidates:
+        try:
+            metric_fn = get_metric(metric_name)
+        except RegistryNotFoundError as exc:  # pragma: no cover - defensive guard
+            raise EvaluationError(f"Unsupported metric '{metric_name}'") from exc
+
+        try:
+            result = metric_fn(predictions, targets)
+        except TypeError:
+            try:
+                result = metric_fn(predictions=predictions, targets=targets, records=records)
+            except TypeError:
+                try:
+                    result = metric_fn(predictions=predictions, targets=targets)
+                except TypeError:
+                    try:
+                        result = metric_fn(records)
+                    except TypeError as final_exc:
+                        raise EvaluationError(
+                            f"Metric '{metric_name}' has incompatible signature"
+                        ) from final_exc
+                    except Exception as exc:  # pragma: no cover - plugin failure
+                        raise EvaluationError(f"Metric '{metric_name}' failed: {exc}") from exc
+                except Exception as exc:  # pragma: no cover - plugin failure
+                    raise EvaluationError(f"Metric '{metric_name}' failed: {exc}") from exc
+            except Exception as exc:  # pragma: no cover - plugin failure
+                raise EvaluationError(f"Metric '{metric_name}' failed: {exc}") from exc
+        except Exception as exc:  # pragma: no cover - plugin failure
+            raise EvaluationError(f"Metric '{metric_name}' failed: {exc}") from exc
+
+        results[metric_name] = result
+
     return results
 
 
@@ -282,6 +319,21 @@ def run_evaluation(
 
     output_dir = Path(eval_cfg.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    dataset_manifest_path: Path | None = None
+    if getattr(eval_cfg, "write_dataset_manifest", True):
+        dataset_manifest_path = output_dir / "dataset_manifest.json"
+        dataset_manifest = {
+            "dataset_name": eval_cfg.dataset_name or dataset_path.stem,
+            "dataset_path": str(dataset_path.resolve()),
+            "split": getattr(eval_cfg, "split", "eval"),
+            "num_rows": len(records),
+            "seed": seed_value,
+        }
+        dataset_manifest_path.write_text(
+            json.dumps(dataset_manifest, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
     export_environment(
         output_dir / "provenance",
         seed=seed_value,
@@ -298,6 +350,7 @@ def run_evaluation(
         "num_records": len(records),
         "metrics": metrics_result,
         "run_id": run_id,
+        "dataset_name": eval_cfg.dataset_name or dataset_path.stem,
     }
     summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
 
@@ -360,4 +413,7 @@ def run_evaluation(
         "metrics_path": str(metrics_path),
         "num_records": len(records),
         "run_id": run_id,
+        "dataset_manifest_path": (
+            str(dataset_manifest_path) if dataset_manifest_path is not None else None
+        ),
     }

--- a/src/tokenization/__init__.py
+++ b/src/tokenization/__init__.py
@@ -15,3 +15,10 @@ except ModuleNotFoundError:
     train_tokenizer = None  # type: ignore[assignment]
 else:  # pragma: no cover - import succeeded
     __all__.append("train_tokenizer")
+
+try:
+    from . import cli  # type: ignore # noqa: F401
+except ModuleNotFoundError:
+    cli = None  # type: ignore[assignment]
+else:  # pragma: no cover - import succeeded
+    __all__.append("cli")

--- a/src/tokenization/cli.py
+++ b/src/tokenization/cli.py
@@ -5,9 +5,8 @@ import json
 import shutil
 import sys
 import types
-from collections.abc import Callable
 from pathlib import Path
-from typing import Annotated
+from typing import Callable
 
 try:  # pragma: no cover - optional dependency
     import typer as _typer  # type: ignore
@@ -80,8 +79,9 @@ if _typer is None:  # pragma: no cover - fallback CLI when typer missing or inco
                     converted.append(arg)
             func(*converted)
 
-    def _fallback_echo(message: object) -> None:
-        print(message)
+    def _fallback_echo(message: object, *, err: bool = False) -> None:
+        stream = sys.stderr if err else sys.stdout
+        print(message, file=stream)
 
     def _fallback_option(default=None, *_: object, **__: object):
         return default
@@ -92,78 +92,87 @@ if _typer is None:  # pragma: no cover - fallback CLI when typer missing or inco
 else:
     typer = _typer
 
-try:  # pragma: no cover - optional dependency
-    from tokenizers import Tokenizer  # type: ignore
-except Exception:  # pragma: no cover - fallback when tokenizers missing
-
-    class Tokenizer:  # type: ignore[no-redef]
-        def __init__(self, data: dict, path: Path) -> None:
-            self._data = data
-            self._path = path
-
-        @classmethod
-        def from_file(cls, path: str) -> Tokenizer:
-            file_path = Path(path)
-            data = json.loads(file_path.read_text())
-            return cls(data, file_path)
-
-        def get_vocab_size(self) -> int:
-            vocab = self._data.get("model", {}).get("vocab")
-            if isinstance(vocab, list):
-                return len(vocab)
-            vocab_list = self._data.get("vocab", [])
-            if isinstance(vocab_list, list):
-                return len(vocab_list)
-            value = self._data.get("vocab_size")
-            return int(value) if isinstance(value, int | float | str) else 0
-
-        def get_special_tokens(self) -> list[str]:
-            added_tokens = self._data.get("added_tokens", [])
-            if not isinstance(added_tokens, list):
-                return []
-            return [
-                item.get("content")
-                for item in added_tokens
-                if isinstance(item, dict) and item.get("special")
-            ]
-
-        def encode(self, text: str):  # pragma: no cover - encode requires optional dependency
-            raise RuntimeError("The 'tokenizers' package is required for encode operations")
-
+from .fast_tokenizer import build_tokenizer
 
 app = typer.Typer(help="Tokenizer utilities")
 
 
-def _load(path: Path) -> Tokenizer:
-    return Tokenizer.from_file(str(path / "tokenizer.json"))
+def _resolve_root(path: Path) -> Path:
+    return path if path.is_dir() else path.parent
+
+
+def _load_tokenizer(path: Path):
+    try:
+        return build_tokenizer(path)
+    except FileNotFoundError as exc:
+        typer.echo(f"Tokenizer not found: {exc}", err=True)
+        raise SystemExit(1)
+    except Exception as exc:
+        typer.echo(f"Failed to load tokenizer from {path}: {exc}", err=True)
+        raise SystemExit(1)
 
 
 @app.command()
-def inspect(path: Path) -> None:
-    tk = _load(path)
-    manifest_path = path / "manifest.json"
+def vocab(
+    tokenizer_path: Path,
+    limit: int = typer.Option(10, help="Number of sample tokens to display"),
+) -> None:
+    """Print vocabulary size with a handful of sample tokens."""
+
+    tokenizer = _load_tokenizer(tokenizer_path)
+    vocab_size = getattr(tokenizer, "vocab_size", None)
+    if vocab_size is None:
+        typer.echo("Tokenizer does not expose a vocab size attribute", err=True)
+        raise SystemExit(1)
+
+    size_int = int(vocab_size)
+    typer.echo(f"Vocab size: {size_int}")
+
+    converter = getattr(tokenizer, "convert_ids_to_tokens", None)
+    if not callable(converter):
+        typer.echo("Tokenizer lacks convert_ids_to_tokens; skipping sample tokens.")
+        return
+
+    for idx in range(min(limit, size_int)):
+        try:
+            token = converter(idx)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            typer.echo(f"Failed to convert token {idx}: {exc}", err=True)
+            break
+        typer.echo(f"{idx}: {token}")
+
+
+@app.command()
+def inspect(tokenizer_path: Path) -> None:
+    """Show manifest metadata for a tokenizer directory."""
+
+    tokenizer = _load_tokenizer(tokenizer_path)
+    root = _resolve_root(tokenizer_path)
+    manifest_path = root / "manifest.json"
     manifest = json.loads(manifest_path.read_text()) if manifest_path.exists() else {}
-    tokenizer_config = json.loads((path / "tokenizer.json").read_text())
+
     special_tokens: object | None = None
-    try:
-        getter = getattr(tk, "get_special_tokens", None)
-        if callable(getter):
-            special_tokens = getter()
-    except Exception:
-        special_tokens = None
-    if special_tokens is None:
-        added_tokens = tokenizer_config.get("added_tokens", [])
-        special_tokens = [item.get("content") for item in added_tokens if item.get("special")]
-        if not special_tokens:
-            cfg = manifest.get("config", {})
-            special_tokens = {
-                "pad": cfg.get("padding"),
-                "truncation": cfg.get("truncation"),
-                "max_length": cfg.get("max_length"),
-            }
-    typer.echo(f"vocab_size: {tk.get_vocab_size()}")
-    typer.echo(f"special_tokens_or_cfg: {special_tokens}")
-    cfg = manifest.get("config", {})
+    getter = getattr(tokenizer, "all_special_tokens", None)
+    if callable(getter):
+        special_tokens = list(getter())
+    if not special_tokens:
+        config_path = root / "tokenizer.json"
+        if config_path.exists():
+            try:
+                tokenizer_config = json.loads(config_path.read_text())
+            except json.JSONDecodeError:
+                tokenizer_config = {}
+            added_tokens = tokenizer_config.get("added_tokens", [])
+            if isinstance(added_tokens, list):
+                special_tokens = [
+                    item.get("content")
+                    for item in added_tokens
+                    if isinstance(item, dict) and item.get("special")
+                ]
+    typer.echo(f"vocab_size: {getattr(tokenizer, 'vocab_size', 'unknown')}")
+    typer.echo(f"special_tokens: {special_tokens}")
+
+    cfg = manifest.get("config", {}) if isinstance(manifest, dict) else {}
     pad = cfg.get("padding")
     trunc = cfg.get("truncation")
     max_len = cfg.get("max_length")
@@ -174,40 +183,68 @@ def inspect(path: Path) -> None:
 def encode(
     tokenizer_path: Path,
     text: str,
-    from_file: Annotated[
-        bool,
-        typer.Option("--from-file", help="Treat TEXT as path"),
-    ] = False,
-    show_ids: Annotated[bool, typer.Option(help="Show token ids")] = True,
-    show_tokens: Annotated[bool, typer.Option(help="Show decoded tokens")] = False,
+    pad_to: int = typer.Option(0, help="Optional padding / truncation length"),
+    from_file: bool = typer.Option(False, help="Treat TEXT as a file path"),
+    show_tokens: bool = typer.Option(False, help="Show token strings"),
 ) -> None:
-    tk = _load(tokenizer_path)
+    """Encode TEXT using the tokenizer located at TOKENIZER_PATH."""
+
+    tokenizer = _load_tokenizer(tokenizer_path)
     if from_file:
-        text = Path(text).read_text()
-    enc = tk.encode(text)
-    if show_ids:
-        typer.echo("ids: " + " ".join(str(i) for i in enc.ids))
+        text = Path(text).read_text(encoding="utf-8")
+
+    encoded = tokenizer(
+        text,
+        padding="max_length" if pad_to else False,
+        max_length=pad_to or None,
+    )
+    input_ids = encoded.get("input_ids") if isinstance(encoded, dict) else None
+    if input_ids is None and hasattr(encoded, "input_ids"):
+        input_ids = getattr(encoded, "input_ids")
+    if input_ids is None:
+        typer.echo("Tokenizer did not return input_ids", err=True)
+        raise SystemExit(1)
+    if input_ids and isinstance(input_ids[0], list):
+        ids_list = input_ids[0]
+    else:
+        ids_list = list(input_ids)
+    typer.echo("ids: " + " ".join(str(i) for i in ids_list))
+
     if show_tokens:
-        typer.echo("tokens: " + " ".join(enc.tokens))
+        converter = getattr(tokenizer, "convert_ids_to_tokens", None)
+        if callable(converter):
+            tokens = [converter(i) for i in ids_list]
+            typer.echo("tokens: " + " ".join(tokens))
+        else:
+            typer.echo("Tokenizer lacks convert_ids_to_tokens; cannot show tokens.")
+
+
+@app.command()
+def decode(tokenizer_path: Path, ids: str) -> None:
+    """Decode a comma-separated list of token ids."""
+
+    tokenizer = _load_tokenizer(tokenizer_path)
+    try:
+        id_list = [int(item.strip()) for item in ids.split(",") if item.strip()]
+    except ValueError as exc:
+        typer.echo(f"Invalid token id in '{ids}': {exc}", err=True)
+        raise SystemExit(1)
+    typer.echo(tokenizer.decode(id_list))
 
 
 @app.command()
 def export(src: Path, dst: Path) -> None:
+    """Copy tokenizer artifacts (json/manifest/spm) to DST."""
+
     dst.mkdir(parents=True, exist_ok=True)
     for name in ("tokenizer.json", "manifest.json", "spm.model", "spm.vocab"):
-        p = src / name
+        p = _resolve_root(src) / name
         if p.exists():
             shutil.copy2(p, dst / name)
-    manifest_path = src / "manifest.json"
-    readme = dst / "README.md"
-    if manifest_path.exists():
-        manifest = json.loads(manifest_path.read_text())
-        readme.write_text(
-            "# Tokenizer Export\n\n````json\n" + json.dumps(manifest, indent=2) + "\n````\n"
-        )
-    else:
-        readme.write_text("# Tokenizer Export\n")
 
 
 if __name__ == "__main__":
     app()
+
+
+__all__ = ["app", "vocab", "inspect", "encode", "decode", "export"]

--- a/src/tokenizer/fast_tokenizer.py
+++ b/src/tokenizer/fast_tokenizer.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Iterable, List, Sequence
 
 try:  # pragma: no cover - optional dependency
     from tokenizers import Tokenizer
 except Exception:  # pragma: no cover - degrade gracefully
     Tokenizer = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    from transformers import AutoTokenizer  # type: ignore
+except Exception:  # pragma: no cover - transformers missing is acceptable
+    AutoTokenizer = None  # type: ignore[assignment]
 
 
 class FastTokenizerWrapper:
@@ -34,3 +40,81 @@ class FastTokenizerWrapper:
 
     def decode(self, token_ids: Iterable[int]) -> str:
         return self.tokenizer.decode(list(token_ids))
+
+    @property
+    def vocab_size(self) -> int:
+        """Expose the underlying vocabulary size."""
+
+        return int(self.tokenizer.get_vocab_size())
+
+    def convert_ids_to_tokens(self, token_ids: Iterable[int] | int) -> List[str] | str:
+        """Convert ids to tokens mimicking Hugging Face API."""
+
+        if isinstance(token_ids, int):
+            return self.tokenizer.id_to_token(int(token_ids))
+        return [self.tokenizer.id_to_token(int(idx)) for idx in token_ids]
+
+    def __call__(
+        self,
+        text: str,
+        padding: str | bool = False,
+        max_length: int | None = None,
+    ) -> dict[str, List[int]]:
+        """Provide a minimal call interface returning input ids."""
+
+        encoding = self.tokenizer.encode(text)
+        ids = list(encoding.ids)
+        if padding == "max_length" and max_length is not None:
+            if len(ids) < max_length:
+                ids = ids + [0] * (max_length - len(ids))
+            else:
+                ids = ids[:max_length]
+        return {"input_ids": ids}
+
+
+def build_tokenizer(path: str | Path) -> object:
+    """Best-effort tokenizer loader for local paths or directories.
+
+    When ``transformers`` is installed we attempt to reuse its loader to
+    benefit from vocab metadata.  Otherwise a ``FastTokenizerWrapper`` backed
+    by :mod:`tokenizers` is returned.  Errors are surfaced with context so CLI
+    callers can handle them gracefully.
+    """
+
+    location = Path(path).expanduser()
+    errors: list[str] = []
+
+    if AutoTokenizer is not None:
+        targets = []
+        if location.is_file():
+            targets.append(location.parent)
+        targets.append(location)
+        for target in targets:
+            try:
+                tokenizer = AutoTokenizer.from_pretrained(
+                    str(target), use_fast=True, trust_remote_code=False
+                )
+            except Exception as exc:  # pragma: no cover - optional dependency path
+                errors.append(f"transformers@{target}: {exc}")
+                continue
+            else:
+                return tokenizer  # type: ignore[return-value]
+
+    candidate = location
+    if location.is_dir():
+        potential = location / "tokenizer.json"
+        if potential.exists():
+            candidate = potential
+
+    if not candidate.exists():
+        raise FileNotFoundError(f"Tokenizer not found at {location}")
+
+    try:
+        return FastTokenizerWrapper(str(candidate))
+    except Exception as exc:  # pragma: no cover - propagate readable error
+        context = "; ".join(errors)
+        if context:
+            raise RuntimeError(
+                f"Unable to build tokenizer from {path}. Attempted loaders: {context}"
+            ) from exc
+        raise

--- a/tests/eval/test_metric_registry_registration.py
+++ b/tests/eval/test_metric_registry_registration.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from codex_ml.metrics.registry import get_metric, metric_registry
+from codex_ml.registry.base import RegistryNotFoundError
+
+
+def test_custom_metric_registration_round_trip() -> None:
+    """Custom metrics can be registered temporarily without leaking state."""
+
+    def _metric(preds, targets):  # type: ignore[unused-argument]
+        return 0.5
+
+    with metric_registry.temporarily_registered({"custom_metric": _metric}):
+        metric = get_metric("custom_metric")
+        assert metric([1, 2, 3], [1, 2, 3]) == 0.5
+
+    with pytest.raises(RegistryNotFoundError):
+        get_metric("custom_metric")


### PR DESCRIPTION
## Summary
- add a Typer-powered tokenization CLI with vocab/encode/decode helpers and extend the fast tokenizer wrapper
- integrate the metric registry into the evaluation runner, emit a dataset manifest, and add coverage for temporary registrations
- document deferred features, update the quickstart/lock-file guidance, and expose the offline nox session

## Testing
- pytest -x -vv *(fails: pytest.ini references pytest-cov which is not available in the sandbox; see `_codex_reports/errors_2025-10-19.md`)*
- nox -s tests_offline *(fails: `nox` is not installed in the sandbox; see `_codex_reports/errors_2025-10-19.md`)*
- ruff check src/tokenizer/fast_tokenizer.py src/tokenization/cli.py src/tokenization/__init__.py src/codex_ml/eval/runner.py src/codex_ml/config/__init__.py tests/eval/test_metric_registry_registration.py
- black src/tokenizer/fast_tokenizer.py src/tokenization/cli.py src/codex_ml/eval/runner.py src/codex_ml/config/__init__.py tests/eval/test_metric_registry_registration.py

------
https://chatgpt.com/codex/tasks/task_e_68f564e0a6848331810676ee47f80442