### PR TITLE
Enhance Docker CI caching and GHCR normalization

### DIFF
--- a/.github/OWNER_APPROVAL.md
+++ b/.github/OWNER_APPROVAL.md
@@ -30,7 +30,9 @@ CI enablement (OWNER APPROVED)
   - Validation only: workflow_dispatch input check_only=true (skips build and push)
 - Multi-arch (optional): repo var or input push_platforms="linux/amd64,linux/arm64"
 - Permissions: Actions “packages: write” must be allowed. GHCR uses the default GITHUB_TOKEN via docker/login-action.
-- GHCR note: image repository and tags are lowercased automatically in CI.
+- Build cache: self-hosted runs restore/persist `/tmp/.buildx-cache` via `actions/cache@v4` keyed on the Dockerfile and lockfiles for faster follow-up builds.
+- GHCR note: image repository and tags are lowercased automatically in CI, and the local `scripts/ci/push_image.sh` helper normalizes `ghcr.io/...` refs as well.
+- Safety: workflows retain per-ref concurrency, explicit job timeouts, and OWNER approval evidence artifacts.
 
 Quick local test
 ```bash

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -127,6 +127,14 @@ jobs:
         if: env.PUSH_PLATFORMS != ''
         uses: docker/setup-qemu-action@v3
 
+      - name: Restore buildx cache (self-hosted)
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-${{ runner.os }}-${{ hashFiles('Dockerfile', 'requirements*.txt', 'requirements.lock', 'uv.lock') }}
+          restore-keys: |
+            buildx-${{ runner.os }}-
+
       - name: Build image (local load for smoke test)
         uses: docker/build-push-action@v6
         with:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -77,6 +77,7 @@ bash scripts/ci/push_image.sh ghcr.io/OWNER/REPO:tag --dry-run
 # After 'docker login ghcr.io' or set GITHUB_TOKEN/GITHUB_ACTOR in CI:
 bash scripts/ci/push_image.sh ghcr.io/OWNER/REPO:tag
 ```
+- GHCR requires lowercase repository/image references. The helper script normalizes `ghcr.io/...` refs before pushing and logs the rewrite.
 Owner approval gate:
 - Push is gated by scripts/ci/owner_approval_guard.sh with TOOL_KEY=docker-build-push.
 - Approval options:
@@ -105,6 +106,10 @@ PLATFORMS=linux/amd64,linux/arm64 BUILDX_FLAGS="--output=type=registry" \
 ```
 - The GitHub Actions workflow (`.github/workflows/docker-build-push.yml`) respects `PUSH_PLATFORMS` to enable
   multi-architecture pushes when an OWNER opts in.
+
+## CI build cache (self-hosted)
+- The Docker workflow restores a persistent local Buildx cache at `/tmp/.buildx-cache` using `actions/cache@v4` when running on self-hosted runners.
+- Cache keys include the Dockerfile and requirements lockfiles to ensure rebuilds occur when inputs change, while restore-keys allow reuse across related revisions.
 
 ## Compose
 For a quick local run after `cp .env.docker.example .env` (or merge with your .env):

--- a/scripts/ci/push_image.sh
+++ b/scripts/ci/push_image.sh
@@ -20,6 +20,18 @@ else
 fi
 
 REGISTRY="$(echo "${IMAGE}" | awk -F/ '{print $1}')"
+
+# Normalize GHCR repository/image refs to lowercase to avoid registry rejections
+if [ "${REGISTRY}" = "ghcr.io" ]; then
+  IMAGE_LC="$(echo "${IMAGE}" | tr '[:upper:]' '[:lower:]')"
+  if [ "${IMAGE}" != "${IMAGE_LC}" ]; then
+    echo "[push] Normalizing GHCR image to lowercase: ${IMAGE} -> ${IMAGE_LC}"
+    IMAGE="${IMAGE_LC}"
+  else
+    echo "[push] GHCR image already lowercase"
+  fi
+fi
+
 echo "[push] Target: ${IMAGE}"
 echo "[push] Registry: ${REGISTRY}"
 


### PR DESCRIPTION
## Summary
- persist the Buildx cache between self-hosted Docker CI runs via actions/cache
- normalize ghcr.io image references to lowercase in the local push helper with clear logging
- document the cache behaviour and GHCR requirements in the operator notes

## Testing
- not run (documentation and CI workflow updates only)

------
https://chatgpt.com/codex/tasks/task_e_68f6b80792988331829421f725ace838