### PR TITLE
Re-export legacy evidence helpers

### DIFF
--- a/src/codex/evidence/__init__.py
+++ b/src/codex/evidence/__init__.py
@@ -1,5 +1,31 @@
 """Evidence helpers for Codex operations."""
 
+from __future__ import annotations
+
+import sys
+from importlib import util
+from pathlib import Path
+from types import ModuleType
+
 from .core import evidence_append
 
-__all__ = ["evidence_append"]
+
+def _load_legacy_module() -> ModuleType:
+    module_name = "codex._legacy_evidence"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    legacy_path = Path(__file__).resolve().parent.parent / "evidence.py"
+    spec = util.spec_from_file_location(module_name, legacy_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load legacy evidence module from {legacy_path!s}")
+    module = util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_legacy = _load_legacy_module()
+append_evidence = _legacy.append_evidence
+utc_now = _legacy.utc_now
+
+__all__ = ["evidence_append", "append_evidence", "utc_now"]


### PR DESCRIPTION
## Summary
- load the historical `codex.evidence` module inside the evidence package
- re-export the legacy `append_evidence` and `utc_now` helpers beside the structured `evidence_append`

## Testing
- `pytest -p pytest_cov -p pytest_randomly tests/d365/test_apply_stubs.py` *(fails: coverage fail-under=70 threshold with partial suite)*
- `pytest -p pytest_cov -p pytest_randomly` *(fails: missing optional dependency `hydra.core`)*

------
https://chatgpt.com/codex/tasks/task_e_68f9c0d928488331a432f51dd52bde8f