### PR TITLE
Ensure pytest-cov loads when plugin autoload is disabled

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -26,6 +26,9 @@ make -f codex.mk codex-coverage        # coverage report
 - `nox -s tests` installs the project in editable mode, runs `pytest` with
   `pytest-cov`/`pytest-randomly`, and enforces coverage using
   `.coveragerc` (`fail_under = 80`, `skip_covered = true`).
+- When running with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`, `pytest.ini`
+  preloads `pytest-cov` via `-p pytest_cov` so coverage flags continue to
+  parse correctly without additional CLI arguments.
 - Pass extra flags through to pytest with `nox -s tests -- -k tokenizer`.
 - After the run, `coverage report` re-applies the configured threshold; tighten
   locally via `COVERAGE_MIN=90 nox -s tests` or `coverage report --fail-under=90`.

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ pythonpath =
 testpaths = tests
 python_files = test_*.py
 addopts =
+    -p pytest_cov
     --disable-plugin-autoload
     -q
     --maxfail=1


### PR DESCRIPTION
## Summary
- preload pytest-cov explicitly via `-p pytest_cov` in `pytest.ini` so coverage flags work when plugin autoloading is disabled
- document the deterministic `pytest` invocation now that pytest-cov is loaded through configuration

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68faa6e4520c83318418d105ae19a058