### PR TITLE
Enhance tokenization CLI error handling

### DIFF
--- a/src/tokenization/cli.py
+++ b/src/tokenization/cli.py
@@ -1,3 +1,5 @@
+"""Command line helpers for inspecting and exercising tokenizers."""
+
 from __future__ import annotations
 
 import inspect as inspect_module
@@ -5,27 +7,32 @@ import json
 import shutil
 import sys
 import types
+from collections.abc import Sequence
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable
+from typing import Any, NoReturn
 
 try:  # pragma: no cover - optional dependency
     import typer as _typer  # type: ignore
-except Exception:  # pragma: no cover - fallback CLI when typer missing
+except Exception:  # pragma: no cover - fallback when typer missing
     _typer = None
 else:
-    required_attrs = {"Typer", "echo", "Option"}
+    required_attrs = {"Typer", "echo", "Option", "Exit"}
     if not required_attrs.issubset(set(dir(_typer))):
         _typer = None
 
-if _typer is None:  # pragma: no cover - fallback CLI when typer missing or incomplete
+
+if _typer is None:  # pragma: no cover - fallback CLI when typer missing
 
     class _FallbackTyper:
+        """Minimal Typer-like interface used when the dependency is unavailable."""
+
         def __init__(self, **kwargs: object) -> None:
-            self._commands: dict[str, tuple[Callable[..., object], inspect_module.Signature]] = {}
+            self._commands: dict[str, tuple[types.FunctionType, inspect_module.Signature]] = {}
             self._help_text = kwargs.get("help")
 
         def command(self, name: str | None = None):
-            def _register(func):
+            def _register(func: types.FunctionType) -> types.FunctionType:
                 cmd_name = name or func.__name__.replace("_", "-")
                 self._commands[cmd_name] = (func, inspect_module.signature(func))
                 return func
@@ -79,6 +86,9 @@ if _typer is None:  # pragma: no cover - fallback CLI when typer missing or inco
                     converted.append(arg)
             func(*converted)
 
+    class _FallbackExit(SystemExit):
+        """Replacement for :class:`typer.Exit` when Typer isn't installed."""
+
     def _fallback_echo(message: object, *, err: bool = False) -> None:
         stream = sys.stderr if err else sys.stdout
         print(message, file=stream)
@@ -87,29 +97,109 @@ if _typer is None:  # pragma: no cover - fallback CLI when typer missing or inco
         return default
 
     typer = types.SimpleNamespace(
-        Typer=_FallbackTyper, echo=_fallback_echo, Option=_fallback_option
+        Typer=_FallbackTyper,
+        echo=_fallback_echo,
+        Option=_fallback_option,
+        Exit=_FallbackExit,
     )
-else:
+else:  # pragma: no cover - typer available
     typer = _typer
 
-from .fast_tokenizer import build_tokenizer
+from tokenizer.fast_tokenizer import build_tokenizer
 
 app = typer.Typer(help="Tokenizer utilities")
 
+_ERROR_REPORT_DIR = Path("_codex_reports")
+_ERROR_QUESTION_TEMPLATE = (
+    "What adjustments would resolve this issue so the {step} command can succeed?"
+)
+
+
+def _format_context(context: dict[str, Any] | str | None) -> str:
+    """Render context information as a JSON string for logging."""
+
+    if context is None:
+        return "None"
+    if isinstance(context, str):
+        return context
+    try:
+        return json.dumps(context, sort_keys=True, default=str)
+    except Exception:
+        return str(context)
+
+
+def _append_error_block(
+    step: str,
+    message: str,
+    context: dict[str, Any] | str | None,
+    question: str | None = None,
+) -> None:
+    """Append a formatted error report entry to the daily error log."""
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    question_text = question or _ERROR_QUESTION_TEMPLATE.format(step=step)
+    log_path = _ERROR_REPORT_DIR / f"errors_{timestamp.split('T')[0]}.md"
+    block = (
+        "\n:::\n"
+        f"Question for ChatGPT @codex {timestamp}:\n"
+        f"While performing Step {step}, encountered the following error:\n"
+        f"{message}\n"
+        f"Context: {_format_context(context)}\n"
+        f"{question_text}\n"
+        ":::"
+    )
+
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:
+        typer.echo(f"Failed to ensure error log directory {log_path.parent}: {exc}", err=True)
+        return
+
+    try:
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(block + "\n")
+    except Exception as exc:
+        typer.echo(f"Failed to append error log to {log_path}: {exc}", err=True)
+
+
+def _fail(
+    step: str,
+    message: str,
+    context: dict[str, Any] | str | None,
+    question: str | None = None,
+) -> NoReturn:
+    """Record an error, surface the message to stderr, and exit."""
+
+    _append_error_block(step, message, context, question)
+    typer.echo(message, err=True)
+    raise typer.Exit(1)
+
+
+def _load_tokenizer(tokenizer_path: Path, *, step: str) -> object:
+    """Load a tokenizer from ``tokenizer_path`` with structured error handling."""
+
+    try:
+        return build_tokenizer(tokenizer_path)
+    except FileNotFoundError as exc:
+        _fail(
+            step,
+            f"Tokenizer not found at {tokenizer_path}",
+            {"tokenizer_path": str(tokenizer_path), "error": str(exc)},
+            "Could you confirm the tokenizer path or share how to generate it?",
+        )
+    except Exception as exc:
+        _fail(
+            step,
+            f"Failed to load tokenizer from {tokenizer_path}: {exc}",
+            {"tokenizer_path": str(tokenizer_path), "error": repr(exc)},
+            "What adjustments are required to load this tokenizer successfully?",
+        )
+
 
 def _resolve_root(path: Path) -> Path:
+    """Return the tokenizer directory regardless of whether ``path`` is a file."""
+
     return path if path.is_dir() else path.parent
-
-
-def _load_tokenizer(path: Path):
-    try:
-        return build_tokenizer(path)
-    except FileNotFoundError as exc:
-        typer.echo(f"Tokenizer not found: {exc}", err=True)
-        raise SystemExit(1)
-    except Exception as exc:
-        typer.echo(f"Failed to load tokenizer from {path}: {exc}", err=True)
-        raise SystemExit(1)
 
 
 @app.command()
@@ -117,26 +207,59 @@ def vocab(
     tokenizer_path: Path,
     limit: int = typer.Option(10, help="Number of sample tokens to display"),
 ) -> None:
-    """Print vocabulary size with a handful of sample tokens."""
+    """Print the tokenizer vocabulary size and a handful of sample tokens."""
 
-    tokenizer = _load_tokenizer(tokenizer_path)
-    vocab_size = getattr(tokenizer, "vocab_size", None)
-    if vocab_size is None:
-        typer.echo("Tokenizer does not expose a vocab size attribute", err=True)
-        raise SystemExit(1)
+    if limit < 0:
+        _fail(
+            "vocab",
+            "limit must be non-negative",
+            {"limit": limit},
+            "Could you provide a non-negative token preview limit?",
+        )
 
-    size_int = int(vocab_size)
-    typer.echo(f"Vocab size: {size_int}")
+    tokenizer = _load_tokenizer(tokenizer_path, step="vocab")
+
+    vocab_attr = getattr(tokenizer, "vocab_size", None)
+    try:
+        if callable(vocab_attr):
+            vocab_size = int(vocab_attr())
+        elif vocab_attr is not None:
+            vocab_size = int(vocab_attr)
+        else:
+            raise AttributeError("Tokenizer does not expose a vocab_size attribute.")
+    except Exception as exc:  # pragma: no cover - defensive casting guards
+        _fail(
+            "vocab",
+            f"Unable to determine vocabulary size: {exc}",
+            {"tokenizer_path": str(tokenizer_path), "error": repr(exc)},
+            "How can we retrieve the vocabulary size for this tokenizer?",
+        )
+
+    typer.echo(f"Vocab size: {vocab_size}")
+
+    if limit == 0:
+        return
 
     converter = getattr(tokenizer, "convert_ids_to_tokens", None)
     if not callable(converter):
         typer.echo("Tokenizer lacks convert_ids_to_tokens; skipping sample tokens.")
         return
 
-    for idx in range(min(limit, size_int)):
+    sample_count = min(limit, vocab_size)
+    for idx in range(sample_count):
         try:
             token = converter(idx)
-        except Exception as exc:  # pragma: no cover - defensive guard
+        except Exception as exc:  # pragma: no cover - optional backend failures
+            _append_error_block(
+                "vocab",
+                f"Failed to preview token {idx}: {exc}",
+                {
+                    "tokenizer_path": str(tokenizer_path),
+                    "token_index": idx,
+                    "error": repr(exc),
+                },
+                "How can we safely preview tokens from this tokenizer?",
+            )
             typer.echo(f"Failed to convert token {idx}: {exc}", err=True)
             break
         typer.echo(f"{idx}: {token}")
@@ -144,38 +267,67 @@ def vocab(
 
 @app.command()
 def inspect(tokenizer_path: Path) -> None:
-    """Show manifest metadata for a tokenizer directory."""
+    """Show manifest metadata and special tokens for the tokenizer."""
 
-    tokenizer = _load_tokenizer(tokenizer_path)
+    tokenizer = _load_tokenizer(tokenizer_path, step="inspect")
     root = _resolve_root(tokenizer_path)
-    manifest_path = root / "manifest.json"
-    manifest = json.loads(manifest_path.read_text()) if manifest_path.exists() else {}
 
-    special_tokens: object | None = None
+    manifest: dict[str, Any] = {}
+    manifest_path = root / "manifest.json"
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            _append_error_block(
+                "inspect",
+                f"Failed to parse manifest.json: {exc}",
+                {"manifest_path": str(manifest_path), "error": repr(exc)},
+                "Could you advise on validating the tokenizer manifest?",
+            )
+            manifest = {}
+
+    special_tokens: list[str] | None = None
     getter = getattr(tokenizer, "all_special_tokens", None)
     if callable(getter):
-        special_tokens = list(getter())
+        try:
+            special_tokens = list(getter())
+        except Exception as exc:  # pragma: no cover - backend specific guard
+            _append_error_block(
+                "inspect",
+                f"Failed to collect special tokens: {exc}",
+                {"tokenizer_path": str(tokenizer_path), "error": repr(exc)},
+                "How can we enumerate special tokens for this tokenizer?",
+            )
+            special_tokens = None
+
     if not special_tokens:
         config_path = root / "tokenizer.json"
         if config_path.exists():
             try:
-                tokenizer_config = json.loads(config_path.read_text())
-            except json.JSONDecodeError:
-                tokenizer_config = {}
-            added_tokens = tokenizer_config.get("added_tokens", [])
-            if isinstance(added_tokens, list):
-                special_tokens = [
-                    item.get("content")
-                    for item in added_tokens
-                    if isinstance(item, dict) and item.get("special")
-                ]
+                tokenizer_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                _append_error_block(
+                    "inspect",
+                    f"Failed to parse tokenizer.json: {exc}",
+                    {"config_path": str(config_path), "error": repr(exc)},
+                    "What steps will restore a readable tokenizer.json?",
+                )
+            else:
+                added = tokenizer_cfg.get("added_tokens", [])
+                if isinstance(added, list):
+                    special_tokens = [
+                        item.get("content")
+                        for item in added
+                        if isinstance(item, dict) and item.get("special")
+                    ]
+
     typer.echo(f"vocab_size: {getattr(tokenizer, 'vocab_size', 'unknown')}")
     typer.echo(f"special_tokens: {special_tokens}")
 
     cfg = manifest.get("config", {}) if isinstance(manifest, dict) else {}
-    pad = cfg.get("padding")
-    trunc = cfg.get("truncation")
-    max_len = cfg.get("max_length")
+    pad = cfg.get("padding") if isinstance(cfg, dict) else None
+    trunc = cfg.get("truncation") if isinstance(cfg, dict) else None
+    max_len = cfg.get("max_length") if isinstance(cfg, dict) else None
     typer.echo(f"padding: {pad} truncation: {trunc} max_length: {max_len}")
 
 
@@ -185,65 +337,238 @@ def encode(
     text: str,
     pad_to: int = typer.Option(0, help="Optional padding / truncation length"),
     from_file: bool = typer.Option(False, help="Treat TEXT as a file path"),
-    show_tokens: bool = typer.Option(False, help="Show token strings"),
+    show_tokens: bool = typer.Option(False, help="Show decoded token strings"),
 ) -> None:
-    """Encode TEXT using the tokenizer located at TOKENIZER_PATH."""
+    """Encode text using the tokenizer located at ``TOKENIZER_PATH``."""
 
-    tokenizer = _load_tokenizer(tokenizer_path)
+    if pad_to < 0:
+        _fail(
+            "encode",
+            "pad_to must be zero or positive",
+            {"pad_to": pad_to},
+            "Could you provide a non-negative padding length?",
+        )
+
+    tokenizer = _load_tokenizer(tokenizer_path, step="encode")
+
+    payload = text
     if from_file:
-        text = Path(text).read_text(encoding="utf-8")
+        input_path = Path(text)
+        try:
+            payload = input_path.read_text(encoding="utf-8")
+        except Exception as exc:
+            _fail(
+                "encode",
+                f"Failed to read input text from {input_path}: {exc}",
+                {"input_path": str(input_path), "error": repr(exc)},
+                "How can we make the input text accessible to the encode command?",
+            )
 
-    encoded = tokenizer(
-        text,
-        padding="max_length" if pad_to else False,
-        max_length=pad_to or None,
-    )
-    input_ids = encoded.get("input_ids") if isinstance(encoded, dict) else None
-    if input_ids is None and hasattr(encoded, "input_ids"):
-        input_ids = getattr(encoded, "input_ids")
-    if input_ids is None:
-        typer.echo("Tokenizer did not return input_ids", err=True)
-        raise SystemExit(1)
-    if input_ids and isinstance(input_ids[0], list):
-        ids_list = input_ids[0]
+    try:
+        encoded = tokenizer(
+            payload,
+            padding="max_length" if pad_to else False,
+            max_length=pad_to or None,
+        )
+    except Exception as exc:
+        _fail(
+            "encode",
+            f"Tokenizer encode failed: {exc}",
+            {"tokenizer_path": str(tokenizer_path), "error": repr(exc)},
+            "What adjustments would allow this tokenizer to encode the text?",
+        )
+
+    ids_candidate: Any | None = None
+    if isinstance(encoded, dict):
+        ids_candidate = encoded.get("input_ids")
+    elif hasattr(encoded, "input_ids"):
+        ids_candidate = getattr(encoded, "input_ids")
+
+    if ids_candidate is None:
+        _fail(
+            "encode",
+            "Tokenizer did not provide input_ids in the response",
+            {
+                "tokenizer_path": str(tokenizer_path),
+                "encoded_type": type(encoded).__name__,
+            },
+            "How can we retrieve token ids from this tokenizer?",
+        )
+
+    try:
+        if isinstance(ids_candidate, Sequence):
+            ids_source = ids_candidate
+        else:
+            ids_source = list(ids_candidate)
+    except Exception as exc:
+        _fail(
+            "encode",
+            f"Unable to interpret input_ids: {exc}",
+            {
+                "tokenizer_path": str(tokenizer_path),
+                "error": repr(exc),
+                "input_ids_type": type(ids_candidate).__name__,
+            },
+            "What adjustments would allow input ids to be materialised as a list?",
+        )
+
+    ids_list: list[int]
+    if (
+        ids_source
+        and isinstance(ids_source[0], Sequence)
+        and not isinstance(ids_source[0], (str, bytes))
+    ):
+        ids_list = [int(x) for x in ids_source[0]]  # type: ignore[index]
     else:
-        ids_list = list(input_ids)
+        ids_list = [int(x) for x in ids_source]
+
     typer.echo("ids: " + " ".join(str(i) for i in ids_list))
 
     if show_tokens:
         converter = getattr(tokenizer, "convert_ids_to_tokens", None)
-        if callable(converter):
-            tokens = [converter(i) for i in ids_list]
-            typer.echo("tokens: " + " ".join(tokens))
-        else:
+        if not callable(converter):
             typer.echo("Tokenizer lacks convert_ids_to_tokens; cannot show tokens.")
+        else:
+            try:
+                tokens = [str(converter(i)) for i in ids_list]
+            except Exception as exc:
+                _append_error_block(
+                    "encode",
+                    f"Failed to convert ids to tokens: {exc}",
+                    {
+                        "tokenizer_path": str(tokenizer_path),
+                        "error": repr(exc),
+                        "ids": ids_list,
+                    },
+                    "How can we inspect token strings for this tokenizer?",
+                )
+                typer.echo(
+                    "Unable to convert ids to tokens; see error report for details.",
+                    err=True,
+                )
+            else:
+                typer.echo("tokens: " + " ".join(tokens))
 
 
 @app.command()
-def decode(tokenizer_path: Path, ids: str) -> None:
+def decode(
+    tokenizer_path: Path,
+    ids: str,
+    skip_special_tokens: bool = typer.Option(
+        False, help="Request special tokens be removed when supported"
+    ),
+) -> None:
     """Decode a comma-separated list of token ids."""
 
-    tokenizer = _load_tokenizer(tokenizer_path)
     try:
         id_list = [int(item.strip()) for item in ids.split(",") if item.strip()]
     except ValueError as exc:
-        typer.echo(f"Invalid token id in '{ids}': {exc}", err=True)
-        raise SystemExit(1)
-    typer.echo(tokenizer.decode(id_list))
+        _fail(
+            "decode",
+            f"Invalid token id list '{ids}': {exc}",
+            {"ids": ids, "error": str(exc)},
+            "Could you provide a comma-separated list of integer ids to decode?",
+        )
+
+    tokenizer = _load_tokenizer(tokenizer_path, step="decode")
+    decode_fn = getattr(tokenizer, "decode", None)
+    if not callable(decode_fn):
+        _fail(
+            "decode",
+            "Tokenizer does not provide a decode function",
+            {"tokenizer_path": str(tokenizer_path)},
+            "Is there an alternative method to decode token ids?",
+        )
+
+    kwargs: dict[str, Any] = {}
+    if skip_special_tokens:
+        kwargs["skip_special_tokens"] = True
+
+    try:
+        decoded = decode_fn(id_list, **kwargs)
+    except TypeError:
+        try:
+            decoded = decode_fn(id_list)
+        except Exception as exc:  # pragma: no cover - backend guard
+            _fail(
+                "decode",
+                f"Tokenizer decode failed: {exc}",
+                {
+                    "tokenizer_path": str(tokenizer_path),
+                    "error": repr(exc),
+                    "ids": id_list,
+                },
+                "What changes are needed so decoding succeeds?",
+            )
+    except Exception as exc:
+        _fail(
+            "decode",
+            f"Tokenizer decode failed: {exc}",
+            {
+                "tokenizer_path": str(tokenizer_path),
+                "error": repr(exc),
+                "ids": id_list,
+            },
+            "What changes are needed so decoding succeeds?",
+        )
+
+    typer.echo(str(decoded))
 
 
 @app.command()
 def export(src: Path, dst: Path) -> None:
-    """Copy tokenizer artifacts (json/manifest/spm) to DST."""
+    """Copy tokenizer artifacts to ``dst`` and write a short README."""
 
-    dst.mkdir(parents=True, exist_ok=True)
+    root = _resolve_root(src)
+    try:
+        dst.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:
+        _fail(
+            "export",
+            f"Failed to prepare export directory {dst}: {exc}",
+            {"destination": str(dst), "error": repr(exc)},
+            "How can we create the export directory for tokenizer artifacts?",
+        )
+
+    copied_files = []
     for name in ("tokenizer.json", "manifest.json", "spm.model", "spm.vocab"):
-        p = _resolve_root(src) / name
-        if p.exists():
-            shutil.copy2(p, dst / name)
+        candidate = root / name
+        if candidate.exists():
+            target = dst / name
+            try:
+                shutil.copy2(candidate, target)
+            except Exception as exc:
+                _append_error_block(
+                    "export",
+                    f"Failed to copy {candidate} to {target}: {exc}",
+                    {
+                        "source": str(candidate),
+                        "destination": str(target),
+                        "error": repr(exc),
+                    },
+                    "How can we ensure tokenizer artifacts are copied successfully?",
+                )
+            else:
+                copied_files.append(str(target))
+
+    readme_path = dst / "README.md"
+    readme_contents = (
+        "# Exported Tokenizer\n\n"
+        "This directory was generated by `tokenization.cli export`.\n\n"
+        "Files copied:\n" + "\n".join(f"- {Path(path).name}" for path in copied_files) + "\n"
+    )
+    try:
+        readme_path.write_text(readme_contents, encoding="utf-8")
+    except Exception as exc:
+        _append_error_block(
+            "export",
+            f"Failed to write README.md: {exc}",
+            {"readme_path": str(readme_path), "error": repr(exc)},
+            "How can we document the exported tokenizer artifacts?",
+        )
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - manual execution hook
     app()
 
 


### PR DESCRIPTION
## Summary
- rebuild `tokenization.cli` around a Typer app (with fallback shim) that records errors to the daily `_codex_reports` log
- add structured error handling for the `vocab`, `inspect`, `encode`, `decode`, and `export` commands, including README generation during export

## Testing
- `python -m tokenization.cli --help`
- `PYTHONPATH=src pytest tests/tokenization/test_cli_inspect_export.py -q` *(fails: pytest.ini expects pytest-cov which is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f571c78ce88331a18f69a92ed20673