### PR TITLE
Fix runner parsing edge cases

### DIFF
--- a/scripts/runner/actions_runner_ephemeral.sh
+++ b/scripts/runner/actions_runner_ephemeral.sh
@@ -79,6 +79,9 @@ if [[ -z "${REG_TOKEN}" ]]; then
   exit 1
 fi
 
+# Avoid ICU dependency issues on minimal hosts during configuration and runtime
+export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+
 echo "[ephemeral] Configuring runner (ephemeral) for ${RUNNER_URL}"
 if [[ -n "${RUNNER_LABELS}" ]]; then
   ./config.sh --unattended --ephemeral --url "${RUNNER_URL}" --token "${REG_TOKEN}" --labels "${RUNNER_LABELS}"
@@ -96,9 +99,6 @@ if command -v jq >/dev/null 2>&1; then
 else
   log_runner_evidence "runner_ephemeral_start" "{\"url\":\"${RUNNER_URL}\",\"labels\":\"${RUNNER_LABELS}\",\"version\":\"${RUNNER_VERSION}\",\"mode\":\"ephemeral\"}"
 fi
-
-# Avoid ICU dependency issues on minimal hosts
-export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 
 echo "[ephemeral] Starting runner. It will process a single job and exit automatically."
 ./run.sh

--- a/scripts/runner/common.sh
+++ b/scripts/runner/common.sh
@@ -53,13 +53,23 @@ parse_owner_repo() {
       cleaned="${cleaned#github.com/}"
       ;;
     *)
-      # Fall back to stripping common URL prefixes if present.
-      cleaned="${cleaned#https://}"
-      cleaned="${cleaned#http://}"
-      cleaned="${cleaned#ssh://}"
-      cleaned="${cleaned#git://}"
-      cleaned="${cleaned#github.com/}"
-      cleaned="${cleaned#github.com:}"
+      # Fall back to stripping everything before the github.com host if present,
+      # which keeps support for credentialed URLs like https://token@github.com/owner/repo
+      # or git@github.com:owner/repo.
+      local with_host="${cleaned#*github.com/}"
+      if [[ "${with_host}" != "${cleaned}" ]]; then
+        cleaned="${with_host}"
+      else
+        with_host="${cleaned#*github.com:}"
+        if [[ "${with_host}" != "${cleaned}" ]]; then
+          cleaned="${with_host}"
+        else
+          cleaned="${cleaned#https://}"
+          cleaned="${cleaned#http://}"
+          cleaned="${cleaned#ssh://}"
+          cleaned="${cleaned#git://}"
+        fi
+      fi
       ;;
   esac
 
@@ -67,6 +77,12 @@ parse_owner_repo() {
   cleaned="${cleaned#github.com/}"
   cleaned="${cleaned#github.com:}"
   cleaned="${cleaned#/}"
+
+  # Organization URLs from the GitHub UI include an "orgs" prefix. Drop it so the
+  # owner segment resolves to the actual organization name instead of "orgs".
+  if [[ "${cleaned}" == orgs/* ]]; then
+    cleaned="${cleaned#orgs/}"
+  fi
 
   local owner="${cleaned%%/*}"
   local repo=""


### PR DESCRIPTION
## Summary
- update `parse_owner_repo` to handle credentialed URLs and strip the GitHub UI `orgs/` prefix
- export `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT` before runner configuration so setup uses invariant mode

## Testing
- pytest-quick


------
https://chatgpt.com/codex/tasks/task_e_68f7a09c3e1c8331a9bc53afc5a8ec11