### PR TITLE
Fix default LoRA enablement in model registry

### DIFF
--- a/src/codex_ml/model_registry.py
+++ b/src/codex_ml/model_registry.py
@@ -196,7 +196,7 @@ def _extract_lora_request(config: Mapping[str, Any] | None) -> LoraRequest | Non
             break
 
     if candidate is not None:
-        enabled = _to_bool(candidate.get("enable"), True)
+        enabled = _to_bool(candidate.get("enable"), False)
         enabled = _to_bool(candidate.get("enabled"), enabled)
         enabled = _to_bool(candidate.get("use"), enabled)
         if not enabled:


### PR DESCRIPTION
## Summary
- ensure `_extract_lora_request` defaults LoRA enable flag to false
- preserve previous behaviour where adapters are only applied when explicitly enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904c9ada0b08331aec1e797178a4a3d