### PR TITLE
Skip docs score specs when audit deps missing

### DIFF
--- a/scripts/space_traversal/audit_runner.py
+++ b/scripts/space_traversal/audit_runner.py
@@ -22,15 +22,7 @@ import re
 import sys
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, List
-
-try:
-    from jinja2 import Environment, FileSystemLoader
-
-    import yaml
-except ImportError:
-    print("Missing dependencies. Install via: pip install pyyaml jinja2", file=sys.stderr)
-    sys.exit(1)
+from typing import TYPE_CHECKING, Any, Callable, Dict, List
 
 # Try scoring utilities
 try:
@@ -57,6 +49,31 @@ try:
     from scripts.space_traversal import dup_similarity  # type: ignore
 except Exception:  # pragma: no cover
     dup_similarity = None  # dynamic import guard
+
+if TYPE_CHECKING:  # pragma: no cover - import-time typing hints only
+    from jinja2 import Environment as _JinjaEnvironment
+    from jinja2 import FileSystemLoader as _JinjaFileSystemLoader
+    import yaml as _YamlModule
+
+
+def _require_yaml():
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - runtime guard
+        raise RuntimeError(
+            "yaml dependency required for audit runner; install pyyaml"
+        ) from exc
+    return yaml
+
+
+def _load_jinja2():
+    try:
+        from jinja2 import Environment, FileSystemLoader  # type: ignore
+    except ImportError as exc:  # pragma: no cover - runtime guard
+        raise RuntimeError(
+            "jinja2 dependency required for audit runner; install jinja2"
+        ) from exc
+    return Environment, FileSystemLoader
 
 # ---------------------------------------------------------------------------
 # Constants & Paths
@@ -137,6 +154,7 @@ def _sha256_file(p: Path) -> str:
 
 
 def load_config() -> dict:
+    yaml = _require_yaml()
     with open(CFG_PATH, "r", encoding="utf-8") as fh:
         return yaml.safe_load(fh)
 
@@ -526,6 +544,7 @@ def stage_s5_gaps(cfg, scored_caps):
 def render_template(cfg, context):
     tpl_path = cfg["output"]["matrix_template"]
     tpl_dir = Path(tpl_path).parent
+    Environment, FileSystemLoader = _load_jinja2()
     env = Environment(
         loader=FileSystemLoader(str(tpl_dir)),
         autoescape=False,

--- a/tests/specs/test_docs_score_synonyms.py
+++ b/tests/specs/test_docs_score_synonyms.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import pytest
+
+pytest.importorskip("jinja2")
+pytest.importorskip("yaml")
+
 # Minimal tests for docs scoring synonyms/variants (offline-safe)
 from scripts.space_traversal.audit_runner import _docs_score, _expand_doc_tokens
 


### PR DESCRIPTION
## Summary
- skip the docs score synonym spec when jinja2 or yaml extras are missing
- lazily import jinja2 and yaml in the audit runner so importing the module no longer exits when the extras are absent

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/specs/test_docs_score_synonyms.py -vv
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q *(fails: ImportError: cannot import name 'functional' from 'torch.nn')*

------
https://chatgpt.com/codex/tasks/task_e_68faaf6308308331940ccc6dd00a4b9d