### PR TITLE
Add rate limit reporting scripts and coverage tests

### DIFF
--- a/.github/workflows/ratelimit_history_prune.yml
+++ b/.github/workflows/ratelimit_history_prune.yml
@@ -1,0 +1,18 @@
+name: Rate-Limit History Prune
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 1 * *" # Monthly at 05:00 UTC
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prune history (keep 90 days)
+        run: |
+          python scripts/connectors/prune_rate_limit_history.py --days 90
+      - name: Upload post-prune listing
+        run: |
+          ls -la connectors/history || true

--- a/docs/deepresearch/manifest_validation.md
+++ b/docs/deepresearch/manifest_validation.md
@@ -1,0 +1,11 @@
+# DeepResearch: Manifest Validation
+> Generated: 2025-11-02 16:45:24 UTC | Author: mbaetiong  
+🧠 Roles: [Primary: Research Integrator], [Secondary: Reviewer] ⚡ Energy: 5
+
+Checks
+- docs/deepresearch/apis contains OpenAPI files (yaml/json)
+- deepresearch/context_manifest.json includes: generated_utc, apis_dir, apis[]
+
+Commands
+- python scripts/deepresearch/generate_context_manifest.py
+- cat deepresearch/context_manifest.json

--- a/docs/ops/ratelimit_tile_html.md
+++ b/docs/ops/ratelimit_tile_html.md
@@ -1,0 +1,16 @@
+# Ops: HTML Renderer for Rate-Limit Tile
+> Generated: 2025-11-02 16:45:24 UTC | Author: mbaetiong  
+🧠 Roles: [Primary: Publisher], [Secondary: Integration Lead] ⚡ Energy: 5
+
+Purpose
+- Render reports/tiles/ratelimit_tile.json into a simple, dependency-free HTML (inline SVG) for sharing.
+
+Commands
+- Build tile JSON:
+  - python scripts/dashboards/build_ratelimit_tile.py
+- Render HTML:
+  - python scripts/dashboards/render_ratelimit_tile_html.py --tile reports/tiles/ratelimit_tile.json --out reports/tiles/ratelimit_tile.html
+
+Notes
+- Uses inline SVG lines + points for core/search/graphql series.
+- Summaries are displayed in a table (min/avg/max).

--- a/scripts/connectors/__init__.py
+++ b/scripts/connectors/__init__.py
@@ -1,0 +1,3 @@
+"""Connector maintenance scripts."""
+
+__all__ = []

--- a/scripts/connectors/prune_rate_limit_history.py
+++ b/scripts/connectors/prune_rate_limit_history.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List
+
+
+def parse_ts_from_name(path: Path) -> datetime | None:
+    try:
+        ts_part = path.stem.split("_", 1)[1]
+        dt = datetime.strptime(ts_part, "%Y%m%dT%H%M%SZ")
+        return dt.replace(tzinfo=timezone.utc)
+    except Exception:
+        return None
+
+
+def prune_older_than(directory: Path, keep_days: int) -> List[str]:
+    cutoff = datetime.now(timezone.utc) - timedelta(days=keep_days)
+    removed: List[str] = []
+    for path in sorted(directory.glob("ratelimit_*.json")):
+        ts = parse_ts_from_name(path)
+        if ts and ts < cutoff:
+            path.unlink(missing_ok=True)
+            removed.append(path.name)
+    return removed
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Prune rate-limit history JSON files older than the configured window"
+    )
+    parser.add_argument("--root", default="connectors/history")
+    parser.add_argument("--days", type=int, default=90)
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+    if not root.exists():
+        print("[OK] Nothing to prune")
+        return 0
+
+    removed = prune_older_than(root, args.days)
+    print(f"[OK] Pruned {len(removed)} file(s) older than {args.days} days")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/scripts/dashboards/__init__.py
+++ b/scripts/dashboards/__init__.py
@@ -1,0 +1,3 @@
+"""Dashboard utilities and scripts."""
+
+__all__ = []

--- a/scripts/dashboards/build_ratelimit_tile.py
+++ b/scripts/dashboards/build_ratelimit_tile.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import mean
+from typing import Dict, List, Sequence, Tuple
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+@dataclass
+class RateLimitEntry:
+    captured: datetime
+    resources: Dict[str, Dict[str, int]]
+
+    def as_series_point(self, key: str) -> Tuple[str, int] | None:
+        resource = self.resources.get(key) or {}
+        remaining = resource.get("remaining")
+        if remaining is None:
+            return None
+        value = int(remaining)
+        return (self.captured.strftime(ISO_FORMAT), value)
+
+
+def parse_timestamp(raw: str | None) -> datetime | None:
+    if not raw:
+        return None
+    raw = raw.strip()
+    try:
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def load_history(directory: Path) -> List[RateLimitEntry]:
+    entries: List[RateLimitEntry] = []
+    if not directory.exists():
+        return entries
+    for path in sorted(directory.glob("ratelimit_*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        captured = parse_timestamp(payload.get("captured_utc"))
+        if not captured:
+            continue
+        resources = (
+            payload.get("data", {})
+            .get("resources", {})
+        )
+        entries.append(RateLimitEntry(captured=captured, resources=resources))
+    entries.sort(key=lambda entry: entry.captured)
+    return entries
+
+
+def build_series(entries: Sequence[RateLimitEntry], key: str) -> List[Tuple[str, int]]:
+    points: List[Tuple[str, int]] = []
+    for entry in entries:
+        point = entry.as_series_point(key)
+        if point is not None:
+            points.append(point)
+    return points
+
+
+def summarize(series: Sequence[Tuple[str, int]]) -> Dict[str, float]:
+    if not series:
+        return {"min": 0, "avg": 0, "max": 0}
+    values = [value for _, value in series]
+    return {
+        "min": min(values),
+        "avg": round(mean(values), 2),
+        "max": max(values),
+    }
+
+
+def build_tile(entries: Sequence[RateLimitEntry]) -> Dict[str, object]:
+    core = build_series(entries, "core")
+    search = build_series(entries, "search")
+    graphql = build_series(entries, "graphql")
+    summary = {
+        "core": summarize(core),
+        "search": summarize(search),
+        "graphql": summarize(graphql),
+    }
+    return {
+        "title": "Rate-Limit (7d)",
+        "series": {
+            "core": core,
+            "search": search,
+            "graphql": graphql,
+        },
+        "summary": summary,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a rate-limit tile JSON document from historical captures"
+    )
+    parser.add_argument(
+        "--history",
+        default="connectors/history",
+        help="Directory containing ratelimit_*.json captures",
+    )
+    parser.add_argument(
+        "--out",
+        default="reports/tiles/ratelimit_tile.json",
+        help="Destination JSON file for the tile",
+    )
+    args = parser.parse_args(argv)
+
+    history_dir = Path(args.history)
+    entries = load_history(history_dir)
+    tile = build_tile(entries)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(tile, indent=2), encoding="utf-8")
+    print(f"[OK] Wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/scripts/dashboards/render_ratelimit_tile_html.py
+++ b/scripts/dashboards/render_ratelimit_tile_html.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+from typing import List, Tuple
+
+
+def load_tile(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def scale_points(series: List[Tuple[str, int]], width: int, height: int, pad: int = 20) -> List[Tuple[float, float]]:
+    if not series:
+        return []
+    xs = list(range(len(series)))
+    ys = [value for _, value in series]
+    min_y, max_y = (min(ys), max(ys)) if ys else (0, 1)
+    if max_y == min_y:
+        max_y = min_y + 1
+    sx = (width - 2 * pad) / max(1, (len(xs) - 1))
+
+    def norm_y(value: float) -> float:
+        return pad + (height - 2 * pad) * (1 - (value - min_y) / (max_y - min_y))
+
+    return [(pad + index * sx, norm_y(value)) for index, value in enumerate(ys)]
+
+
+def to_polyline(points: List[Tuple[float, float]], color: str) -> str:
+    if not points:
+        return ""
+    pts = " ".join(f"{x:.1f},{y:.1f}" for x, y in points)
+    return f'<polyline fill="none" stroke="{color}" stroke-width="2" points="{pts}"/>'
+
+
+def to_circles(points: List[Tuple[float, float]], color: str) -> str:
+    return "\n".join(f'<circle cx="{x:.1f}" cy="{y:.1f}" r="2" fill="{color}"/>' for x, y in points)
+
+
+def render_html(tile: dict, width: int = 800, height: int = 240) -> str:
+    title = html.escape(str(tile.get("title", "Rate-Limit (7d)")))
+    series = tile.get("series", {})
+    core = series.get("core", [])
+    search = series.get("search", [])
+    graphql = series.get("graphql", [])
+
+    core_pts = scale_points(core, width, height)
+    search_pts = scale_points(search, width, height)
+    graphql_pts = scale_points(graphql, width, height)
+
+    svg_parts = [
+        f'<svg width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-label="{title}">',
+        '<rect x="0" y="0" width="100%" height="100%" fill="#ffffff" />',
+        to_polyline(core_pts, "#2563eb"),
+        to_circles(core_pts, "#2563eb"),
+        to_polyline(search_pts, "#65a30d"),
+        to_circles(search_pts, "#65a30d"),
+        to_polyline(graphql_pts, "#dc2626"),
+        to_circles(graphql_pts, "#dc2626"),
+        "</svg>",
+    ]
+    svg = "\n".join(filter(None, svg_parts))
+
+    summaries = tile.get("summary", {})
+
+    def summary_row(name: str, key: str, color: str) -> str:
+        summary = summaries.get(key, {"min": 0, "max": 0, "avg": 0})
+        return (
+            "<tr>"
+            f"<td><span style='color:{color};font-weight:600'>{name}</span></td>"
+            f"<td>{summary.get('min', 0)}</td>"
+            f"<td>{summary.get('avg', 0)}</td>"
+            f"<td>{summary.get('max', 0)}</td>"
+            "</tr>"
+        )
+
+    table = "\n".join(
+        [
+            "<table>",
+            "<thead><tr><th>Resource</th><th>Min</th><th>Avg</th><th>Max</th></tr></thead>",
+            "<tbody>",
+            summary_row("core", "core", "#2563eb"),
+            summary_row("search", "search", "#65a30d"),
+            summary_row("graphql", "graphql", "#dc2626"),
+            "</tbody>",
+            "</table>",
+        ]
+    )
+
+    return f"""<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <title>{title}</title>
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <style>
+    body{{font-family:system-ui,-apple-system,'Segoe UI',Roboto,Ubuntu,Cantarell,'Noto Sans',sans-serif;margin:2rem;color:#111}}
+    h1{{margin:0 0 1rem 0}}
+    table{{border-collapse:collapse;margin-top:1rem}}
+    th,td{{border:1px solid #ddd;padding:0.4rem 0.6rem;text-align:left}}
+    th{{background:#f3f4f6}}
+  </style>
+</head>
+<body>
+  <h1>{title}</h1>
+  {svg}
+  {table}
+</body>
+</html>
+"""
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render an HTML chart for a rate-limit tile JSON document"
+    )
+    parser.add_argument("--tile", default="reports/tiles/ratelimit_tile.json")
+    parser.add_argument("--out", default="reports/tiles/ratelimit_tile.html")
+    parser.add_argument("--width", type=int, default=800)
+    parser.add_argument("--height", type=int, default=240)
+    args = parser.parse_args(argv)
+
+    tile = load_tile(Path(args.tile))
+    html_doc = render_html(tile, args.width, args.height)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(html_doc, encoding="utf-8")
+    print(f"[OK] Wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/scripts/deepresearch/__init__.py
+++ b/scripts/deepresearch/__init__.py
@@ -1,0 +1,3 @@
+"""DeepResearch helper scripts."""
+
+__all__ = []

--- a/scripts/deepresearch/generate_context_manifest.py
+++ b/scripts/deepresearch/generate_context_manifest.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+
+def discover_api_files(root: Path) -> List[Path]:
+    if not root.exists():
+        return []
+    return sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix.lower() in {".yaml", ".yml", ".json"}
+    )
+
+
+def build_manifest(apis_dir: Path) -> dict:
+    api_files = discover_api_files(apis_dir)
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return {
+        "generated_utc": generated,
+        "apis_dir": str(apis_dir),
+        "apis": [
+            {
+                "path": str(path.relative_to(apis_dir)),
+                "name": path.stem,
+            }
+            for path in api_files
+        ],
+    }
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate the DeepResearch context manifest"
+    )
+    parser.add_argument(
+        "--apis-dir",
+        default="docs/deepresearch/apis",
+        help="Directory containing OpenAPI documents",
+    )
+    parser.add_argument(
+        "--out",
+        default="deepresearch/context_manifest.json",
+        help="Manifest output path",
+    )
+    args = parser.parse_args(argv)
+
+    apis_dir = Path(args.apis_dir)
+    manifest = build_manifest(apis_dir)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    print(f"[OK] Wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/dashboards/test_build_ratelimit_tile.py
+++ b/tests/dashboards/test_build_ratelimit_tile.py
@@ -1,0 +1,51 @@
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+
+def write_entry(path, remaining_core, remaining_search, remaining_graphql, dt):
+    data = {
+        "captured_utc": dt.isoformat(),
+        "data": {
+            "resources": {
+                "core": {"remaining": remaining_core},
+                "search": {"remaining": remaining_search},
+                "graphql": {"remaining": remaining_graphql},
+            }
+        },
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_build_ratelimit_tile_from_history(tmp_path):
+    history_dir = tmp_path / "connectors/history"
+    history_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc)
+    for i in range(3):
+        ts = now - timedelta(days=i)
+        write_entry(
+            history_dir / f"ratelimit_{ts.strftime('%Y%m%dT%H%M%SZ')}.json",
+            4500 - i,
+            180 - i,
+            5000 - i,
+            ts,
+        )
+
+    (tmp_path / "reports/tiles").mkdir(parents=True, exist_ok=True)
+
+    code = subprocess.call(
+        [
+            sys.executable,
+            "-c",
+            "import scripts.dashboards.build_ratelimit_tile as m; m.main()",
+        ],
+        cwd=tmp_path,
+    )
+    assert code == 0
+
+    tile = json.loads(
+        (tmp_path / "reports/tiles/ratelimit_tile.json").read_text(encoding="utf-8")
+    )
+    assert "series" in tile and "core" in tile["series"]
+    assert len(tile["series"]["core"]) >= 1

--- a/tests/dashboards/test_render_ratelimit_tile_html.py
+++ b/tests/dashboards/test_render_ratelimit_tile_html.py
@@ -1,0 +1,67 @@
+import json
+import subprocess
+import sys
+
+import pytest
+
+from scripts.dashboards.render_ratelimit_tile_html import scale_points
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        [("a", 5)],
+        [("a", 3), ("b", 3), ("c", 3)],
+    ],
+)
+def test_scale_points_handles_constant_series(values):
+    width, height = 120, 100
+    points = scale_points(values, width, height)
+
+    assert len(points) == len(values)
+
+    xs = [p[0] for p in points]
+    assert xs == sorted(xs)
+    assert xs[0] >= 20
+    assert xs[-1] <= width - 20
+
+    ys = [p[1] for p in points]
+    assert max(ys) - min(ys) < 1e-6
+
+
+def test_render_main_writes_html(tmp_path):
+    reports_dir = tmp_path / "reports/tiles"
+    reports_dir.mkdir(parents=True)
+    tile_data = {
+        "title": "My Tile",
+        "series": {
+            "core": [["2024-01-01", 4500], ["2024-01-02", 4490]],
+            "search": [["2024-01-01", 180], ["2024-01-02", 175]],
+            "graphql": [["2024-01-01", 5000], ["2024-01-02", 4995]],
+        },
+        "summary": {
+            "core": {"min": 4400, "avg": 4450, "max": 4500},
+            "search": {"min": 170, "avg": 175, "max": 180},
+            "graphql": {"min": 4900, "avg": 4950, "max": 5000},
+        },
+    }
+    tile_path = reports_dir / "ratelimit_tile.json"
+    tile_path.write_text(json.dumps(tile_data), encoding="utf-8")
+
+    code = subprocess.call(
+        [
+            sys.executable,
+            "-c",
+            "import scripts.dashboards.render_ratelimit_tile_html as m; m.main()",
+        ],
+        cwd=tmp_path,
+    )
+    assert code == 0
+
+    html_path = reports_dir / "ratelimit_tile.html"
+    html = html_path.read_text(encoding="utf-8")
+
+    assert "<svg" in html
+    assert "polyline" in html
+    assert "<table" in html
+    assert html.count("My Tile") >= 2

--- a/tests/deepresearch/test_context_manifest.py
+++ b/tests/deepresearch/test_context_manifest.py
@@ -1,0 +1,26 @@
+import json
+import subprocess
+import sys
+
+
+def test_manifest_contains_apis(tmp_path):
+    apis = tmp_path / "docs/deepresearch/apis"
+    apis.mkdir(parents=True, exist_ok=True)
+    (apis / "a.yaml").write_text("openapi: 3.1.0", encoding="utf-8")
+    (apis / "b.json").write_text('{"openapi":"3.1.0"}', encoding="utf-8")
+
+    code = subprocess.call(
+        [
+            sys.executable,
+            "-c",
+            "import scripts.deepresearch.generate_context_manifest as m; m.main()",
+        ],
+        cwd=tmp_path,
+    )
+    assert code == 0
+
+    manifest = json.loads(
+        (tmp_path / "deepresearch/context_manifest.json").read_text(encoding="utf-8")
+    )
+    assert isinstance(manifest.get("apis"), list)
+    assert len(manifest["apis"]) == 2

--- a/tests/scripts/test_prune_rate_limit_history.py
+++ b/tests/scripts/test_prune_rate_limit_history.py
@@ -1,0 +1,31 @@
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+
+def create_hist(root, dt):
+    path = root / f"ratelimit_{dt.strftime('%Y%m%dT%H%M%SZ')}.json"
+    path.write_text("{}", encoding="utf-8")
+
+
+def test_prune_removes_old(tmp_path):
+    root = tmp_path / "connectors/history"
+    root.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc)
+    create_hist(root, now - timedelta(days=120))
+    create_hist(root, now - timedelta(days=10))
+
+    code = subprocess.call(
+        [
+            sys.executable,
+            "scripts/connectors/prune_rate_limit_history.py",
+            "--root",
+            str(root),
+            "--days",
+            "90",
+        ]
+    )
+    assert code == 0
+
+    files = list(root.glob("ratelimit_*.json"))
+    assert len(files) == 1


### PR DESCRIPTION
## Summary
- add scripts for generating the rate-limit tile JSON/HTML and pruning stale history data
- document the workflows for the new scripts and provide automation to prune old captures
- cover the new utilities with pytest-based integration tests

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/dashboards/test_render_ratelimit_tile_html.py tests/dashboards/test_build_ratelimit_tile.py tests/scripts/test_prune_rate_limit_history.py tests/deepresearch/test_context_manifest.py

------
https://chatgpt.com/codex/tasks/task_e_69078ce07ee08331a37557b8bc83779d