### PR TITLE
Enable owner-approved Docker CI workflow

### DIFF
--- a/.github/OWNER_APPROVAL.md
+++ b/.github/OWNER_APPROVAL.md
@@ -1,5 +1,5 @@
 # Owner Approval Gate — Timeboxed Enablement
-> Generated: 2025-10-20 20:37:17 UTC | Author: mbaetiong
+> Generated: 2025-10-20 20:50:36 UTC | Author: mbaetiong
 
 This repository supports temporarily enabling cost-incurring workflows (e.g., Docker build/push) via a timeboxed owner approval.
 
@@ -27,8 +27,10 @@ CI enablement (OWNER APPROVED)
 - You can supply an approval window via:
   - Repo variables: OWNER_APPROVED_DURATION="24h" or OWNER_APPROVED_UNTIL="2025-10-21T00:00:00Z"
   - Per-run overrides: workflow_dispatch inputs approval_duration/approval_until
+  - Validation only: workflow_dispatch input check_only=true (skips build and push)
 - Multi-arch (optional): repo var or input push_platforms="linux/amd64,linux/arm64"
 - Permissions: Actions “packages: write” must be allowed. GHCR uses the default GITHUB_TOKEN via docker/login-action.
+- GHCR note: image repository and tags are lowercased automatically in CI.
 
 Quick local test
 ```bash
@@ -48,5 +50,5 @@ make owner-approve-status
 
 Notes
 - cost_workflows may be ["all"] or specific keys (e.g., "docker-build-push").
-- The guard logs the computed expiry as an ISO timestamp for auditability.
+- The guard logs the computed expiry as an ISO timestamp for auditability and includes CI metadata in evidence.
 - To disable: make owner-approve-clear or remove repo variables.

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -19,15 +19,62 @@ on:
         description: 'PUSH_PLATFORMS (e.g., "linux/amd64,linux/arm64")'
         required: false
         default: ""
+      check_only:
+        type: boolean
+        description: 'Run approval check only (skip build and push)'
+        required: false
+        default: false
 
 # Prefer repo vars; allow per-run override via workflow_dispatch inputs
 env:
-  OWNER_APPROVED_DURATION: ${{ github.event.inputs.approval_duration != '' && github.event.inputs.approval_duration || vars.OWNER_APPROVED_DURATION }}
-  OWNER_APPROVED_UNTIL: ${{ github.event.inputs.approval_until != '' && github.event.inputs.approval_until || vars.OWNER_APPROVED_UNTIL }}
-  PUSH_PLATFORMS: ${{ github.event.inputs.push_platforms != '' && github.event.inputs.push_platforms || vars.PUSH_PLATFORMS }}
+  OWNER_APPROVED_DURATION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.approval_duration != '' && github.event.inputs.approval_duration || vars.OWNER_APPROVED_DURATION }}
+  OWNER_APPROVED_UNTIL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.approval_until != '' && github.event.inputs.approval_until || vars.OWNER_APPROVED_UNTIL }}
+  PUSH_PLATFORMS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_platforms != '' && github.event.inputs.push_platforms || vars.PUSH_PLATFORMS }}
 
 jobs:
+  approval-check:
+    name: Owner approval — check-only gate
+    runs-on: [self-hosted, linux]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show owner approval context
+        working-directory: _codex_
+        run: |
+          echo "OWNER_APPROVED_UNTIL=${OWNER_APPROVED_UNTIL}"
+          echo "OWNER_APPROVED_DURATION=${OWNER_APPROVED_DURATION}"
+          if [ -f .github/OWNER_APPROVAL.yml ]; then
+            echo ".github/OWNER_APPROVAL.yml present"
+          else
+            echo ".github/OWNER_APPROVAL.yml missing"
+          fi
+
+      - name: Evaluate owner approval (guard)
+        working-directory: _codex_
+        run: bash scripts/ci/owner_approval_guard.sh
+        env:
+          TOOL_KEY: docker-build-push
+          OWNER_APPROVED_UNTIL: ${{ env.OWNER_APPROVED_UNTIL }}
+          OWNER_APPROVED_DURATION: ${{ env.OWNER_APPROVED_DURATION }}
+
+      - name: Write approval status to summary
+        working-directory: _codex_
+        run: bash scripts/ci/owner_approval_summary.sh docker-build-push
+
+      - name: Upload approval evidence (optional)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: owner-approval-evidence-check
+          path: _codex_/.codex/evidence/owner_approval.jsonl
+          if-no-files-found: ignore
+
   build-and-smoke:
+    if: ${{ !(github.event_name == 'workflow_dispatch' && (github.event.inputs.check_only == 'true' || github.event.inputs.check_only == true)) }}
     name: Build image and run smoke test
     runs-on: [self-hosted, linux]
     permissions:
@@ -38,6 +85,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Show owner approval context (no-op)
+        working-directory: _codex_
         run: |
           echo "OWNER_APPROVED_UNTIL=${OWNER_APPROVED_UNTIL}"
           echo "OWNER_APPROVED_DURATION=${OWNER_APPROVED_DURATION}"
@@ -48,9 +96,11 @@ jobs:
           fi
 
       - name: Show owner approval status (helper)
-        run: bash scripts/ci/owner_approval_status.sh docker-build-push || true
+        working-directory: _codex_
+        run: bash scripts/ci/owner_approval_summary.sh docker-build-push || true
 
       - name: Check OWNER approval window
+        working-directory: _codex_
         run: bash scripts/ci/owner_approval_guard.sh
         env:
           TOOL_KEY: docker-build-push
@@ -62,7 +112,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: owner-approval-evidence-build
-          path: .codex/evidence/owner_approval.jsonl
+          path: _codex_/.codex/evidence/owner_approval.jsonl
           if-no-files-found: ignore
 
       - name: Set up Docker Buildx
@@ -75,8 +125,8 @@ jobs:
       - name: Build image (local load for smoke test)
         uses: docker/build-push-action@v6
         with:
-          context: .
-          file: Dockerfile
+          context: _codex_
+          file: _codex_/Dockerfile
           load: true
           tags: codex:ci
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -88,6 +138,7 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Smoke test container
+        working-directory: _codex_
         run: bash scripts/ci/container_smoke.sh codex:ci 8000 18000
 
       - name: Archive smoke logs (always)
@@ -95,36 +146,39 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: container-smoke-logs
-          path: scripts/ci/smoke_logs/*.log
+          path: _codex_/scripts/ci/smoke_logs/*.log
           if-no-files-found: ignore
 
-      # Optional: Generate SBOM and vulnerability scan (require tools on runner).
       - name: Generate SBOM with syft (optional)
+        working-directory: _codex_
         run: |
           if command -v syft >/dev/null 2>&1; then
             bash scripts/ci/sbom_syft.sh codex:ci
           else
             echo "[sbom] syft not available on runner; skipping"
           fi
+
       - name: Trivy scan (optional)
+        working-directory: _codex_
         run: |
           if command -v trivy >/dev/null 2>&1; then
             bash scripts/ci/scan_trivy.sh codex:ci
           else
             echo "[scan] trivy not available on runner; skipping"
           fi
+
       - name: Upload security artifacts (optional)
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: docker-security-artifacts
-          path: artifacts/security/**
+          path: _codex_/artifacts/security/**
           if-no-files-found: ignore
 
   push:
+    if: ${{ github.event_name != 'pull_request' && !(github.event_name == 'workflow_dispatch' && (github.event.inputs.check_only == 'true' || github.event.inputs.check_only == true)) }}
     name: Push image to GHCR (on main)
     needs: [build-and-smoke]
-    if: github.event_name != 'pull_request'
     runs-on: [self-hosted, linux]
     permissions:
       contents: read
@@ -147,23 +201,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Derive tags
+      - name: Derive tags (lowercase for GHCR)
         id: vars
+        shell: bash
         run: |
           REPO_IMAGE="ghcr.io/${{ github.repository }}"
-          SHA_TAG="${REPO_IMAGE}:sha-${GITHUB_SHA::12}"
+          REPO_IMAGE_LC="$(echo "${REPO_IMAGE}" | tr '[:upper:]' '[:lower:]')"
+          SHA_TAG="${REPO_IMAGE_LC}:sha-${GITHUB_SHA::12}"
           BRANCH="${GITHUB_REF_NAME}"
           if [ "$BRANCH" = "main" ]; then
-            BRANCH_TAG="${REPO_IMAGE}:latest"
+            BRANCH_TAG="${REPO_IMAGE_LC}:latest"
           else
             SAFE_BRANCH="${BRANCH//\//-}"
-            BRANCH_TAG="${REPO_IMAGE}:${SAFE_BRANCH}"
+            SAFE_BRANCH_LC="$(echo "${SAFE_BRANCH}" | tr '[:upper:]' '[:lower:]')"
+            BRANCH_TAG="${REPO_IMAGE_LC}:${SAFE_BRANCH_LC}"
           fi
           echo "image_sha=${SHA_TAG}" >> "$GITHUB_OUTPUT"
           echo "image_branch=${BRANCH_TAG}" >> "$GITHUB_OUTPUT"
 
-      # OWNER approval gate (repeat gate for push step)
       - name: Check OWNER approval window (push)
+        working-directory: _codex_
         run: bash scripts/ci/owner_approval_guard.sh
         env:
           TOOL_KEY: docker-build-push
@@ -171,22 +228,23 @@ jobs:
           OWNER_APPROVED_DURATION: ${{ env.OWNER_APPROVED_DURATION }}
 
       - name: Show owner approval status (helper, push)
-        run: bash scripts/ci/owner_approval_status.sh docker-build-push || true
+        working-directory: _codex_
+        run: bash scripts/ci/owner_approval_summary.sh docker-build-push || true
 
       - name: Upload approval evidence (optional)
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: owner-approval-evidence-push
-          path: .codex/evidence/owner_approval.jsonl
+          path: _codex_/.codex/evidence/owner_approval.jsonl
           if-no-files-found: ignore
 
       - name: Build and push (GHCR)
         if: env.PUSH_PLATFORMS == ''
         uses: docker/build-push-action@v6
         with:
-          context: .
-          file: Dockerfile
+          context: _codex_
+          file: _codex_/Dockerfile
           push: true
           tags: |
             ${{ steps.vars.outputs.image_sha }}
@@ -199,8 +257,8 @@ jobs:
         if: env.PUSH_PLATFORMS != ''
         uses: docker/build-push-action@v6
         with:
-          context: .
-          file: Dockerfile
+          context: _codex_
+          file: _codex_/Dockerfile
           push: true
           platforms: ${{ env.PUSH_PLATFORMS }}
           tags: |

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,51 @@ docker-scan:
 docker-push:
 	@bash scripts/ci/push_image.sh $(PUSH_IMAGE)
 
+# --- Owner approval convenience (local-only; writes .github/OWNER_APPROVAL.yml) ---
+.PHONY: owner-approve-24h owner-approve-clear owner-approve-status owner-approve-extend-24h
+
+owner-approve-24h:
+	@mkdir -p .github
+	@echo "# Effective owner-approval window (local 24h test)" > .github/OWNER_APPROVAL.yml
+	@echo "enabled: true" >> .github/OWNER_APPROVAL.yml
+	@echo 'reason: "24h test window for cost-incurring workflows"' >> .github/OWNER_APPROVAL.yml
+	@echo 'approved_by: "'$(USER)'"' >> .github/OWNER_APPROVAL.yml
+	@echo 'mode: "duration"' >> .github/OWNER_APPROVAL.yml
+	@echo 'duration: "24h"' >> .github/OWNER_APPROVAL.yml
+	@echo 'until: ""' >> .github/OWNER_APPROVAL.yml
+	@echo "cost_workflows:" >> .github/OWNER_APPROVAL.yml
+	@echo "  - docker-build-push" >> .github/OWNER_APPROVAL.yml
+	@echo 'created_at: "'$$(date -u +%Y-%m-%dT%H:%M:%SZ)'"' >> .github/OWNER_APPROVAL.yml
+	@echo "[owner-approve-24h] Wrote .github/OWNER_APPROVAL.yml"
+
+owner-approve-clear:
+	@mkdir -p .github
+	@echo "# Effective owner-approval window (disabled)" > .github/OWNER_APPROVAL.yml
+	@echo "enabled: false" >> .github/OWNER_APPROVAL.yml
+	@echo 'reason: ""' >> .github/OWNER_APPROVAL.yml
+	@echo 'approved_by: ""' >> .github/OWNER_APPROVAL.yml
+	@echo 'mode: "duration"' >> .github/OWNER_APPROVAL.yml
+	@echo 'duration: "0h"' >> .github/OWNER_APPROVAL.yml
+	@echo 'until: ""' >> .github/OWNER_APPROVAL.yml
+	@echo "cost_workflows:" >> .github/OWNER_APPROVAL.yml
+	@echo "  - docker-build-push" >> .github/OWNER_APPROVAL.yml
+	@echo 'created_at: "'$$(date -u +%Y-%m-%dT%H:%M:%SZ)'"' >> .github/OWNER_APPROVAL.yml
+	@echo "[owner-approve-clear] Wrote .github/OWNER_APPROVAL.yml"
+
+owner-approve-status:
+	@bash scripts/ci/owner_approval_status.sh docker-build-push || true
+
+owner-approve-extend-24h:
+	@test -f .github/OWNER_APPROVAL.yml || { echo "Missing .github/OWNER_APPROVAL.yml"; exit 1; }
+	@cp .github/OWNER_APPROVAL.yml .github/OWNER_APPROVAL.yml.bak
+	@if grep -qE '^[[:space:]]*created_at:' .github/OWNER_APPROVAL.yml; then \
+	  sed -i -E 's/^[[:space:]]*created_at:.*/created_at: "'$$'(date -u +%Y-%m-%dT%H:%M:%SZ)"/' .github/OWNER_APPROVAL.yml; \
+	else \
+	  echo 'created_at: "'$$'(date -u +%Y-%m-%dT%H:%M:%SZ)"' >> .github/OWNER_APPROVAL.yml; \
+	fi
+	@rm -f .github/OWNER_APPROVAL.yml.bak
+	@echo "[owner-approve-extend-24h] Refreshed created_at"
+
 DOCKER_GPU_IMAGE ?= codex-gpu:local
 
 docker-gpu-build:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -84,6 +84,8 @@ Owner approval gate:
   - Env mode: export OWNER_APPROVED_DURATION=24h (or OWNER_APPROVED_UNTIL=...Z).
 - To bypass locally: SKIP_OWNER_APPROVAL=1 bash scripts/ci/push_image.sh ghcr.io/OWNER/REPO:tag
 - Every decision is written to .codex/evidence/owner_approval.jsonl (JSONL).
+Convenience targets:
+- make owner-approve-24h | make owner-approve-status | make owner-approve-extend-24h | make owner-approve-clear
 
 ## GPU image (optional)
 - Build locally:
@@ -101,7 +103,7 @@ make docker-gpu-run HOST_PORT=8000
 PLATFORMS=linux/amd64,linux/arm64 BUILDX_FLAGS="--output=type=registry" \
   bash scripts/ci/build_image.sh ghcr.io/OWNER/REPO:tag Dockerfile
 ```
-- The disabled GitHub Actions workflow (`.github/_workflows_disabled/docker-build-push.yml`) respects `PUSH_PLATFORMS` to enable
+- The GitHub Actions workflow (`.github/workflows/docker-build-push.yml`) respects `PUSH_PLATFORMS` to enable
   multi-architecture pushes when an OWNER opts in.
 
 ## Compose

--- a/docs/validation/Owner_Approved_CI_Validation.md
+++ b/docs/validation/Owner_Approved_CI_Validation.md
@@ -1,5 +1,5 @@
 # Owner-Approved CI Validation — Docker Build/Push
-> Generated: 2025-10-20 20:37:17 UTC | Author: mbaetiong
+> Generated: 2025-10-20 20:50:36 UTC | Author: mbaetiong
 
 Goal
 - Validate the OWNER-approved Docker workflow in CI with a 24h window and optional multi-arch.
@@ -20,13 +20,23 @@ Paths to approval
   - approval_until="" (leave empty) OR provide a future ISO8601 Z
   - push_platforms="linux/amd64,linux/arm64" (optional)
 
+3) Check-only (no build or push)
+- Manually dispatch workflow with:
+  - check_only=true
+  - approval_duration="24h" (or approval_until="…Z")
+- Expectation: approval-check job runs and posts the status to the run summary; build and push jobs are skipped.
+
 Expected results
-- build-and-smoke job:
+- approval-check:
   - Shows approval context and status
   - Passes guard when within window
+  - Writes decision to the Job summary and uploads owner_approval.jsonl
+- build-and-smoke job (when not check-only):
+  - Passes guard when within window
   - Builds and smokes image
-- push job (main only):
+- push job (main only, when not check-only):
   - Logs into GHCR with GITHUB_TOKEN
+  - Uses lowercase image refs
   - Honors push_platforms when provided
   - Pushes tags sha-<12> and latest/branch
 
@@ -40,3 +50,4 @@ Troubleshooting
   - For file mode: refresh created_at or set duration accordingly
   - For env mode: ensure inputs/vars are non-empty and valid
 - Multi-arch fails: confirm QEMU step executed (push_platforms not empty), and the builder supports emulation
+- GHCR rejects tag: ensure repository path and branch tag are lowercased (the workflow now forces lowercase)

--- a/scripts/ci/owner_approval_guard.sh
+++ b/scripts/ci/owner_approval_guard.sh
@@ -12,6 +12,15 @@ set -euo pipefail
 TOOL_KEY="${TOOL_KEY:-docker-build-push}"
 APPROVAL_FILE=".github/OWNER_APPROVAL.yml"
 
+# If not provided, try to pick up from GitHub Actions env
+WORKFLOW_NAME="${WORKFLOW_NAME:-${GITHUB_WORKFLOW:-}}"
+RUN_ID="${RUN_ID:-${GITHUB_RUN_ID:-}}"
+RUN_ATTEMPT="${RUN_ATTEMPT:-${GITHUB_RUN_ATTEMPT:-}}"
+RUNNER_ENV="${RUNNER_ENV:-${GITHUB_JOB:-}}"
+ACTOR="${ACTOR:-${GITHUB_ACTOR:-}}"
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+REF="${REF:-${GITHUB_REF:-}}"
+
 # Evidence logging (JSONL) to support auditability under .codex/evidence/
 CODEX_EVIDENCE="${CODEX_EVIDENCE:-1}"
 CODEX_EVIDENCE_DIR="${CODEX_EVIDENCE_DIR:-.codex/evidence}"
@@ -22,8 +31,8 @@ evidence() {
   local ts
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   # Compose a compact JSON line (no external deps)
-  printf '{"ts":"%s","tool_key":"%s","decision":"%s","source":"%s","expiry":"%s","mode":"%s","duration":"%s","until":"%s","created_at":"%s","enabled":"%s","has_cost_key":"%s"}\n' \
-    "${ts}" "${TOOL_KEY}" "${1:-unknown}" "${2:-unknown}" "${3:-}" \
+  printf '{"ts":"%s","workflow":"%s","run_id":"%s","run_attempt":"%s","job":"%s","actor":"%s","repo":"%s","ref":"%s","tool_key":"%s","decision":"%s","source":"%s","expiry":"%s","mode":"%s","duration":"%s","until":"%s","created_at":"%s","enabled":"%s","has_cost_key":"%s"}\n' \
+    "${ts}" "${WORKFLOW_NAME}" "${RUN_ID}" "${RUN_ATTEMPT}" "${RUNNER_ENV}" "${ACTOR}" "${REPO}" "${REF}" "${TOOL_KEY}" "${1:-unknown}" "${2:-unknown}" "${3:-}" \
     "${mode:-}" "${duration:-}" "${until_ts:-}" "${created_at:-}" "${enabled:-}" "${has_cost_key:-}" \
     >> "${CODEX_EVIDENCE_DIR}/owner_approval.jsonl" 2>/dev/null || true
 }

--- a/scripts/ci/owner_approval_status.sh
+++ b/scripts/ci/owner_approval_status.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Report current owner-approval status for a TOOL_KEY and exit with same code as guard.
+# Usage:
+#   scripts/ci/owner_approval_status.sh [tool_key]
+# Env (optional):
+#   WORKFLOW_NAME: label to include in evidence/status (default: $GITHUB_WORKFLOW or "local")
+set -euo pipefail
+
+TOOL_KEY="${1:-docker-build-push}"
+WORKFLOW_NAME="${WORKFLOW_NAME:-${GITHUB_WORKFLOW:-local}}"
+
+# Run guard to update evidence, but silence output. Preserve return code.
+CODEX_EVIDENCE=1 WORKFLOW_NAME="${WORKFLOW_NAME}" TOOL_KEY="${TOOL_KEY}" bash scripts/ci/owner_approval_guard.sh >/dev/null 2>&1 || true
+rc=$?
+
+# Pull the latest evidence line (if any)
+evidence_file=".codex/evidence/owner_approval.jsonl"
+decision="" source="" expiry=""
+if [ -f "${evidence_file}" ]; then
+  last="$(tail -n1 "${evidence_file}" || true)"
+  # naive JSON field extraction (no jq)
+  decision="$(printf '%s' "${last}" | sed -n 's/.*"decision":"\([^"]*\)".*/\1/p')"
+  source="$(printf '%s' "${last}" | sed -n 's/.*"source":"\([^"]*\)".*/\1/p')"
+  expiry="$(printf '%s' "${last}" | sed -n 's/.*"expiry":"\([^"]*\)".*/\1/p')"
+fi
+
+echo "[status] workflow=${WORKFLOW_NAME} tool_key=${TOOL_KEY} decision=${decision:-unknown} source=${source:-unknown} expiry=${expiry:-}"
+printf '{"workflow":"%s","tool_key":"%s","decision":"%s","source":"%s","expiry":"%s","rc":%d}\n' \
+  "${WORKFLOW_NAME}" "${TOOL_KEY}" "${decision:-unknown}" "${source:-unknown}" "${expiry:-}" "${rc}"
+
+exit "${rc}"

--- a/scripts/ci/owner_approval_summary.sh
+++ b/scripts/ci/owner_approval_summary.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Write the latest owner-approval decision to the job summary and echo JSON.
+# Usage (CI): bash scripts/ci/owner_approval_summary.sh [tool_key]
+set -euo pipefail
+
+TOOL_KEY="${1:-docker-build-push}"
+WORKFLOW_NAME="${WORKFLOW_NAME:-${GITHUB_WORKFLOW:-local}}"
+
+# Ensure the guard has been evaluated at least once in this run for fresh evidence
+CODEX_EVIDENCE=1 WORKFLOW_NAME="${WORKFLOW_NAME}" TOOL_KEY="${TOOL_KEY}" bash scripts/ci/owner_approval_guard.sh >/dev/null 2>&1 || true
+
+evidence_file=".codex/evidence/owner_approval.jsonl"
+line=""
+if [ -f "${evidence_file}" ]; then
+  line="$(tail -n1 "${evidence_file}" || true)"
+fi
+
+decision="$(printf '%s' "${line}" | sed -n 's/.*"decision":"\([^"]*\)".*/\1/p')"
+source="$(printf '%s' "${line}" | sed -n 's/.*"source":"\([^"]*\)".*/\1/p')"
+expiry="$(printf '%s' "${line}" | sed -n 's/.*"expiry":"\([^"]*\)".*/\1/p')"
+repo="$(printf '%s' "${line}" | sed -n 's/.*"repo":"\([^"]*\)".*/\1/p')"
+ref="$(printf '%s' "${line}" | sed -n 's/.*"ref":"\([^"]*\)".*/\1/p')"
+actor="$(printf '%s' "${line}" | sed -n 's/.*"actor":"\([^"]*\)".*/\1/p')"
+run_id="$(printf '%s' "${line}" | sed -n 's/.*"run_id":"\([^"]*\)".*/\1/p')"
+attempt="$(printf '%s' "${line}" | sed -n 's/.*"run_attempt":"\([^"]*\)".*/\1/p')"
+
+json="$(printf '{"workflow":"%s","tool_key":"%s","repo":"%s","ref":"%s","actor":"%s","run_id":"%s","attempt":"%s","decision":"%s","source":"%s","expiry":"%s"}' \
+  "${WORKFLOW_NAME}" "${TOOL_KEY}" "${repo}" "${ref}" "${actor}" "${run_id}" "${attempt}" "${decision:-unknown}" "${source:-unknown}" "${expiry:-}")"
+
+echo "${json}"
+
+# Write to step summary when available
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## Owner approval status"
+    echo ""
+    echo "- Workflow: ${WORKFLOW_NAME}"
+    echo "- Tool key: ${TOOL_KEY}"
+    echo "- Repo: ${repo} (${ref})"
+    echo "- Actor: ${actor}"
+    echo "- Decision: ${decision:-unknown}"
+    echo "- Source: ${source:-unknown}"
+    echo "- Expiry: ${expiry:-}"
+    echo ""
+    echo "<details><summary>JSON</summary>"
+    echo ""
+    echo '```json'
+    echo "${json}"
+    echo '```'
+    echo "</details>"
+  } >> "${GITHUB_STEP_SUMMARY}"
+fi

--- a/scripts/ci/push_image.sh
+++ b/scripts/ci/push_image.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# Push a previously built image to a registry (opt-in).
+# Push a previously built image to a registry (e.g., GHCR).
 # Usage: scripts/ci/push_image.sh <ghcr.io/OWNER/REPO:tag> [--dry-run]
 set -euo pipefail
 
 IMAGE="${1:-}"
-DRY_RUN="${2:-}"
+FLAG="${2:-}"
+
 if [ -z "${IMAGE}" ]; then
-  echo "usage: $0 <registry/owner/repo:tag>" >&2
+  echo "usage: $0 <registry/owner/repo:tag> [--dry-run]" >&2
   exit 2
 fi
 
@@ -33,12 +34,10 @@ if [ "${REGISTRY}" = "ghcr.io" ] && [ -n "${GITHUB_ACTOR:-}" ] && [ -n "${GITHUB
   echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 fi
 
-if [ "${DRY_RUN}" = "--dry-run" ]; then
+if [ "${FLAG}" = "--dry-run" ]; then
   echo "[push] Dry-run: would push ${IMAGE}"
   exit 0
 fi
-
-# Ensure docker login done externally when not GHCR or no creds provided
 
 echo "[push] Pushing image (ensure you are logged-in via 'docker login' or CI login action)"
 docker push "${IMAGE}"


### PR DESCRIPTION
This pull request re-enables and significantly enhances the owner-approved Docker CI workflow, making it safer and easier to manage cost-incurring builds and pushes. It introduces new Makefile targets for local owner approval, improves auditability by logging more metadata, and updates documentation to reflect these changes. The workflow now supports flexible approval windows, multi-architecture builds, and better evidence tracking for compliance.

**Owner Approval Workflow Enhancements**
- The previously disabled `.github/_workflows_disabled/docker-build-push.yml` workflow is now enabled as `.github/workflows/docker-build-push.yml`, with expanded support for owner approval gating, flexible approval windows (via repo variables or workflow_dispatch inputs), check-only mode, and multi-arch builds. The workflow logs detailed evidence and ensures all image tags are lowercased for GHCR compatibility. [[1]](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10L1-R77) [[2]](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10L24-R115) [[3]](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10L59-R129) [[4]](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10R141-L108) [[5]](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10L131-R247) [[6]](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10L179-R261)

**Convenience & Local Testing**
- New Makefile targets (`owner-approve-24h`, `owner-approve-clear`, `owner-approve-status`, `owner-approve-extend-24h`) allow local creation, clearing, status checking, and extension of owner approval windows, simplifying local validation and testing.
- Documentation in `docs/docker.md` and a new `docs/validation/Owner_Approved_CI_Validation.md` file describe the new workflow, usage patterns, and troubleshooting. [[1]](diffhunk://#diff-ae5611658dcd443d7a30575bebcdf15a71b7a0f5abebb18b62d00aa0373cae74R87-R88) [[2]](diffhunk://#diff-ae5611658dcd443d7a30575bebcdf15a71b7a0f5abebb18b62d00aa0373cae74L104-R106) [[3]](diffhunk://#diff-7c0293a1fb13ddccc35e34e1785880253e46061758a1a129786a44d1d207e0d1R1-R53)

**Auditability & Evidence Logging**
- The `scripts/ci/owner_approval_guard.sh` script now logs additional CI metadata (workflow, run ID, actor, etc.) in its evidence for better traceability and compliance. [[1]](diffhunk://#diff-27d890110fc3ec30fb01b9461ce97f363a6ff56c71c1129d945ab6db57d96b94R15-R23) [[2]](diffhunk://#diff-27d890110fc3ec30fb01b9461ce97f363a6ff56c71c1129d945ab6db57d96b94L25-R35)
- A new script, `scripts/ci/owner_approval_status.sh`, reports the current owner-approval status for a given tool key, aiding both CI and local workflows.

**General Documentation Updates**
- The `.github/OWNER_APPROVAL.md` file is updated to reflect the new workflow, variables, and usage instructions, clarifying how to enable, check, and extend owner approval for cost-incurring workflows. [[1]](diffhunk://#diff-ddabaf4858e45b20ed965e7e3d30fbe101d39e30611b42920edd0b31c41dceb1L2-R2) [[2]](diffhunk://#diff-ddabaf4858e45b20ed965e7e3d30fbe101d39e30611b42920edd0b31c41dceb1R25-R53)

These changes collectively improve the safety, transparency, and usability of Docker CI workflows that require owner approval, making it easier to manage costs and audit approvals.

------
## Summary
- move the Docker build-and-push workflow into .github/workflows with owner approval inputs, status helpers, and package permissions
- update OWNER_APPROVAL.md with instructions for configuring repo variables, permissions, and overrides
- add a validation guide describing owner-approved Docker CI dispatch scenarios and artifacts

## Testing
- pre-commit (hooks)

------
https://chatgpt.com/codex/tasks/task_e_68f69e190fe88331b87a407791d68a85