### PR TITLE
Add prompt sanitisation, config validation tools, and plugin entry points

### DIFF
--- a/configs/base/app.yaml
+++ b/configs/base/app.yaml
@@ -41,6 +41,18 @@ pipeline:
 symbolic_pipeline:
   enabled: false
 
+plugins:
+  enable_entry_points: false
+  entry_points:
+    groups:
+      tokenizers: codex_ml.tokenizers
+      models: codex_ml.models
+      datasets: codex_ml.datasets
+      metrics: codex_ml.metrics
+      trainers: codex_ml.trainers
+      reward_models: codex_ml.reward_models
+      rl_agents: codex_ml.rl_agents
+
 trainer:
   lora_r: 0
   lora_alpha: 16

--- a/configs/evaluation/default.yaml
+++ b/configs/evaluation/default.yaml
@@ -1,4 +1,5 @@
 seed: 1234
+sanitize_prompts: true
 dataset:
   loader: jsonl
   path: data/offline/sample.jsonl

--- a/configs/schemas/README.md
+++ b/configs/schemas/README.md
@@ -8,6 +8,8 @@ Structured schema helpers for Codex configurations live here. The package expose
 - `training.schema.yaml` – YAML schema covering core training settings.
 - `data.schema.yaml` – Dataset manifest schema for ingestion utilities.
 - `model.schema.yaml` – Model configuration schema capturing LoRA/precision toggles.
+- `training_profile.schema.json` – JSON schema for the Hydra profile used by `codex_ml.cli.train`.
+- `evaluation.schema.json` – JSON schema for the evaluation CLI defaults.
 
 ## Validating Configurations
 

--- a/configs/schemas/evaluation.schema.json
+++ b/configs/schemas/evaluation.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codexml.dev/schemas/evaluation.schema.json",
+  "title": "CodexEvaluationConfig",
+  "type": "object",
+  "properties": {
+    "seed": {"type": "integer"},
+    "sanitize_prompts": {"type": "boolean"},
+    "dataset": {
+      "type": "object",
+      "required": ["loader", "path"],
+      "properties": {
+        "loader": {"type": "string"},
+        "path": {"type": ["string", "null"]},
+        "params": {"type": "object", "additionalProperties": true}
+      },
+      "additionalProperties": true
+    },
+    "model": {
+      "type": "object",
+      "properties": {
+        "name": {"type": ["string", "null"]},
+        "cfg": {"type": "object", "additionalProperties": true}
+      },
+      "additionalProperties": true
+    },
+    "tokenizer": {
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "cfg": {"type": "object", "additionalProperties": true}
+      },
+      "additionalProperties": true
+    },
+    "metrics": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "output_dir": {"type": "string"},
+    "write_dataset_manifest": {"type": "boolean"},
+    "mlflow": {"type": "object", "additionalProperties": true},
+    "limit": {"type": ["integer", "null"]}
+  },
+  "required": ["dataset", "metrics"],
+  "additionalProperties": true
+}

--- a/configs/schemas/training.schema.yaml
+++ b/configs/schemas/training.schema.yaml
@@ -27,6 +27,8 @@ properties:
         minimum: 1
       deterministic:
         type: boolean
+      sanitize_prompts:
+        type: boolean
       checkpoint:
         type: object
         properties:

--- a/configs/schemas/training_profile.schema.json
+++ b/configs/schemas/training_profile.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://codexml.dev/schemas/training_profile.schema.json",
+  "title": "CodexTrainingProfile",
+  "type": "object",
+  "properties": {
+    "seed": {"type": "integer"},
+    "epochs": {"type": "integer", "minimum": 1},
+    "grad_accum": {"type": "integer", "minimum": 1},
+    "steps_per_epoch": {"type": "integer", "minimum": 1},
+    "device": {"type": ["string", "null"]},
+    "dtype": {"type": ["string", "null"]},
+    "amp": {"type": ["boolean", "string", "null"]},
+    "sanitize_prompts": {"type": "boolean"},
+    "lora": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "enable": {"type": "boolean"},
+        "r": {"type": "integer", "minimum": 1},
+        "alpha": {"type": "integer", "minimum": 0},
+        "dropout": {"type": "number", "minimum": 0.0}
+      },
+      "additionalProperties": true
+    },
+    "checkpoint": {
+      "type": "object",
+      "properties": {
+        "dir": {"type": ["string", "null"]},
+        "resume": {"type": "boolean"},
+        "retention": {"type": "object", "additionalProperties": true}
+      },
+      "additionalProperties": true
+    },
+    "scheduler": {"type": "object", "additionalProperties": true},
+    "reproducibility": {"type": "object", "additionalProperties": true},
+    "telemetry": {"type": "object", "additionalProperties": true},
+    "dataset": {"type": "object", "additionalProperties": true}
+  },
+  "required": ["epochs", "grad_accum", "steps_per_epoch"],
+  "additionalProperties": true
+}

--- a/configs/training/base.yaml
+++ b/configs/training/base.yaml
@@ -7,6 +7,7 @@ training:
   device: cpu
   dtype: float32
   deterministic: true
+  sanitize_prompts: true
   optimizer:
     name: adamw_torch
     weight_decay: 0.01

--- a/configs/training/profiles/default.yaml
+++ b/configs/training/profiles/default.yaml
@@ -8,6 +8,8 @@ device: null
 dtype: null
 amp: false
 
+sanitize_prompts: true
+
 model_name: null
 
 lora:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+- Safety: training and evaluation CLIs honour new `sanitize_prompts` flags and
+  sanitize inline datasets by default.
+- Checkpointing: PEFT/LoRA adapters are bundled alongside standard model
+  weights, enabling seamless resume when `peft` is available.
+- Tooling: `tools/validate_configs.py` validates Hydra configs against JSON/YAML
+  schemas and is wired into the `nox -s gates` session.
+- Tooling: `tools/ndjson_to_csv.py` converts metrics logs to CSV; sample data
+  lives at `samples/metrics_sample.ndjson`.
+- Plugins: opt-in entry-point discovery via `plugins.enable_entry_points` and
+  config-driven group overrides.
+
 ## 2025-10-26
 
 ### Added

--- a/docs/Usage_Guide.md
+++ b/docs/Usage_Guide.md
@@ -31,6 +31,10 @@ trainer) and writes checkpoints plus metrics under
 `artifacts/runs/quickstart/`. Override parameters inline to explore different
 presets without editing YAML.
 
+⚠️ **Prompt safety:** the training profile sanitises embedded datasets by
+default. To inspect raw fixtures set `training.sanitize_prompts=false` on the
+command line.
+
 ## 3. Evaluate a saved checkpoint
 
 ```bash
@@ -44,6 +48,8 @@ python -m codex_ml.cli.evaluate \
 Evaluation reuses the cached tokenizer and dataset defaults recorded in the
 Hydra tree. Append `--log-metrics .codex/metrics/eval.ndjson` to persist a
 machine-readable summary.
+Disable prompt redaction with `sanitize_prompts=false` if you need to inspect
+the untouched dataset.
 
 ## 4. Tokenizer CLI essentials
 
@@ -80,7 +86,32 @@ Hydra resolves the defaults list from the lock-file snapshot, so overrides are
 deterministic. The `--info defaults` flag prints the composed order if you need
 to confirm which config group contributes a value.
 
-## 7. Additional references
+## 7. Enable entry-point plugins
+
+Third-party extensions can be loaded via Python entry points. Opt in by setting
+`plugins.enable_entry_points=true` and overriding the groups as needed:
+
+```bash
+python -m codex_ml.cli.train plugins.enable_entry_points=true \
+  plugins.entry_points.groups.tokenizers=my_project.tokenizers
+```
+
+The loader is defensive—failures to import a plugin are logged and do not abort
+the run.
+
+## 8. Convert NDJSON metrics to CSV
+
+Metrics writers emit newline-delimited JSON files under `artifacts/runs/…`.
+Convert them to CSV with the helper in `tools/`:
+
+```bash
+python tools/ndjson_to_csv.py .codex/metrics/training.ndjson artifacts/runs/metrics.csv
+```
+
+The repository ships a sample log at `samples/metrics_sample.ndjson` for quick
+tests.
+
+## 9. Additional references
 
 - [Quickstart walkthrough](../quickstart.md)
 - [CLI reference](../CLI.md)

--- a/docs/experiments/README.md
+++ b/docs/experiments/README.md
@@ -26,7 +26,16 @@ runs/
 
 All files are valid line-delimited JSON and can be consumed with tools such as
 `jq`, `sqlite-utils`, or the helper script
-[`examples/mlflow_offline.py`](../../examples/mlflow_offline.py).
+[`examples/mlflow_offline.py`](../../examples/mlflow_offline.py).  To export a
+CSV summary, run:
+
+```bash
+python tools/ndjson_to_csv.py runs/20240101-120000-toy-train/metrics.ndjson \
+  runs/20240101-120000-toy-train/metrics.csv
+```
+
+The repository includes `samples/metrics_sample.ndjson` for quick tests of the
+converter.
 
 ## Enabling optional trackers
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -48,6 +48,28 @@ Apply the overrides by passing the YAML string to `sanitize_prompt` (or wiring
 them into the `SafetyConfig` used by training/evaluation tooling). Invalid or
 malicious YAML is ignored and the base policy remains in effect.
 
+### CLI defaults
+
+Training and evaluation entrypoints now invoke the sanitiser automatically. The
+Hydra training profile exposes `training.sanitize_prompts` (default: `true`),
+while the evaluation defaults expose a top-level `sanitize_prompts` flag. When
+enabled, datasets embedded in the config (for example
+`dataset.train_texts` or `dataset.prompts`) are rewritten in-memory with their
+redacted counterparts before the run starts. The sanitisation code is wrapped in
+`try/except` blocks so that environments without the optional `codex_ml.safety`
+module still execute successfully.
+
+Disable sanitisation only when working with trusted fixtures:
+
+```bash
+python -m codex_ml.cli.train training.sanitize_prompts=false
+python -m codex_ml.cli.evaluate sanitize_prompts=false
+```
+
+Doing so preserves raw prompts in the training/evaluation loop, so the run log
+will retain sensitive strings. Always review and scrub generated artifacts
+before sharing them externally.
+
 ## Local secret scanning
 
 Use the lightweight scanner to spot obvious secrets before pushing changes:

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,6 +20,7 @@ _SELECTION_DEFAULT_SAMPLE = Path("samples/assistant_message_summary.sample.json"
 _SCHEMA_VALIDATE = Path("tools/schema_validate.py")
 _SELECTION_SCHEMA = Path("schemas/selection_guard_rules.schema.json")
 _EVALUATOR_SCHEMA = Path("schemas/codex_eval_rules.v3.schema.json")
+_CONFIG_VALIDATOR = Path("tools/validate_configs.py")
 
 
 def _resolve_summary(posargs: Iterable[str]) -> Optional[Path]:
@@ -127,6 +128,10 @@ def gates(session: nox.Session) -> None:
             "3",
             success_codes=[0, 1, 2],
         )
+    if _CONFIG_VALIDATOR.exists():
+        session.run("python", str(_CONFIG_VALIDATOR), "--quiet")
+    else:
+        _log_skip(session, "config schemas", f"missing {_CONFIG_VALIDATOR}")
 
 
 @nox.session

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,6 +14,7 @@ detect-secrets
 pre-commit==4.0.1
 nox==2025.5.1
 yamllint
+jsonschema>=4.21
 shellcheck-py
 pip-audit
 cyclonedx-bom>=4.0.0

--- a/samples/metrics_sample.ndjson
+++ b/samples/metrics_sample.ndjson
@@ -1,0 +1,2 @@
+{"epoch": 1, "loss": 2.5, "accuracy": 0.4}
+{"epoch": 2, "loss": 1.8, "accuracy": 0.55, "notes": "improved"}

--- a/src/codex_ml/cli/evaluate.py
+++ b/src/codex_ml/cli/evaluate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence
@@ -18,6 +19,8 @@ from codex_ml.eval.metrics import accuracy, classification_f1, perplexity, token
 from codex_ml.registry.models import get_model
 from codex_ml.utils.checkpoint import load_checkpoint
 from codex_ml.utils.optional import optional_import
+
+LOGGER = logging.getLogger(__name__)
 
 hydra, _HAS_HYDRA = optional_import("hydra")
 if _HAS_HYDRA:  # pragma: no cover - optional dependency
@@ -46,6 +49,89 @@ METRIC_FUNCS = {
 }
 
 _ = run_cmd
+
+
+def _coerce_sequence(value: Any) -> list[Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    if isinstance(value, str):
+        return [value]
+    return None
+
+
+def _sanitize_prompt_list(items: list[Any]) -> tuple[list[Any], bool]:
+    try:
+        from codex_ml.safety import SafetyConfig, sanitize_prompt
+    except Exception:  # pragma: no cover - optional dependency path
+        return list(items), False
+
+    cfg = SafetyConfig()
+    sanitised: list[Any] = []
+    changed = False
+    for entry in items:
+        if isinstance(entry, str):
+            result = sanitize_prompt(entry, cfg)
+            text = result.get("text", entry)
+            sanitised.append(text)
+            if text != entry:
+                changed = True
+            continue
+        if isinstance(entry, dict):
+            updated = dict(entry)
+            mutated = False
+            for key in ("prompt", "input", "text"):
+                raw = updated.get(key)
+                if isinstance(raw, str):
+                    result = sanitize_prompt(raw, cfg)
+                    text = result.get("text", raw)
+                    if text != raw:
+                        updated[key] = text
+                        mutated = True
+            sanitised.append(updated if mutated else entry)
+            if mutated:
+                changed = True
+            continue
+        sanitised.append(entry)
+    return sanitised, changed
+
+
+def _apply_prompt_sanitization(mapping: Dict[str, Any], keys: Sequence[str]) -> int:
+    total = 0
+    for key in keys:
+        sequence = _coerce_sequence(mapping.get(key))
+        if not sequence:
+            continue
+        sanitised, changed = _sanitize_prompt_list(sequence)
+        if changed:
+            mapping[key] = sanitised
+            total += 1
+    return total
+
+
+def _sanitize_eval_config(cfg_map: Dict[str, Any]) -> int:
+    sanitize_flag = cfg_map.get("sanitize_prompts", True)
+    if not isinstance(sanitize_flag, bool):
+        sanitize_flag = True
+    if not sanitize_flag:
+        LOGGER.debug("Prompt sanitisation disabled for evaluation config")
+        return 0
+
+    total = 0
+    dataset_cfg = cfg_map.get("dataset")
+    if isinstance(dataset_cfg, dict):
+        total += _apply_prompt_sanitization(
+            dataset_cfg,
+            ("texts", "prompts", "samples", "records"),
+        )
+    total += _apply_prompt_sanitization(
+        cfg_map,
+        ("prompts", "inputs", "texts"),
+    )
+    if total:
+        LOGGER.info("Sanitised %d prompt field(s) in evaluation configuration", total)
+    return total
 
 
 def _to_path(value: str | Path | None) -> Path | None:
@@ -165,6 +251,8 @@ if _HAS_HYDRA:
         with capture_exceptions(logger):
             log_event(logger, "cli.start", prog=sys.argv[0], args=arg_list)
             cfg_map = OmegaConf.to_container(cfg, resolve=True)  # type: ignore[union-attr]
+            if isinstance(cfg_map, dict):
+                _sanitize_eval_config(cfg_map)
             checkpoint_dir = (
                 cfg_map.get("checkpoint", {}).get("dir")  # type: ignore[assignment]
                 if isinstance(cfg_map, dict)

--- a/src/codex_ml/cli/train.py
+++ b/src/codex_ml/cli/train.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
 
 import hydra
 from codex_ml.codex_structured_logging import (
@@ -15,11 +16,14 @@ from codex_ml.codex_structured_logging import (
     log_event,
     run_cmd,
 )
+from codex_ml.plugins import load_entry_point_plugins
 from codex_ml.train_loop import run_training
 from hydra.utils import to_absolute_path
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
 _ = (ArgparseJSONParser, run_cmd)
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _to_path(value: str | Path | None) -> Path | None:
@@ -49,13 +53,102 @@ def _cfg_to_list(value: Any) -> list[Any]:
     return [value]
 
 
+def _coerce_sequence(value: Any) -> list[Any] | None:
+    """Return ``value`` as a list when it represents a textual sequence."""
+
+    if value is None:
+        return None
+    if isinstance(value, ListConfig):
+        return list(value)
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    if isinstance(value, str):
+        return [value]
+    return None
+
+
+def _sanitize_prompt_sequence(values: list[Any]) -> tuple[list[Any], bool]:
+    """Sanitise prompt-like entries using the safety module when available."""
+
+    try:
+        from codex_ml.safety import SafetyConfig, sanitize_prompt
+    except Exception:  # pragma: no cover - safety module optional
+        return list(values), False
+
+    cfg = SafetyConfig()
+    sanitised: list[Any] = []
+    changed = False
+    for entry in values:
+        if isinstance(entry, str):
+            result = sanitize_prompt(entry, cfg)
+            text = result.get("text", entry)
+            sanitised.append(text)
+            if text != entry:
+                changed = True
+            continue
+        if isinstance(entry, dict):
+            updated = dict(entry)
+            mutated = False
+            for key in ("prompt", "input", "text"):
+                raw = updated.get(key)
+                if isinstance(raw, str):
+                    result = sanitize_prompt(raw, cfg)
+                    text = result.get("text", raw)
+                    if text != raw:
+                        updated[key] = text
+                        mutated = True
+            sanitised.append(updated if mutated else entry)
+            if mutated:
+                changed = True
+            continue
+        sanitised.append(entry)
+    return sanitised, changed
+
+
+def _apply_prompt_sanitization(
+    config_obj: Any,
+    keys: Sequence[str],
+    *,
+    update_dict: Dict[str, Any] | None = None,
+) -> int:
+    """Sanitise string sequences stored under ``keys`` inside ``config_obj``."""
+
+    if config_obj is None:
+        return 0
+    total = 0
+    for key in keys:
+        try:
+            raw = config_obj.get(key) if hasattr(config_obj, "get") else getattr(config_obj, key)
+        except Exception:
+            raw = None
+        sequence = _coerce_sequence(raw)
+        if sequence is None or not sequence:
+            continue
+        sanitised, changed = _sanitize_prompt_sequence(sequence)
+        if not changed:
+            continue
+        total += 1
+        if update_dict is not None:
+            update_dict[key] = sanitised
+        try:
+            if isinstance(config_obj, DictConfig):
+                config_obj[key] = sanitised
+            elif isinstance(config_obj, dict):
+                config_obj[key] = sanitised
+        except Exception:
+            pass
+    return total
+
+
 def _run_from_cfg(cfg: DictConfig) -> tuple[int, Path | None]:
     artifacts_cfg = _cfg_to_dict(cfg.get("artifacts"))
     art_dir = _to_path(cfg.get("artifacts_dir") or artifacts_cfg.get("dir"))
 
     dataset_cfg = cfg.get("dataset")
+    dataset_cfg_dict: Dict[str, Any] = {}
     dataset_sources_raw = []
     dataset_cache_dir = None
+    dataset_cast_policy = None
     if isinstance(dataset_cfg, (DictConfig, dict)):
         dataset_cfg_dict = _cfg_to_dict(dataset_cfg)
         dataset_sources_raw = _cfg_to_list(dataset_cfg_dict.get("sources"))
@@ -67,6 +160,53 @@ def _run_from_cfg(cfg: DictConfig) -> tuple[int, Path | None]:
         dataset_cast_policy = cfg.get("dataset_cast_policy")
     dataset_sources = [p for p in (_to_path(item) for item in dataset_sources_raw) if p is not None]
     dataset_cache_path = _to_path(dataset_cache_dir)
+
+    sanitize_flag = True
+    raw_flag = cfg.get("sanitize_prompts")
+    if isinstance(raw_flag, bool):
+        sanitize_flag = raw_flag
+    training_section = cfg.get("training")
+    if isinstance(training_section, (DictConfig, dict)):
+        training_dict = _cfg_to_dict(training_section)
+        if "sanitize_prompts" in training_dict:
+            sanitize_flag = bool(training_dict["sanitize_prompts"])
+
+    if sanitize_flag:
+        total_sanitised = 0
+        if dataset_cfg_dict:
+            total_sanitised += _apply_prompt_sanitization(
+                dataset_cfg,
+                ("train_texts", "texts", "val_texts", "eval_texts"),
+                update_dict=dataset_cfg_dict,
+            )
+        total_sanitised += _apply_prompt_sanitization(
+            cfg,
+            ("texts", "train_texts", "val_texts", "eval_texts"),
+        )
+        if total_sanitised:
+            LOGGER.info("Sanitised %d prompt field(s) in training configuration", total_sanitised)
+    else:
+        LOGGER.debug("Prompt sanitisation disabled via configuration")
+
+    plugin_cfg = _cfg_to_dict(cfg.get("plugins"))
+    entry_cfg = _cfg_to_dict(plugin_cfg.get("entry_points"))
+    entry_enable = bool(plugin_cfg.get("enable_entry_points", entry_cfg.get("enable", False)))
+    entry_groups = entry_cfg.get("groups") or plugin_cfg.get("entry_point_groups")
+    groups_spec: dict[str, str] | list[str] | None = None
+    if isinstance(entry_groups, dict):
+        groups_spec = {str(k): str(v) for k, v in entry_groups.items()}
+    elif isinstance(entry_groups, (list, tuple, set)):
+        groups_spec = [str(item) for item in entry_groups]
+    elif isinstance(entry_groups, str):
+        groups_spec = [entry_groups]
+    summary = load_entry_point_plugins(
+        enable=entry_enable,
+        groups=groups_spec,
+        logger=LOGGER,
+    )
+    if entry_enable and any(count for count in summary.values()):
+        loaded_str = ", ".join(f"{name}={count}" for name, count in summary.items())
+        LOGGER.info("Entry-point plugins loaded: %s", loaded_str)
 
     checkpoint_cfg = _cfg_to_dict(cfg.get("checkpoint"))
     checkpoint_dir = _to_path(checkpoint_cfg.get("dir") or checkpoint_cfg.get("path"))

--- a/src/codex_ml/plugins/__init__.py
+++ b/src/codex_ml/plugins/__init__.py
@@ -1,5 +1,11 @@
 """Plugin registry utilities for codex_ml."""
 
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Callable
+
 from .base import BasePlugin, MetricsPlugin, ModelPlugin, TokenizerPlugin
 from .loader import load_plugins
 from .programmatic import PluginRegistry, registry
@@ -20,6 +26,92 @@ from .registries import (
     trainers,
 )
 
+_ENTRY_POINT_LOADERS: dict[str, tuple[Callable[[bool, str], tuple[int, dict[str, str]]], str]]
+_ENTRY_POINT_LOADERS = {
+    "tokenizers": (load_tokenizer_entry_points, "codex_ml.tokenizers"),
+    "models": (load_model_entry_points, "codex_ml.models"),
+    "datasets": (load_dataset_entry_points, "codex_ml.datasets"),
+    "metrics": (load_metric_entry_points, "codex_ml.metrics"),
+    "trainers": (load_trainer_entry_points, "codex_ml.trainers"),
+    "reward_models": (load_reward_model_entry_points, "codex_ml.reward_models"),
+    "rl_agents": (load_rl_agent_entry_points, "codex_ml.rl_agents"),
+}
+
+
+def load_entry_point_plugins(
+    *,
+    enable: bool = False,
+    groups: Mapping[str, str] | Sequence[str] | None = None,
+    logger: logging.Logger | None = None,
+) -> dict[str, int]:
+    """Load plugins registered via Python entry points.
+
+    Parameters
+    ----------
+    enable:
+        When ``False`` the function returns a mapping with zero counts without
+        performing discovery.
+    groups:
+        Optional mapping overriding the default entry-point groups for the
+        built-in registries. Sequence values are interpreted as registry names
+        (e.g. ``["tokenizers", "models"]``) or as raw entry-point groups when
+        they do not match a known registry.
+    logger:
+        Optional logger used to emit warnings when entry points fail to load.
+    """
+
+    resolved: dict[str, str] = {}
+    if groups is None:
+        resolved = {name: default for name, (_, default) in _ENTRY_POINT_LOADERS.items()}
+    elif isinstance(groups, Mapping):
+        resolved = {str(name): str(group) for name, group in groups.items()}
+    else:
+        for item in groups:
+            key = str(item)
+            if key in _ENTRY_POINT_LOADERS:
+                resolved[key] = _ENTRY_POINT_LOADERS[key][1]
+            else:
+                resolved[key] = key
+
+    results: dict[str, int] = {}
+    if not enable:
+        for name in resolved or _ENTRY_POINT_LOADERS.keys():
+            results[name] = 0
+        return results
+
+    for name, (loader_fn, default_group) in _ENTRY_POINT_LOADERS.items():
+        group_name = resolved.get(name, default_group)
+        try:
+            loaded, errors = loader_fn(True, group=group_name)
+        except Exception as exc:  # pragma: no cover - defensive
+            if logger is not None:
+                logger.debug("Failed to load %s entry-point plugins: %s", name, exc)
+            results[name] = 0
+            continue
+        results[name] = int(loaded)
+        if errors and logger is not None:
+            for ep_name, message in errors.items():
+                logger.warning(
+                    "Plugin entry point '%s' (%s) failed to load: %s",
+                    ep_name,
+                    name,
+                    message,
+                )
+
+    for name, group_name in resolved.items():
+        if name in results:
+            continue
+        try:
+            count = load_plugins(group_name)
+        except Exception as exc:  # pragma: no cover - defensive
+            if logger is not None:
+                logger.debug("Generic plugin loader failed for %s: %s", name, exc)
+            results[name] = 0
+            continue
+        results[name] = int(count)
+
+    return results
+
 __all__ = [
     "tokenizers",
     "models",
@@ -35,6 +127,7 @@ __all__ = [
     "load_trainer_entry_points",
     "load_reward_model_entry_points",
     "load_rl_agent_entry_points",
+    "load_entry_point_plugins",
     "load_plugins",
     "BasePlugin",
     "MetricsPlugin",

--- a/src/training/checkpointing.py
+++ b/src/training/checkpointing.py
@@ -18,6 +18,51 @@ except Exception:  # pragma: no cover - gracefully degrade when torch missing
 LOGGER = logging.getLogger(__name__)
 
 
+def _extract_lora_state(model: Any) -> dict[str, Any] | None:
+    """Return a CPU copy of the LoRA/PEFT state when available."""
+
+    if torch is None:
+        return None
+    try:  # pragma: no cover - optional dependency
+        from peft import get_peft_model_state_dict
+    except Exception:
+        return None
+    try:
+        state = get_peft_model_state_dict(model)
+    except Exception as exc:  # pragma: no cover - defensive
+        LOGGER.debug("Unable to capture LoRA state: %s", exc)
+        return None
+    if not isinstance(state, Mapping) or not state:
+        return None
+    cpu_state: dict[str, Any] = {}
+    for key, value in state.items():
+        tensor = value
+        try:
+            if hasattr(tensor, "detach") and hasattr(tensor, "cpu"):
+                tensor = tensor.detach().cpu()
+        except Exception:  # pragma: no cover - optional conversion failures
+            pass
+        cpu_state[str(key)] = tensor
+    return cpu_state if cpu_state else None
+
+
+def _restore_lora_state(model: Any, payload: Mapping[str, Any]) -> None:
+    if torch is None:
+        return
+    lora_state = payload.get("peft_state")
+    if not isinstance(lora_state, Mapping):
+        return
+    try:  # pragma: no cover - optional dependency
+        from peft import set_peft_model_state_dict
+    except Exception:
+        LOGGER.debug("peft not available; skipping LoRA restore")
+        return
+    try:
+        set_peft_model_state_dict(model, dict(lora_state))
+    except Exception as exc:  # pragma: no cover - defensive
+        LOGGER.debug("Failed to restore LoRA weights: %s", exc)
+
+
 def _torch_supports_weights_only() -> bool:
     if torch is None:
         return False
@@ -194,6 +239,9 @@ def save_checkpoint(
         "rng_cpu": rng_state.cpu,
         "rng_cuda_all": rng_state.cuda_all,
     }
+    lora_state = _extract_lora_state(model)
+    if lora_state:
+        payload["peft_state"] = lora_state
     if extra:
         payload.update(extra)
     torch.save(payload, filename)
@@ -226,6 +274,7 @@ def load_checkpoint(
     )
     payload = _torch_load(str(path), map_location=location)
     model.load_state_dict(payload["model_state"], strict=strict)
+    _restore_lora_state(model, payload)
     if optimizer is not None and "optimizer_state" in payload:
         optimizer.load_state_dict(payload["optimizer_state"])
     if restore_rng:

--- a/tests/checkpoint/test_checkpoint_peft_state.py
+++ b/tests/checkpoint/test_checkpoint_peft_state.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+src_dir = Path(__file__).resolve().parents[2] / "src"
+sys.path.insert(0, str(src_dir))
+
+spec = importlib.util.spec_from_file_location(
+    "training.checkpointing", src_dir / "training" / "checkpointing.py"
+)
+assert spec and spec.loader
+checkpointing = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = checkpointing
+spec.loader.exec_module(checkpointing)
+save_checkpoint = checkpointing.save_checkpoint
+load_checkpoint = checkpointing.load_checkpoint
+
+pytest.importorskip("torch")
+pytest.importorskip("peft")
+
+import torch  # noqa: E402  (import after skip checks)
+from peft import LoraConfig, TaskType, get_peft_model, get_peft_model_state_dict  # noqa: E402
+
+
+def _make_model() -> torch.nn.Module:
+    base = torch.nn.Linear(4, 4)
+    cfg = LoraConfig(r=2, lora_alpha=4, lora_dropout=0.0, target_modules=["weight"], task_type=TaskType.FEATURE_EXTRACTION)
+    return get_peft_model(base, cfg)
+
+
+def test_checkpoint_includes_lora_state(tmp_path: Path):
+    model = _make_model()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    state_before = get_peft_model_state_dict(model)
+
+    ckpt_dir = tmp_path / "ckpt"
+    save_checkpoint(
+        model,
+        optimizer,
+        epoch=1,
+        val_metric=0.1,
+        out_dir=ckpt_dir,
+        mode="min",
+    )
+    ckpt_files = list(ckpt_dir.glob("epoch*-metric*.pt"))
+    assert ckpt_files, "checkpoint was not written"
+    payload = torch.load(ckpt_files[0], map_location="cpu")
+    assert "peft_state" in payload
+    assert payload["peft_state"], "peft_state payload should not be empty"
+
+    restored = _make_model()
+    for name, param in restored.named_parameters():
+        if "lora" in name:
+            param.data.zero_()
+    load_checkpoint(ckpt_files[0], restored, optimizer=None, restore_rng=False)
+    state_after = get_peft_model_state_dict(restored)
+    assert set(state_before.keys()) == set(state_after.keys())
+    for key in state_before:
+        assert torch.allclose(state_before[key], state_after[key])

--- a/tests/plugins/test_entry_point_loader_function.py
+++ b/tests/plugins/test_entry_point_loader_function.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from codex_ml import plugins
+
+
+def test_load_entry_point_plugins_disabled_returns_zero():
+    result = plugins.load_entry_point_plugins(enable=False)
+    assert isinstance(result, dict)
+    assert all(count == 0 for count in result.values())
+
+
+def test_load_entry_point_plugins_custom_group(monkeypatch):
+    monkeypatch.setattr(plugins, "load_plugins", lambda group: 7)
+    result = plugins.load_entry_point_plugins(enable=True, groups={"custom": "codex.custom"})
+    assert result["custom"] == 7

--- a/tests/tools/test_ndjson_to_csv.py
+++ b/tests/tools/test_ndjson_to_csv.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+from tools import ndjson_to_csv
+
+
+def test_convert_file(tmp_path):
+    ndjson_path = REPO_ROOT / "samples" / "metrics_sample.ndjson"
+    csv_path = tmp_path / "metrics.csv"
+    count, fields = ndjson_to_csv.convert_file(ndjson_path, csv_path)
+    assert count == 2
+    assert set(fields) >= {"epoch", "loss", "accuracy"}
+    contents = csv_path.read_text(encoding="utf-8")
+    assert "epoch" in contents
+    assert "loss" in contents
+    assert "accuracy" in contents

--- a/tests/tools/test_validate_configs.py
+++ b/tests/tools/test_validate_configs.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+pytest.importorskip("jsonschema")
+
+from tools import validate_configs
+
+
+def test_validate_pair_for_training_profile():
+    config_path = REPO_ROOT / "configs" / "training" / "profiles" / "default.yaml"
+    schema_path = REPO_ROOT / "configs" / "schemas" / "training_profile.schema.json"
+    errors = validate_configs.validate_pair(config_path, schema_path)
+    assert errors == []
+
+
+def test_validate_pair_reports_errors(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text("epochs: 0\n", encoding="utf-8")
+    schema = tmp_path / "schema.json"
+    schema.write_text(
+        json.dumps(
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {"epochs": {"type": "integer", "minimum": 1}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    errors = validate_configs.validate_pair(config, schema)
+    assert errors
+    assert any("minimum" in err for err in errors)

--- a/tests/unit/test_cli_prompt_sanitisation.py
+++ b/tests/unit/test_cli_prompt_sanitisation.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+import pytest
+
+pytest.importorskip("hydra")
+pytest.importorskip("omegaconf")
+
+os.environ.setdefault("CODEX_ALLOW_MISSING_HYDRA_EXTRA", "1")
+
+try:  # pragma: no cover - hydra stub may omit utils
+    import hydra.utils  # type: ignore[attr-defined]
+except ModuleNotFoundError:
+    pytest.skip("Hydra utilities unavailable", allow_module_level=True)
+
+from omegaconf import OmegaConf
+
+from codex_ml.cli.evaluate import _sanitize_eval_config
+from codex_ml.cli.train import _run_from_cfg
+
+
+def _make_base_cfg() -> Dict:
+    return {
+        "epochs": 1,
+        "grad_accum": 1,
+        "steps_per_epoch": 1,
+        "sanitize_prompts": True,
+        "dataset": {"train_texts": ["AKIA1234567890123456"]},
+        "checkpoint": {},
+        "telemetry": {},
+        "optimizer": {},
+        "reproducibility": {},
+        "lora": {},
+        "amp": {},
+    }
+
+
+def test_train_cli_sanitises_dataset(monkeypatch):
+    calls: Dict[str, object] = {}
+
+    def _stub_run_training(**kwargs):
+        calls["called"] = True
+        return {"status": "ok"}
+
+    monkeypatch.setattr("codex_ml.cli.train.run_training", _stub_run_training)
+    cfg = OmegaConf.create(_make_base_cfg())
+    _run_from_cfg(cfg)
+    assert calls.get("called")
+    assert "«REDACTED:SECRET»" in cfg.dataset.train_texts[0]
+
+
+def test_train_cli_respects_disable_flag(monkeypatch):
+    def _stub_run_training(**kwargs):  # pragma: no cover - shared stub
+        return {"status": "ok"}
+
+    monkeypatch.setattr("codex_ml.cli.train.run_training", _stub_run_training)
+    cfg = OmegaConf.create(_make_base_cfg())
+    cfg.sanitize_prompts = False
+    original = cfg.dataset.train_texts[0]
+    _run_from_cfg(cfg)
+    assert cfg.dataset.train_texts[0] == original
+
+
+def test_evaluate_cli_sanitises_config():
+    cfg_map = {
+        "sanitize_prompts": True,
+        "dataset": {"texts": ["sk-test-secret-123"]},
+        "prompts": ["AKIA0000000000000000"],
+    }
+    count = _sanitize_eval_config(cfg_map)
+    assert count >= 1
+    assert "«REDACTED:SECRET»" in cfg_map["dataset"]["texts"][0]
+    assert "«REDACTED:SECRET»" in cfg_map["prompts"][0]
+
+
+def test_evaluate_cli_disable_flag():
+    cfg_map = {
+        "sanitize_prompts": False,
+        "dataset": {"texts": ["sk-test-secret-123"]},
+        "prompts": ["AKIA0000000000000000"],
+    }
+    count = _sanitize_eval_config(cfg_map)
+    assert count == 0
+    assert cfg_map["dataset"]["texts"][0] == "sk-test-secret-123"
+    assert cfg_map["prompts"][0] == "AKIA0000000000000000"

--- a/tools/ndjson_to_csv.py
+++ b/tools/ndjson_to_csv.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Convert newline-delimited JSON metrics logs into CSV format."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Sequence, Tuple
+
+Record = Dict[str, Any]
+
+
+def iter_records(path: Path) -> Iterator[Record]:
+    """Yield parsed JSON objects from ``path`` line-by-line."""
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            yield payload
+
+
+def merge_fieldnames(records: Iterable[Record]) -> List[str]:
+    fields: set[str] = set()
+    for record in records:
+        fields.update(str(key) for key in record.keys())
+    return sorted(fields)
+
+
+def convert_records(records: Sequence[Record]) -> Tuple[List[str], List[Record]]:
+    fieldnames = merge_fieldnames(records)
+    normalised: List[Record] = []
+    for record in records:
+        row = {name: record.get(name, "") for name in fieldnames}
+        normalised.append(row)
+    return fieldnames, normalised
+
+
+def write_csv(fieldnames: Sequence[str], rows: Sequence[Record], dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def convert_file(ndjson_path: Path, csv_path: Path) -> Tuple[int, List[str]]:
+    records = list(iter_records(ndjson_path))
+    if not records:
+        write_csv([], [], csv_path)
+        return 0, []
+    fieldnames, rows = convert_records(records)
+    write_csv(fieldnames, rows, csv_path)
+    return len(rows), fieldnames
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Convert NDJSON metrics logs to CSV")
+    parser.add_argument("ndjson", help="Path to NDJSON metrics log")
+    parser.add_argument("csv", help="Output CSV path")
+    parser.add_argument("--quiet", action="store_true", help="Suppress summary output")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    count, fields = convert_file(Path(args.ndjson), Path(args.csv))
+    if not args.quiet:
+        if count:
+            print(f"Wrote {count} records with fields: {', '.join(fields)}")
+        else:
+            print("No records to convert")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/tools/validate_configs.py
+++ b/tools/validate_configs.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Validate Hydra configuration files against JSON/YAML schemas."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Iterator, List, Tuple
+
+try:  # pragma: no cover - optional dependency guard
+    import yaml
+except Exception:  # pragma: no cover - fallback when PyYAML missing
+    yaml = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency guard
+    from jsonschema import Draft202012Validator, Draft7Validator
+except Exception:  # pragma: no cover
+    Draft202012Validator = None  # type: ignore[assignment]
+    Draft7Validator = None  # type: ignore[assignment]
+
+DEFAULT_TARGETS: Tuple[Tuple[Path, Path], ...] = (
+    (Path("configs/training/base.yaml"), Path("configs/schemas/training.schema.yaml")),
+    (
+        Path("configs/training/profiles/default.yaml"),
+        Path("configs/schemas/training_profile.schema.json"),
+    ),
+    (Path("configs/evaluation/default.yaml"), Path("configs/schemas/evaluation.schema.json")),
+)
+
+
+def _load_yaml(path: Path) -> Any:
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to load configuration files")
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _load_schema(path: Path) -> Any:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        if yaml is None:
+            raise RuntimeError("PyYAML is required to load YAML schemas")
+        return yaml.safe_load(text)
+    return json.loads(text)
+
+
+def _iter_errors(instance: Any, schema: Any) -> Iterator[str]:
+    if Draft202012Validator is not None:
+        validator = Draft202012Validator(schema)
+    elif Draft7Validator is not None:
+        validator = Draft7Validator(schema)
+    else:
+        raise RuntimeError("jsonschema is required to validate configurations")
+    for error in validator.iter_errors(instance):
+        path = "/".join(str(elem) for elem in error.path)
+        location = path or "<root>"
+        yield f"{location}: {error.message}"
+
+
+def validate_pair(config_path: Path, schema_path: Path) -> List[str]:
+    try:
+        instance = _load_yaml(config_path)
+    except Exception as exc:
+        return [f"failed to load config: {exc}"]
+    try:
+        schema = _load_schema(schema_path)
+    except Exception as exc:
+        return [f"failed to load schema: {exc}"]
+    return list(_iter_errors(instance, schema))
+
+
+def _resolve_targets(args: argparse.Namespace) -> Iterable[Tuple[Path, Path]]:
+    if args.config and args.schema:
+        return ((Path(args.config), Path(args.schema)),)
+    if args.config or args.schema:
+        raise SystemExit("--config and --schema must be provided together")
+    return DEFAULT_TARGETS
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate Codex configuration files")
+    parser.add_argument("--config", help="Path to config file", default=None)
+    parser.add_argument("--schema", help="Path to schema file", default=None)
+    parser.add_argument("--quiet", action="store_true", help="Suppress OK messages")
+    parsed = parser.parse_args(list(argv) if argv is not None else None)
+
+    exit_code = 0
+    for config_path, schema_path in _resolve_targets(parsed):
+        if not config_path.exists():
+            print(f"skip: {config_path} (missing)")
+            continue
+        if not schema_path.exists():
+            print(f"skip: {schema_path} (missing)")
+            continue
+        errors = validate_pair(config_path, schema_path)
+        if errors:
+            exit_code = 1
+            print(f"FAIL {config_path} -> {schema_path}")
+            for error in errors:
+                print(f"  - {error}")
+        elif not parsed.quiet:
+            print(f"OK   {config_path}")
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- integrate prompt sanitisation flags into the training and evaluation CLIs and wire optional entry-point plugin loading
- persist LoRA/PEFT weights in checkpoints and extend documentation plus configs for the new safety and plugin settings
- add configuration validation and NDJSON-to-CSV tooling alongside focused unit tests and sample data

## Testing
- PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_cli_prompt_sanitisation.py tests/checkpoint/test_checkpoint_peft_state.py tests/tools/test_ndjson_to_csv.py tests/tools/test_validate_configs.py tests/plugins/test_entry_point_loader_function.py

------
https://chatgpt.com/codex/tasks/task_e_68fe821a94b08331bd8c5fb81278352f