### PR TITLE
0 b base 

### DIFF
--- a/codex_task_sequence.py
+++ b/codex_task_sequence.py
@@ -1,0 +1,31 @@
+"""Compatibility shim for the legacy :mod:`codex_task_sequence` module.
+
+This module preserves the historical import path for the task sequence CLI
+after it was relocated to :mod:`cli.task_sequence`. Downstream tools and tests
+that import :mod:`codex_task_sequence` continue to function without change.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+_implementation_module = import_module("cli.task_sequence")
+
+__doc__ = _implementation_module.__doc__
+
+_globals = globals()
+_implementation_attrs = vars(_implementation_module)
+
+for _name, _value in _implementation_attrs.items():
+    if _name.startswith("__") and _name.endswith("__"):
+        continue
+    _globals[_name] = _value
+
+if "__all__" in _implementation_attrs:
+    __all__ = list(_implementation_attrs["__all__"])
+else:
+    __all__ = [name for name in _implementation_attrs if not name.startswith("_")]
+implementation_module = "cli.task_sequence"
+
+# Provide access to the underlying module for advanced callers.
+module = _implementation_module

--- a/reports/phase3_cli_validation.md
+++ b/reports/phase3_cli_validation.md
@@ -1,0 +1,36 @@
+# Phase 3 CLI Consolidation Validation
+
+This log captures validation steps executed on 2025-10-24 21:15:51 UTC.
+
+## Step 1: Packaging Configuration
+- Verified `pyproject.toml` parses via `tomllib`.
+- Confirmed 5 expected console script entry points defined.
+
+## Step 2: CLI Package Discovery
+- Ensured `cli*` pattern included under `[tool.setuptools.packages.find]`.
+
+## Step 3: Entry Point Installation (CPU)
+- Installed project in editable mode with `CODEX_FORCE_CPU=1`.
+- Confirmed editable wheel build succeeded and package reinstalled cleanly.
+
+## Step 4: CLI Entry Points
+- Confirmed availability of `codex-setup`, `codex-patch-runner`, `codex-update-runner`, `codex-workflow`, and `codex-audit-runner` in `PATH`.
+
+## Step 5: Targeted Tests
+- `pytest tests/cli/ -v --tb=short` → **FAILED** due to Typer option declaration error (`AttributeError: 'bool' object has no attribute 'isidentifier'`).
+- `pytest tests/specs/test_audit_explain_cli.py::test_audit_explain_cli_smoke` → **SKIPPED** with warnings (PytestRemovedIn9Warning, pkg_resources deprecation, tokenizer adapter warning).
+
+## Step 6: Distribution Builds
+- `python -m build --sdist` produced `dist/codex_ml-0.0.0.tar.gz`.
+- `python -m build --wheel` produced `dist/codex_ml-0.0.0-py3-none-any.whl`.
+
+## Step 7: Summary Metrics
+- `git log --oneline work..main` failed (missing `main` remote reference in local checkout).
+- `git diff --stat main work` failed for same reason.
+- `pyproject.toml` currently declares 24 `codex-` entry points total.
+- Listing of `cli/` directory captured for audit trail.
+
+## Notes
+- Consider resolving Typer CLI option declaration to fix CLI test suite.
+- Register `pytest` custom marks (e.g., `smoke`) to silence warnings.
+- Replace uses of `pkg_resources` before Setuptools 81 deprecates API.

--- a/tests/test_codex_best_effort.py
+++ b/tests/test_codex_best_effort.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from codex_task_sequence import setup_mlflow_tracking
+from cli.task_sequence import setup_mlflow_tracking
 from configs.base_config import BASE_TRAINING_CONFIG, get_base_training_config
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -68,7 +68,7 @@ def test_setup_mlflow_tracking_dry_run(tmp_path) -> None:
 
 
 def test_setup_mlflow_tracking_file_uri(tmp_path, monkeypatch) -> None:
-    import codex_task_sequence as cts
+    import cli.task_sequence as cts
 
     state = {"uri": ""}
 

--- a/tests/test_codex_sequence_validations.py
+++ b/tests/test_codex_sequence_validations.py
@@ -124,7 +124,7 @@ def test_base_config_module_loads() -> None:
 
 
 def test_mlflow_optional(monkeypatch) -> None:
-    from codex_task_sequence import setup_mlflow_tracking
+    from cli.task_sequence import setup_mlflow_tracking
 
     monkeypatch.setitem(sys.modules, "mlflow", None)
     assert setup_mlflow_tracking(Path("mlruns"), dry_run=True) is False
@@ -133,7 +133,7 @@ def test_mlflow_optional(monkeypatch) -> None:
 def test_setup_mlflow_tracking_enforces_file_uri(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    from codex_task_sequence import setup_mlflow_tracking
+    from cli.task_sequence import setup_mlflow_tracking
 
     recorded: dict[str, str] = {}
 

--- a/tools/post_check_validation.py
+++ b/tools/post_check_validation.py
@@ -86,7 +86,7 @@ def _check_codex_setup_bootstrap() -> CheckReport:
     name = "Iteration 1 – codex_setup bootstrap"
     try:
         with _sys_path():
-            module = import_module("codex_setup")
+            module = import_module("cli.setup")
     except Exception as exc:  # pragma: no cover - import failure reported as failure
         return CheckReport(name=name, passed=False, details=[f"import failed: {exc!r}"])
 
@@ -156,7 +156,7 @@ def _check_task_sequence_seed_and_mlflow() -> CheckReport:
     name = "Iteration 2 – task sequence seed & MLflow"
     try:
         with _sys_path():
-            module = import_module("codex_task_sequence")
+            module = import_module("cli.task_sequence")
     except Exception as exc:  # pragma: no cover - import failure reported as failure
         return CheckReport(name=name, passed=False, details=[f"import failed: {exc!r}"])
 


### PR DESCRIPTION
This pull request focuses on consolidating CLI modules by relocating legacy modules to the `cli` package and providing compatibility shims for downstream consumers. It also updates tests and validation scripts to use the new import paths, and adds a validation log for the CLI consolidation process.

### CLI module consolidation and compatibility

* Added a compatibility shim in `codex_task_sequence.py` that forwards imports to `cli.task_sequence`, preserving the legacy import path for downstream tools and tests.
* Updated imports in tests (`tests/test_codex_best_effort.py`, `tests/test_codex_sequence_validations.py`) and validation scripts (`tools/post_check_validation.py`) to use `cli.task_sequence` and `cli.setup` instead of the legacy modules. [[1]](diffhunk://#diff-04eb87f55416dcde34bbb037d619053102d8654cd04b856c3e26d51592e62accL11-R11) [[2]](diffhunk://#diff-04eb87f55416dcde34bbb037d619053102d8654cd04b856c3e26d51592e62accL71-R71) [[3]](diffhunk://#diff-254e3d7d731eb97c23eb87e7b9433cc9666179ce34256c761253d6d1bce081f0L127-R127) [[4]](diffhunk://#diff-254e3d7d731eb97c23eb87e7b9433cc9666179ce34256c761253d6d1bce081f0L136-R136) [[5]](diffhunk://#diff-ed0fb840a56053c2e167d479f722d7fcc2702b6070d43e52b1ce43c64fc9f4f1L89-R89) [[6]](diffhunk://#diff-ed0fb840a56053c2e167d479f722d7fcc2702b6070d43e52b1ce43c64fc9f4f1L159-R159)

### Validation and documentation

* Added a detailed validation log in `reports/phase3_cli_validation.md` documenting the steps, outcomes, and issues encountered during the CLI consolidation process.