### PR TITLE
Fix continual replay overrides to avoid mutating base config

### DIFF
--- a/src/codex_ml/training/strategies.py
+++ b/src/codex_ml/training/strategies.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable as IterableABC
 from contextlib import suppress
+from copy import deepcopy
 from dataclasses import dataclass, replace
 from importlib import import_module
 from pathlib import Path
@@ -290,7 +291,8 @@ class ContinualReplayStrategy:
         for index, phase in enumerate(schedule):
             phase_name = phase.get("name") or f"phase-{index}"
             epochs = int(phase.get("epochs", getattr(config, "epochs", 1)))
-            overrides = dict(getattr(config, "extra", {}) or {})
+            base_extra = getattr(config, "extra", {}) or {}
+            overrides = deepcopy(base_extra) if isinstance(base_extra, dict) else {}
             phase_overrides_src = phase.get("overrides", {})
             if isinstance(phase_overrides_src, dict):
                 phase_overrides = dict(phase_overrides_src)


### PR DESCRIPTION
## Summary
- deep copy the extra configuration in `ContinualReplayStrategy` before applying per-phase overrides to prevent base config mutation
- import `deepcopy` for use when cloning the extra configuration

## Testing
- pytest tests/test_training_continual_strategy.py -k continual_replay --maxfail=1 *(fails: ValueError message does not include the expected "continual schedule" substring in existing error text)*

------
https://chatgpt.com/codex/tasks/task_e_68fec3039b1c833180ece3401daf05a5