### PR TITLE
Fix missing dataclass helpers import

### DIFF
--- a/src/codex_ml/training/strategies.py
+++ b/src/codex_ml/training/strategies.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from collections.abc import Iterable as IterableABC
 from contextlib import suppress
 from copy import deepcopy
-from dataclasses import dataclass, replace
+from dataclasses import asdict, dataclass, is_dataclass, replace
 from importlib import import_module
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Protocol


### PR DESCRIPTION
## Summary
- import `asdict` and `is_dataclass` in `ContinualReplayStrategy` module so continual schedules using dataclasses work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fed13cd644833189210f8c195d3335