### PR TITLE
Handle optional Hydra dependency in structured config

### DIFF
--- a/configs/schema.py
+++ b/configs/schema.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Optional
 
-from hydra.core.config_store import ConfigStore
+try:
+    from hydra.core.config_store import ConfigStore
+except ModuleNotFoundError as exc:  # pragma: no cover - depends on optional dependency
+    raise ModuleNotFoundError(
+        "Hydra is required to use the structured configuration schema. "
+        "Install the optional 'hydra-core' dependency to enable this module."
+    ) from exc
 from omegaconf import MISSING
 
 

--- a/tests/configs/test_hydra_structured_config.py
+++ b/tests/configs/test_hydra_structured_config.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import pytest
+
+pytest.importorskip("hydra")
+pytest.importorskip("hydra.core")
+
 from configs.schema import register_schema
 from hydra import compose, initialize
 from hydra.core.global_hydra import GlobalHydra


### PR DESCRIPTION
## Summary
- skip hydra structured config tests when Hydra is unavailable
- raise a descriptive error when loading the structured config schema without hydra-core

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS= pytest tests/configs/test_hydra_structured_config.py -k hydra_structured_config -p no:pytest_cov
- pip install hydra-core
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS= pytest tests/configs/test_hydra_structured_config.py -k hydra_structured_config -p no:pytest_cov
- pip uninstall -y hydra-core omegaconf antlr4-python3-runtime PyYAML

------
https://chatgpt.com/codex/tasks/task_e_68fab40b36708331a7522630eb19daa3