### PR TITLE
docs: record archive policy merge completion

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -39,7 +39,7 @@
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
     }
   ],
-  "generated_at": "2025-10-24T04:32:30Z",
+  "generated_at": "2025-10-24T05:31:39Z",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -145,144 +145,144 @@
     ],
     ".codex/evidence/archive_ops.jsonl": [
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "9adcbabd0741f341f938d2087f41ccfb65bf858d",
         "is_verified": false,
-        "line_number": 1,
-        "type": "Hex High Entropy String"
+        "line_number": 1
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "49ffe0e5ef3d260827fae91e2a2ef0dad9ebcc7f",
         "is_verified": false,
-        "line_number": 2,
-        "type": "Hex High Entropy String"
+        "line_number": 2
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "a096131840cd301f365c80e5ca4aeb23de2eac5a",
         "is_verified": false,
-        "line_number": 3,
-        "type": "Hex High Entropy String"
+        "line_number": 3
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "b315280727171960db23b718fa78a009e25283db",
         "is_verified": false,
-        "line_number": 4,
-        "type": "Hex High Entropy String"
+        "line_number": 4
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "35c0e383e7308f94927d2d7a916f9115c6f69bed",
         "is_verified": false,
-        "line_number": 5,
-        "type": "Hex High Entropy String"
+        "line_number": 5
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "138ac94241782e5fea535299c7cab85dc6dd04bb",
         "is_verified": false,
-        "line_number": 6,
-        "type": "Hex High Entropy String"
+        "line_number": 6
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "c0546cad91c3f8417ffc9c7a3ee6c9699917abd5",
         "is_verified": false,
-        "line_number": 7,
-        "type": "Hex High Entropy String"
+        "line_number": 7
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "ded20d89ac629790b9542b4f33784ce249266cdd",
         "is_verified": false,
-        "line_number": 8,
-        "type": "Hex High Entropy String"
+        "line_number": 8
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "ffec98a7290646e5098ff31c53abf5f9e2c1da62",
         "is_verified": false,
-        "line_number": 9,
-        "type": "Hex High Entropy String"
+        "line_number": 9
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "70abc5cdf33d11734afb10cfee30685a1d65444b",
         "is_verified": false,
-        "line_number": 10,
-        "type": "Hex High Entropy String"
+        "line_number": 10
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "6a3f0e9a8ec545210f34911005c1b07c8e65ae2d",
         "is_verified": false,
-        "line_number": 12,
-        "type": "Hex High Entropy String"
+        "line_number": 12
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "7c52fecc757df55d080b10ac5641b41029ae54a9",
         "is_verified": false,
-        "line_number": 14,
-        "type": "Hex High Entropy String"
+        "line_number": 14
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "762ca44d307d83f099cea790d3bd7082978083ad",
         "is_verified": false,
-        "line_number": 16,
-        "type": "Hex High Entropy String"
+        "line_number": 16
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "07d3a46354b09ef77057d81064f51e03f59a6258",
         "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String"
+        "line_number": 18
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "1fcd8fdefe8fb82428956820906ed4351745e26b",
         "is_verified": false,
-        "line_number": 20,
-        "type": "Hex High Entropy String"
+        "line_number": 20
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "816202d13f88070dba6a3637b8f124178b8ac26c",
         "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String"
+        "line_number": 22
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "7954cd4f45eb1b7a79f0f4c62dd85f5e6efa4d38",
         "is_verified": false,
-        "line_number": 24,
-        "type": "Hex High Entropy String"
+        "line_number": 24
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "f29742096924b47423e4e052f6e8fbcdb1282ca1",
         "is_verified": false,
-        "line_number": 26,
-        "type": "Hex High Entropy String"
+        "line_number": 26
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "0941f0af30d61a91c0ffcae70deb1047cd0168eb",
         "is_verified": false,
-        "line_number": 28,
-        "type": "Hex High Entropy String"
+        "line_number": 28
       },
       {
+        "type": "Hex High Entropy String",
         "filename": ".codex/evidence/archive_ops.jsonl",
         "hashed_secret": "31617a5dfd111eed5fa5c9450cac97e0fa7a9050",
         "is_verified": false,
-        "line_number": 31,
-        "type": "Hex High Entropy String"
+        "line_number": 31
       }
     ],
     ".codex/evidence/provenance/root-cleanup/intoto.jsonl": [


### PR DESCRIPTION
## Summary
- append a merge completion entry to `.codex/evidence/archive_ops.jsonl` for the archive policy consolidation
- refresh `.secrets.baseline` so the archive merge commit hash stays allowlisted for detect-secrets
- publish `merge_summary_archive_policy_20251024.txt` detailing the post-merge validation results

## Testing
- pytest -v --tb=short *(fails: missing pytest_cov plugin in environment)*
- pytest --cov=src/codex --cov-report=term-missing *(fails: missing pytest_cov plugin in environment)*
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ *(fails: missing pytest_cov plugin in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb0ed4b98c83318631ffadcab49912