### PR TITLE
Restore positional argument support in train_val_test_split shim

### DIFF
--- a/src/codex_ml/data/splits.py
+++ b/src/codex_ml/data/splits.py
@@ -64,10 +64,22 @@ class SplitDistribution(dict):
         return {split: self[split] / total for split in SPLITS}
 
 
-def train_val_test_split(*args, **kwargs):
+def train_val_test_split(
+    dataset,
+    val_frac: float = 0.1,
+    test_frac: float = 0.1,
+    seed: int = 0,
+    **kwargs,
+):
     """Backward-compatible shim for legacy callers."""
 
-    return _train_val_test_split(*args, **kwargs)
+    return _train_val_test_split(
+        dataset,
+        val_frac=val_frac,
+        test_frac=test_frac,
+        seed=seed,
+        **kwargs,
+    )
 
 
 __docformat__ = "restructuredtext"


### PR DESCRIPTION
## Summary
- restore the shim signature to accept the legacy positional val/test fractions and seed arguments
- forward the positional parameters to the underlying `codex_ml.data.split.train_val_test_split` as keywords to preserve compatibility

## Testing
- python - <<'PY'
from codex_ml.data.splits import train_val_test_split

dataset = list(range(10))
train, val, test = train_val_test_split(dataset, 0.2, 0.1, 42)
print(len(train), len(val), len(test))
PY


------
https://chatgpt.com/codex/tasks/task_e_69072ce826fc833186ded71004374a79