### PR TITLE
Fix config Makefile nox target path

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -1,5 +1,8 @@
 .PHONY: help setup fmt lint type test cover sast track cli clean sbom
 
+MAKEFILE_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+NOX := nox --noxfile $(MAKEFILE_DIR)noxfile.py
+
 help:
 	@echo "Targets: setup fmt lint type test cover sast track cli clean"
 
@@ -37,10 +40,10 @@ sast:
 	fi
 
 track:
-	nox --noxfile config/noxfile.py -s tracking_smoke
+	$(NOX) -s tracking_smoke
 
 cli:
-	nox --noxfile config/noxfile.py -s cli
+	$(NOX) -s cli
 
 sbom:
 	python ../scripts/sbom_cyclonedx.py --lock ../requirements/lock.txt --lock ../uv.lock --output ../dist/sbom.json


### PR DESCRIPTION
## Summary
- compute the config Makefile directory so helper targets can locate the relocated noxfile
- update the `track` and `cli` recipes to invoke `nox` with the computed `--noxfile` path

## Testing
- not run (Makefile `test` recipe still uses spaces instead of tabs, causing `make` to abort before reaching the updated targets)


------
https://chatgpt.com/codex/tasks/task_e_68fb66ca87948331bd4db01c5934bfc4