### PR TITLE
Fix curriculum preset lookup path

### DIFF
--- a/src/codex_ml/cli/main.py
+++ b/src/codex_ml/cli/main.py
@@ -132,7 +132,7 @@ if typer is not None:
                     "PyYAML is required to load curriculum presets; install with `pip install pyyaml`."
                 )
             preset_path = (
-                Path(__file__).resolve().parents[2]
+                Path(__file__).resolve().parents[3]
                 / "configs"
                 / "training"
                 / "continual"


### PR DESCRIPTION
## Summary
- correct the continual curriculum preset loader to resolve from the repository root configs directory

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690132d7490483318330b44f10fcb42e