### PR TITLE
Add safety controls to Docker build workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,5 +1,13 @@
 name: CI - Build, Smoke Test, and Push Docker (GHCR) — OWNER APPROVED
 
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["main"]
@@ -35,6 +43,7 @@ jobs:
   approval-check:
     name: Owner approval — check-only gate
     runs-on: [self-hosted, linux]
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write
@@ -77,6 +86,7 @@ jobs:
     if: ${{ !(github.event_name == 'workflow_dispatch' && (github.event.inputs.check_only == 'true' || github.event.inputs.check_only == true)) }}
     name: Build image and run smoke test
     runs-on: [self-hosted, linux]
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -129,6 +139,10 @@ jobs:
           file: _codex_/Dockerfile
           load: true
           tags: codex:ci
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -180,6 +194,7 @@ jobs:
     name: Push image to GHCR (on main)
     needs: [build-and-smoke]
     runs-on: [self-hosted, linux]
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -219,6 +234,16 @@ jobs:
           echo "image_sha=${SHA_TAG}" >> "$GITHUB_OUTPUT"
           echo "image_branch=${BRANCH_TAG}" >> "$GITHUB_OUTPUT"
 
+      - name: Compose image labels (OCI)
+        id: oci
+        shell: bash
+        run: |
+          echo 'labels<<EOF' >> "$GITHUB_OUTPUT"
+          echo "org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" >> "$GITHUB_OUTPUT"
+          echo "org.opencontainers.image.revision=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "org.opencontainers.image.ref.name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
       - name: Check OWNER approval window (push)
         working-directory: _codex_
         run: bash scripts/ci/owner_approval_guard.sh
@@ -246,6 +271,7 @@ jobs:
           context: _codex_
           file: _codex_/Dockerfile
           push: true
+          labels: ${{ steps.oci.outputs.labels }}
           tags: |
             ${{ steps.vars.outputs.image_sha }}
             ${{ steps.vars.outputs.image_branch }}
@@ -261,9 +287,21 @@ jobs:
           file: _codex_/Dockerfile
           push: true
           platforms: ${{ env.PUSH_PLATFORMS }}
+          labels: ${{ steps.oci.outputs.labels }}
           tags: |
             ${{ steps.vars.outputs.image_sha }}
             ${{ steps.vars.outputs.image_branch }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false
+
+      - name: Summary — published image tags
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Docker push results"
+            echo
+            echo "- Image (sha): ${{ steps.vars.outputs.image_sha }}"
+            echo "- Image (branch/latest): ${{ steps.vars.outputs.image_branch }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/validation/Owner_Approved_CI_Validation.md
+++ b/docs/validation/Owner_Approved_CI_Validation.md
@@ -1,13 +1,13 @@
 # Owner-Approved CI Validation — Docker Build/Push
-> Generated: 2025-10-20 20:50:36 UTC | Author: mbaetiong
+> Generated: 2025-10-20 21:43:01 UTC | Author: mbaetiong
 
 Goal
-- Validate the OWNER-approved Docker workflow in CI with a 24h window and optional multi-arch.
+- Validate the OWNER-approved Docker workflow in CI with a 24h window and optional multi-arch, with concurrency and timeouts configured for safety.
 
 Pre-checks
-- Actions permissions allow packages: write
-- Runner has Docker Buildx; QEMU will be set up automatically when needed
-- No extra secrets required; GHCR login uses GITHUB_TOKEN
+- Actions permissions allow packages: write (repo settings).
+- Runner has Docker Buildx; QEMU will be set up automatically when needed.
+- No extra secrets required; GHCR login uses GITHUB_TOKEN.
 
 Paths to approval
 1) Repo variables
@@ -19,26 +19,30 @@ Paths to approval
   - approval_duration="24h"
   - approval_until="" (leave empty) OR provide a future ISO8601 Z
   - push_platforms="linux/amd64,linux/arm64" (optional)
-
-3) Check-only (no build or push)
-- Manually dispatch workflow with:
-  - check_only=true
-  - approval_duration="24h" (or approval_until="…Z")
-- Expectation: approval-check job runs and posts the status to the run summary; build and push jobs are skipped.
+  - check_only=true (optional for validation-only run)
 
 Expected results
 - approval-check:
   - Shows approval context and status
   - Passes guard when within window
   - Writes decision to the Job summary and uploads owner_approval.jsonl
-- build-and-smoke job (when not check-only):
+  - Respects timeout-minutes (10m) and benefits from workflow-level permissions and concurrency guard
+- build-and-smoke:
   - Passes guard when within window
-  - Builds and smokes image
-- push job (main only, when not check-only):
+  - Builds and smokes image (local load)
+  - Applies OCI metadata labels (source, revision, ref.name)
+  - Respects timeout-minutes (45m)
+- push (main only):
   - Logs into GHCR with GITHUB_TOKEN
   - Uses lowercase image refs
-  - Honors push_platforms when provided
+  - Applies OCI metadata labels (source, revision, ref.name)
   - Pushes tags sha-<12> and latest/branch
+  - Writes pushed tags to the GitHub Step Summary for auditability
+  - Respects timeout-minutes (45m) and concurrency guard (docker-${{ github.ref }})
+
+Operational safety
+- Concurrency: docker-${{ github.ref }} cancels overlapping runs on the same ref to avoid registry conflicts.
+- Timeouts: approval-check (10m); build-and-smoke (45m); push (45m).
 
 Artifacts
 - owner-approval-evidence-*: .codex/evidence/owner_approval.jsonl (approve/deny decisions)
@@ -47,7 +51,8 @@ Artifacts
 
 Troubleshooting
 - Guard denies with “enabled=false” or “expired”:
-  - For file mode: refresh created_at or set duration accordingly
-  - For env mode: ensure inputs/vars are non-empty and valid
+  - File mode: refresh created_at or adjust duration
+  - Env mode: ensure inputs/vars are set and valid
 - Multi-arch fails: confirm QEMU step executed (push_platforms not empty), and the builder supports emulation
-- GHCR rejects tag: ensure repository path and branch tag are lowercased (the workflow now forces lowercase)
+- GHCR rejects tag: ensure repository path and branch tag are lowercased (workflow enforces lowercase)
+- Step summary missing tags: ensure push job ran (not skipped by check_only or PR event)


### PR DESCRIPTION
## Summary
- add top-level permissions and concurrency guard to the Docker build/push workflow
- introduce job timeouts, OCI label metadata, and publish push results to the step summary
- refresh the validation guide to document the new concurrency, timeout, and summary behavior

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f6b0e14f8c8331b9f096ff16786f73