### PR TITLE
Fix token quota bypass in rate limiting middleware (follow-up)

### DIFF
--- a/services/msp_gateway/middleware/rate_limit.py
+++ b/services/msp_gateway/middleware/rate_limit.py
@@ -222,6 +222,24 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 requested_tokens = self._extract_requested_tokens(body_bytes)
                 # Ensure downstream handlers can re-read the body
                 request._body = body_bytes
+                body_consumed = False
+
+                async def receive_with_body():
+                    nonlocal body_consumed
+                    if not body_consumed:
+                        body_consumed = True
+                        return {
+                            "type": "http.request",
+                            "body": body_bytes,
+                            "more_body": False,
+                        }
+                    return {
+                        "type": "http.request",
+                        "body": b"",
+                        "more_body": False,
+                    }
+
+                request._receive = receive_with_body
 
             available_tokens = token_bucket.available_tokens()
 


### PR DESCRIPTION
## Summary
- wrap the cached inference request body in a custom receive coroutine so BaseHTTPMiddleware forwards it downstream intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69059ae155948331a0fc09ffa0bc2db2