### PR TITLE
Fix tenant context ordering and persist tenant admin updates

### DIFF
--- a/services/msp_gateway/app.py
+++ b/services/msp_gateway/app.py
@@ -55,8 +55,11 @@ def create_app() -> FastAPI:
     )
     
     # Add custom middleware
-    app.add_middleware(RateLimitMiddleware)
+    # Starlette executes middleware in reverse order of registration, so we
+    # register the tenant context middleware first to ensure the rate limiter
+    # runs after the tenant has been attached to the request state.
     app.add_middleware(TenantContextMiddleware)
+    app.add_middleware(RateLimitMiddleware)
     
     # Include routers
     app.include_router(kb_router)

--- a/services/msp_gateway/middleware/tenant_context.py
+++ b/services/msp_gateway/middleware/tenant_context.py
@@ -230,8 +230,103 @@ class TenantRegistry:
                     "updated_at": row[8],
                 })
             return tenants
-        
+
         return list(self.tenants.values())
+
+    def update_tenant(
+        self,
+        tenant_id: str,
+        *,
+        name: Optional[str] = None,
+        quota: Optional[Dict[str, int]] = None,
+        policies: Optional[list] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        active: Optional[bool] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Update an existing tenant and persist changes"""
+
+        tenant = self.get_tenant(tenant_id)
+        if not tenant:
+            return None
+
+        updated_fields: Dict[str, Any] = {}
+        if name is not None:
+            updated_fields["name"] = name
+        if quota is not None:
+            updated_fields["quota"] = quota
+        if policies is not None:
+            updated_fields["policies"] = policies
+        if metadata is not None:
+            updated_fields["metadata"] = metadata
+        if active is not None:
+            updated_fields["active"] = bool(active)
+
+        now = datetime.utcnow().isoformat()
+
+        if self.backend == "sqlite":
+            import json
+
+            conn = sqlite3.connect(settings.db_path)
+            cursor = conn.cursor()
+
+            set_clauses = []
+            params: list[Any] = []
+
+            if "name" in updated_fields:
+                set_clauses.append("name = ?")
+                params.append(updated_fields["name"])
+            if "quota" in updated_fields:
+                set_clauses.append("quota_json = ?")
+                params.append(json.dumps(updated_fields["quota"]))
+            if "policies" in updated_fields:
+                set_clauses.append("policies_json = ?")
+                params.append(json.dumps(updated_fields["policies"]))
+            if "metadata" in updated_fields:
+                set_clauses.append("metadata_json = ?")
+                params.append(json.dumps(updated_fields["metadata"]))
+            if "active" in updated_fields:
+                set_clauses.append("active = ?")
+                params.append(1 if updated_fields["active"] else 0)
+
+            set_clauses.append("updated_at = ?")
+            params.append(now)
+            params.append(tenant_id)
+
+            try:
+                cursor.execute(
+                    f"UPDATE tenants SET {', '.join(set_clauses)} WHERE tenant_id = ?",
+                    params,
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        # Update in-memory cache
+        for field, value in updated_fields.items():
+            tenant[field] = value
+        tenant["updated_at"] = now
+        self.tenants[tenant_id] = tenant
+
+        # Update API key registry based on tenant status
+        if "active" in updated_fields:
+            if updated_fields["active"]:
+                auth_manager.register_api_key(tenant["api_key"], tenant_id)
+            else:
+                auth_manager.revoke_api_key(tenant["api_key"])
+
+        logger.info(
+            "Tenant %s updated with fields: %s",
+            tenant_id,
+            ", ".join(updated_fields.keys()) if updated_fields else "updated_at",
+        )
+
+        return tenant
+
+    def deactivate_tenant(self, tenant_id: str) -> bool:
+        """Deactivate a tenant and revoke credentials"""
+
+        updated = self.update_tenant(tenant_id, active=False)
+        return updated is not None
 
 
 # Global tenant registry

--- a/services/msp_gateway/routers/admin.py
+++ b/services/msp_gateway/routers/admin.py
@@ -6,7 +6,7 @@ Admin operations for tenant management and system configuration
 import logging
 from typing import List
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Response, status
 
 from ..schemas.requests import TenantCreateRequest, TenantUpdateRequest
 from ..schemas.responses import TenantResponse
@@ -156,41 +156,36 @@ async def update_tenant(tenant_id: str, update_request: TenantUpdateRequest):
             detail="Admin API is disabled"
         )
     
-    # Get existing tenant
-    tenant_data = tenant_registry.get_tenant(tenant_id)
-    if not tenant_data:
+    updated_tenant = tenant_registry.update_tenant(
+        tenant_id,
+        name=update_request.name,
+        quota=update_request.quota,
+        policies=update_request.policies,
+        metadata=update_request.metadata,
+        active=update_request.active,
+    )
+
+    if not updated_tenant:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Tenant not found: {tenant_id}"
         )
-    
-    # Update tenant data (simple in-memory update for now)
-    # In production, this would update the database
-    if update_request.name is not None:
-        tenant_data["name"] = update_request.name
-    if update_request.quota is not None:
-        tenant_data["quota"] = update_request.quota
-    if update_request.policies is not None:
-        tenant_data["policies"] = update_request.policies
-    if update_request.metadata is not None:
-        tenant_data["metadata"] = update_request.metadata
-    if update_request.active is not None:
-        tenant_data["active"] = update_request.active
-    
-    from datetime import datetime
-    tenant_data["updated_at"] = datetime.utcnow().isoformat()
-    
-    logger.info(f"Tenant updated: {tenant_id}")
-    
+
+    logger.info(
+        "Tenant updated: %s (fields: %s)",
+        tenant_id,
+        ", ".join(update_request.model_dump(exclude_none=True).keys()) or "updated_at",
+    )
+
     return TenantResponse(
-        tenant_id=tenant_data["tenant_id"],
-        name=tenant_data["name"],
-        quota=tenant_data["quota"],
-        policies=tenant_data["policies"],
-        active=tenant_data["active"],
-        created_at=tenant_data["created_at"],
-        updated_at=tenant_data["updated_at"],
-        metadata=tenant_data["metadata"],
+        tenant_id=updated_tenant["tenant_id"],
+        name=updated_tenant["name"],
+        quota=updated_tenant["quota"],
+        policies=updated_tenant["policies"],
+        active=updated_tenant["active"],
+        created_at=updated_tenant["created_at"],
+        updated_at=updated_tenant["updated_at"],
+        metadata=updated_tenant["metadata"],
     )
 
 
@@ -207,15 +202,11 @@ async def delete_tenant(tenant_id: str):
             detail="Admin API is disabled"
         )
     
-    tenant_data = tenant_registry.get_tenant(tenant_id)
-    if not tenant_data:
+    if not tenant_registry.deactivate_tenant(tenant_id):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Tenant not found: {tenant_id}"
         )
-    
-    # Deactivate tenant (soft delete)
-    tenant_data["active"] = False
-    
+
     logger.info(f"Tenant deactivated: {tenant_id}")
-    return None
+    return Response(status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Summary
- ensure the tenant context middleware is registered ahead of the rate limiter so quotas see resolved tenants
- persist tenant updates and deactivations through the tenant registry, including API key revocation/reactivation
- update the admin router to use the new registry helpers and return the appropriate HTTP responses

## Testing
- pytest services/msp_gateway -q

------
https://chatgpt.com/codex/tasks/task_e_69057df57d4c8331916acb87b0a21c33