### PR TITLE
Enforce owner approval guard on Docker pushes

### DIFF
--- a/.github/_workflows_disabled/docker-build-push.yml
+++ b/.github/_workflows_disabled/docker-build-push.yml
@@ -38,6 +38,13 @@ jobs:
           TOOL_KEY: docker-build-push
           OWNER_APPROVED_UNTIL: ${{ vars.OWNER_APPROVED_UNTIL }}
           OWNER_APPROVED_DURATION: ${{ vars.OWNER_APPROVED_DURATION }}
+      - name: Upload approval evidence (optional)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: owner-approval-evidence-build
+          path: .codex/evidence/owner_approval.jsonl
+          if-no-files-found: ignore
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -143,6 +150,13 @@ jobs:
           TOOL_KEY: docker-build-push
           OWNER_APPROVED_UNTIL: ${{ vars.OWNER_APPROVED_UNTIL }}
           OWNER_APPROVED_DURATION: ${{ vars.OWNER_APPROVED_DURATION }}
+      - name: Upload approval evidence (optional)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: owner-approval-evidence-push
+          path: .codex/evidence/owner_approval.jsonl
+          if-no-files-found: ignore
 
       - name: Build and push (GHCR)
         if: env.PUSH_PLATFORMS == ''

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -77,6 +77,13 @@ bash scripts/ci/push_image.sh ghcr.io/OWNER/REPO:tag --dry-run
 # After 'docker login ghcr.io' or set GITHUB_TOKEN/GITHUB_ACTOR in CI:
 bash scripts/ci/push_image.sh ghcr.io/OWNER/REPO:tag
 ```
+Owner approval gate:
+- Push is gated by scripts/ci/owner_approval_guard.sh with TOOL_KEY=docker-build-push.
+- Approval options:
+  - File mode: .github/OWNER_APPROVAL.yml with enabled: true, mode: duration, duration: "24h" and a fresh created_at.
+  - Env mode: export OWNER_APPROVED_DURATION=24h (or OWNER_APPROVED_UNTIL=...Z).
+- To bypass locally: SKIP_OWNER_APPROVAL=1 bash scripts/ci/push_image.sh ghcr.io/OWNER/REPO:tag
+- Every decision is written to .codex/evidence/owner_approval.jsonl (JSONL).
 
 ## GPU image (optional)
 - Build locally:

--- a/docs/validation/Owner_Approval_Validation.md
+++ b/docs/validation/Owner_Approval_Validation.md
@@ -10,6 +10,7 @@ Summary
 | Env var (24h) | OWNER_APPROVED_DURATION=24h bash scripts/ci/owner_approval_test.sh docker-build-push | RESULT: APPROVED |
 | Expired (file) | Edit .github/OWNER_APPROVAL.yml created_at to >24h past, rerun test | RESULT: DENIED |
 | Wrong tool key | TOOL_KEY=security-scans with file only listing docker-build-push | RESULT: DENIED |
+| Push (guarded) | bash scripts/ci/push_image.sh ghcr.io/OWNER/REPO:tag --dry-run | Requires APPROVED; otherwise denied |
 
 Steps
 1) File-based 24h window
@@ -30,8 +31,18 @@ OWNER_APPROVED_DURATION=24h bash scripts/ci/owner_approval_test.sh docker-build-
 # Alternatively (until timestamp):
 OWNER_APPROVED_UNTIL="2025-10-21T19:43:52Z" bash scripts/ci/owner_approval_test.sh docker-build-push
 ```
+4) Push (guarded)
+```bash
+# Expect APPROVED within window:
+bash scripts/ci/push_image.sh ghcr.io/OWNER/REPO:tag --dry-run
+# After clearing approval:
+make owner-approve-clear
+# Expect denial:
+bash scripts/ci/push_image.sh ghcr.io/OWNER/REPO:tag --dry-run || echo "Denied as expected"
+```
 
 Notes
 - The guard supports both bullet lists and inline lists for cost_workflows.
 - Comments and quotes in YAML scalars are ignored by the parser.
 - When enabling CI later, the disabled workflow already calls the guard at the start of build and push jobs.
+- Decisions are recorded in .codex/evidence/owner_approval.jsonl for auditability.

--- a/scripts/ci/owner_approval_guard.sh
+++ b/scripts/ci/owner_approval_guard.sh
@@ -12,6 +12,22 @@ set -euo pipefail
 TOOL_KEY="${TOOL_KEY:-docker-build-push}"
 APPROVAL_FILE=".github/OWNER_APPROVAL.yml"
 
+# Evidence logging (JSONL) to support auditability under .codex/evidence/
+CODEX_EVIDENCE="${CODEX_EVIDENCE:-1}"
+CODEX_EVIDENCE_DIR="${CODEX_EVIDENCE_DIR:-.codex/evidence}"
+evidence() {
+  # evidence <decision> <source> <expiry_iso>
+  [ "${CODEX_EVIDENCE}" = "1" ] || return 0
+  mkdir -p "${CODEX_EVIDENCE_DIR}" 2>/dev/null || true
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  # Compose a compact JSON line (no external deps)
+  printf '{"ts":"%s","tool_key":"%s","decision":"%s","source":"%s","expiry":"%s","mode":"%s","duration":"%s","until":"%s","created_at":"%s","enabled":"%s","has_cost_key":"%s"}\n' \
+    "${ts}" "${TOOL_KEY}" "${1:-unknown}" "${2:-unknown}" "${3:-}" \
+    "${mode:-}" "${duration:-}" "${until_ts:-}" "${created_at:-}" "${enabled:-}" "${has_cost_key:-}" \
+    >> "${CODEX_EVIDENCE_DIR}/owner_approval.jsonl" 2>/dev/null || true
+}
+
 now_epoch() { date -u +%s; }
 
 trim() { awk '{$1=$1;print}'; } # trim leading/trailing whitespace on a single line
@@ -61,13 +77,16 @@ approve_via_env() {
   if [ -n "${OWNER_APPROVED_UNTIL:-}" ]; then
     ts="$(parse_iso_to_epoch "${OWNER_APPROVED_UNTIL}")" || {
       echo "[approval] OWNER_APPROVED_UNTIL is invalid: ${OWNER_APPROVED_UNTIL}" >&2
+      evidence "denied" "env-until-invalid" ""
       return 2
     }
     if [ "$now" -le "$ts" ]; then
       echo "[approval] APPROVED via OWNER_APPROVED_UNTIL (${OWNER_APPROVED_UNTIL}) for TOOL_KEY=${TOOL_KEY}"
+      evidence "approved" "env-until" "${OWNER_APPROVED_UNTIL}"
       return 0
     else
       echo "[approval] OWNER_APPROVED_UNTIL expired (${OWNER_APPROVED_UNTIL})" >&2
+      evidence "denied" "env-until-expired" "${OWNER_APPROVED_UNTIL}"
       return 2
     fi
   fi
@@ -76,10 +95,14 @@ approve_via_env() {
     local secs
     secs="$(parse_duration_to_secs "${OWNER_APPROVED_DURATION}")" || {
       echo "[approval] OWNER_APPROVED_DURATION invalid: ${OWNER_APPROVED_DURATION}" >&2
+      evidence "denied" "env-duration-invalid" ""
       return 2
     }
     local until_epoch="$(( now + secs ))"
-    echo "[approval] APPROVED via OWNER_APPROVED_DURATION=${OWNER_APPROVED_DURATION} until $(date -u -d "@$until_epoch" +%Y-%m-%dT%H:%M:%SZ) for TOOL_KEY=${TOOL_KEY}"
+    local until_iso
+    until_iso="$(date -u -d "@$until_epoch" +%Y-%m-%dT%H:%M:%SZ)"
+    echo "[approval] APPROVED via OWNER_APPROVED_DURATION=${OWNER_APPROVED_DURATION} until ${until_iso} for TOOL_KEY=${TOOL_KEY}"
+    evidence "approved" "env-duration" "${until_iso}"
     return 0
   fi
 
@@ -94,6 +117,7 @@ fi
 # Parse minimal YAML (no external deps).
 if [ ! -f "${APPROVAL_FILE}" ]; then
   echo "[approval] ${APPROVAL_FILE} not found; deny" >&2
+  evidence "denied" "file-missing" ""
   exit 2
 fi
 
@@ -136,25 +160,27 @@ done
 
 if [ "${enabled}" != "true" ]; then
   echo "[approval] OWNER_APPROVAL.yml enabled=false; deny" >&2
+  evidence "denied" "file-disabled" ""
   exit 2
 fi
 
 if [ "${has_cost_key}" != "true" ]; then
   echo "[approval] TOOL_KEY=${TOOL_KEY} not listed in cost_workflows; deny" >&2
+  evidence "denied" "file-missing-tool-key" ""
   exit 2
 fi
 
 now="$(now_epoch)"
 # Compute expiry by mode
 if [ "${mode}" = "until" ]; then
-  [ -z "${until_ts}" ] && { echo "[approval] mode=until but 'until' not set; deny" >&2; exit 2; }
-  exp="$(parse_iso_to_epoch "${until_ts}")" || { echo "[approval] 'until' invalid: ${until_ts}" >&2; exit 2; }
+  [ -z "${until_ts}" ] && { echo "[approval] mode=until but 'until' not set; deny" >&2; evidence "denied" "file-until-missing" ""; exit 2; }
+  exp="$(parse_iso_to_epoch "${until_ts}")" || { echo "[approval] 'until' invalid: ${until_ts}" >&2; evidence "denied" "file-until-invalid" ""; exit 2; }
 elif [ "${mode}" = "duration" ]; then
-  [ -z "${duration}" ] && { echo "[approval] mode=duration but 'duration' empty; deny" >&2; exit 2; }
-  secs="$(parse_duration_to_secs "${duration}")" || { echo "[approval] duration invalid: ${duration}" >&2; exit 2; }
+  [ -z "${duration}" ] && { echo "[approval] mode=duration but 'duration' empty; deny" >&2; evidence "denied" "file-duration-missing" ""; exit 2; }
+  secs="$(parse_duration_to_secs "${duration}")" || { echo "[approval] duration invalid: ${duration}" >&2; evidence "denied" "file-duration-invalid" ""; exit 2; }
   # Determine start time: created_at (preferred), then git last change time of this file, else file mtime.
   if [ -n "${created_at}" ]; then
-    start="$(parse_iso_to_epoch "${created_at}")" || { echo "[approval] created_at invalid: ${created_at}" >&2; exit 2; }
+    start="$(parse_iso_to_epoch "${created_at}")" || { echo "[approval] created_at invalid: ${created_at}" >&2; evidence "denied" "file-created_at-invalid" ""; exit 2; }
   else
     if git log -1 --format=%ct -- "${APPROVAL_FILE}" >/dev/null 2>&1; then
       start="$(git log -1 --format=%ct -- "${APPROVAL_FILE}")"
@@ -165,13 +191,17 @@ elif [ "${mode}" = "duration" ]; then
   exp="$(( start + secs ))"
 else
   echo "[approval] Unknown mode: ${mode} (expected 'until' or 'duration')" >&2
+  evidence "denied" "file-mode-invalid" ""
   exit 2
 fi
 
 if [ "$now" -le "$exp" ]; then
-  echo "[approval] APPROVED until $(date -u -d "@$exp" +%Y-%m-%dT%H:%M:%SZ) for TOOL_KEY=${TOOL_KEY}"
+  until_iso="$(date -u -d "@$exp" +%Y-%m-%dT%H:%M:%SZ)"
+  echo "[approval] APPROVED until ${until_iso} for TOOL_KEY=${TOOL_KEY}"
+  evidence "approved" "file-${mode}" "${until_iso}"
   exit 0
 fi
 
 echo "[approval] Window expired at $(date -u -d "@$exp" +%Y-%m-%dT%H:%M:%SZ); deny" >&2
+evidence "denied" "file-expired" "$(date -u -d "@$exp" +%Y-%m-%dT%H:%M:%SZ)"
 exit 2

--- a/scripts/ci/push_image.sh
+++ b/scripts/ci/push_image.sh
@@ -10,6 +10,14 @@ if [ -z "${IMAGE}" ]; then
   exit 2
 fi
 
+# Owner approval guard (cost-incurring). Set SKIP_OWNER_APPROVAL=1 to bypass locally.
+if [ "${SKIP_OWNER_APPROVAL:-0}" != "1" ]; then
+  echo "[push] Checking owner approval window for TOOL_KEY=docker-build-push"
+  TOOL_KEY=docker-build-push bash scripts/ci/owner_approval_guard.sh
+else
+  echo "[push] SKIP_OWNER_APPROVAL=1 set; bypassing owner approval guard"
+fi
+
 REGISTRY="$(echo "${IMAGE}" | awk -F/ '{print $1}')"
 echo "[push] Target: ${IMAGE}"
 echo "[push] Registry: ${REGISTRY}"


### PR DESCRIPTION
## Summary
- add evidence logging to the owner approval guard so each decision writes to `.codex/evidence/owner_approval.jsonl`
- require the guard when running `scripts/ci/push_image.sh` and document the approval window options and bypass flow
- surface optional evidence artifact uploads in the disabled Docker build/push workflow and extend the validation guide for the guarded push path

## Testing
- git commit (pre-commit hooks)


------
https://chatgpt.com/codex/tasks/task_e_68f69883970c8331b462efb498c8615f