### PR TITLE
Add repository mapping utility and generated map output

### DIFF
--- a/_codex_repo_map.json
+++ b/_codex_repo_map.json
@@ -1,0 +1,33208 @@
+{
+  ".ini": [
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/ATen/templates/RegisterDispatchDefinitions.ini",
+      "size": 455
+    },
+    {
+      "path": "configs/development/pytest.ini",
+      "size": 1713
+    },
+    {
+      "path": "configs/development/tox.ini",
+      "size": 542
+    },
+    {
+      "path": "pytest.ini",
+      "size": 415
+    }
+  ],
+  ".ipynb": [
+    {
+      "path": "examples/notebooks/chat_finetune.ipynb",
+      "size": 1408
+    },
+    {
+      "path": "examples/notebooks/demo_infer.ipynb",
+      "size": 1029
+    },
+    {
+      "path": "examples/notebooks/demo_train_eval.ipynb",
+      "size": 925
+    },
+    {
+      "path": "examples/notebooks/tokenizer_quickstart.ipynb",
+      "size": 987
+    },
+    {
+      "path": "notebooks/gpu_training_example.ipynb",
+      "size": 590
+    },
+    {
+      "path": "notebooks/quick_start.ipynb",
+      "size": 5507
+    },
+    {
+      "path": "notebooks/quickstart.ipynb",
+      "size": 2701
+    }
+  ],
+  ".json": [
+    {
+      "path": ".codex/automation_out/coverage_report.json",
+      "size": 467
+    },
+    {
+      "path": ".codex/automation_out/db_catalog.json",
+      "size": 3
+    },
+    {
+      "path": ".codex/automation_out/db_inventory.json",
+      "size": 69
+    },
+    {
+      "path": ".codex/cache/maint_vendor_hash_post.json",
+      "size": 40
+    },
+    {
+      "path": ".codex/cache/maint_vendor_hash_pre_sync.json",
+      "size": 40
+    },
+    {
+      "path": ".codex/cache/maintenance_summary.json",
+      "size": 2094
+    },
+    {
+      "path": ".codex/cache/secrets.status.json",
+      "size": 226
+    },
+    {
+      "path": ".codex/cache/setup_summary.json",
+      "size": 2124
+    },
+    {
+      "path": ".codex/cache/vendor_hash_post_purge.json",
+      "size": 40
+    },
+    {
+      "path": ".codex/cache/vendor_hash_pre_sync.json",
+      "size": 40
+    },
+    {
+      "path": ".codex/change_log_compare_report.json",
+      "size": 2839
+    },
+    {
+      "path": ".codex/codex.env.json",
+      "size": 1552
+    },
+    {
+      "path": ".codex/copilot_bridge/config/bridge.config.json",
+      "size": 333
+    },
+    {
+      "path": ".codex/copilot_bridge/manifests/bridge_manifest.schema.json",
+      "size": 1911
+    },
+    {
+      "path": ".codex/copilot_bridge/package.json",
+      "size": 357
+    },
+    {
+      "path": ".codex/evidence/artifacts/archive_plan_root_cleanup_2025-10-17.json",
+      "size": 1918
+    },
+    {
+      "path": ".codex/evidence/provenance/root-cleanup/slsa.json",
+      "size": 731
+    },
+    {
+      "path": ".codex/flags.json",
+      "size": 118
+    },
+    {
+      "path": ".codex/inventory.json",
+      "size": 445
+    },
+    {
+      "path": ".codex/lint-policy.json",
+      "size": 69
+    },
+    {
+      "path": ".codex/mapping.json",
+      "size": 569
+    },
+    {
+      "path": ".codex/mapping_table.json",
+      "size": 2456
+    },
+    {
+      "path": ".codex/ruff.json",
+      "size": 44152
+    },
+    {
+      "path": ".codex/schemas/ledger_event.schema.json",
+      "size": 434
+    },
+    {
+      "path": ".codex/search_hits.json",
+      "size": 1481
+    },
+    {
+      "path": ".codex/smoke_checks.json",
+      "size": 1797
+    },
+    {
+      "path": ".codex/status/env.json",
+      "size": 144
+    },
+    {
+      "path": ".codex/status/manifest-2025-09-22T02-15-21Z.json",
+      "size": 2005
+    },
+    {
+      "path": ".codex/status/provenance.json",
+      "size": 1103
+    },
+    {
+      "path": ".codex/status/results.json",
+      "size": 356
+    },
+    {
+      "path": ".codex/status/status_update_scan.json",
+      "size": 12746
+    },
+    {
+      "path": ".codex/status_scan.json",
+      "size": 92234
+    },
+    {
+      "path": ".codex/validation/20250910T052842Z/compare_report.json",
+      "size": 1480
+    },
+    {
+      "path": ".codex/validation/20250910T052842Z/post_manifest.json",
+      "size": 86429
+    },
+    {
+      "path": ".codex/validation/20250910T052842Z/pre_manifest.json",
+      "size": 85763
+    },
+    {
+      "path": ".codex/validation/20250910T071257Z/compare_report.json",
+      "size": 0
+    },
+    {
+      "path": ".codex/validation/20250910T071257Z/post_manifest.json",
+      "size": 86896
+    },
+    {
+      "path": ".codex/validation/20250910T071257Z/pre_manifest.json",
+      "size": 86896
+    },
+    {
+      "path": ".codex/validation/20250910T080054Z/compare_report.json",
+      "size": 361
+    },
+    {
+      "path": ".codex/validation/20250910T080054Z/post_manifest.json",
+      "size": 121097
+    },
+    {
+      "path": ".codex/validation/20250910T080054Z/pre_manifest.json",
+      "size": 121096
+    },
+    {
+      "path": ".codex/validation/20250910T113918Z/compare_report.json",
+      "size": 1188
+    },
+    {
+      "path": ".codex/validation/20250910T113918Z/post_manifest.json",
+      "size": 123145
+    },
+    {
+      "path": ".codex/validation/20250910T113918Z/pre_manifest.json",
+      "size": 122636
+    },
+    {
+      "path": ".codex/validation/20250910T135035Z/compare_report.json",
+      "size": 2839
+    },
+    {
+      "path": ".codex/validation/20250910T135035Z/post_manifest.json",
+      "size": 124510
+    },
+    {
+      "path": ".codex/validation/20250910T135035Z/pre_manifest.json",
+      "size": 123796
+    },
+    {
+      "path": ".codex/validation/20250910T151757Z/compare_report.json",
+      "size": 8555
+    },
+    {
+      "path": ".codex/validation/20250910T151757Z/post_manifest.json",
+      "size": 217760
+    },
+    {
+      "path": ".codex/validation/20250910T151757Z/pre_manifest.json",
+      "size": 217289
+    },
+    {
+      "path": ".codex/validation/20250910T210555Z/compare_report.json",
+      "size": 420
+    },
+    {
+      "path": ".codex/validation/20250910T210555Z/post_manifest.json",
+      "size": 127692
+    },
+    {
+      "path": ".codex/validation/20250910T210555Z/pre_manifest.json",
+      "size": 127692
+    },
+    {
+      "path": ".codex/validation/20250911T161728Z/compare_report.json",
+      "size": 486
+    },
+    {
+      "path": ".codex/validation/file_integrity_compare.json",
+      "size": 1197
+    },
+    {
+      "path": ".codex/validation/post_manifest.json",
+      "size": 155978
+    },
+    {
+      "path": ".codex/validation/pre_manifest.json",
+      "size": 155829
+    },
+    {
+      "path": ".codex/validation/structure_audit.json",
+      "size": 928
+    },
+    {
+      "path": ".codex/validation/tests_docs_links_audit.json",
+      "size": 3542
+    },
+    {
+      "path": ".statusrc.json",
+      "size": 301
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/resources/empty_template_package.json",
+      "size": 73
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/graph_break_registry.json",
+      "size": 84700
+    },
+    {
+      "path": ".vscode/settings.json",
+      "size": 74
+    },
+    {
+      "path": "LICENSES/codex-universal-image-sbom.spdx.json",
+      "size": 36165
+    },
+    {
+      "path": "_codex/status/manifest-20250922T013307Z.json",
+      "size": 1095
+    },
+    {
+      "path": "_codex/status/manifest-20250922T013826Z.json",
+      "size": 1834
+    },
+    {
+      "path": "_codex_reports/2025-10-06/artifacts_manifest.json",
+      "size": 4824
+    },
+    {
+      "path": "_codex_reports/2025-10-06/audit.json",
+      "size": 353877
+    },
+    {
+      "path": "_codex_reports/2025-10-06/audit_enriched.json",
+      "size": 354006
+    },
+    {
+      "path": "_codex_reports/2025-10-06/capability_matrix.json",
+      "size": 39815
+    },
+    {
+      "path": "_codex_reports/2025-10-06/env_report.json",
+      "size": 1426
+    },
+    {
+      "path": "_codex_reports/2025-10-06/errors.json",
+      "size": 1155
+    },
+    {
+      "path": "_codex_reports/2025-10-06/git_meta.json",
+      "size": 2047
+    },
+    {
+      "path": "_codex_reports/2025-10-06/reproducibility.json",
+      "size": 4247
+    },
+    {
+      "path": "_codex_reports/2025-10-06/seed_scan.json",
+      "size": 3135
+    },
+    {
+      "path": "_codex_reports/2025-10-06/tokenizer_check.json",
+      "size": 84
+    },
+    {
+      "path": "_codex_reports/2025-10-06/trainer_smoke.json",
+      "size": 396
+    },
+    {
+      "path": "artifacts/archive_plan_root.json",
+      "size": 4851
+    },
+    {
+      "path": "artifacts/metrics/cli_entry_points.json",
+      "size": 500
+    },
+    {
+      "path": "artifacts/metrics/cli_help.json",
+      "size": 4302
+    },
+    {
+      "path": "artifacts/metrics/docstring_coverage.json",
+      "size": 112925
+    },
+    {
+      "path": "artifacts/metrics/import_graph.json",
+      "size": 144320
+    },
+    {
+      "path": "artifacts/metrics/metrics.json",
+      "size": 1079
+    },
+    {
+      "path": "artifacts/metrics/stubs.json",
+      "size": 48247
+    },
+    {
+      "path": "artifacts/models/tiny_sequence_model/model.json",
+      "size": 297
+    },
+    {
+      "path": "artifacts/models/tiny_tokenizer/vocab.json",
+      "size": 93
+    },
+    {
+      "path": "artifacts/notebook_checks/checks.json",
+      "size": 287
+    },
+    {
+      "path": "artifacts/rl/scripted_agent/policy.json",
+      "size": 143
+    },
+    {
+      "path": "assets/manifest.json",
+      "size": 138711
+    },
+    {
+      "path": "audit_artifacts/_scoring_warnings.json",
+      "size": 2
+    },
+    {
+      "path": "audit_artifacts/capabilities_raw.json",
+      "size": 4595
+    },
+    {
+      "path": "audit_artifacts/capabilities_scored.json",
+      "size": 1269
+    },
+    {
+      "path": "audit_artifacts/component_gaps.json",
+      "size": 3614
+    },
+    {
+      "path": "audit_artifacts/context_index.json",
+      "size": 556359
+    },
+    {
+      "path": "audit_artifacts/facets.json",
+      "size": 55345
+    },
+    {
+      "path": "audit_artifacts/gaps.json",
+      "size": 203066
+    },
+    {
+      "path": "audit_run_manifest.json",
+      "size": 1526
+    },
+    {
+      "path": "compare_report.json",
+      "size": 392
+    },
+    {
+      "path": "configs/deployment/d365/solution_manifest.json",
+      "size": 556
+    },
+    {
+      "path": "configs/desired/zendesk/macros.desired.json",
+      "size": 1017
+    },
+    {
+      "path": "configs/desired/zendesk/routing.desired.json",
+      "size": 491
+    },
+    {
+      "path": "configs/desired/zendesk/talk_ivr.desired.json",
+      "size": 849
+    },
+    {
+      "path": "configs/desired/zendesk/ticket_fields.desired.json",
+      "size": 821
+    },
+    {
+      "path": "configs/desired/zendesk/ticket_forms.desired.json",
+      "size": 743
+    },
+    {
+      "path": "configs/desired/zendesk/triggers.desired.json",
+      "size": 1514
+    },
+    {
+      "path": "configs/desired/zendesk/views.desired.json",
+      "size": 994
+    },
+    {
+      "path": "configs/desired/zendesk/webhooks.desired.json",
+      "size": 611
+    },
+    {
+      "path": "configs/schemas/checkpoint_manifest.schema.json",
+      "size": 652
+    },
+    {
+      "path": "configs/schemas/dataset_manifest.schema.json",
+      "size": 1404
+    },
+    {
+      "path": "configs/schemas/evaluation.schema.json",
+      "size": 1372
+    },
+    {
+      "path": "configs/schemas/ratelimit_tile.schema.json",
+      "size": 1461
+    },
+    {
+      "path": "configs/schemas/security_policy.schema.json",
+      "size": 1023
+    },
+    {
+      "path": "configs/schemas/training_profile.schema.json",
+      "size": 1565
+    },
+    {
+      "path": "configs/security_policy.policy.json",
+      "size": 225
+    },
+    {
+      "path": "configs/synonyms/synonyms.json",
+      "size": 496
+    },
+    {
+      "path": "copilot/extension/extension_manifest.json",
+      "size": 454
+    },
+    {
+      "path": "copilot/extension/package.json",
+      "size": 487
+    },
+    {
+      "path": "data/offline/length_reward.json",
+      "size": 115
+    },
+    {
+      "path": "data/offline/trainer_functional.json",
+      "size": 104
+    },
+    {
+      "path": "data/offline/weighted_accuracy.json",
+      "size": 41
+    },
+    {
+      "path": "data/zendesk_api_index.json",
+      "size": 3160
+    },
+    {
+      "path": "data/zendesk_docs_manifest.json",
+      "size": 1610
+    },
+    {
+      "path": "docs/diffs/trigger_example.json",
+      "size": 493
+    },
+    {
+      "path": "docs/reference/labels_preset.json",
+      "size": 831
+    },
+    {
+      "path": "docs/status_updates/artifacts/2025-10-29-survey-0D_base-and-1926/readiness.json",
+      "size": 178
+    },
+    {
+      "path": "docs/status_updates/artifacts/2025-10-29-survey-0D_base-and-1926/readiness.validated.json",
+      "size": 155
+    },
+    {
+      "path": "docs/status_updates/artifacts/2025-10-30-survey-main-and-0/readiness.json",
+      "size": 156
+    },
+    {
+      "path": "docs/status_updates/artifacts/2025-10-30-survey-work-and-0_/readiness.json",
+      "size": 156
+    },
+    {
+      "path": "docs/status_updates/artifacts/2025-10-30-survey-work-and-1926_/readiness.json",
+      "size": 340
+    },
+    {
+      "path": "docs/status_updates/deploy_dry_run.json",
+      "size": 884
+    },
+    {
+      "path": "docs/status_updates/readiness.schema.json",
+      "size": 1511
+    },
+    {
+      "path": "docs/status_updates/status_report.json",
+      "size": 529
+    },
+    {
+      "path": "docs/templates/status/codex_status_template.schema.json",
+      "size": 9361
+    },
+    {
+      "path": "docs/templates/status/codex_status_template.schema_v1.2.json",
+      "size": 41811
+    },
+    {
+      "path": "docs/templates/status/example_report_detailed_v1.2.json",
+      "size": 3906
+    },
+    {
+      "path": "examples/roles/d365_roles.example.json",
+      "size": 335
+    },
+    {
+      "path": "examples/roles/zendesk_roles.example.json",
+      "size": 204
+    },
+    {
+      "path": "great_expectations/expectations/clean_data_suite.json",
+      "size": 901
+    },
+    {
+      "path": "manifests/codex_eval_rules.v3.json",
+      "size": 3813
+    },
+    {
+      "path": "manifests/selection_guard_rules.json",
+      "size": 772
+    },
+    {
+      "path": "mcp/mcp.json",
+      "size": 440
+    },
+    {
+      "path": "policies/tenant_policy.schema.json",
+      "size": 4216
+    },
+    {
+      "path": "reports/daily/_codex_status_update-2025-11-04-22:25Z-UTC_auto-debug.json",
+      "size": 1358
+    },
+    {
+      "path": "samples/assistant_message_summary.sample.json",
+      "size": 1375
+    },
+    {
+      "path": "schemas/archive_evidence_schema_v1.json",
+      "size": 1645
+    },
+    {
+      "path": "schemas/archive_evidence_schema_v2.json",
+      "size": 3827
+    },
+    {
+      "path": "schemas/cli/gh_api_envelope.schema.json",
+      "size": 622
+    },
+    {
+      "path": "schemas/cli/list_plugins.schema.json",
+      "size": 1593
+    },
+    {
+      "path": "schemas/codex_eval_rules.v3.schema.json",
+      "size": 665
+    },
+    {
+      "path": "schemas/metrics-ndjson-v0.3.json",
+      "size": 585
+    },
+    {
+      "path": "schemas/metrics.ndjson.schema.json",
+      "size": 742
+    },
+    {
+      "path": "schemas/run_metrics.schema.json",
+      "size": 960
+    },
+    {
+      "path": "schemas/run_params.schema.json",
+      "size": 1085
+    },
+    {
+      "path": "schemas/selection_guard_rules.schema.json",
+      "size": 601
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/agents/codex_client/codex_client/tool_specs.json",
+      "size": 2137
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/agents/codex_client/toolspecs/git_create_pr.json",
+      "size": 421
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/agents/codex_client/toolspecs/kb_search.json",
+      "size": 377
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/agents/codex_client/toolspecs/repo_hygiene.json",
+      "size": 272
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/agents/codex_client/toolspecs/tests_run.json",
+      "size": 203
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/copilot/app/app_manifest.json",
+      "size": 357
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/copilot/extension/extension_manifest.json",
+      "size": 396
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/copilot/extension/package.json",
+      "size": 235
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/mcp/examples/mcp.json",
+      "size": 169
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/mcp/mcp.json",
+      "size": 237
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/ops/observability/audit_schema.json",
+      "size": 623
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/ops/policies/allowlist.example.json",
+      "size": 113
+    },
+    {
+      "path": "tests/schemas/eval_probe.schema.json",
+      "size": 726
+    },
+    {
+      "path": "tests/schemas/train_probe.schema.json",
+      "size": 563
+    },
+    {
+      "path": "tools/label_policy.json",
+      "size": 280
+    }
+  ],
+  ".md": [
+    {
+      "path": ".codex/README.md",
+      "size": 2355
+    },
+    {
+      "path": ".codex/archive/README_UPDATED.md",
+      "size": 4767
+    },
+    {
+      "path": ".codex/automation_out/change_log.md",
+      "size": 2880
+    },
+    {
+      "path": ".codex/change_log-large.md",
+      "size": 3438867
+    },
+    {
+      "path": ".codex/change_log.md",
+      "size": 518293
+    },
+    {
+      "path": ".codex/deferred_items.md",
+      "size": 511
+    },
+    {
+      "path": ".codex/disabled_workflows/README.md",
+      "size": 279
+    },
+    {
+      "path": ".codex/evidence/phase3_summary.md",
+      "size": 893
+    },
+    {
+      "path": ".codex/guardrails.md",
+      "size": 10996
+    },
+    {
+      "path": ".codex/inventory.md",
+      "size": 6350
+    },
+    {
+      "path": ".codex/mapping.md",
+      "size": 1505
+    },
+    {
+      "path": ".codex/mapping_table.md",
+      "size": 364
+    },
+    {
+      "path": ".codex/notes/CODEBASE_AUDIT.md",
+      "size": 11715
+    },
+    {
+      "path": ".codex/notes/Codex_Answers.md",
+      "size": 1672
+    },
+    {
+      "path": ".codex/notes/Codex_Questions.md",
+      "size": 1573
+    },
+    {
+      "path": ".codex/notes/ERROR_CAPTURE_BLOCKS.md",
+      "size": 3674
+    },
+    {
+      "path": ".codex/notes/MERGE_NOTES.md",
+      "size": 1472
+    },
+    {
+      "path": ".codex/notes/REPRO_NOTES.md",
+      "size": 676
+    },
+    {
+      "path": ".codex/notes/RESEARCH_QUESTIONS.md",
+      "size": 1104
+    },
+    {
+      "path": ".codex/release/PINNED_SHAS.md",
+      "size": 1161
+    },
+    {
+      "path": ".codex/reports/Archive_Policy_Operations.md",
+      "size": 1434
+    },
+    {
+      "path": ".codex/reports/PHASE2_FINAL_STATUS.md",
+      "size": 12406
+    },
+    {
+      "path": ".codex/reports/PHASE2_STANDARDIZATION_SUMMARY.md",
+      "size": 10780
+    },
+    {
+      "path": ".codex/reports/archive_policy_operations.md",
+      "size": 1925
+    },
+    {
+      "path": ".codex/results.md",
+      "size": 649677
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-08-28.md",
+      "size": 24126
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-08-29.md",
+      "size": 4398
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-08-30.md",
+      "size": 4517
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-08-31.md",
+      "size": 4449
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-02.md",
+      "size": 11589
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-03.md",
+      "size": 13936
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-04.md",
+      "size": 14087
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-05.md",
+      "size": 19198
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-07.md",
+      "size": 81639
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-14.md",
+      "size": 54376
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-15.md",
+      "size": 86320
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-16.md",
+      "size": 65533
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-18.md",
+      "size": 64168
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-20.md",
+      "size": 63970
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-21.md",
+      "size": 16484
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-22.md",
+      "size": 33966
+    },
+    {
+      "path": ".codex/status/_codex_status_update-2025-09-23.md",
+      "size": 30627
+    },
+    {
+      "path": ".codex/status/status_update_change_log.md",
+      "size": 2582
+    },
+    {
+      "path": ".codex/validation/AUDIT_RECOMMENDATIONS.md",
+      "size": 1644
+    },
+    {
+      "path": ".codex/validation/gha_audit.md",
+      "size": 361
+    },
+    {
+      "path": ".codex/validation/structure_audit.md",
+      "size": 928
+    },
+    {
+      "path": ".codex/validation/tests_docs_links_audit.md",
+      "size": 3542
+    },
+    {
+      "path": ".github/Copilot.md",
+      "size": 6125
+    },
+    {
+      "path": ".github/ENABLE_WORKFLOW.md",
+      "size": 3688
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/capability_request.md",
+      "size": 481
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/performance_regression.md",
+      "size": 577
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/schema_failure.md",
+      "size": 482
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/security_gap.md",
+      "size": 485
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/status_report.md",
+      "size": 571
+    },
+    {
+      "path": ".github/OWNER_APPROVAL.md",
+      "size": 1793
+    },
+    {
+      "path": ".github/README.md",
+      "size": 322
+    },
+    {
+      "path": ".github/SUPPORT.md",
+      "size": 2026
+    },
+    {
+      "path": ".github/_workflows_disabled/README.md",
+      "size": 211
+    },
+    {
+      "path": ".github/agents/README.md",
+      "size": 197
+    },
+    {
+      "path": ".github/chatmodes/template.chatmode.md",
+      "size": 0
+    },
+    {
+      "path": ".github/copilot-instructions.md",
+      "size": 10349
+    },
+    {
+      "path": ".github/docs/ARCHIVE_CONFIG_ADR.md",
+      "size": 2137
+    },
+    {
+      "path": ".github/docs/ARCHIVE_DEPLOYMENT_GUIDE.md",
+      "size": 2965
+    },
+    {
+      "path": ".github/docs/ARCHIVE_IMPROVEMENTS_INDEX.md",
+      "size": 2875
+    },
+    {
+      "path": ".github/docs/ARCHIVE_IMPROVEMENTS_USAGE.md",
+      "size": 3788
+    },
+    {
+      "path": ".github/docs/CI_Copilot.md",
+      "size": 483
+    },
+    {
+      "path": ".github/docs/Copilot_Audit_InstructionEnhancement.md",
+      "size": 686
+    },
+    {
+      "path": ".github/docs/Copilot_Status_CheatSheet.md",
+      "size": 813
+    },
+    {
+      "path": ".github/docs/CrossRepoPatterns_Analysis.md",
+      "size": 2141
+    },
+    {
+      "path": ".github/docs/DeepResearch_GitHooksAutoFix.md",
+      "size": 2990
+    },
+    {
+      "path": ".github/docs/Implementation_LLMAutoFixHook.md",
+      "size": 4117
+    },
+    {
+      "path": ".github/docs/InstructionEnhancement_Copilot.md",
+      "size": 2078
+    },
+    {
+      "path": ".github/docs/Onboarding_Status_v1.2_Copilot.md",
+      "size": 413
+    },
+    {
+      "path": ".github/docs/OpenQuestions-UPDATED-ArchiveConsolidation.md",
+      "size": 2269
+    },
+    {
+      "path": ".github/docs/PoC_Repo_Layout_Copilot.md",
+      "size": 1754
+    },
+    {
+      "path": ".github/docs/Remaining_Implementation_Plan_Copilot.md",
+      "size": 20846
+    },
+    {
+      "path": ".github/docs/SBOM_Config_InstructionEnhancement.md",
+      "size": 1836
+    },
+    {
+      "path": ".github/docs/SQLITE_RESTORE_FIX_ADR.md",
+      "size": 7600
+    },
+    {
+      "path": ".github/docs/Security_Gates_Copilot.md",
+      "size": 1620
+    },
+    {
+      "path": ".github/docs/SelfHostedRunner_InstructionEnhancement.md",
+      "size": 2073
+    },
+    {
+      "path": ".github/docs/Space_TraversalWorkflow_Copilot.md",
+      "size": 2974
+    },
+    {
+      "path": ".github/docs/Status_Authoring_Cookbook_Copilot.md",
+      "size": 658
+    },
+    {
+      "path": ".github/docs/cli_migration_execution_guide.md",
+      "size": 3415
+    },
+    {
+      "path": ".github/pull_request_template.md",
+      "size": 8719
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip-25.3.dist-info/licenses/src/pip/_vendor/idna/LICENSE.md",
+      "size": 1541
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/idna/LICENSE.md",
+      "size": 1541
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/README.md",
+      "size": 147
+    },
+    {
+      "path": "AGENT_CONTINUATION_PROMPT.md",
+      "size": 10399
+    },
+    {
+      "path": "CHANGELOG_CodexAudit.md",
+      "size": 15633
+    },
+    {
+      "path": "CHANGELOG_CodexAudit_batch5_addition.md",
+      "size": 2840
+    },
+    {
+      "path": "CHATGPT_CONTINUATION.md",
+      "size": 7892
+    },
+    {
+      "path": "CODEX_STATUS_IMPLEMENTATION_SUMMARY.md",
+      "size": 4166
+    },
+    {
+      "path": "CODE_OF_CONDUCT.md",
+      "size": 3122
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "size": 2141
+    },
+    {
+      "path": "GOVERNANCE.md",
+      "size": 5361
+    },
+    {
+      "path": "IMPLEMENTATION_SUMMARY_OLD.md",
+      "size": 6060
+    },
+    {
+      "path": "IMPLEMENTATION_VALIDATION.md",
+      "size": 8200
+    },
+    {
+      "path": "LICENSES/codex-universal-image-sbom.md",
+      "size": 7878
+    },
+    {
+      "path": "MSP_IMPLEMENTATION_SUMMARY.md",
+      "size": 9466
+    },
+    {
+      "path": "NEWCOMER_GUIDE.md",
+      "size": 16766
+    },
+    {
+      "path": "P1_FIX_API_KEY_OPTIONAL.md",
+      "size": 5628
+    },
+    {
+      "path": "PROMPTS/CHATGPT_SEARCH_RECIPES.md",
+      "size": 10034
+    },
+    {
+      "path": "README.md",
+      "size": 13250
+    },
+    {
+      "path": "SECURITY.md",
+      "size": 8029
+    },
+    {
+      "path": "SELECTION_REPORT.md",
+      "size": 669
+    },
+    {
+      "path": "STATUS_SCHEMA_IMPLEMENTATION.md",
+      "size": 8901
+    },
+    {
+      "path": "STATUS_UPDATE_AUDIT_REPORT.md",
+      "size": 16917
+    },
+    {
+      "path": "WAVE2_IMPLEMENTATION.md",
+      "size": 8830
+    },
+    {
+      "path": "WAVE4_IMPLEMENTATION.md",
+      "size": 8499
+    },
+    {
+      "path": "WORK_SUMMARY.md",
+      "size": 7925
+    },
+    {
+      "path": "_codex/status/_codex_status_update-2025-09-21.md",
+      "size": 3069
+    },
+    {
+      "path": "_codex/status/_codex_status_update-2025-09-22.md",
+      "size": 44070
+    },
+    {
+      "path": "_codex_/docs/templates/README.md",
+      "size": 201
+    },
+    {
+      "path": "_codex_reports/2025-10-06/_codex_status_update-2025-10-06.md",
+      "size": 5687
+    },
+    {
+      "path": "_codex_reports/2025-10-06/audit_raw.md",
+      "size": 17638
+    },
+    {
+      "path": "_codex_reports/2025-10-06/errors_log.md",
+      "size": 641
+    },
+    {
+      "path": "_codex_reports/audit_requirement_mapping.md",
+      "size": 3821
+    },
+    {
+      "path": "_codex_reports/errors_2025-10-19.md",
+      "size": 93759
+    },
+    {
+      "path": "_codex_reports/errors_2025-11-05.md",
+      "size": 1140
+    },
+    {
+      "path": "_codex_reports/status_update_2025-10-19.md",
+      "size": 1063
+    },
+    {
+      "path": "agents/codex_client/README.md",
+      "size": 1788
+    },
+    {
+      "path": "analysis/branch_0B_base_overview.md",
+      "size": 619
+    },
+    {
+      "path": "analysis/commit_2d1469d_scope.md",
+      "size": 608
+    },
+    {
+      "path": "analysis/root_python_migration_plan.md",
+      "size": 8111
+    },
+    {
+      "path": "archive/removed/CODEBASE_AUDIT_2025-08-26_203612.md",
+      "size": 535
+    },
+    {
+      "path": "archive/removed/CODEBASE_AUDIT_2025-09-27_ITERATION3.md",
+      "size": 543
+    },
+    {
+      "path": "archive/removed/Codex_Questions.md",
+      "size": 501
+    },
+    {
+      "path": "archive/removed/_codex_codex-ready-sequence-and-patches-2025-09-27.md",
+      "size": 571
+    },
+    {
+      "path": "archive/removed/_codex_status_update-0C_base_-2025-09-27.md",
+      "size": 551
+    },
+    {
+      "path": "archive/removed/_codex_status_update-2025-10-06.md",
+      "size": 533
+    },
+    {
+      "path": "archive/removed/_codex_status_update-2025-10-16.md",
+      "size": 533
+    },
+    {
+      "path": "archive/removed/codex_ready_sequence-2025-10-16.md",
+      "size": 533
+    },
+    {
+      "path": "archive/removed/done_resolution_plans_10-6_to_10-7.md",
+      "size": 539
+    },
+    {
+      "path": "artifacts/diffs/training_py01_removal.md",
+      "size": 278
+    },
+    {
+      "path": "artifacts/docs/README.md",
+      "size": 3716
+    },
+    {
+      "path": "audit_artifacts/README.md",
+      "size": 1351
+    },
+    {
+      "path": "cli/README.md",
+      "size": 2333
+    },
+    {
+      "path": "codex_digest/EXECUTION.md",
+      "size": 1229
+    },
+    {
+      "path": "codex_digest/README.md",
+      "size": 980
+    },
+    {
+      "path": "codex_task_report.md",
+      "size": 1026
+    },
+    {
+      "path": "codex_task_sequence_lora_metrics.md",
+      "size": 4963
+    },
+    {
+      "path": "config/README.md",
+      "size": 375
+    },
+    {
+      "path": "configs/README.md",
+      "size": 3170
+    },
+    {
+      "path": "configs/schemas/README.md",
+      "size": 1508
+    },
+    {
+      "path": "copilot/app/README.md",
+      "size": 382
+    },
+    {
+      "path": "copilot/extension/README.md",
+      "size": 1109
+    },
+    {
+      "path": "docs/ARCHITECTURE.md",
+      "size": 16108
+    },
+    {
+      "path": "docs/CHANGELOG.md",
+      "size": 5099
+    },
+    {
+      "path": "docs/CHANGELOG/change_log.md",
+      "size": 1569
+    },
+    {
+      "path": "docs/CHANGELOG/changelog_codex.md",
+      "size": 20879
+    },
+    {
+      "path": "docs/CHANGELOG/changelog_session_logging.md",
+      "size": 372
+    },
+    {
+      "path": "docs/CHECKPOINTS.md",
+      "size": 480
+    },
+    {
+      "path": "docs/CLI.md",
+      "size": 820
+    },
+    {
+      "path": "docs/CODEX_STRUCTURE_CONSOLIDATION_PROMPT.md",
+      "size": 2012
+    },
+    {
+      "path": "docs/CONTRIBUTING.addendum.md",
+      "size": 1616
+    },
+    {
+      "path": "docs/CONTRIBUTING.md",
+      "size": 2867
+    },
+    {
+      "path": "docs/Fence_Discipline_OnePager.md",
+      "size": 1132
+    },
+    {
+      "path": "docs/FollowUp_Implementation_Plan.md",
+      "size": 5027
+    },
+    {
+      "path": "docs/How_We_Release.md",
+      "size": 724
+    },
+    {
+      "path": "docs/Implementation_Update_merged.md",
+      "size": 6942
+    },
+    {
+      "path": "docs/PHASE1_SETUP_REQUIREMENTS.md",
+      "size": 1111
+    },
+    {
+      "path": "docs/PR_PLAN.md",
+      "size": 1703
+    },
+    {
+      "path": "docs/QUALITY_GATES.md",
+      "size": 920
+    },
+    {
+      "path": "docs/QUICKSTART.md",
+      "size": 2217
+    },
+    {
+      "path": "docs/Quickstart_Local_Quality_Gates.md",
+      "size": 587
+    },
+    {
+      "path": "docs/README.md",
+      "size": 5522
+    },
+    {
+      "path": "docs/README_ROOT.md",
+      "size": 8534
+    },
+    {
+      "path": "docs/RELEASE_CHECKLIST.md",
+      "size": 418
+    },
+    {
+      "path": "docs/SEARCH_NOTES.md",
+      "size": 1221
+    },
+    {
+      "path": "docs/SECURITY.md",
+      "size": 907
+    },
+    {
+      "path": "docs/SOP_CHATGPT_CODEX_PRS_LOCAL.md",
+      "size": 814
+    },
+    {
+      "path": "docs/Traversal_Workflow.md",
+      "size": 5702
+    },
+    {
+      "path": "docs/Usage_Guide.md",
+      "size": 4081
+    },
+    {
+      "path": "docs/agents.md",
+      "size": 2693
+    },
+    {
+      "path": "docs/api.md",
+      "size": 392
+    },
+    {
+      "path": "docs/api/README.md",
+      "size": 9538
+    },
+    {
+      "path": "docs/api_catalog.md",
+      "size": 1784
+    },
+    {
+      "path": "docs/arch/_archive-policy/README-standardization.md",
+      "size": 5284
+    },
+    {
+      "path": "docs/arch/_archive-policy/_deprecated/v2-archiving-summary.md",
+      "size": 986
+    },
+    {
+      "path": "docs/arch/_archive-policy/_deprecated/v3-archiving-summary.md",
+      "size": 895
+    },
+    {
+      "path": "docs/arch/_archive-policy/_deprecated/v4-archiving-summary.md",
+      "size": 837
+    },
+    {
+      "path": "docs/arch/_archive-policy/archive-policy-pr-plan.md",
+      "size": 4997
+    },
+    {
+      "path": "docs/arch/_archive-policy/canonical-archiving-policy.md",
+      "size": 4083
+    },
+    {
+      "path": "docs/arch/_archive-policy/index.md",
+      "size": 2544
+    },
+    {
+      "path": "docs/arch/_archive-policy/standardization-framework.md",
+      "size": 9804
+    },
+    {
+      "path": "docs/arch/adr-2025-10-17-root-docs-cleanup.md",
+      "size": 3077
+    },
+    {
+      "path": "docs/arch/adr-2025-11-02-archive-sigstore-integration.md",
+      "size": 4778
+    },
+    {
+      "path": "docs/arch/adr-2025-11-03-evidence-schema-versioning.md",
+      "size": 5607
+    },
+    {
+      "path": "docs/arch/adr-template.md",
+      "size": 1160
+    },
+    {
+      "path": "docs/arch/tombstone_template.md",
+      "size": 818
+    },
+    {
+      "path": "docs/architecture.md",
+      "size": 1578
+    },
+    {
+      "path": "docs/architecture/codex_pipeline.md",
+      "size": 2659
+    },
+    {
+      "path": "docs/architecture/interfaces.md",
+      "size": 2276
+    },
+    {
+      "path": "docs/archive/pages_publish_tiles_yml_archive.md",
+      "size": 1973
+    },
+    {
+      "path": "docs/bridge/README.md",
+      "size": 2897
+    },
+    {
+      "path": "docs/bridge/governance.md",
+      "size": 2767
+    },
+    {
+      "path": "docs/bridge/overview.md",
+      "size": 3716
+    },
+    {
+      "path": "docs/bridge/ubuntu_cli.md",
+      "size": 2785
+    },
+    {
+      "path": "docs/changes/MSP_Capability_Audit_Changeplan_Tree.md",
+      "size": 2288
+    },
+    {
+      "path": "docs/changes/MSP_Capability_Audit_File_Map.md",
+      "size": 4194
+    },
+    {
+      "path": "docs/checklists/approval_gate_checklist.md",
+      "size": 1561
+    },
+    {
+      "path": "docs/checklists/zendesk_first_cycle_verification.md",
+      "size": 1266
+    },
+    {
+      "path": "docs/checkpoint_integrity.md",
+      "size": 1025
+    },
+    {
+      "path": "docs/checkpoint_schema_v2.md",
+      "size": 389
+    },
+    {
+      "path": "docs/ci.md",
+      "size": 967
+    },
+    {
+      "path": "docs/ci_cd_strategy.md",
+      "size": 1937
+    },
+    {
+      "path": "docs/cli.md",
+      "size": 578
+    },
+    {
+      "path": "docs/cli/status_audit.md",
+      "size": 2768
+    },
+    {
+      "path": "docs/codex/IMPLEMENTATION_GUIDE.md",
+      "size": 8062
+    },
+    {
+      "path": "docs/codex/PRE_FLIGHT_CHECKLIST.md",
+      "size": 4508
+    },
+    {
+      "path": "docs/compliance/archive_standards_mapping.md",
+      "size": 8451
+    },
+    {
+      "path": "docs/concepts.md",
+      "size": 294
+    },
+    {
+      "path": "docs/configs/OmegaConf_Schema.md",
+      "size": 3258
+    },
+    {
+      "path": "docs/configuration/HYDRA_GUIDE.md",
+      "size": 5563
+    },
+    {
+      "path": "docs/configuration/hydra_quickstart.md",
+      "size": 1308
+    },
+    {
+      "path": "docs/control_surface.md",
+      "size": 4363
+    },
+    {
+      "path": "docs/crm/admin-runbooks/archive.md",
+      "size": 2411
+    },
+    {
+      "path": "docs/crm/admin-runbooks/d365.md",
+      "size": 1685
+    },
+    {
+      "path": "docs/crm/admin-runbooks/knowledge.md",
+      "size": 1139
+    },
+    {
+      "path": "docs/crm/admin-runbooks/release.md",
+      "size": 2309
+    },
+    {
+      "path": "docs/crm/admin-runbooks/zendesk.md",
+      "size": 1129
+    },
+    {
+      "path": "docs/data/Caching.md",
+      "size": 7846
+    },
+    {
+      "path": "docs/data/Local_Files.md",
+      "size": 6964
+    },
+    {
+      "path": "docs/data_determinism.md",
+      "size": 258
+    },
+    {
+      "path": "docs/database/datasette_option.md",
+      "size": 807
+    },
+    {
+      "path": "docs/database/duckdb_option.md",
+      "size": 872
+    },
+    {
+      "path": "docs/database/sqlite_option.md",
+      "size": 799
+    },
+    {
+      "path": "docs/decision_records/ADR-codex-evaluator-v3.md",
+      "size": 2030
+    },
+    {
+      "path": "docs/decision_records/ADR-intent-approval-gate.md",
+      "size": 1216
+    },
+    {
+      "path": "docs/decision_records/ADR-open-entropy-resolutions.md",
+      "size": 1438
+    },
+    {
+      "path": "docs/decision_records/ADR-self-management-nox.md",
+      "size": 1403
+    },
+    {
+      "path": "docs/decision_records/ADR-status-reporter.md",
+      "size": 1202
+    },
+    {
+      "path": "docs/deep_research_prompts.md",
+      "size": 3602
+    },
+    {
+      "path": "docs/deepresearch/manifest_validation.md",
+      "size": 432
+    },
+    {
+      "path": "docs/deferred_items.md",
+      "size": 2855
+    },
+    {
+      "path": "docs/deployment/aws_sagemaker.md",
+      "size": 1685
+    },
+    {
+      "path": "docs/deployment/azure_ml.md",
+      "size": 1201
+    },
+    {
+      "path": "docs/deployment/deploy_pipeline.md",
+      "size": 419
+    },
+    {
+      "path": "docs/deployment/docker_gpu.md",
+      "size": 7285
+    },
+    {
+      "path": "docs/deployment/gcp_vertex.md",
+      "size": 1370
+    },
+    {
+      "path": "docs/deployment/health_probes.md",
+      "size": 2339
+    },
+    {
+      "path": "docs/deployment/kubernetes.md",
+      "size": 1686
+    },
+    {
+      "path": "docs/deployment/reasoning_pod.md",
+      "size": 2162
+    },
+    {
+      "path": "docs/deployment/tls_mtls.md",
+      "size": 1597
+    },
+    {
+      "path": "docs/detectors.md",
+      "size": 277
+    },
+    {
+      "path": "docs/dev-notes.md",
+      "size": 1766
+    },
+    {
+      "path": "docs/dev/CODE_STYLE_GUIDE.md",
+      "size": 1403
+    },
+    {
+      "path": "docs/dev/CONTRIBUTING.md",
+      "size": 1118
+    },
+    {
+      "path": "docs/dev/Import_Contracts.md",
+      "size": 1115
+    },
+    {
+      "path": "docs/dev/plugins.md",
+      "size": 1333
+    },
+    {
+      "path": "docs/dev/testing.md",
+      "size": 3146
+    },
+    {
+      "path": "docs/dev/training.md",
+      "size": 1648
+    },
+    {
+      "path": "docs/dev/unified_training.md",
+      "size": 1464
+    },
+    {
+      "path": "docs/developer/Coverage_Policy.md",
+      "size": 763
+    },
+    {
+      "path": "docs/developer/Patch_Debris_Guard.md",
+      "size": 551
+    },
+    {
+      "path": "docs/developer/Plugin_Registry_CLI.md",
+      "size": 538
+    },
+    {
+      "path": "docs/docker.md",
+      "size": 5870
+    },
+    {
+      "path": "docs/docker_guide.md",
+      "size": 1310
+    },
+    {
+      "path": "docs/docker_hardening.md",
+      "size": 1731
+    },
+    {
+      "path": "docs/dynamical-system.md",
+      "size": 7672
+    },
+    {
+      "path": "docs/ephemeral-runners.md",
+      "size": 4450
+    },
+    {
+      "path": "docs/examples/eval_metrics.md",
+      "size": 733
+    },
+    {
+      "path": "docs/examples/lora_quickstart.md",
+      "size": 657
+    },
+    {
+      "path": "docs/examples/mint_tokens_per_run.md",
+      "size": 2033
+    },
+    {
+      "path": "docs/examples/model_card_template.md",
+      "size": 166
+    },
+    {
+      "path": "docs/examples/python-variant/README.md",
+      "size": 591
+    },
+    {
+      "path": "docs/examples/training-configs.md",
+      "size": 543
+    },
+    {
+      "path": "docs/experiments.md",
+      "size": 2841
+    },
+    {
+      "path": "docs/experiments/README.md",
+      "size": 2143
+    },
+    {
+      "path": "docs/experiments/mlflow_offline.md",
+      "size": 846
+    },
+    {
+      "path": "docs/explanations/docs_architecture_diataxis.md",
+      "size": 612
+    },
+    {
+      "path": "docs/extensibility.md",
+      "size": 3730
+    },
+    {
+      "path": "docs/gaps_report.md",
+      "size": 3701
+    },
+    {
+      "path": "docs/getting-started.md",
+      "size": 2443
+    },
+    {
+      "path": "docs/governance/CONTRIBUTING.md",
+      "size": 10452
+    },
+    {
+      "path": "docs/guides/AGENTS.md",
+      "size": 7721
+    },
+    {
+      "path": "docs/guides/BASH_HEREDOC_REFERENCE.md",
+      "size": 4579
+    },
+    {
+      "path": "docs/guides/CHECKPOINT_SAFETY.md",
+      "size": 3728
+    },
+    {
+      "path": "docs/guides/CODEX_TOOL_SELECTION.md",
+      "size": 4981
+    },
+    {
+      "path": "docs/guides/LOGGING.md",
+      "size": 1041
+    },
+    {
+      "path": "docs/guides/TESTING_GUIDE.md",
+      "size": 1753
+    },
+    {
+      "path": "docs/guides/_codex__Newcomer_Codebase_Overview.md",
+      "size": 13679
+    },
+    {
+      "path": "docs/guides/archive_standardization_guide.md",
+      "size": 13534
+    },
+    {
+      "path": "docs/guides/asset_instruction_playbook.md",
+      "size": 3116
+    },
+    {
+      "path": "docs/guides/auditing.md",
+      "size": 2910
+    },
+    {
+      "path": "docs/guides/checkpointing.md",
+      "size": 645
+    },
+    {
+      "path": "docs/guides/code_style_guide.md",
+      "size": 869
+    },
+    {
+      "path": "docs/guides/codex_archive_runbook.md",
+      "size": 4162
+    },
+    {
+      "path": "docs/guides/codex_setup.md",
+      "size": 6911
+    },
+    {
+      "path": "docs/guides/codex_zendesk_integration_deep_dive.md",
+      "size": 9625
+    },
+    {
+      "path": "docs/guides/config_overrides.md",
+      "size": 2776
+    },
+    {
+      "path": "docs/guides/continual_learning.md",
+      "size": 1454
+    },
+    {
+      "path": "docs/guides/continual_learning_readiness.md",
+      "size": 3573
+    },
+    {
+      "path": "docs/guides/continuous_improvement.md",
+      "size": 1371
+    },
+    {
+      "path": "docs/guides/first_principles_curricula.md",
+      "size": 3712
+    },
+    {
+      "path": "docs/guides/lfs_policy.md",
+      "size": 277
+    },
+    {
+      "path": "docs/guides/metrics.md",
+      "size": 7600
+    },
+    {
+      "path": "docs/guides/mlflow_offline.md",
+      "size": 1997
+    },
+    {
+      "path": "docs/guides/offline_catalogue.md",
+      "size": 6053
+    },
+    {
+      "path": "docs/guides/offline_transformers.md",
+      "size": 2623
+    },
+    {
+      "path": "docs/guides/peft_lora.md",
+      "size": 1609
+    },
+    {
+      "path": "docs/guides/pipeline_smoke_test.md",
+      "size": 3383
+    },
+    {
+      "path": "docs/guides/plugins.md",
+      "size": 11049
+    },
+    {
+      "path": "docs/guides/reasoning.md",
+      "size": 2186
+    },
+    {
+      "path": "docs/guides/reasoning_overview.md",
+      "size": 4742
+    },
+    {
+      "path": "docs/guides/serving_reproducibility.md",
+      "size": 1990
+    },
+    {
+      "path": "docs/guides/session_hooks.md",
+      "size": 915
+    },
+    {
+      "path": "docs/guides/tokenization.md",
+      "size": 1047
+    },
+    {
+      "path": "docs/guides/zendesk_ai_app_builder_limitations.md",
+      "size": 7959
+    },
+    {
+      "path": "docs/how-to/admin_bootstrap.md",
+      "size": 1830
+    },
+    {
+      "path": "docs/how-to/bootstrap_runner.md",
+      "size": 1021
+    },
+    {
+      "path": "docs/how-to/checkpoint_metadata.md",
+      "size": 1365
+    },
+    {
+      "path": "docs/how-to/codeowners_validation.md",
+      "size": 1081
+    },
+    {
+      "path": "docs/how-to/dataset_manifest.md",
+      "size": 962
+    },
+    {
+      "path": "docs/how-to/hydra_sweeps.md",
+      "size": 667
+    },
+    {
+      "path": "docs/how-to/metrics_db.md",
+      "size": 1494
+    },
+    {
+      "path": "docs/how-to/metrics_ingestion.md",
+      "size": 1138
+    },
+    {
+      "path": "docs/how-to/metrics_validate_tail_badge.md",
+      "size": 970
+    },
+    {
+      "path": "docs/how-to/offline_tracking.md",
+      "size": 1196
+    },
+    {
+      "path": "docs/how-to/repo_admin_bootstrap.md",
+      "size": 3885
+    },
+    {
+      "path": "docs/how-to/repodeterminism_smoke.md",
+      "size": 1083
+    },
+    {
+      "path": "docs/how-to/run_audit_0D_base_.md",
+      "size": 1577
+    },
+    {
+      "path": "docs/how-to/tokenizer_migration.md",
+      "size": 895
+    },
+    {
+      "path": "docs/hydra_defaults_and_sweeps.md",
+      "size": 839
+    },
+    {
+      "path": "docs/hydra_quickstart.md",
+      "size": 422
+    },
+    {
+      "path": "docs/incident_runbook.md",
+      "size": 230
+    },
+    {
+      "path": "docs/index.md",
+      "size": 1788
+    },
+    {
+      "path": "docs/integrations/bridge_pattern_integration.md",
+      "size": 7263
+    },
+    {
+      "path": "docs/integrations/customgpt_actions.md",
+      "size": 678
+    },
+    {
+      "path": "docs/integrations/github_copilot_cli.md",
+      "size": 3767
+    },
+    {
+      "path": "docs/integrations/github_copilot_cli2.md",
+      "size": 16011
+    },
+    {
+      "path": "docs/integrity_and_uris.md",
+      "size": 589
+    },
+    {
+      "path": "docs/logging/end_to_end_logging.md",
+      "size": 2925
+    },
+    {
+      "path": "docs/logging/log_redaction_policy.md",
+      "size": 778
+    },
+    {
+      "path": "docs/logging/log_rotation.md",
+      "size": 1482
+    },
+    {
+      "path": "docs/logging/logging_guide.md",
+      "size": 1306
+    },
+    {
+      "path": "docs/maintenance/Torch_CPU_Policy.md",
+      "size": 1769
+    },
+    {
+      "path": "docs/manifest_integrity.md",
+      "size": 274
+    },
+    {
+      "path": "docs/metrics.md",
+      "size": 9016
+    },
+    {
+      "path": "docs/model_cards/template.md",
+      "size": 382
+    },
+    {
+      "path": "docs/modeling/LoRA.md",
+      "size": 679
+    },
+    {
+      "path": "docs/modeling/registry.md",
+      "size": 1452
+    },
+    {
+      "path": "docs/modules/checkpoint_manager.md",
+      "size": 372
+    },
+    {
+      "path": "docs/modules/cli.md",
+      "size": 1605
+    },
+    {
+      "path": "docs/modules/configuration.md",
+      "size": 5079
+    },
+    {
+      "path": "docs/modules/connectors.md",
+      "size": 651
+    },
+    {
+      "path": "docs/modules/data_handling.md",
+      "size": 1879
+    },
+    {
+      "path": "docs/modules/data_registry.md",
+      "size": 1195
+    },
+    {
+      "path": "docs/modules/evaluation_runner.md",
+      "size": 1688
+    },
+    {
+      "path": "docs/modules/metric_registry.md",
+      "size": 1243
+    },
+    {
+      "path": "docs/modules/metrics.md",
+      "size": 1224
+    },
+    {
+      "path": "docs/modules/model_registry.md",
+      "size": 2131
+    },
+    {
+      "path": "docs/modules/modeling.md",
+      "size": 3177
+    },
+    {
+      "path": "docs/modules/observability.md",
+      "size": 5934
+    },
+    {
+      "path": "docs/modules/plugins.md",
+      "size": 6571
+    },
+    {
+      "path": "docs/modules/privacy.md",
+      "size": 246
+    },
+    {
+      "path": "docs/modules/safety.md",
+      "size": 1465
+    },
+    {
+      "path": "docs/modules/tokenisation.md",
+      "size": 1309
+    },
+    {
+      "path": "docs/modules/tokenizer_trainer.md",
+      "size": 1004
+    },
+    {
+      "path": "docs/modules/training_engine.md",
+      "size": 1721
+    },
+    {
+      "path": "docs/monitoring/prometheus_setup.md",
+      "size": 2886
+    },
+    {
+      "path": "docs/monitoring/session_tracking.md",
+      "size": 2009
+    },
+    {
+      "path": "docs/ndjson_summary.md",
+      "size": 536
+    },
+    {
+      "path": "docs/next_steps.md",
+      "size": 1159
+    },
+    {
+      "path": "docs/offline_quickstart.md",
+      "size": 3396
+    },
+    {
+      "path": "docs/offline_testing.md",
+      "size": 2423
+    },
+    {
+      "path": "docs/ops.md",
+      "size": 108
+    },
+    {
+      "path": "docs/ops/CLI_JSON_Schemas.md",
+      "size": 783
+    },
+    {
+      "path": "docs/ops/Commits.md",
+      "size": 807
+    },
+    {
+      "path": "docs/ops/DEPLOYMENT_RUNBOOK.md",
+      "size": 1300
+    },
+    {
+      "path": "docs/ops/Deterministic_Installs.md",
+      "size": 691
+    },
+    {
+      "path": "docs/ops/GitHub_App_Integration.md",
+      "size": 4201
+    },
+    {
+      "path": "docs/ops/Local_Tooling_Prereqs.md",
+      "size": 1380
+    },
+    {
+      "path": "docs/ops/RUNBOOK.md",
+      "size": 7777
+    },
+    {
+      "path": "docs/ops/Security_Artifacts.md",
+      "size": 1053
+    },
+    {
+      "path": "docs/ops/artifacts_bundle_spec.md",
+      "size": 456
+    },
+    {
+      "path": "docs/ops/audit_runbook.md",
+      "size": 1298
+    },
+    {
+      "path": "docs/ops/badges.md",
+      "size": 610
+    },
+    {
+      "path": "docs/ops/baseline_rotation_policy.md",
+      "size": 2165
+    },
+    {
+      "path": "docs/ops/branching_release_strategy.md",
+      "size": 808
+    },
+    {
+      "path": "docs/ops/dashboard_release_publish.md",
+      "size": 598
+    },
+    {
+      "path": "docs/ops/deployment.md",
+      "size": 2632
+    },
+    {
+      "path": "docs/ops/deployment_architecture.md",
+      "size": 1600
+    },
+    {
+      "path": "docs/ops/environment.md",
+      "size": 2902
+    },
+    {
+      "path": "docs/ops/experiment_tracking.md",
+      "size": 816
+    },
+    {
+      "path": "docs/ops/github_connector_prep.md",
+      "size": 599
+    },
+    {
+      "path": "docs/ops/grpc_parity.md",
+      "size": 174
+    },
+    {
+      "path": "docs/ops/hydra_defaults_audit.md",
+      "size": 964
+    },
+    {
+      "path": "docs/ops/hydra_distributed_overrides.md",
+      "size": 388
+    },
+    {
+      "path": "docs/ops/incident_response_status_v1.2.md",
+      "size": 1270
+    },
+    {
+      "path": "docs/ops/local_gates.md",
+      "size": 1990
+    },
+    {
+      "path": "docs/ops/monitoring.md",
+      "size": 5864
+    },
+    {
+      "path": "docs/ops/offline_first_guidelines.md",
+      "size": 408
+    },
+    {
+      "path": "docs/ops/offline_workflow.md",
+      "size": 1593
+    },
+    {
+      "path": "docs/ops/pages_publish_tiles.md",
+      "size": 720
+    },
+    {
+      "path": "docs/ops/promotion_checklist.md",
+      "size": 3847
+    },
+    {
+      "path": "docs/ops/ratelimit_tile_html.md",
+      "size": 655
+    },
+    {
+      "path": "docs/ops/release_checklist_status_v1.2.md",
+      "size": 519
+    },
+    {
+      "path": "docs/ops/repo_rulesets_vs_protection.md",
+      "size": 808
+    },
+    {
+      "path": "docs/ops/retention.md",
+      "size": 274
+    },
+    {
+      "path": "docs/ops/runbook_logging.md",
+      "size": 2913
+    },
+    {
+      "path": "docs/ops/secrets_baseline_workflow.md",
+      "size": 659
+    },
+    {
+      "path": "docs/ops/security.md",
+      "size": 417
+    },
+    {
+      "path": "docs/ops/selection_guard.md",
+      "size": 1161
+    },
+    {
+      "path": "docs/ops/selection_reports.md",
+      "size": 973
+    },
+    {
+      "path": "docs/ops/semgrep_sarif.md",
+      "size": 405
+    },
+    {
+      "path": "docs/ops/status_ci_matrix.md",
+      "size": 957
+    },
+    {
+      "path": "docs/ops/status_reports.md",
+      "size": 3418
+    },
+    {
+      "path": "docs/ops/training_args.md",
+      "size": 2215
+    },
+    {
+      "path": "docs/ops/triage_status_failures.md",
+      "size": 772
+    },
+    {
+      "path": "docs/ops/ubuntu_setup.md",
+      "size": 676
+    },
+    {
+      "path": "docs/ops/vendor_audit_conclusive_findings.md",
+      "size": 15012
+    },
+    {
+      "path": "docs/ops/vendor_audit_stress_validation.md",
+      "size": 4194
+    },
+    {
+      "path": "docs/ops/visual_regression_baseline.md",
+      "size": 496
+    },
+    {
+      "path": "docs/ops/visual_thresholds_policy.md",
+      "size": 852
+    },
+    {
+      "path": "docs/optional_dependencies.md",
+      "size": 5011
+    },
+    {
+      "path": "docs/packaging/Packaging_and_Release.md",
+      "size": 3576
+    },
+    {
+      "path": "docs/patch-troubleshooting.md",
+      "size": 1572
+    },
+    {
+      "path": "docs/performance.md",
+      "size": 138
+    },
+    {
+      "path": "docs/phase4_changes.md",
+      "size": 1352
+    },
+    {
+      "path": "docs/plans/MSP_Audit_Gap_Remediation_Execution_Blueprint.md",
+      "size": 5464
+    },
+    {
+      "path": "docs/plans/MSP_Audit_Gap_Remediation_Plan_of_Action.md",
+      "size": 1423
+    },
+    {
+      "path": "docs/plugins.md",
+      "size": 1652
+    },
+    {
+      "path": "docs/plugins/Plugin_API_Broader.md",
+      "size": 13146
+    },
+    {
+      "path": "docs/plugins/Plugin_Registry.md",
+      "size": 747
+    },
+    {
+      "path": "docs/policies/archive-policy.md",
+      "size": 311
+    },
+    {
+      "path": "docs/policies/branch-protection-checklist.md",
+      "size": 3313
+    },
+    {
+      "path": "docs/process/Agent_Session_Closing_Notes.md",
+      "size": 785
+    },
+    {
+      "path": "docs/profiling/benchmarking.md",
+      "size": 1615
+    },
+    {
+      "path": "docs/prompts/chatgpt5_connectivity_recipes.md",
+      "size": 898
+    },
+    {
+      "path": "docs/prompts/codex_run_prompt_0A_base_.md",
+      "size": 4397
+    },
+    {
+      "path": "docs/prompts/codex_run_prompt_0D_base_.md",
+      "size": 1286
+    },
+    {
+      "path": "docs/prompts/custom_gpt_self_healing_engineer.md",
+      "size": 9683
+    },
+    {
+      "path": "docs/pruning_log.md",
+      "size": 743
+    },
+    {
+      "path": "docs/quality_gates.md",
+      "size": 200
+    },
+    {
+      "path": "docs/question_handling_reference.md",
+      "size": 4721
+    },
+    {
+      "path": "docs/quickstart.md",
+      "size": 12261
+    },
+    {
+      "path": "docs/quickstarts/offline_microperf.md",
+      "size": 1885
+    },
+    {
+      "path": "docs/reference/Archival_Compliance_Gates.md",
+      "size": 1251
+    },
+    {
+      "path": "docs/reference/Detector_Meta_Registry.md",
+      "size": 1829
+    },
+    {
+      "path": "docs/reference/Duplicate_Heuristic_Extended.md",
+      "size": 1895
+    },
+    {
+      "path": "docs/reference/Knobs_And_Toggles.md",
+      "size": 2738
+    },
+    {
+      "path": "docs/reference/P5_Scoring_Integration.md",
+      "size": 2772
+    },
+    {
+      "path": "docs/reference/P6_AST_Synonyms_Context.md",
+      "size": 6614
+    },
+    {
+      "path": "docs/reference/Security_Entropy.md",
+      "size": 1464
+    },
+    {
+      "path": "docs/reference/Trend_Aggregation.md",
+      "size": 1518
+    },
+    {
+      "path": "docs/reference/audit_prompt.md",
+      "size": 20680
+    },
+    {
+      "path": "docs/reference/codex_questions.md",
+      "size": 711
+    },
+    {
+      "path": "docs/reference/feature_flags.md",
+      "size": 1797
+    },
+    {
+      "path": "docs/reference/metrics_cli.md",
+      "size": 1197
+    },
+    {
+      "path": "docs/reference/open_questions_by_capability.md",
+      "size": 521
+    },
+    {
+      "path": "docs/reference/policy.md",
+      "size": 892
+    },
+    {
+      "path": "docs/reference/tools.md",
+      "size": 732
+    },
+    {
+      "path": "docs/releasing.md",
+      "size": 108
+    },
+    {
+      "path": "docs/remediation/README.md",
+      "size": 827
+    },
+    {
+      "path": "docs/remediation/components.md",
+      "size": 1177
+    },
+    {
+      "path": "docs/remediation/detectors.md",
+      "size": 795
+    },
+    {
+      "path": "docs/remediation/policy.md",
+      "size": 771
+    },
+    {
+      "path": "docs/repro.md",
+      "size": 4305
+    },
+    {
+      "path": "docs/repro_guidance.md",
+      "size": 333
+    },
+    {
+      "path": "docs/repro_offline_hardening_status.md",
+      "size": 6900
+    },
+    {
+      "path": "docs/reproducibility.md",
+      "size": 6052
+    },
+    {
+      "path": "docs/resume_cookbook.md",
+      "size": 101
+    },
+    {
+      "path": "docs/review/diff_intake_confirmation.md",
+      "size": 4980
+    },
+    {
+      "path": "docs/rubrics/codex_eval_rubric_v3.md",
+      "size": 1839
+    },
+    {
+      "path": "docs/runbooks/offline_wheelhouse.md",
+      "size": 3078
+    },
+    {
+      "path": "docs/runbooks/zendesk_admin_workflow.md",
+      "size": 1702
+    },
+    {
+      "path": "docs/runbooks/zendesk_docs_pipeline.md",
+      "size": 454
+    },
+    {
+      "path": "docs/runbooks/zendesk_e2e_support_workflows_plan.md",
+      "size": 4348
+    },
+    {
+      "path": "docs/safety.md",
+      "size": 3299
+    },
+    {
+      "path": "docs/safety/differential_privacy.md",
+      "size": 2354
+    },
+    {
+      "path": "docs/safety/moderation_adapter.md",
+      "size": 2946
+    },
+    {
+      "path": "docs/safety/policy_guidance.md",
+      "size": 5790
+    },
+    {
+      "path": "docs/safety/safety_guide.md",
+      "size": 975
+    },
+    {
+      "path": "docs/safety_api.md",
+      "size": 107
+    },
+    {
+      "path": "docs/samples/intent_validation_example.md",
+      "size": 1802
+    },
+    {
+      "path": "docs/security/Bandit_Fixes.md",
+      "size": 1627
+    },
+    {
+      "path": "docs/security/SECURITY_POLICY.md",
+      "size": 943
+    },
+    {
+      "path": "docs/security/Secret_Masking_Guide_v1.2.md",
+      "size": 496
+    },
+    {
+      "path": "docs/security/THREAT_MODEL.md",
+      "size": 2661
+    },
+    {
+      "path": "docs/security/authentication.md",
+      "size": 1285
+    },
+    {
+      "path": "docs/security/incident_response.md",
+      "size": 1611
+    },
+    {
+      "path": "docs/security/remove-env-file.md",
+      "size": 890
+    },
+    {
+      "path": "docs/security/secret_handling.md",
+      "size": 1304
+    },
+    {
+      "path": "docs/security/secret_masking.md",
+      "size": 264
+    },
+    {
+      "path": "docs/specs/FORMAL_ARTIFACTS.md",
+      "size": 1609
+    },
+    {
+      "path": "docs/sqlite.md",
+      "size": 98
+    },
+    {
+      "path": "docs/starterpacks/zendesk_desired_state/README.md",
+      "size": 4025
+    },
+    {
+      "path": "docs/status/Removed_Strikeouts_2025-11-05.md",
+      "size": 6767
+    },
+    {
+      "path": "docs/status/codex_status_update_2025_CLEAN.md",
+      "size": 9985
+    },
+    {
+      "path": "docs/status_update_outstanding_questions.md",
+      "size": 6900
+    },
+    {
+      "path": "docs/status_update_prompt.md",
+      "size": 9107
+    },
+    {
+      "path": "docs/status_updates/README.md",
+      "size": 1129
+    },
+    {
+      "path": "docs/status_updates/SURVEYS.md",
+      "size": 1268
+    },
+    {
+      "path": "docs/status_updates/TEMPLATE_status_update.md",
+      "size": 3203
+    },
+    {
+      "path": "docs/status_updates/TEMPLATE_survey.md",
+      "size": 2568
+    },
+    {
+      "path": "docs/status_updates/artifacts/2025-10-29-survey-0D_base-and-1926/STATUS.md",
+      "size": 243
+    },
+    {
+      "path": "docs/status_updates/artifacts/2025-10-29-survey-0D_base-and-1926/report.md",
+      "size": 16979
+    },
+    {
+      "path": "docs/status_updates/artifacts/2025-10-29-survey-work-and-1926/report.md",
+      "size": 5205
+    },
+    {
+      "path": "docs/status_updates/artifacts/2025-10-30-survey-main-and-0/report.md",
+      "size": 1612
+    },
+    {
+      "path": "docs/status_updates/artifacts/2025-10-30-survey-work-and-0_/report.md",
+      "size": 2797
+    },
+    {
+      "path": "docs/status_updates/artifacts/2025-10-30-survey-work-and-1926_/report.md",
+      "size": 6886
+    },
+    {
+      "path": "docs/status_updates/deploy_dry_run.md",
+      "size": 669
+    },
+    {
+      "path": "docs/status_updates/status_report.md",
+      "size": 546
+    },
+    {
+      "path": "docs/status_updates/status_update_{{date}}.md",
+      "size": 7060
+    },
+    {
+      "path": "docs/status_updates/survey-0D_base-and-1926-2025-10-29.md",
+      "size": 16979
+    },
+    {
+      "path": "docs/status_updates/survey-0D_base_-and-1926-2025-10-29.md",
+      "size": 24176
+    },
+    {
+      "path": "docs/status_updates/survey-0D_base_-and-1926-2025-10-30.md",
+      "size": 110531
+    },
+    {
+      "path": "docs/status_updates/survey-main-and-0-2025-10-30.md",
+      "size": 1612
+    },
+    {
+      "path": "docs/status_updates/survey-work-and-0_-2025-10-30.md",
+      "size": 2797
+    },
+    {
+      "path": "docs/status_updates/survey-work-and-1926-2025-10-29.md",
+      "size": 4416
+    },
+    {
+      "path": "docs/status_updates/survey-work-and-1926_-2025-10-30.md",
+      "size": 6886
+    },
+    {
+      "path": "docs/status_updates/templates/SURVEY_TEMPLATE.md",
+      "size": 2056
+    },
+    {
+      "path": "docs/suggested_tasks/offline_logging_security_updates.md",
+      "size": 1761
+    },
+    {
+      "path": "docs/suggested_tasks/remediation_phase1_task_queue_2025-09-17.md",
+      "size": 21090
+    },
+    {
+      "path": "docs/suggested_tasks/remediation_plan_status_update_2025-09-17.md",
+      "size": 13563
+    },
+    {
+      "path": "docs/suggested_tasks/status_update_2025-09-16.md",
+      "size": 16601
+    },
+    {
+      "path": "docs/suggested_tasks/status_update_2025-09-17.md",
+      "size": 50178
+    },
+    {
+      "path": "docs/telemetry.md",
+      "size": 102
+    },
+    {
+      "path": "docs/templates/Migration_CLIHardening.md",
+      "size": 3673
+    },
+    {
+      "path": "docs/templates/Migration_PythonFileRelocation.md",
+      "size": 4592
+    },
+    {
+      "path": "docs/templates/Planning_IntentValidation.md",
+      "size": 3748
+    },
+    {
+      "path": "docs/templates/README.md",
+      "size": 4145
+    },
+    {
+      "path": "docs/templates/intent_validation_gate.md",
+      "size": 3571
+    },
+    {
+      "path": "docs/templates/status/Audit_Integrity_Guide_v1.2.md",
+      "size": 829
+    },
+    {
+      "path": "docs/templates/status/FAQ_v1.2.md",
+      "size": 733
+    },
+    {
+      "path": "docs/templates/status/ID_Conventions_v1.2.md",
+      "size": 1515
+    },
+    {
+      "path": "docs/templates/status/ML_Test_Score_v1.2.md",
+      "size": 2264
+    },
+    {
+      "path": "docs/templates/status/README.md",
+      "size": 5876
+    },
+    {
+      "path": "docs/templates/status/SCHEMA_ENHANCEMENTS_v1.2.md",
+      "size": 13491
+    },
+    {
+      "path": "docs/templates/status/Tokenization_Insights_v1.2.md",
+      "size": 882
+    },
+    {
+      "path": "docs/templates/status/authoring_guide_v1.1.md",
+      "size": 3865
+    },
+    {
+      "path": "docs/templates/status/authoring_guide_v1.2.md",
+      "size": 6940
+    },
+    {
+      "path": "docs/templates/status/authoring_quickstart_v1.2.md",
+      "size": 3041
+    },
+    {
+      "path": "docs/templates/status/automation_connectors_v1.2.md",
+      "size": 781
+    },
+    {
+      "path": "docs/templates/status/automation_ingest_spec_v1.2.md",
+      "size": 2183
+    },
+    {
+      "path": "docs/templates/status/capability_matrix_example_v1.2.md",
+      "size": 724
+    },
+    {
+      "path": "docs/templates/status/capability_scoring_guide_v1.2.md",
+      "size": 601
+    },
+    {
+      "path": "docs/templates/status/ci_integration_checklist_v1.2.md",
+      "size": 511
+    },
+    {
+      "path": "docs/templates/status/codex_status_template_v1.1.md",
+      "size": 12873
+    },
+    {
+      "path": "docs/templates/status/codex_status_template_v1.2.md",
+      "size": 20320
+    },
+    {
+      "path": "docs/templates/status/coverage_reporting_guide_v1.2.md",
+      "size": 725
+    },
+    {
+      "path": "docs/templates/status/daily_report_do_and_dont_v1.2.md",
+      "size": 527
+    },
+    {
+      "path": "docs/templates/status/decision_log_guide_v1.2.md",
+      "size": 605
+    },
+    {
+      "path": "docs/templates/status/diff_style_guide_v1.1.md",
+      "size": 1431
+    },
+    {
+      "path": "docs/templates/status/diff_style_guide_v1.2.md",
+      "size": 2175
+    },
+    {
+      "path": "docs/templates/status/evidence_citation_guide_v1.2.md",
+      "size": 1146
+    },
+    {
+      "path": "docs/templates/status/example_report_v1.2.md",
+      "size": 1520
+    },
+    {
+      "path": "docs/templates/status/execution_readiness_checklist_v1.2.md",
+      "size": 1620
+    },
+    {
+      "path": "docs/templates/status/fields_to_tests_mapping_v1.2.md",
+      "size": 1448
+    },
+    {
+      "path": "docs/templates/status/glossary_v1.2.md",
+      "size": 640
+    },
+    {
+      "path": "docs/templates/status/governance_raci_v1.2.md",
+      "size": 584
+    },
+    {
+      "path": "docs/templates/status/html_renderer_guide_v1.2.md",
+      "size": 699
+    },
+    {
+      "path": "docs/templates/status/kpis_v1.2.md",
+      "size": 730
+    },
+    {
+      "path": "docs/templates/status/owner_mapping_v1.2.md",
+      "size": 663
+    },
+    {
+      "path": "docs/templates/status/patch_review_checklist_v1.2.md",
+      "size": 471
+    },
+    {
+      "path": "docs/templates/status/patch_style_examples_v1.2.md",
+      "size": 469
+    },
+    {
+      "path": "docs/templates/status/perf_baselines_v1.2.md",
+      "size": 571
+    },
+    {
+      "path": "docs/templates/status/questions_answers_guide_v1.2.md",
+      "size": 953
+    },
+    {
+      "path": "docs/templates/status/report_checklist_v1.2.md",
+      "size": 878
+    },
+    {
+      "path": "docs/templates/status/report_template_variables.md",
+      "size": 651
+    },
+    {
+      "path": "docs/templates/status/review_examples_v1.2.md",
+      "size": 512
+    },
+    {
+      "path": "docs/templates/status/reviewer_checklist_v1.2.md",
+      "size": 897
+    },
+    {
+      "path": "docs/templates/status/rollback_playbook_v1.2.md",
+      "size": 374
+    },
+    {
+      "path": "docs/templates/status/schema_remediation_process_v1.2.md",
+      "size": 690
+    },
+    {
+      "path": "docs/templates/status/security_input_validation_matrix_v1.2.md",
+      "size": 865
+    },
+    {
+      "path": "docs/templates/status/security_policy_v1.2.md",
+      "size": 509
+    },
+    {
+      "path": "docs/templates/status/serving_readiness_checklist_v1.2.md",
+      "size": 705
+    },
+    {
+      "path": "docs/templates/status/status_gate_policy_v1.2.md",
+      "size": 907
+    },
+    {
+      "path": "docs/templates/status/status_json_fields_catalog_v1.2.md",
+      "size": 1165
+    },
+    {
+      "path": "docs/templates/status/status_json_minimal_examples_v1.2.md",
+      "size": 2971
+    },
+    {
+      "path": "docs/templates/status/status_quality_rubric_v1.2.md",
+      "size": 1822
+    },
+    {
+      "path": "docs/templates/status/validation_matrix_v1.2.md",
+      "size": 989
+    },
+    {
+      "path": "docs/templates/status/visual_baseline_guide_v1.2.md",
+      "size": 1341
+    },
+    {
+      "path": "docs/templates/status/visual_regression_guide_v1.2.md",
+      "size": 720
+    },
+    {
+      "path": "docs/templates/status_update.md",
+      "size": 427
+    },
+    {
+      "path": "docs/tests_overview.md",
+      "size": 73
+    },
+    {
+      "path": "docs/tokenization/Adapter_Consolidation.md",
+      "size": 508
+    },
+    {
+      "path": "docs/tokenization_api.md",
+      "size": 137
+    },
+    {
+      "path": "docs/tokenization_cache.md",
+      "size": 1523
+    },
+    {
+      "path": "docs/tokenizer_invariants.md",
+      "size": 1079
+    },
+    {
+      "path": "docs/tracking.md",
+      "size": 486
+    },
+    {
+      "path": "docs/tracking/Offline_MLflow.md",
+      "size": 6310
+    },
+    {
+      "path": "docs/tracking/TensorBoard.md",
+      "size": 6672
+    },
+    {
+      "path": "docs/tracking_offline.md",
+      "size": 811
+    },
+    {
+      "path": "docs/tracking_offline_bootstrap.md",
+      "size": 641
+    },
+    {
+      "path": "docs/training/Checkpointing_Surfaces.md",
+      "size": 2239
+    },
+    {
+      "path": "docs/training/Distributed_Minimal_Hooks.md",
+      "size": 1054
+    },
+    {
+      "path": "docs/training/Evaluation_CLI.md",
+      "size": 1334
+    },
+    {
+      "path": "docs/training/Evaluation_CLI_Addendum.md",
+      "size": 1224
+    },
+    {
+      "path": "docs/training/distributed_troubleshooting.md",
+      "size": 10379
+    },
+    {
+      "path": "docs/training/reproducibility.md",
+      "size": 676
+    },
+    {
+      "path": "docs/training/symbolic_training.md",
+      "size": 4395
+    },
+    {
+      "path": "docs/troubleshooting.md",
+      "size": 1959
+    },
+    {
+      "path": "docs/troubleshooting/API_Docs_Troubleshooting.md",
+      "size": 7371
+    },
+    {
+      "path": "docs/troubleshooting/error_log.md",
+      "size": 3945
+    },
+    {
+      "path": "docs/troubleshooting/open_questions.md",
+      "size": 4188
+    },
+    {
+      "path": "docs/tutorials/end_to_end_cpu.md",
+      "size": 267
+    },
+    {
+      "path": "docs/tutorials/quickstart.md",
+      "size": 213
+    },
+    {
+      "path": "docs/unified_training.md",
+      "size": 1759
+    },
+    {
+      "path": "docs/usage.md",
+      "size": 2232
+    },
+    {
+      "path": "docs/usage/smoke.md",
+      "size": 355
+    },
+    {
+      "path": "docs/validation/API_Docs_Build_Validation.md",
+      "size": 4742
+    },
+    {
+      "path": "docs/validation/Agent_Run_Validation.md",
+      "size": 1001
+    },
+    {
+      "path": "docs/validation/Atomic_Diffs_Next_Unresolved_2025-10-11.md",
+      "size": 855
+    },
+    {
+      "path": "docs/validation/Atomic_Diffs_Next_Unresolved_2025-10-18.md",
+      "size": 730
+    },
+    {
+      "path": "docs/validation/Bridge_Run_Validation.md",
+      "size": 1931
+    },
+    {
+      "path": "docs/validation/CI_Fast_Defaults.md",
+      "size": 1781
+    },
+    {
+      "path": "docs/validation/CODEBASE_Curated_PatchPlan_main_2025-10-18.md",
+      "size": 2638
+    },
+    {
+      "path": "docs/validation/CODEBASE_Status_Audit_2025-10-14.md",
+      "size": 10457
+    },
+    {
+      "path": "docs/validation/Capability_Gaps_Validation.md",
+      "size": 1033
+    },
+    {
+      "path": "docs/validation/Determinism_Checklist.md",
+      "size": 1003
+    },
+    {
+      "path": "docs/validation/Docker_Validation.md",
+      "size": 1958
+    },
+    {
+      "path": "docs/validation/EphemeralRunner_Validation.md",
+      "size": 1406
+    },
+    {
+      "path": "docs/validation/Gaps_Coverage_Checklist_And_Scripts.md",
+      "size": 2326
+    },
+    {
+      "path": "docs/validation/Hydra_Config_Validation.md",
+      "size": 1163
+    },
+    {
+      "path": "docs/validation/Metrics_Validation.md",
+      "size": 8123
+    },
+    {
+      "path": "docs/validation/Offline_Audit_Validation.md",
+      "size": 2507
+    },
+    {
+      "path": "docs/validation/Owner_Approval_Validation.md",
+      "size": 2137
+    },
+    {
+      "path": "docs/validation/Owner_Approved_CI_Validation.md",
+      "size": 2659
+    },
+    {
+      "path": "docs/validation/Patch_Completeness_Review_2025-10-18.md",
+      "size": 2093
+    },
+    {
+      "path": "docs/validation/Patch_Scope_Confirmation_2025-10-18.md",
+      "size": 2305
+    },
+    {
+      "path": "docs/validation/Post_Apply_Validation_Checklist_2025-10-11.md",
+      "size": 1054
+    },
+    {
+      "path": "docs/validation/Repo_Variables_Management_Validation.md",
+      "size": 1468
+    },
+    {
+      "path": "docs/validation/Repro_Validation.md",
+      "size": 4929
+    },
+    {
+      "path": "docs/validation/Runner_Status_Validation.md",
+      "size": 1675
+    },
+    {
+      "path": "docs/validation/SBOM_Config_Validation.md",
+      "size": 843
+    },
+    {
+      "path": "docs/validation/Schema_Validation_Tooling.md",
+      "size": 1334
+    },
+    {
+      "path": "docs/validation/Security_Validation.md",
+      "size": 1185
+    },
+    {
+      "path": "docs/validation/SelfHostedRunner_Validation.md",
+      "size": 2052
+    },
+    {
+      "path": "docs/validation/Status_Report_Validation.md",
+      "size": 1593
+    },
+    {
+      "path": "docs/validation/Status_Update_Audit_Prompt.md",
+      "size": 1505
+    },
+    {
+      "path": "docs/validation/Tokenization_Validation.md",
+      "size": 654
+    },
+    {
+      "path": "docs/validation/Traversal_Workflow.md",
+      "size": 4757
+    },
+    {
+      "path": "docs/validation/Usage_Guide.md",
+      "size": 3037
+    },
+    {
+      "path": "docs/validation/Workflow_Expiry_Enforcer_Validation.md",
+      "size": 1695
+    },
+    {
+      "path": "docs/validation/fetch_messages_Validation.md",
+      "size": 581
+    },
+    {
+      "path": "docs/validation/make_docs_build.md",
+      "size": 2780
+    },
+    {
+      "path": "docs/validation/status_update_exhaustiveness.md",
+      "size": 2689
+    },
+    {
+      "path": "docs/validation/tokenization_Validation.md",
+      "size": 1251
+    },
+    {
+      "path": "docs/validation/zendesk_ai_builder_readiness_validation.md",
+      "size": 1984
+    },
+    {
+      "path": "docs/zendesk/AI_AGENT_APP_BUILDER.md",
+      "size": 46410
+    },
+    {
+      "path": "docs/zendesk/CANONICAL_CAPABILITY_MAP.md",
+      "size": 26678
+    },
+    {
+      "path": "docs/zendesk/README.md",
+      "size": 11433
+    },
+    {
+      "path": "docs/zendesk/VALIDATION_REPORT.md",
+      "size": 11120
+    },
+    {
+      "path": "docs/zendesk/WORKFLOW_DIAGRAMS.md",
+      "size": 22903
+    },
+    {
+      "path": "docs/zendesk/ZENDESK_NEWCOMER_GUIDE.md",
+      "size": 24741
+    },
+    {
+      "path": "docs/zendesk_api_catalog_generated.md",
+      "size": 1380
+    },
+    {
+      "path": "docs/zendesk_api_reference.md",
+      "size": 4170
+    },
+    {
+      "path": "examples/TROUBLESHOOTING.md",
+      "size": 972
+    },
+    {
+      "path": "examples/zendesk/README.md",
+      "size": 6932
+    },
+    {
+      "path": "experiments/2025-01-15_smoke.md",
+      "size": 1893
+    },
+    {
+      "path": "mcp/server/README.md",
+      "size": 472
+    },
+    {
+      "path": "ops/threat_model/STRIDE.md",
+      "size": 602
+    },
+    {
+      "path": "patches/I2_Data_Spine_P2.1-P2.3.md",
+      "size": 6537
+    },
+    {
+      "path": "reports/PHASE_3_COMPLETION_REPORT.md",
+      "size": 2987
+    },
+    {
+      "path": "reports/POST_CHECK_VALIDATION_2025-09-27.md",
+      "size": 4785
+    },
+    {
+      "path": "reports/_codex_status_update-0D_base_-2025-10-10.md",
+      "size": 7222
+    },
+    {
+      "path": "reports/_codex_status_update-2025-09-28.md",
+      "size": 639
+    },
+    {
+      "path": "reports/_codex_status_update-2025-09-29.md",
+      "size": 45261
+    },
+    {
+      "path": "reports/_codex_status_update-2025-09-30.md",
+      "size": 13122
+    },
+    {
+      "path": "reports/_codex_status_update-2025-10-05.md",
+      "size": 33103
+    },
+    {
+      "path": "reports/_codex_status_update-2025-10-05_followthrough.md",
+      "size": 8467
+    },
+    {
+      "path": "reports/branch_analysis.md",
+      "size": 1046
+    },
+    {
+      "path": "reports/capability_audit.md",
+      "size": 4248
+    },
+    {
+      "path": "reports/capability_matrix_20251101_082306.md",
+      "size": 19147
+    },
+    {
+      "path": "reports/codex_status_update_20251020_040601.md",
+      "size": 1347
+    },
+    {
+      "path": "reports/codex_status_update_20251030_194819.md",
+      "size": 1433
+    },
+    {
+      "path": "reports/codex_status_update_20251030_195118.md",
+      "size": 1433
+    },
+    {
+      "path": "reports/codex_status_update_20251030_195203.md",
+      "size": 1433
+    },
+    {
+      "path": "reports/codex_status_update_20251030_195644.md",
+      "size": 1433
+    },
+    {
+      "path": "reports/codex_status_update_audit_report.md",
+      "size": 14515
+    },
+    {
+      "path": "reports/critical_repo_summary.md",
+      "size": 4977
+    },
+    {
+      "path": "reports/daily/README.md",
+      "size": 2378
+    },
+    {
+      "path": "reports/daily/_codex_status_update-2025-11-04.md",
+      "size": 18649
+    },
+    {
+      "path": "reports/daily/error-_codex_status_update-2025-11-04.md",
+      "size": 2238
+    },
+    {
+      "path": "reports/deferred.md",
+      "size": 1141
+    },
+    {
+      "path": "reports/gap_risk_resolution.md",
+      "size": 4835
+    },
+    {
+      "path": "reports/high_signal_findings.md",
+      "size": 1205
+    },
+    {
+      "path": "reports/iteration1_audit.md",
+      "size": 11054
+    },
+    {
+      "path": "reports/local_checks.md",
+      "size": 1424
+    },
+    {
+      "path": "reports/observability_runbook.md",
+      "size": 3445
+    },
+    {
+      "path": "reports/offline_validation_2025-10-07.md",
+      "size": 976
+    },
+    {
+      "path": "reports/phase3_cli_test_results.md",
+      "size": 2106
+    },
+    {
+      "path": "reports/phase3_cli_validation.md",
+      "size": 1794
+    },
+    {
+      "path": "reports/repo_map.md",
+      "size": 13564
+    },
+    {
+      "path": "reports/report_templates.md",
+      "size": 5354
+    },
+    {
+      "path": "reports/reproducibility.md",
+      "size": 1097
+    },
+    {
+      "path": "reports/security_audit.md",
+      "size": 1873
+    },
+    {
+      "path": "samples/README.md",
+      "size": 603
+    },
+    {
+      "path": "samples/broken_fence.sample.md",
+      "size": 181
+    },
+    {
+      "path": "scripts/agent/README.md",
+      "size": 953
+    },
+    {
+      "path": "scripts/space_traversal/detectors/README.md",
+      "size": 748
+    },
+    {
+      "path": "services/ita/README.md",
+      "size": 2312
+    },
+    {
+      "path": "services/msp_gateway/README.md",
+      "size": 9588
+    },
+    {
+      "path": "src/ingestion/README.md",
+      "size": 614
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/README-FROM-USER.md",
+      "size": 195
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/README.md",
+      "size": 1178
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/copilot/app/README.md",
+      "size": 364
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/copilot/extension/README.md",
+      "size": 648
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/mcp/server/README.md",
+      "size": 270
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/ops/threat_model/STRIDE.md",
+      "size": 500
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/tools/codex_safety/README.md",
+      "size": 212
+    },
+    {
+      "path": "templates/github_repo_baseline/ISSUE_TEMPLATE/bug_report.md",
+      "size": 182
+    },
+    {
+      "path": "templates/github_repo_baseline/ISSUE_TEMPLATE/feature_request.md",
+      "size": 155
+    },
+    {
+      "path": "templates/github_repo_baseline/PULL_REQUEST_TEMPLATE.md",
+      "size": 262
+    },
+    {
+      "path": "tests/assets/README.md",
+      "size": 331
+    },
+    {
+      "path": "tests/data/validate_fences_sample.md",
+      "size": 65
+    },
+    {
+      "path": "tests/fixtures/markdown/bad.md",
+      "size": 58
+    },
+    {
+      "path": "tests/fixtures/markdown/ok.md",
+      "size": 24
+    },
+    {
+      "path": "tests/samples/bad_fences.md",
+      "size": 359
+    },
+    {
+      "path": "tests/samples/good_fences.md",
+      "size": 63
+    },
+    {
+      "path": "tools/README.md",
+      "size": 1862
+    },
+    {
+      "path": "tools/archive_manager/README.md",
+      "size": 2463
+    },
+    {
+      "path": "tools/codex_safety/README.md",
+      "size": 242
+    },
+    {
+      "path": "tools/survey/README.md",
+      "size": 847
+    },
+    {
+      "path": "transformed_pr_overview.md",
+      "size": 7198
+    }
+  ],
+  ".py": [
+    {
+      "path": ".codex/codex_repo_scout.py",
+      "size": 18378
+    },
+    {
+      "path": ".codex/run_db_utils_workflow.py",
+      "size": 15842
+    },
+    {
+      "path": ".codex/run_repo_scout.py",
+      "size": 16952
+    },
+    {
+      "path": ".codex/run_workflow.py",
+      "size": 16783
+    },
+    {
+      "path": ".codex/scripts/local_ci.py",
+      "size": 6236
+    },
+    {
+      "path": ".codex/smoke/import_check.py",
+      "size": 2465
+    },
+    {
+      "path": ".venv/bin/activate_this.py",
+      "size": 2383
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/_distutils_hack/__init__.py",
+      "size": 6002
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/_distutils_hack/override.py",
+      "size": 44
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/_virtualenv.py",
+      "size": 4342
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/_yaml/__init__.py",
+      "size": 1402
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/cfgv.py",
+      "size": 12220
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/__init__.py",
+      "size": 625
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/compat.py",
+      "size": 41467
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/database.py",
+      "size": 51160
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/index.py",
+      "size": 20797
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/locators.py",
+      "size": 51026
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/manifest.py",
+      "size": 14168
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/markers.py",
+      "size": 5269
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/metadata.py",
+      "size": 38724
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/resources.py",
+      "size": 10820
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/scripts.py",
+      "size": 18612
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/util.py",
+      "size": 66682
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/version.py",
+      "size": 23727
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib/wheel.py",
+      "size": 44271
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/filelock/__init__.py",
+      "size": 1769
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/filelock/_api.py",
+      "size": 14545
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/filelock/_error.py",
+      "size": 787
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/filelock/_soft.py",
+      "size": 1711
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/filelock/_unix.py",
+      "size": 2351
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/filelock/_util.py",
+      "size": 1715
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/filelock/_windows.py",
+      "size": 2179
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/filelock/asyncio.py",
+      "size": 12483
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/filelock/version.py",
+      "size": 513
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/__init__.py",
+      "size": 2053
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/_version.py",
+      "size": 710
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/archive.py",
+      "size": 2411
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/asyn.py",
+      "size": 36365
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/caching.py",
+      "size": 34294
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/callbacks.py",
+      "size": 9210
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/compression.py",
+      "size": 5086
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/config.py",
+      "size": 4279
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/conftest.py",
+      "size": 1245
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/core.py",
+      "size": 23828
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/dircache.py",
+      "size": 2717
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/exceptions.py",
+      "size": 331
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/fuse.py",
+      "size": 10177
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/generic.py",
+      "size": 13409
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/gui.py",
+      "size": 14002
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/arrow.py",
+      "size": 8623
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/asyn_wrapper.py",
+      "size": 3679
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/cache_mapper.py",
+      "size": 2421
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/cache_metadata.py",
+      "size": 8536
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/cached.py",
+      "size": 35168
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/dask.py",
+      "size": 4466
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/data.py",
+      "size": 1658
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/dbfs.py",
+      "size": 16217
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/dirfs.py",
+      "size": 12108
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/ftp.py",
+      "size": 11639
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/gist.py",
+      "size": 8341
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/git.py",
+      "size": 3731
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/github.py",
+      "size": 11653
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/http.py",
+      "size": 30435
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/http_sync.py",
+      "size": 30133
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/jupyter.py",
+      "size": 3811
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/libarchive.py",
+      "size": 7102
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/local.py",
+      "size": 16936
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/memory.py",
+      "size": 10488
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/reference.py",
+      "size": 48704
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/sftp.py",
+      "size": 5631
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/smb.py",
+      "size": 15236
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/tar.py",
+      "size": 4111
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/webhdfs.py",
+      "size": 16769
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/implementations/zip.py",
+      "size": 6072
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/json.py",
+      "size": 3814
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/mapping.py",
+      "size": 8343
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/parquet.py",
+      "size": 19448
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/registry.py",
+      "size": 12048
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/spec.py",
+      "size": 77298
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/tests/abstract/__init__.py",
+      "size": 10181
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/tests/abstract/common.py",
+      "size": 4973
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/tests/abstract/copy.py",
+      "size": 19967
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/tests/abstract/get.py",
+      "size": 20755
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/tests/abstract/mv.py",
+      "size": 1982
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/tests/abstract/open.py",
+      "size": 329
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/tests/abstract/pipe.py",
+      "size": 402
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/tests/abstract/put.py",
+      "size": 21201
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/transaction.py",
+      "size": 2398
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/fsspec/utils.py",
+      "size": 22995
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/__init__.py",
+      "size": 1037
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/_src/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/_src/aot_autograd/__init__.py",
+      "size": 291
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/_src/eager_transforms/__init__.py",
+      "size": 291
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/_src/make_functional/__init__.py",
+      "size": 235
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/_src/vmap/__init__.py",
+      "size": 467
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/compile/__init__.py",
+      "size": 756
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/dim/__init__.py",
+      "size": 4660
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/dim/batch_tensor.py",
+      "size": 668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/dim/delayed_mul_tensor.py",
+      "size": 2377
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/dim/dim.py",
+      "size": 3382
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/dim/magic_trace.py",
+      "size": 1329
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/dim/op_properties.py",
+      "size": 6687
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/dim/reference.py",
+      "size": 20332
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/dim/tree_map.py",
+      "size": 375
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/dim/wrap_type.py",
+      "size": 1871
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/einops/__init__.py",
+      "size": 59
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/einops/_parsing.py",
+      "size": 12309
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/einops/rearrange.py",
+      "size": 8088
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/experimental/__init__.py",
+      "size": 273
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/experimental/control_flow.py",
+      "size": 144
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/functorch/experimental/ops.py",
+      "size": 57
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/identify/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/identify/cli.py",
+      "size": 739
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/identify/extensions.py",
+      "size": 14385
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/identify/identify.py",
+      "size": 7916
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/identify/interpreters.py",
+      "size": 688
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/identify/vendor/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/identify/vendor/licenses.py",
+      "size": 335105
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/isympy.py",
+      "size": 11220
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/__init__.py",
+      "size": 1928
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/_identifier.py",
+      "size": 1958
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/async_utils.py",
+      "size": 2834
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/bccache.py",
+      "size": 14061
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/compiler.py",
+      "size": 74131
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/constants.py",
+      "size": 1433
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/debug.py",
+      "size": 6297
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/defaults.py",
+      "size": 1267
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/environment.py",
+      "size": 61513
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/exceptions.py",
+      "size": 5071
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/ext.py",
+      "size": 31875
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/filters.py",
+      "size": 55212
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/idtracking.py",
+      "size": 10555
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/lexer.py",
+      "size": 29786
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/loaders.py",
+      "size": 24055
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/meta.py",
+      "size": 4397
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/nativetypes.py",
+      "size": 4210
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/nodes.py",
+      "size": 34579
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/optimizer.py",
+      "size": 1651
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/parser.py",
+      "size": 40383
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/runtime.py",
+      "size": 34249
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/sandbox.py",
+      "size": 15009
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/tests.py",
+      "size": 5926
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/utils.py",
+      "size": 24129
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2/visitor.py",
+      "size": 3557
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/markupsafe/__init__.py",
+      "size": 10958
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/markupsafe/_native.py",
+      "size": 1713
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/__init__.py",
+      "size": 8765
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/calculus/__init__.py",
+      "size": 162
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/calculus/approximation.py",
+      "size": 8817
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/calculus/calculus.py",
+      "size": 112
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/calculus/differentiation.py",
+      "size": 20226
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/calculus/extrapolation.py",
+      "size": 73306
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/calculus/inverselaplace.py",
+      "size": 36056
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/calculus/odes.py",
+      "size": 9908
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/calculus/optimization.py",
+      "size": 32856
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/calculus/polynomials.py",
+      "size": 7877
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/calculus/quadrature.py",
+      "size": 42432
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/ctx_base.py",
+      "size": 15985
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/ctx_fp.py",
+      "size": 6572
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/ctx_iv.py",
+      "size": 17211
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/ctx_mp.py",
+      "size": 49452
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/ctx_mp_python.py",
+      "size": 37815
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/function_docs.py",
+      "size": 283512
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/__init__.py",
+      "size": 330
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/bessel.py",
+      "size": 37938
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/elliptic.py",
+      "size": 42237
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/expintegrals.py",
+      "size": 11644
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/factorials.py",
+      "size": 5273
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/functions.py",
+      "size": 18100
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/hypergeometric.py",
+      "size": 51570
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/orthogonal.py",
+      "size": 16097
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/qfunctions.py",
+      "size": 7633
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/rszeta.py",
+      "size": 46184
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/signals.py",
+      "size": 703
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/theta.py",
+      "size": 37320
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/zeta.py",
+      "size": 36410
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/functions/zetazeros.py",
+      "size": 30858
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/identification.py",
+      "size": 29253
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/libmp/__init__.py",
+      "size": 3790
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/libmp/backend.py",
+      "size": 3360
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/libmp/gammazeta.py",
+      "size": 71469
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/libmp/libelefun.py",
+      "size": 43861
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/libmp/libhyper.py",
+      "size": 36624
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/libmp/libintmath.py",
+      "size": 16688
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/libmp/libmpc.py",
+      "size": 26875
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/libmp/libmpf.py",
+      "size": 45021
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/libmp/libmpi.py",
+      "size": 27622
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/math2.py",
+      "size": 18561
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/matrices/__init__.py",
+      "size": 94
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/matrices/calculus.py",
+      "size": 18609
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/matrices/eigen.py",
+      "size": 24394
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/matrices/eigen_symmetric.py",
+      "size": 58534
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/matrices/linalg.py",
+      "size": 26958
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/matrices/matrices.py",
+      "size": 32331
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/rational.py",
+      "size": 5976
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/extratest_gamma.py",
+      "size": 7228
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/extratest_zeta.py",
+      "size": 1003
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/runtests.py",
+      "size": 5189
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_basic_ops.py",
+      "size": 15348
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_bitwise.py",
+      "size": 7686
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_calculus.py",
+      "size": 9187
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_compatibility.py",
+      "size": 2306
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_convert.py",
+      "size": 8834
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_diff.py",
+      "size": 2466
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_division.py",
+      "size": 5340
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_eigen.py",
+      "size": 3905
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_eigen_symmetric.py",
+      "size": 8778
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_elliptic.py",
+      "size": 26225
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_fp.py",
+      "size": 89997
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_functions.py",
+      "size": 30955
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_functions2.py",
+      "size": 96990
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_gammazeta.py",
+      "size": 27917
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_hp.py",
+      "size": 10461
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_identify.py",
+      "size": 692
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_interval.py",
+      "size": 17527
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_levin.py",
+      "size": 5090
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_linalg.py",
+      "size": 10440
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_matrices.py",
+      "size": 7944
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_mpmath.py",
+      "size": 196
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_ode.py",
+      "size": 1822
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_pickle.py",
+      "size": 401
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_power.py",
+      "size": 5227
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_quad.py",
+      "size": 3893
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_rootfinding.py",
+      "size": 3132
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_special.py",
+      "size": 2848
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_str.py",
+      "size": 544
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_summation.py",
+      "size": 2035
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_trig.py",
+      "size": 4799
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/test_visualization.py",
+      "size": 944
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/tests/torture.py",
+      "size": 7868
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/usertools.py",
+      "size": 3029
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath/visualization.py",
+      "size": 10627
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/__init__.py",
+      "size": 1272
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/__init__.py",
+      "size": 6559
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/__init__.py",
+      "size": 1234
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/clique.py",
+      "size": 7691
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/clustering_coefficient.py",
+      "size": 2164
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/connectivity.py",
+      "size": 13118
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/density.py",
+      "size": 15250
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/distance_measures.py",
+      "size": 5805
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/dominating_set.py",
+      "size": 4710
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/kcomponents.py",
+      "size": 13259
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/matching.py",
+      "size": 1175
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/maxcut.py",
+      "size": 4333
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/ramsey.py",
+      "size": 1358
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/steinertree.py",
+      "size": 8763
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_approx_clust_coeff.py",
+      "size": 1171
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_clique.py",
+      "size": 3021
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_connectivity.py",
+      "size": 5952
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_density.py",
+      "size": 5008
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_distance_measures.py",
+      "size": 2023
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_dominating_set.py",
+      "size": 2686
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_kcomponents.py",
+      "size": 9346
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_matching.py",
+      "size": 186
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_maxcut.py",
+      "size": 2804
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_ramsey.py",
+      "size": 1143
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_steinertree.py",
+      "size": 9675
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_traveling_salesman.py",
+      "size": 31911
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_treewidth.py",
+      "size": 8868
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/tests/test_vertex_cover.py",
+      "size": 1942
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/traveling_salesman.py",
+      "size": 56210
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/treewidth.py",
+      "size": 8389
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/approximation/vertex_cover.py",
+      "size": 2803
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/__init__.py",
+      "size": 294
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/connectivity.py",
+      "size": 4220
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/correlation.py",
+      "size": 8689
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/mixing.py",
+      "size": 7586
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/neighbor_degree.py",
+      "size": 5282
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/pairs.py",
+      "size": 3841
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/tests/base_test.py",
+      "size": 2651
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/tests/test_connectivity.py",
+      "size": 4978
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/tests/test_correlation.py",
+      "size": 5068
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/tests/test_mixing.py",
+      "size": 6802
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/tests/test_neighbor_degree.py",
+      "size": 3934
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/assortativity/tests/test_pairs.py",
+      "size": 3008
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/asteroidal.py",
+      "size": 5500
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/__init__.py",
+      "size": 3883
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/basic.py",
+      "size": 8375
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/centrality.py",
+      "size": 9156
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/cluster.py",
+      "size": 7346
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/covering.py",
+      "size": 2163
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/edgelist.py",
+      "size": 11409
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/extendability.py",
+      "size": 3989
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/generators.py",
+      "size": 20408
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/link_analysis.py",
+      "size": 12772
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/matching.py",
+      "size": 21631
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/matrix.py",
+      "size": 6164
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/projection.py",
+      "size": 17252
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/redundancy.py",
+      "size": 3402
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/spectral.py",
+      "size": 1902
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_basic.py",
+      "size": 4291
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_centrality.py",
+      "size": 6362
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_cluster.py",
+      "size": 2801
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_covering.py",
+      "size": 1221
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_edgelist.py",
+      "size": 8471
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_extendability.py",
+      "size": 7043
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_generators.py",
+      "size": 13203
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_link_analysis.py",
+      "size": 6914
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_matching.py",
+      "size": 11973
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_matrix.py",
+      "size": 3052
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_project.py",
+      "size": 15134
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_redundancy.py",
+      "size": 917
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bipartite/tests/test_spectral_bipartivity.py",
+      "size": 2358
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/boundary.py",
+      "size": 5339
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/bridges.py",
+      "size": 6066
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/broadcasting.py",
+      "size": 4892
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/__init__.py",
+      "size": 558
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/betweenness.py",
+      "size": 16174
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/betweenness_subset.py",
+      "size": 9336
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/closeness.py",
+      "size": 10281
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/current_flow_betweenness.py",
+      "size": 11848
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/current_flow_betweenness_subset.py",
+      "size": 8107
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/current_flow_closeness.py",
+      "size": 3327
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/degree_alg.py",
+      "size": 3900
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/dispersion.py",
+      "size": 3631
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/eigenvector.py",
+      "size": 13625
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/flow_matrix.py",
+      "size": 3834
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/group.py",
+      "size": 27960
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/harmonic.py",
+      "size": 2849
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/katz.py",
+      "size": 11044
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/laplacian.py",
+      "size": 5556
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/load.py",
+      "size": 6859
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/percolation.py",
+      "size": 4419
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/reaching.py",
+      "size": 7255
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/second_order.py",
+      "size": 5012
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/subgraph_alg.py",
+      "size": 9515
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_betweenness_centrality.py",
+      "size": 32505
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_betweenness_centrality_subset.py",
+      "size": 12554
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_closeness_centrality.py",
+      "size": 8728
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py",
+      "size": 7870
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality_subset.py",
+      "size": 5839
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_current_flow_closeness.py",
+      "size": 1379
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_degree_centrality.py",
+      "size": 4101
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_dispersion.py",
+      "size": 1959
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_eigenvector_centrality.py",
+      "size": 5258
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_group.py",
+      "size": 8685
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_harmonic_centrality.py",
+      "size": 3867
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_katz_centrality.py",
+      "size": 11242
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_laplacian_centrality.py",
+      "size": 5898
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_load_centrality.py",
+      "size": 11343
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_percolation_centrality.py",
+      "size": 2591
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_reaching.py",
+      "size": 5090
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_second_order_centrality.py",
+      "size": 1999
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_subgraph.py",
+      "size": 3729
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_trophic.py",
+      "size": 8796
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/tests/test_voterank.py",
+      "size": 1687
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/trophic.py",
+      "size": 5328
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/centrality/voterank_alg.py",
+      "size": 3231
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/chains.py",
+      "size": 6968
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/chordal.py",
+      "size": 13403
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/clique.py",
+      "size": 25985
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/cluster.py",
+      "size": 22511
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/coloring/__init__.py",
+      "size": 182
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/coloring/equitable_coloring.py",
+      "size": 16315
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/coloring/greedy_coloring.py",
+      "size": 20043
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/coloring/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/coloring/tests/test_coloring.py",
+      "size": 23697
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/communicability_alg.py",
+      "size": 4545
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/__init__.py",
+      "size": 1280
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/asyn_fluid.py",
+      "size": 5935
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/centrality.py",
+      "size": 6635
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/community_utils.py",
+      "size": 908
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/divisive.py",
+      "size": 6655
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/kclique.py",
+      "size": 2460
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/kernighan_lin.py",
+      "size": 4349
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/label_propagation.py",
+      "size": 11878
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/leiden.py",
+      "size": 6962
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/local.py",
+      "size": 7316
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/louvain.py",
+      "size": 15424
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/lukes.py",
+      "size": 8115
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/modularity_max.py",
+      "size": 18082
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/quality.py",
+      "size": 11943
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_asyn_fluid.py",
+      "size": 3332
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_centrality.py",
+      "size": 2932
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_divisive.py",
+      "size": 3441
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_kclique.py",
+      "size": 2413
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_kernighan_lin.py",
+      "size": 2710
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_label_propagation.py",
+      "size": 7985
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_leiden.py",
+      "size": 4803
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_local.py",
+      "size": 1809
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_louvain.py",
+      "size": 8071
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_lukes.py",
+      "size": 3961
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_modularity_max.py",
+      "size": 10617
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_quality.py",
+      "size": 5275
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/community/tests/test_utils.py",
+      "size": 704
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/__init__.py",
+      "size": 173
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/attracting.py",
+      "size": 2712
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/biconnected.py",
+      "size": 12782
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/connected.py",
+      "size": 4471
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/semiconnected.py",
+      "size": 2030
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/strongly_connected.py",
+      "size": 9542
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/tests/test_attracting.py",
+      "size": 2243
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/tests/test_biconnected.py",
+      "size": 6036
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/tests/test_connected.py",
+      "size": 4815
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/tests/test_semiconnected.py",
+      "size": 1792
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/tests/test_strongly_connected.py",
+      "size": 6021
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/tests/test_weakly_connected.py",
+      "size": 3083
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/components/weakly_connected.py",
+      "size": 4467
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/__init__.py",
+      "size": 281
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/connectivity.py",
+      "size": 29367
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/cuts.py",
+      "size": 23199
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/disjoint_paths.py",
+      "size": 14649
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/edge_augmentation.py",
+      "size": 44063
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/edge_kcomponents.py",
+      "size": 20894
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/kcomponents.py",
+      "size": 8171
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/kcutsets.py",
+      "size": 9371
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/stoerwagner.py",
+      "size": 5431
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/tests/test_connectivity.py",
+      "size": 15027
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/tests/test_cuts.py",
+      "size": 10356
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/tests/test_disjoint_paths.py",
+      "size": 8392
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/tests/test_edge_augmentation.py",
+      "size": 15739
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/tests/test_edge_kcomponents.py",
+      "size": 16453
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/tests/test_kcomponents.py",
+      "size": 8554
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/tests/test_kcutsets.py",
+      "size": 8503
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/tests/test_stoer_wagner.py",
+      "size": 3011
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/connectivity/utils.py",
+      "size": 3217
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/core.py",
+      "size": 17479
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/covering.py",
+      "size": 5278
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/cuts.py",
+      "size": 9990
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/cycles.py",
+      "size": 43303
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/d_separation.py",
+      "size": 26089
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/dag.py",
+      "size": 47248
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/distance_measures.py",
+      "size": 39927
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/distance_regular.py",
+      "size": 7053
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/dominance.py",
+      "size": 3450
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/dominating.py",
+      "size": 8145
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/efficiency_measures.py",
+      "size": 4741
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/euler.py",
+      "size": 14205
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/__init__.py",
+      "size": 341
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/boykovkolmogorov.py",
+      "size": 13334
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/capacityscaling.py",
+      "size": 14469
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/dinitz_alg.py",
+      "size": 8341
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/edmondskarp.py",
+      "size": 8056
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/gomory_hu.py",
+      "size": 6345
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/maxflow.py",
+      "size": 22975
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/mincost.py",
+      "size": 12853
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/networksimplex.py",
+      "size": 25098
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/preflowpush.py",
+      "size": 15721
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/shortestaugmentingpath.py",
+      "size": 10372
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/tests/test_gomory_hu.py",
+      "size": 4471
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/tests/test_maxflow.py",
+      "size": 18936
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/tests/test_maxflow_large_graph.py",
+      "size": 4614
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/tests/test_mincost.py",
+      "size": 17806
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/tests/test_networksimplex.py",
+      "size": 14162
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/flow/utils.py",
+      "size": 6248
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/graph_hashing.py",
+      "size": 16919
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/graphical.py",
+      "size": 15831
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/hierarchy.py",
+      "size": 1786
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/hybrid.py",
+      "size": 6209
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isolate.py",
+      "size": 2301
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/__init__.py",
+      "size": 406
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/ismags.py",
+      "size": 43875
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/isomorph.py",
+      "size": 10561
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/isomorphvf2.py",
+      "size": 47637
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/matchhelpers.py",
+      "size": 10884
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/temporalisomorphvf2.py",
+      "size": 10948
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/tests/test_ismags.py",
+      "size": 11433
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/tests/test_isomorphism.py",
+      "size": 4768
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py",
+      "size": 12879
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/tests/test_match_helpers.py",
+      "size": 2483
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/tests/test_temporalisomorphvf2.py",
+      "size": 7343
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/tests/test_tree_isomorphism.py",
+      "size": 5681
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/tests/test_vf2pp.py",
+      "size": 49934
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/tests/test_vf2pp_helpers.py",
+      "size": 90317
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/tests/test_vf2userfunc.py",
+      "size": 6625
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/tree_isomorphism.py",
+      "size": 9039
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/vf2pp.py",
+      "size": 36677
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/isomorphism/vf2userfunc.py",
+      "size": 7371
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/link_analysis/__init__.py",
+      "size": 118
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/link_analysis/hits_alg.py",
+      "size": 10421
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/link_analysis/pagerank_alg.py",
+      "size": 17228
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/link_analysis/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/link_analysis/tests/test_hits.py",
+      "size": 2548
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/link_analysis/tests/test_pagerank.py",
+      "size": 7282
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/link_prediction.py",
+      "size": 22253
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/lowest_common_ancestors.py",
+      "size": 9286
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/matching.py",
+      "size": 44518
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/minors/__init__.py",
+      "size": 587
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/minors/contraction.py",
+      "size": 24354
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/minors/tests/test_contraction.py",
+      "size": 17644
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/mis.py",
+      "size": 2344
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/moral.py",
+      "size": 1535
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/node_classification.py",
+      "size": 6469
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/non_randomness.py",
+      "size": 3068
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/operators/__init__.py",
+      "size": 201
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/operators/all.py",
+      "size": 9718
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/operators/binary.py",
+      "size": 13150
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/operators/product.py",
+      "size": 19632
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/operators/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/operators/tests/test_all.py",
+      "size": 8250
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/operators/tests/test_binary.py",
+      "size": 12160
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/operators/tests/test_product.py",
+      "size": 15155
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/operators/tests/test_unary.py",
+      "size": 1415
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/operators/unary.py",
+      "size": 1795
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/planar_drawing.py",
+      "size": 16254
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/planarity.py",
+      "size": 49891
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/polynomials.py",
+      "size": 11278
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/reciprocity.py",
+      "size": 2855
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/regular.py",
+      "size": 6794
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/richclub.py",
+      "size": 4892
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/__init__.py",
+      "size": 285
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/astar.py",
+      "size": 8937
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/dense.py",
+      "size": 8261
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/generic.py",
+      "size": 25238
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/tests/test_astar.py",
+      "size": 8989
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/tests/test_dense.py",
+      "size": 6747
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/tests/test_dense_numpy.py",
+      "size": 2299
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/tests/test_generic.py",
+      "size": 18405
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/tests/test_unweighted.py",
+      "size": 5879
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/tests/test_weighted.py",
+      "size": 35032
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/unweighted.py",
+      "size": 15527
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/shortest_paths/weighted.py",
+      "size": 82423
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/similarity.py",
+      "size": 60915
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/simple_paths.py",
+      "size": 30298
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/smallworld.py",
+      "size": 13565
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/smetric.py",
+      "size": 770
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/sparsifiers.py",
+      "size": 10048
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/structuralholes.py",
+      "size": 12626
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/summarization.py",
+      "size": 23251
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/swap.py",
+      "size": 14744
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_asteroidal.py",
+      "size": 502
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_boundary.py",
+      "size": 6227
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_bridges.py",
+      "size": 4026
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_broadcasting.py",
+      "size": 2021
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_chains.py",
+      "size": 4196
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_chordal.py",
+      "size": 4438
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_clique.py",
+      "size": 9413
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_cluster.py",
+      "size": 17037
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_communicability.py",
+      "size": 2938
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_core.py",
+      "size": 9619
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_covering.py",
+      "size": 2718
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_cuts.py",
+      "size": 5376
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_cycles.py",
+      "size": 34851
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_d_separation.py",
+      "size": 10714
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_dag.py",
+      "size": 29486
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_distance_measures.py",
+      "size": 28793
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_distance_regular.py",
+      "size": 2915
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_dominance.py",
+      "size": 9184
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_dominating.py",
+      "size": 3112
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_efficiency.py",
+      "size": 1894
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_euler.py",
+      "size": 11209
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_graph_hashing.py",
+      "size": 31567
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_graphical.py",
+      "size": 5366
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_hierarchy.py",
+      "size": 1184
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_hybrid.py",
+      "size": 720
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_isolate.py",
+      "size": 555
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_link_prediction.py",
+      "size": 20028
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_lowest_common_ancestors.py",
+      "size": 14160
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_matching.py",
+      "size": 17897
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_max_weight_clique.py",
+      "size": 6739
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_mis.py",
+      "size": 1865
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_moral.py",
+      "size": 452
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_node_classification.py",
+      "size": 4663
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_non_randomness.py",
+      "size": 1000
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_planar_drawing.py",
+      "size": 8765
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_planarity.py",
+      "size": 17312
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_polynomials.py",
+      "size": 1983
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_reciprocity.py",
+      "size": 1296
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_regular.py",
+      "size": 2610
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_richclub.py",
+      "size": 3962
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_similarity.py",
+      "size": 34412
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_simple_paths.py",
+      "size": 25181
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_smallworld.py",
+      "size": 2390
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_smetric.py",
+      "size": 144
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_sparsifiers.py",
+      "size": 4044
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_structuralholes.py",
+      "size": 7592
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_summarization.py",
+      "size": 21312
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_swap.py",
+      "size": 6144
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_threshold.py",
+      "size": 9564
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_time_dependent.py",
+      "size": 13342
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_tournament.py",
+      "size": 4107
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_triads.py",
+      "size": 8221
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_vitality.py",
+      "size": 1380
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_voronoi.py",
+      "size": 3477
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_walks.py",
+      "size": 1499
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tests/test_wiener.py",
+      "size": 3209
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/threshold.py",
+      "size": 32858
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/time_dependent.py",
+      "size": 5762
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tournament.py",
+      "size": 11604
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/traversal/__init__.py",
+      "size": 142
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/traversal/beamsearch.py",
+      "size": 3473
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/traversal/breadth_first_search.py",
+      "size": 18307
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/traversal/depth_first_search.py",
+      "size": 16795
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/traversal/edgebfs.py",
+      "size": 6333
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/traversal/edgedfs.py",
+      "size": 6041
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/traversal/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/traversal/tests/test_beamsearch.py",
+      "size": 900
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/traversal/tests/test_bfs.py",
+      "size": 6447
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/traversal/tests/test_dfs.py",
+      "size": 10580
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/traversal/tests/test_edgebfs.py",
+      "size": 4702
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/traversal/tests/test_edgedfs.py",
+      "size": 4775
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/__init__.py",
+      "size": 149
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/branchings.py",
+      "size": 34339
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/coding.py",
+      "size": 13466
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/decomposition.py",
+      "size": 3071
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/mst.py",
+      "size": 46151
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/operations.py",
+      "size": 4048
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/recognition.py",
+      "size": 7569
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/tests/test_branchings.py",
+      "size": 17731
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/tests/test_coding.py",
+      "size": 3955
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/tests/test_decomposition.py",
+      "size": 1871
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/tests/test_mst.py",
+      "size": 31631
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/tests/test_operations.py",
+      "size": 1961
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/tree/tests/test_recognition.py",
+      "size": 4521
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/triads.py",
+      "size": 14229
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/vitality.py",
+      "size": 2289
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/voronoi.py",
+      "size": 3183
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/walks.py",
+      "size": 2427
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/algorithms/wiener.py",
+      "size": 7639
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/__init__.py",
+      "size": 364
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/coreviews.py",
+      "size": 13251
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/digraph.py",
+      "size": 48101
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/filters.py",
+      "size": 2817
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/function.py",
+      "size": 39334
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/graph.py",
+      "size": 71659
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/graphviews.py",
+      "size": 8520
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/multidigraph.py",
+      "size": 36351
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/multigraph.py",
+      "size": 47248
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/reportviews.py",
+      "size": 46132
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/dispatch_interface.py",
+      "size": 6479
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/historical_tests.py",
+      "size": 16174
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_coreviews.py",
+      "size": 12128
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_digraph.py",
+      "size": 12283
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_digraph_historical.py",
+      "size": 3668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_filters.py",
+      "size": 5851
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_function.py",
+      "size": 34997
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_graph.py",
+      "size": 31105
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_graph_historical.py",
+      "size": 258
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_graphviews.py",
+      "size": 11438
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_multidigraph.py",
+      "size": 16342
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_multigraph.py",
+      "size": 18777
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_reportviews.py",
+      "size": 41332
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_special.py",
+      "size": 4053
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/classes/tests/test_subgraphviews.py",
+      "size": 13669
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/conftest.py",
+      "size": 7941
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/convert.py",
+      "size": 16143
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/convert_matrix.py",
+      "size": 45342
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/drawing/__init__.py",
+      "size": 160
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/drawing/layout.py",
+      "size": 66075
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/drawing/nx_agraph.py",
+      "size": 13987
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/drawing/nx_latex.py",
+      "size": 24846
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/drawing/nx_pydot.py",
+      "size": 9992
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/drawing/nx_pylab.py",
+      "size": 105946
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/drawing/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/drawing/tests/test_agraph.py",
+      "size": 8788
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/drawing/tests/test_latex.py",
+      "size": 8621
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/drawing/tests/test_layout.py",
+      "size": 23709
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/drawing/tests/test_pydot.py",
+      "size": 4973
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/drawing/tests/test_pylab.py",
+      "size": 59298
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/exception.py",
+      "size": 3787
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/__init__.py",
+      "size": 1366
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/atlas.py",
+      "size": 6955
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/classic.py",
+      "size": 32000
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/cographs.py",
+      "size": 1891
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/community.py",
+      "size": 34911
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/degree_seq.py",
+      "size": 30178
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/directed.py",
+      "size": 18139
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/duplication.py",
+      "size": 5831
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/ego.py",
+      "size": 1894
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/expanders.py",
+      "size": 14460
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/geometric.py",
+      "size": 39461
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/harary_graph.py",
+      "size": 6159
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/internet_as_graphs.py",
+      "size": 14172
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/intersection.py",
+      "size": 4101
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/interval_graph.py",
+      "size": 2204
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/joint_degree_seq.py",
+      "size": 24773
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/lattice.py",
+      "size": 13500
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/line.py",
+      "size": 17542
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/mycielski.py",
+      "size": 3314
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/nonisomorphic_trees.py",
+      "size": 5710
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/random_clustered.py",
+      "size": 4183
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/random_graphs.py",
+      "size": 51346
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/small.py",
+      "size": 28298
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/social.py",
+      "size": 23437
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/spectral_graph_forge.py",
+      "size": 4282
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/stochastic.py",
+      "size": 1981
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/sudoku.py",
+      "size": 4288
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_atlas.py",
+      "size": 2530
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_classic.py",
+      "size": 24218
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_cographs.py",
+      "size": 458
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_community.py",
+      "size": 11311
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_degree_seq.py",
+      "size": 7306
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_directed.py",
+      "size": 5758
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_duplication.py",
+      "size": 3155
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_ego.py",
+      "size": 1327
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_expanders.py",
+      "size": 5949
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_geometric.py",
+      "size": 18091
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_harary_graph.py",
+      "size": 4936
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_internet_as_graphs.py",
+      "size": 6795
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_intersection.py",
+      "size": 819
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_interval_graph.py",
+      "size": 4277
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_joint_degree_seq.py",
+      "size": 4270
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_lattice.py",
+      "size": 9290
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_line.py",
+      "size": 10378
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_mycielski.py",
+      "size": 946
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_nonisomorphic_trees.py",
+      "size": 2034
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_random_clustered.py",
+      "size": 1297
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_random_graphs.py",
+      "size": 18925
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_small.py",
+      "size": 7103
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_spectral_graph_forge.py",
+      "size": 1594
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_stochastic.py",
+      "size": 2179
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_sudoku.py",
+      "size": 1968
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_time_series.py",
+      "size": 2230
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_trees.py",
+      "size": 7006
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/tests/test_triads.py",
+      "size": 333
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/time_series.py",
+      "size": 2439
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/trees.py",
+      "size": 36517
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/generators/triads.py",
+      "size": 2452
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/lazy_imports.py",
+      "size": 5764
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/__init__.py",
+      "size": 568
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/algebraicconnectivity.py",
+      "size": 21118
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/attrmatrix.py",
+      "size": 15900
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/bethehessianmatrix.py",
+      "size": 2697
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/graphmatrix.py",
+      "size": 5623
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/laplacianmatrix.py",
+      "size": 17360
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/modularitymatrix.py",
+      "size": 4706
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/spectrum.py",
+      "size": 4215
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/tests/test_algebraic_connectivity.py",
+      "size": 13735
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/tests/test_attrmatrix.py",
+      "size": 2833
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/tests/test_bethehessian.py",
+      "size": 1268
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/tests/test_graphmatrix.py",
+      "size": 8655
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/tests/test_laplacian.py",
+      "size": 13953
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/tests/test_modularity.py",
+      "size": 3056
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/linalg/tests/test_spectrum.py",
+      "size": 2769
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/__init__.py",
+      "size": 561
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/adjlist.py",
+      "size": 8438
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/edgelist.py",
+      "size": 14292
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/gexf.py",
+      "size": 39638
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/gml.py",
+      "size": 31193
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/graph6.py",
+      "size": 11684
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/graphml.py",
+      "size": 39326
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/json_graph/__init__.py",
+      "size": 677
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/json_graph/adjacency.py",
+      "size": 4716
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/json_graph/cytoscape.py",
+      "size": 5841
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/json_graph/node_link.py",
+      "size": 10829
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/json_graph/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/json_graph/tests/test_adjacency.py",
+      "size": 2456
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/json_graph/tests/test_cytoscape.py",
+      "size": 2044
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/json_graph/tests/test_node_link.py",
+      "size": 6468
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/json_graph/tests/test_tree.py",
+      "size": 1352
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/json_graph/tree.py",
+      "size": 3851
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/leda.py",
+      "size": 2852
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/multiline_adjlist.py",
+      "size": 11384
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/p2g.py",
+      "size": 3253
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/pajek.py",
+      "size": 8746
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/sparse6.py",
+      "size": 10442
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/tests/test_adjlist.py",
+      "size": 10134
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/tests/test_edgelist.py",
+      "size": 10113
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/tests/test_gexf.py",
+      "size": 20262
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/tests/test_gml.py",
+      "size": 21399
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/tests/test_graph6.py",
+      "size": 6559
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/tests/test_graphml.py",
+      "size": 67573
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/tests/test_leda.py",
+      "size": 1392
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/tests/test_p2g.py",
+      "size": 1320
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/tests/test_pajek.py",
+      "size": 4629
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/tests/test_sparse6.py",
+      "size": 5288
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/tests/test_text.py",
+      "size": 55319
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/readwrite/text.py",
+      "size": 29140
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/relabel.py",
+      "size": 10300
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/tests/test_all_random_functions.py",
+      "size": 8623
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/tests/test_convert.py",
+      "size": 12731
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/tests/test_convert_numpy.py",
+      "size": 19032
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/tests/test_convert_pandas.py",
+      "size": 13346
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/tests/test_convert_scipy.py",
+      "size": 10381
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/tests/test_exceptions.py",
+      "size": 927
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/tests/test_import.py",
+      "size": 220
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/tests/test_lazy_imports.py",
+      "size": 2675
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/tests/test_relabel.py",
+      "size": 14517
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/__init__.py",
+      "size": 302
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/backends.py",
+      "size": 95569
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/configs.py",
+      "size": 15234
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/decorators.py",
+      "size": 44713
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/heaps.py",
+      "size": 10355
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/mapped_queue.py",
+      "size": 10184
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/misc.py",
+      "size": 21257
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/random_sequence.py",
+      "size": 4237
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/rcm.py",
+      "size": 4618
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/tests/test__init.py",
+      "size": 363
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/tests/test_backends.py",
+      "size": 6523
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/tests/test_config.py",
+      "size": 8717
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/tests/test_decorators.py",
+      "size": 14050
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/tests/test_heaps.py",
+      "size": 3711
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/tests/test_mapped_queue.py",
+      "size": 7354
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/tests/test_misc.py",
+      "size": 8683
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/tests/test_random_sequence.py",
+      "size": 925
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/tests/test_rcm.py",
+      "size": 1421
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/tests/test_unionfind.py",
+      "size": 1579
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx/utils/union_find.py",
+      "size": 3338
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/nodeenv.py",
+      "size": 46675
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/__init__.py",
+      "size": 353
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/__main__.py",
+      "size": 854
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/__pip-runner__.py",
+      "size": 1450
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/__init__.py",
+      "size": 511
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/build_env.py",
+      "size": 14201
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cache.py",
+      "size": 10345
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/__init__.py",
+      "size": 131
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/autocompletion.py",
+      "size": 7193
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/base_command.py",
+      "size": 8716
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/cmdoptions.py",
+      "size": 31025
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/command_context.py",
+      "size": 817
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/index_command.py",
+      "size": 5717
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/main.py",
+      "size": 2815
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/main_parser.py",
+      "size": 4329
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/parser.py",
+      "size": 10916
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/progress_bars.py",
+      "size": 4668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/req_command.py",
+      "size": 13799
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/spinners.py",
+      "size": 7362
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/cli/status_codes.py",
+      "size": 116
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/__init__.py",
+      "size": 4026
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/cache.py",
+      "size": 8230
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/check.py",
+      "size": 2244
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/completion.py",
+      "size": 4530
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/configuration.py",
+      "size": 10105
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/debug.py",
+      "size": 6805
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/download.py",
+      "size": 5075
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/freeze.py",
+      "size": 3099
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/hash.py",
+      "size": 1679
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/help.py",
+      "size": 1108
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/index.py",
+      "size": 5243
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/inspect.py",
+      "size": 3177
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/install.py",
+      "size": 30472
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/list.py",
+      "size": 13514
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/lock.py",
+      "size": 5797
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/search.py",
+      "size": 5782
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/show.py",
+      "size": 8066
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/uninstall.py",
+      "size": 3868
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/commands/wheel.py",
+      "size": 6013
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/configuration.py",
+      "size": 14568
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/distributions/__init__.py",
+      "size": 858
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/distributions/base.py",
+      "size": 1830
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/distributions/installed.py",
+      "size": 929
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/distributions/sdist.py",
+      "size": 6627
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/distributions/wheel.py",
+      "size": 1364
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/exceptions.py",
+      "size": 29592
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/index/__init__.py",
+      "size": 29
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/index/collector.py",
+      "size": 16185
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/index/package_finder.py",
+      "size": 38835
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/index/sources.py",
+      "size": 8639
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/locations/__init__.py",
+      "size": 14185
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/locations/_distutils.py",
+      "size": 5975
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/locations/_sysconfig.py",
+      "size": 7716
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/locations/base.py",
+      "size": 2550
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/main.py",
+      "size": 338
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/metadata/__init__.py",
+      "size": 5824
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/metadata/_json.py",
+      "size": 2711
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/metadata/base.py",
+      "size": 25420
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/metadata/importlib/__init__.py",
+      "size": 135
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/metadata/importlib/_compat.py",
+      "size": 2804
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/metadata/importlib/_dists.py",
+      "size": 8420
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/metadata/importlib/_envs.py",
+      "size": 5333
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/metadata/pkg_resources.py",
+      "size": 10544
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/__init__.py",
+      "size": 62
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/candidate.py",
+      "size": 753
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/direct_url.py",
+      "size": 6555
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/format_control.py",
+      "size": 2471
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/index.py",
+      "size": 1030
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/installation_report.py",
+      "size": 2839
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/link.py",
+      "size": 21793
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/pylock.py",
+      "size": 6211
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/scheme.py",
+      "size": 575
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/search_scope.py",
+      "size": 4507
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/selection_prefs.py",
+      "size": 2016
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/target_python.py",
+      "size": 4243
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/models/wheel.py",
+      "size": 2920
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/network/__init__.py",
+      "size": 49
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/network/auth.py",
+      "size": 20681
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/network/cache.py",
+      "size": 4862
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/network/download.py",
+      "size": 12682
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/network/lazy_wheel.py",
+      "size": 7646
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/network/session.py",
+      "size": 19188
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/network/utils.py",
+      "size": 4091
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/network/xmlrpc.py",
+      "size": 1830
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/operations/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/operations/check.py",
+      "size": 5894
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/operations/freeze.py",
+      "size": 9854
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/operations/install/__init__.py",
+      "size": 50
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/operations/install/wheel.py",
+      "size": 27956
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/operations/prepare.py",
+      "size": 28914
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/pyproject.py",
+      "size": 4555
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/req/__init__.py",
+      "size": 3041
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/req/constructors.py",
+      "size": 18581
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/req/req_dependency_group.py",
+      "size": 2618
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/req/req_file.py",
+      "size": 20130
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/req/req_install.py",
+      "size": 31273
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/req/req_set.py",
+      "size": 2828
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/req/req_uninstall.py",
+      "size": 24099
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/base.py",
+      "size": 577
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/legacy/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/legacy/resolver.py",
+      "size": 24060
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/resolvelib/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/resolvelib/base.py",
+      "size": 5047
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/resolvelib/candidates.py",
+      "size": 20454
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/resolvelib/factory.py",
+      "size": 33628
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/resolvelib/found_candidates.py",
+      "size": 6018
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/resolvelib/provider.py",
+      "size": 11441
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/resolvelib/reporter.py",
+      "size": 3909
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/resolvelib/requirements.py",
+      "size": 8076
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/resolution/resolvelib/resolver.py",
+      "size": 13437
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/self_outdated_check.py",
+      "size": 8471
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/_jaraco_text.py",
+      "size": 3350
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/_log.py",
+      "size": 1015
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/appdirs.py",
+      "size": 1681
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/compat.py",
+      "size": 2514
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/compatibility_tags.py",
+      "size": 6630
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/datetime.py",
+      "size": 241
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/deprecation.py",
+      "size": 3696
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/direct_url_helpers.py",
+      "size": 3200
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/egg_link.py",
+      "size": 2459
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/entrypoints.py",
+      "size": 3324
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/filesystem.py",
+      "size": 5497
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/filetypes.py",
+      "size": 689
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/glibc.py",
+      "size": 3726
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/hashes.py",
+      "size": 4998
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/logging.py",
+      "size": 12108
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/misc.py",
+      "size": 23374
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/packaging.py",
+      "size": 1601
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/retry.py",
+      "size": 1461
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/subprocess.py",
+      "size": 8983
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/temp_dir.py",
+      "size": 9307
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/unpacking.py",
+      "size": 12974
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/urls.py",
+      "size": 1601
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/virtualenv.py",
+      "size": 3455
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/utils/wheel.py",
+      "size": 4468
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/vcs/__init__.py",
+      "size": 596
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/vcs/bazaar.py",
+      "size": 3734
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/vcs/git.py",
+      "size": 19144
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/vcs/mercurial.py",
+      "size": 5575
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/vcs/subversion.py",
+      "size": 11787
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/vcs/versioncontrol.py",
+      "size": 22502
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_internal/wheel_builder.py",
+      "size": 9010
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/__init__.py",
+      "size": 4907
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/__init__.py",
+      "size": 677
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/_cmd.py",
+      "size": 1737
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/adapter.py",
+      "size": 6599
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/cache.py",
+      "size": 1953
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/caches/__init__.py",
+      "size": 303
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/caches/file_cache.py",
+      "size": 4117
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/caches/redis_cache.py",
+      "size": 1386
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/controller.py",
+      "size": 19101
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/filewrapper.py",
+      "size": 4291
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/heuristics.py",
+      "size": 4881
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/serialize.py",
+      "size": 5163
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/wrapper.py",
+      "size": 1417
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/certifi/__init__.py",
+      "size": 94
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/certifi/__main__.py",
+      "size": 255
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/certifi/core.py",
+      "size": 3442
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/dependency_groups/__init__.py",
+      "size": 250
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/dependency_groups/__main__.py",
+      "size": 1709
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/dependency_groups/_implementation.py",
+      "size": 8041
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/dependency_groups/_lint_dependency_groups.py",
+      "size": 1710
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/dependency_groups/_pip_wrapper.py",
+      "size": 1865
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/dependency_groups/_toml_compat.py",
+      "size": 285
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/distlib/__init__.py",
+      "size": 625
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/distlib/compat.py",
+      "size": 41467
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/distlib/resources.py",
+      "size": 10820
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/distlib/scripts.py",
+      "size": 18612
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/distlib/util.py",
+      "size": 66682
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/distro/__init__.py",
+      "size": 981
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/distro/__main__.py",
+      "size": 64
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/distro/distro.py",
+      "size": 49430
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/idna/__init__.py",
+      "size": 868
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/idna/codec.py",
+      "size": 3422
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/idna/compat.py",
+      "size": 316
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/idna/core.py",
+      "size": 13239
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/idna/idnadata.py",
+      "size": 78306
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/idna/intranges.py",
+      "size": 1898
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/idna/package_data.py",
+      "size": 21
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/idna/uts46data.py",
+      "size": 239289
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/msgpack/__init__.py",
+      "size": 1109
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/msgpack/exceptions.py",
+      "size": 1081
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/msgpack/ext.py",
+      "size": 5726
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/msgpack/fallback.py",
+      "size": 32390
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/__init__.py",
+      "size": 494
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/_elffile.py",
+      "size": 3286
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/_manylinux.py",
+      "size": 9596
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/_musllinux.py",
+      "size": 2694
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/_parser.py",
+      "size": 10221
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/_structures.py",
+      "size": 1431
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/_tokenizer.py",
+      "size": 5310
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/licenses/__init__.py",
+      "size": 5727
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/licenses/_spdx.py",
+      "size": 48398
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/markers.py",
+      "size": 12049
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/metadata.py",
+      "size": 34739
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/requirements.py",
+      "size": 2947
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/specifiers.py",
+      "size": 40079
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/tags.py",
+      "size": 22745
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/utils.py",
+      "size": 5050
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/packaging/version.py",
+      "size": 16688
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pkg_resources/__init__.py",
+      "size": 124451
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/platformdirs/__init__.py",
+      "size": 22344
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/platformdirs/__main__.py",
+      "size": 1505
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/platformdirs/android.py",
+      "size": 9013
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/platformdirs/api.py",
+      "size": 9281
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/platformdirs/macos.py",
+      "size": 6322
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/platformdirs/unix.py",
+      "size": 10458
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/platformdirs/version.py",
+      "size": 704
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/platformdirs/windows.py",
+      "size": 10125
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/__init__.py",
+      "size": 2983
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/__main__.py",
+      "size": 353
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/console.py",
+      "size": 1718
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/filter.py",
+      "size": 1910
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/filters/__init__.py",
+      "size": 40392
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/formatter.py",
+      "size": 4390
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/formatters/__init__.py",
+      "size": 5385
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/formatters/_mapping.py",
+      "size": 4176
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/lexer.py",
+      "size": 35349
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/lexers/__init__.py",
+      "size": 12115
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/lexers/_mapping.py",
+      "size": 77602
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/lexers/python.py",
+      "size": 53853
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/modeline.py",
+      "size": 1005
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/plugin.py",
+      "size": 1891
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/regexopt.py",
+      "size": 3072
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/scanner.py",
+      "size": 3092
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/sphinxext.py",
+      "size": 7981
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/style.py",
+      "size": 6420
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/styles/__init__.py",
+      "size": 2042
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/styles/_mapping.py",
+      "size": 3312
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/token.py",
+      "size": 6226
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/unistring.py",
+      "size": 63208
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pygments/util.py",
+      "size": 10031
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/__init__.py",
+      "size": 691
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_impl.py",
+      "size": 14936
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/__init__.py",
+      "size": 557
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py",
+      "size": 12216
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/__init__.py",
+      "size": 5057
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/__version__.py",
+      "size": 435
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/_internal_utils.py",
+      "size": 1495
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/adapters.py",
+      "size": 26429
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/api.py",
+      "size": 6449
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/auth.py",
+      "size": 10186
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/certs.py",
+      "size": 441
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/compat.py",
+      "size": 1822
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/cookies.py",
+      "size": 18590
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/exceptions.py",
+      "size": 4272
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/help.py",
+      "size": 3813
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/hooks.py",
+      "size": 733
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/models.py",
+      "size": 35575
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/packages.py",
+      "size": 1057
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/sessions.py",
+      "size": 30503
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/status_codes.py",
+      "size": 4322
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/structures.py",
+      "size": 2912
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/requests/utils.py",
+      "size": 33225
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/resolvelib/__init__.py",
+      "size": 541
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/resolvelib/providers.py",
+      "size": 8914
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/resolvelib/reporters.py",
+      "size": 2037
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/resolvelib/resolvers/__init__.py",
+      "size": 640
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/resolvelib/resolvers/abstract.py",
+      "size": 1543
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/resolvelib/resolvers/criterion.py",
+      "size": 1768
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/resolvelib/resolvers/exceptions.py",
+      "size": 1768
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/resolvelib/resolvers/resolution.py",
+      "size": 24212
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/resolvelib/structs.py",
+      "size": 6420
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/__init__.py",
+      "size": 6090
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/__main__.py",
+      "size": 7896
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_cell_widths.py",
+      "size": 10209
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_emoji_codes.py",
+      "size": 140235
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_emoji_replace.py",
+      "size": 1064
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_export_format.py",
+      "size": 2128
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_extension.py",
+      "size": 265
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_fileno.py",
+      "size": 799
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_inspect.py",
+      "size": 9656
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_log_render.py",
+      "size": 3225
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_loop.py",
+      "size": 1236
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_null_file.py",
+      "size": 1394
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_palettes.py",
+      "size": 7063
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_pick.py",
+      "size": 423
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_ratio.py",
+      "size": 5325
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_spinners.py",
+      "size": 19919
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_stack.py",
+      "size": 351
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_timer.py",
+      "size": 417
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_win32_console.py",
+      "size": 22755
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_windows.py",
+      "size": 1925
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_windows_renderer.py",
+      "size": 2783
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/_wrap.py",
+      "size": 3404
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/abc.py",
+      "size": 890
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/align.py",
+      "size": 10324
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/ansi.py",
+      "size": 6921
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/bar.py",
+      "size": 3263
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/box.py",
+      "size": 10686
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/cells.py",
+      "size": 5130
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/color.py",
+      "size": 18211
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/color_triplet.py",
+      "size": 1054
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/columns.py",
+      "size": 7131
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/console.py",
+      "size": 100849
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/constrain.py",
+      "size": 1288
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/containers.py",
+      "size": 5502
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/control.py",
+      "size": 6487
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/default_styles.py",
+      "size": 8257
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/diagnose.py",
+      "size": 1025
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/emoji.py",
+      "size": 2367
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/errors.py",
+      "size": 642
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/file_proxy.py",
+      "size": 1683
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/filesize.py",
+      "size": 2484
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/highlighter.py",
+      "size": 9586
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/json.py",
+      "size": 5031
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/jupyter.py",
+      "size": 3252
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/layout.py",
+      "size": 14004
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/live.py",
+      "size": 15180
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/live_render.py",
+      "size": 3521
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/logging.py",
+      "size": 12468
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/markup.py",
+      "size": 8451
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/measure.py",
+      "size": 5305
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/padding.py",
+      "size": 4908
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/pager.py",
+      "size": 828
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/palette.py",
+      "size": 3396
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/panel.py",
+      "size": 11157
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/pretty.py",
+      "size": 36391
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/progress.py",
+      "size": 60408
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/progress_bar.py",
+      "size": 8162
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/prompt.py",
+      "size": 12447
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/protocol.py",
+      "size": 1391
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/region.py",
+      "size": 166
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/repr.py",
+      "size": 4431
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/rule.py",
+      "size": 4602
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/scope.py",
+      "size": 2843
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/screen.py",
+      "size": 1591
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/segment.py",
+      "size": 24743
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/spinner.py",
+      "size": 4214
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/status.py",
+      "size": 4424
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/style.py",
+      "size": 26990
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/styled.py",
+      "size": 1258
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/syntax.py",
+      "size": 36371
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/table.py",
+      "size": 40049
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/terminal_theme.py",
+      "size": 3370
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/text.py",
+      "size": 47552
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/theme.py",
+      "size": 3771
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/themes.py",
+      "size": 102
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/traceback.py",
+      "size": 35861
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/rich/tree.py",
+      "size": 9451
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/tomli/__init__.py",
+      "size": 314
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/tomli/_parser.py",
+      "size": 25778
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/tomli/_re.py",
+      "size": 3235
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/tomli/_types.py",
+      "size": 254
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/tomli_w/__init__.py",
+      "size": 169
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/tomli_w/_writer.py",
+      "size": 6961
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/truststore/__init__.py",
+      "size": 1320
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/truststore/_api.py",
+      "size": 11413
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/truststore/_macos.py",
+      "size": 20503
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/truststore/_openssl.py",
+      "size": 2412
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/truststore/_ssl_constants.py",
+      "size": 1130
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/truststore/_windows.py",
+      "size": 17993
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/__init__.py",
+      "size": 3333
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/_collections.py",
+      "size": 11372
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/_version.py",
+      "size": 64
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/connection.py",
+      "size": 20314
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/connectionpool.py",
+      "size": 40408
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/contrib/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/contrib/_appengine_environ.py",
+      "size": 957
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/contrib/_securetransport/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/contrib/_securetransport/bindings.py",
+      "size": 17632
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/contrib/_securetransport/low_level.py",
+      "size": 13922
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/contrib/appengine.py",
+      "size": 11036
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/contrib/ntlmpool.py",
+      "size": 4528
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/contrib/pyopenssl.py",
+      "size": 17081
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/contrib/securetransport.py",
+      "size": 34446
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/contrib/socks.py",
+      "size": 7097
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/exceptions.py",
+      "size": 8217
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/fields.py",
+      "size": 8579
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/filepost.py",
+      "size": 2440
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/packages/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/packages/backports/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/packages/backports/makefile.py",
+      "size": 1417
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/packages/backports/weakref_finalize.py",
+      "size": 5343
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/packages/six.py",
+      "size": 34665
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/poolmanager.py",
+      "size": 19990
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/request.py",
+      "size": 6691
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/response.py",
+      "size": 30641
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/__init__.py",
+      "size": 1155
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/connection.py",
+      "size": 4901
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/proxy.py",
+      "size": 1605
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/queue.py",
+      "size": 498
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/request.py",
+      "size": 3997
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/response.py",
+      "size": 3510
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/retry.py",
+      "size": 22050
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/ssl_.py",
+      "size": 17460
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/ssl_match_hostname.py",
+      "size": 5758
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/ssltransport.py",
+      "size": 6895
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/timeout.py",
+      "size": 10168
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/url.py",
+      "size": 14296
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/util/wait.py",
+      "size": 5403
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/__init__.py",
+      "size": 124456
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/backports/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/backports/tarfile.py",
+      "size": 106920
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/importlib_resources/__init__.py",
+      "size": 506
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/importlib_resources/_adapters.py",
+      "size": 4504
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/importlib_resources/_common.py",
+      "size": 5457
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/importlib_resources/_compat.py",
+      "size": 2925
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/importlib_resources/_itertools.py",
+      "size": 884
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/importlib_resources/_legacy.py",
+      "size": 3481
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/importlib_resources/abc.py",
+      "size": 5140
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/importlib_resources/readers.py",
+      "size": 3581
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/importlib_resources/simple.py",
+      "size": 2576
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/jaraco/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/jaraco/context.py",
+      "size": 9573
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/jaraco/functools/__init__.py",
+      "size": 16705
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/jaraco/text/__init__.py",
+      "size": 15526
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/more_itertools/__init__.py",
+      "size": 149
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/more_itertools/more.py",
+      "size": 143053
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/more_itertools/recipes.py",
+      "size": 27548
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/__init__.py",
+      "size": 496
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/_elffile.py",
+      "size": 3266
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/_manylinux.py",
+      "size": 9590
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/_musllinux.py",
+      "size": 2676
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/_parser.py",
+      "size": 10347
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/_structures.py",
+      "size": 1431
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/_tokenizer.py",
+      "size": 5292
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/markers.py",
+      "size": 8208
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/metadata.py",
+      "size": 33036
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/requirements.py",
+      "size": 2933
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/specifiers.py",
+      "size": 39784
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/tags.py",
+      "size": 18950
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/utils.py",
+      "size": 5268
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/packaging/version.py",
+      "size": 16236
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/platformdirs/__init__.py",
+      "size": 12806
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/platformdirs/__main__.py",
+      "size": 1164
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/platformdirs/android.py",
+      "size": 4068
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/platformdirs/api.py",
+      "size": 4910
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/platformdirs/macos.py",
+      "size": 2655
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/platformdirs/unix.py",
+      "size": 6911
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/platformdirs/version.py",
+      "size": 160
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/platformdirs/windows.py",
+      "size": 6596
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/_vendor/zipp.py",
+      "size": 8425
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pkg_resources/extern/__init__.py",
+      "size": 3123
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/platformdirs/__init__.py",
+      "size": 22284
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/platformdirs/__main__.py",
+      "size": 1493
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/platformdirs/android.py",
+      "size": 9013
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/platformdirs/api.py",
+      "size": 9281
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/platformdirs/macos.py",
+      "size": 6322
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/platformdirs/unix.py",
+      "size": 10458
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/platformdirs/version.py",
+      "size": 704
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/platformdirs/windows.py",
+      "size": 10125
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/__main__.py",
+      "size": 127
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/all_languages.py",
+      "size": 1412
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/clientlib.py",
+      "size": 15282
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/color.py",
+      "size": 3219
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/autoupdate.py",
+      "size": 7157
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/clean.py",
+      "size": 429
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/gc.py",
+      "size": 2804
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/hook_impl.py",
+      "size": 9400
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/init_templatedir.py",
+      "size": 1135
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/install_uninstall.py",
+      "size": 5341
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/migrate_config.py",
+      "size": 4154
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/run.py",
+      "size": 14115
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/sample_config.py",
+      "size": 453
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/try_repo.py",
+      "size": 2578
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/validate_config.py",
+      "size": 371
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/commands/validate_manifest.py",
+      "size": 377
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/constants.py",
+      "size": 282
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/envcontext.py",
+      "size": 1593
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/error_handler.py",
+      "size": 2621
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/errors.py",
+      "size": 78
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/file_lock.py",
+      "size": 2342
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/git.py",
+      "size": 8524
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/hook.py",
+      "size": 1513
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/lang_base.py",
+      "size": 5238
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/conda.py",
+      "size": 2421
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/coursier.py",
+      "size": 2508
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/dart.py",
+      "size": 3118
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/docker.py",
+      "size": 5621
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/docker_image.py",
+      "size": 847
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/dotnet.py",
+      "size": 3463
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/fail.py",
+      "size": 685
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/golang.py",
+      "size": 4658
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/haskell.py",
+      "size": 1662
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/julia.py",
+      "size": 4432
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/lua.py",
+      "size": 2535
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/node.py",
+      "size": 3853
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/perl.py",
+      "size": 1491
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/pygrep.py",
+      "size": 3816
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/python.py",
+      "size": 7320
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/r.py",
+      "size": 7901
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/ruby.py",
+      "size": 4636
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/rust.py",
+      "size": 5492
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/script.py",
+      "size": 786
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/swift.py",
+      "size": 1605
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/languages/system.py",
+      "size": 300
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/logging_handler.py",
+      "size": 1019
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/main.py",
+      "size": 15564
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/meta_hooks/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/meta_hooks/check_hooks_apply.py",
+      "size": 1207
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/meta_hooks/check_useless_excludes.py",
+      "size": 2553
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/meta_hooks/identity.py",
+      "size": 346
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/output.py",
+      "size": 911
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/parse_shebang.py",
+      "size": 2481
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/prefix.py",
+      "size": 495
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/repository.py",
+      "size": 7608
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/resources/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/resources/empty_template_setup.py",
+      "size": 93
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/staged_files_only.py",
+      "size": 4155
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/store.py",
+      "size": 9392
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/util.py",
+      "size": 7038
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/xargs.py",
+      "size": 5541
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/yaml.py",
+      "size": 561
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/yaml_rewrite.py",
+      "size": 1337
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/__init__.py",
+      "size": 8950
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_core_metadata.py",
+      "size": 9826
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/__init__.py",
+      "size": 359
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_collections.py",
+      "size": 5440
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_functools.py",
+      "size": 1771
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_itertools.py",
+      "size": 1453
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_log.py",
+      "size": 42
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_macos_compat.py",
+      "size": 239
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_modified.py",
+      "size": 2410
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_msvccompiler.py",
+      "size": 19641
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/__init__.py",
+      "size": 496
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/_elffile.py",
+      "size": 3266
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/_manylinux.py",
+      "size": 9590
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/_musllinux.py",
+      "size": 2676
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/_parser.py",
+      "size": 10347
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/_structures.py",
+      "size": 1431
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/_tokenizer.py",
+      "size": 5292
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/markers.py",
+      "size": 8208
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/metadata.py",
+      "size": 33036
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/requirements.py",
+      "size": 2933
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/specifiers.py",
+      "size": 39784
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/tags.py",
+      "size": 18950
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/utils.py",
+      "size": 5268
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/_vendor/packaging/version.py",
+      "size": 16236
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/archive_util.py",
+      "size": 8551
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/bcppcompiler.py",
+      "size": 14674
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/ccompiler.py",
+      "size": 48935
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/cmd.py",
+      "size": 17877
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/__init__.py",
+      "size": 416
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/_framework_compat.py",
+      "size": 1609
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/bdist.py",
+      "size": 5354
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/bdist_dumb.py",
+      "size": 4582
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/bdist_rpm.py",
+      "size": 21686
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/build.py",
+      "size": 5729
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/build_clib.py",
+      "size": 7684
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/build_ext.py",
+      "size": 31850
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/build_py.py",
+      "size": 16552
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/build_scripts.py",
+      "size": 5534
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/check.py",
+      "size": 4928
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/clean.py",
+      "size": 2595
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/config.py",
+      "size": 13008
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/install.py",
+      "size": 30079
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/install_data.py",
+      "size": 2764
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/install_egg_info.py",
+      "size": 2788
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/install_headers.py",
+      "size": 1184
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/install_lib.py",
+      "size": 8410
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/install_scripts.py",
+      "size": 1937
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/register.py",
+      "size": 11793
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/sdist.py",
+      "size": 19196
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/command/upload.py",
+      "size": 7493
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/compat/__init__.py",
+      "size": 429
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/compat/py38.py",
+      "size": 790
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/compat/py39.py",
+      "size": 1964
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/config.py",
+      "size": 5226
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/core.py",
+      "size": 9318
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/cygwinccompiler.py",
+      "size": 11954
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/debug.py",
+      "size": 139
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/dep_util.py",
+      "size": 349
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/dir_util.py",
+      "size": 8007
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/dist.py",
+      "size": 50977
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/errors.py",
+      "size": 3589
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/extension.py",
+      "size": 10206
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/fancy_getopt.py",
+      "size": 17822
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/file_util.py",
+      "size": 7944
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/filelist.py",
+      "size": 13654
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/log.py",
+      "size": 1200
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/msvc9compiler.py",
+      "size": 30129
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/msvccompiler.py",
+      "size": 23451
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/spawn.py",
+      "size": 3626
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/sysconfig.py",
+      "size": 18688
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/text_file.py",
+      "size": 12098
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/unixccompiler.py",
+      "size": 15698
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/util.py",
+      "size": 18093
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/version.py",
+      "size": 12634
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/versionpredicate.py",
+      "size": 5205
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_distutils/zosccompiler.py",
+      "size": 6589
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_entry_points.py",
+      "size": 2333
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_imp.py",
+      "size": 2443
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_importlib.py",
+      "size": 1454
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_itertools.py",
+      "size": 675
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_normalization.py",
+      "size": 4567
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_path.py",
+      "size": 1178
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_reqs.py",
+      "size": 1112
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/backports/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/backports/tarfile.py",
+      "size": 106920
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_metadata/__init__.py",
+      "size": 26498
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_metadata/_adapters.py",
+      "size": 2454
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_metadata/_collections.py",
+      "size": 743
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_metadata/_compat.py",
+      "size": 1859
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_metadata/_functools.py",
+      "size": 2895
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_metadata/_itertools.py",
+      "size": 2068
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_metadata/_meta.py",
+      "size": 1165
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_metadata/_py39compat.py",
+      "size": 1098
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_metadata/_text.py",
+      "size": 2166
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_resources/__init__.py",
+      "size": 506
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_resources/_adapters.py",
+      "size": 4504
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_resources/_common.py",
+      "size": 5457
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_resources/_compat.py",
+      "size": 2925
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_resources/_itertools.py",
+      "size": 884
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_resources/_legacy.py",
+      "size": 3481
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_resources/abc.py",
+      "size": 5140
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_resources/readers.py",
+      "size": 3581
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/importlib_resources/simple.py",
+      "size": 2576
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/jaraco/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/jaraco/context.py",
+      "size": 9570
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/jaraco/functools/__init__.py",
+      "size": 16696
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/jaraco/text/__init__.py",
+      "size": 15517
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/more_itertools/__init__.py",
+      "size": 82
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/more_itertools/more.py",
+      "size": 117959
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/more_itertools/recipes.py",
+      "size": 16256
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/ordered_set.py",
+      "size": 15130
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/__init__.py",
+      "size": 496
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/_elffile.py",
+      "size": 3266
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/_manylinux.py",
+      "size": 9590
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/_musllinux.py",
+      "size": 2676
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/_parser.py",
+      "size": 10347
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/_structures.py",
+      "size": 1431
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/_tokenizer.py",
+      "size": 5292
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/markers.py",
+      "size": 8208
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/metadata.py",
+      "size": 33036
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/requirements.py",
+      "size": 2933
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/specifiers.py",
+      "size": 39784
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/tags.py",
+      "size": 18950
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/utils.py",
+      "size": 5268
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/packaging/version.py",
+      "size": 16236
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/tomli/__init__.py",
+      "size": 396
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/tomli/_parser.py",
+      "size": 22633
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/tomli/_re.py",
+      "size": 2943
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/tomli/_types.py",
+      "size": 254
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/wheel/__init__.py",
+      "size": 59
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/wheel/macosx_libfile.py",
+      "size": 16103
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/wheel/metadata.py",
+      "size": 5876
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/wheel/util.py",
+      "size": 621
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/wheel/wheelfile.py",
+      "size": 7696
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/_vendor/zipp.py",
+      "size": 8425
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/archive_util.py",
+      "size": 7331
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/build_meta.py",
+      "size": 19085
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/__init__.py",
+      "size": 396
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/_requirestxt.py",
+      "size": 4245
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/alias.py",
+      "size": 2383
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/bdist_egg.py",
+      "size": 16525
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/bdist_rpm.py",
+      "size": 1289
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/bdist_wheel.py",
+      "size": 21412
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/build.py",
+      "size": 5816
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/build_clib.py",
+      "size": 4539
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/build_ext.py",
+      "size": 17760
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/build_py.py",
+      "size": 15193
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/develop.py",
+      "size": 6892
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/dist_info.py",
+      "size": 3507
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/easy_install.py",
+      "size": 86995
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/editable_wheel.py",
+      "size": 35275
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/egg_info.py",
+      "size": 26522
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/install.py",
+      "size": 5779
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/install_egg_info.py",
+      "size": 2066
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/install_lib.py",
+      "size": 3965
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/install_scripts.py",
+      "size": 2474
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/register.py",
+      "size": 466
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/rotate.py",
+      "size": 2144
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/saveopts.py",
+      "size": 657
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/sdist.py",
+      "size": 6808
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/setopt.py",
+      "size": 5018
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/test.py",
+      "size": 8104
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/upload.py",
+      "size": 460
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/command/upload_docs.py",
+      "size": 7821
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/compat/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/compat/py310.py",
+      "size": 165
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/compat/py311.py",
+      "size": 735
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/compat/py39.py",
+      "size": 493
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/config/__init__.py",
+      "size": 1499
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py",
+      "size": 14700
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/config/_validate_pyproject/__init__.py",
+      "size": 1042
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/config/_validate_pyproject/error_reporting.py",
+      "size": 11862
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/config/_validate_pyproject/extra_validations.py",
+      "size": 1625
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/config/_validate_pyproject/fastjsonschema_exceptions.py",
+      "size": 1612
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/config/_validate_pyproject/fastjsonschema_validations.py",
+      "size": 295453
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/config/_validate_pyproject/formats.py",
+      "size": 12062
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/config/expand.py",
+      "size": 15527
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/config/pyprojecttoml.py",
+      "size": 17653
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/config/setupcfg.py",
+      "size": 25592
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/depends.py",
+      "size": 5551
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/discovery.py",
+      "size": 21124
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/dist.py",
+      "size": 37933
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/errors.py",
+      "size": 2669
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/extension.py",
+      "size": 5794
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/extern/__init__.py",
+      "size": 2728
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/glob.py",
+      "size": 4852
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/installer.py",
+      "size": 4969
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/launch.py",
+      "size": 812
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/logging.py",
+      "size": 1239
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/modified.py",
+      "size": 190
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/monkey.py",
+      "size": 4333
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/msvc.py",
+      "size": 47532
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/namespaces.py",
+      "size": 3128
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/package_index.py",
+      "size": 39081
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/sandbox.py",
+      "size": 14730
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/unicode_utils.py",
+      "size": 3181
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/version.py",
+      "size": 161
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/warnings.py",
+      "size": 3699
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/wheel.py",
+      "size": 8682
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools/windows_support.py",
+      "size": 720
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/__init__.py",
+      "size": 29422
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/abc.py",
+      "size": 3764
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/algebras/__init__.py",
+      "size": 62
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/algebras/quaternion.py",
+      "size": 47483
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/algebras/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/algebras/tests/test_quaternion.py",
+      "size": 16809
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/__init__.py",
+      "size": 550
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/ask.py",
+      "size": 19376
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/ask_generated.py",
+      "size": 23558
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/assume.py",
+      "size": 14606
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/cnf.py",
+      "size": 12509
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/facts.py",
+      "size": 8391
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/handlers/__init__.py",
+      "size": 330
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/handlers/calculus.py",
+      "size": 7799
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/handlers/common.py",
+      "size": 4314
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/handlers/matrices.py",
+      "size": 22321
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/handlers/ntheory.py",
+      "size": 7660
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/handlers/order.py",
+      "size": 12280
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/handlers/sets.py",
+      "size": 25841
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/lra_satask.py",
+      "size": 9563
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/predicates/__init__.py",
+      "size": 110
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/predicates/calculus.py",
+      "size": 1889
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/predicates/common.py",
+      "size": 2279
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/predicates/matrices.py",
+      "size": 12142
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/predicates/ntheory.py",
+      "size": 2546
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/predicates/order.py",
+      "size": 9511
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/predicates/sets.py",
+      "size": 9238
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/refine.py",
+      "size": 11946
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/relation/__init__.py",
+      "size": 261
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/relation/binrel.py",
+      "size": 6313
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/relation/equality.py",
+      "size": 7148
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/satask.py",
+      "size": 11745
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/sathandlers.py",
+      "size": 9418
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/tests/test_assumptions_2.py",
+      "size": 1070
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/tests/test_context.py",
+      "size": 1153
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/tests/test_matrices.py",
+      "size": 12258
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/tests/test_query.py",
+      "size": 104495
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/tests/test_refine.py",
+      "size": 8834
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/tests/test_rel_queries.py",
+      "size": 6677
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/tests/test_satask.py",
+      "size": 15741
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/tests/test_sathandlers.py",
+      "size": 1842
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/tests/test_wrapper.py",
+      "size": 1159
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/assumptions/wrapper.py",
+      "size": 5434
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/benchmarks/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/benchmarks/bench_discrete_log.py",
+      "size": 2473
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/benchmarks/bench_meijerint.py",
+      "size": 11610
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/benchmarks/bench_symbench.py",
+      "size": 2997
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/calculus/__init__.py",
+      "size": 828
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/calculus/accumulationbounds.py",
+      "size": 28682
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/calculus/euler.py",
+      "size": 3436
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/calculus/finite_diff.py",
+      "size": 17053
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/calculus/singularities.py",
+      "size": 12184
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/calculus/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/calculus/tests/test_accumulationbounds.py",
+      "size": 11195
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/calculus/tests/test_euler.py",
+      "size": 2683
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/calculus/tests/test_finite_diff.py",
+      "size": 7670
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/calculus/tests/test_singularities.py",
+      "size": 5272
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/calculus/tests/test_util.py",
+      "size": 18557
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/calculus/util.py",
+      "size": 28880
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/categories/__init__.py",
+      "size": 984
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/categories/baseclasses.py",
+      "size": 31360
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/categories/diagram_drawing.py",
+      "size": 95173
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/categories/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/categories/tests/test_baseclasses.py",
+      "size": 5767
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/categories/tests/test_drawing.py",
+      "size": 27848
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/__init__.py",
+      "size": 974
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/abstract_nodes.py",
+      "size": 490
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/algorithms.py",
+      "size": 6383
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/approximations.py",
+      "size": 6448
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/ast.py",
+      "size": 56788
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/cfunctions.py",
+      "size": 12331
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/cnodes.py",
+      "size": 3409
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/cutils.py",
+      "size": 383
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/cxxnodes.py",
+      "size": 342
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/fnodes.py",
+      "size": 18936
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/futils.py",
+      "size": 1792
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/matrix_nodes.py",
+      "size": 2284
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/numpy_nodes.py",
+      "size": 4543
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/pynodes.py",
+      "size": 243
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/pyutils.py",
+      "size": 838
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/rewriting.py",
+      "size": 11585
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/scipy_nodes.py",
+      "size": 2508
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_abstract_nodes.py",
+      "size": 451
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_algorithms.py",
+      "size": 6919
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_applications.py",
+      "size": 2277
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_approximations.py",
+      "size": 2035
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_ast.py",
+      "size": 21688
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_cfunctions.py",
+      "size": 5119
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_cnodes.py",
+      "size": 3039
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_cxxnodes.py",
+      "size": 366
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_fnodes.py",
+      "size": 6650
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_matrix_nodes.py",
+      "size": 1896
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_numpy_nodes.py",
+      "size": 2199
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_pynodes.py",
+      "size": 432
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_pyutils.py",
+      "size": 299
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_rewriting.py",
+      "size": 15852
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/codegen/tests/test_scipy_nodes.py",
+      "size": 1495
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/__init__.py",
+      "size": 1500
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/coset_table.py",
+      "size": 43296
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/fp_groups.py",
+      "size": 47779
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/free_groups.py",
+      "size": 39740
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/galois.py",
+      "size": 17867
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/generators.py",
+      "size": 7479
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/graycode.py",
+      "size": 11207
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/group_constructs.py",
+      "size": 2021
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/group_numbers.py",
+      "size": 9163
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/homomorphisms.py",
+      "size": 18844
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/named_groups.py",
+      "size": 8378
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/partitions.py",
+      "size": 20841
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/pc_groups.py",
+      "size": 21414
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/perm_groups.py",
+      "size": 184825
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/permutations.py",
+      "size": 87737
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/polyhedron.py",
+      "size": 35928
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/prufer.py",
+      "size": 12061
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/rewritingsystem.py",
+      "size": 17095
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/rewritingsystem_fsm.py",
+      "size": 2433
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/schur_number.py",
+      "size": 4437
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/subsets.py",
+      "size": 16047
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tensor_can.py",
+      "size": 40738
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_coset_table.py",
+      "size": 28474
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_fp_groups.py",
+      "size": 10203
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_free_groups.py",
+      "size": 6411
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_galois.py",
+      "size": 2763
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_generators.py",
+      "size": 3567
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_graycode.py",
+      "size": 2800
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_group_constructs.py",
+      "size": 450
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_group_numbers.py",
+      "size": 4149
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_homomorphisms.py",
+      "size": 3745
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_named_groups.py",
+      "size": 1931
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_partitions.py",
+      "size": 4097
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_pc_groups.py",
+      "size": 2728
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_perm_groups.py",
+      "size": 41195
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_permutations.py",
+      "size": 20189
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_polyhedron.py",
+      "size": 4180
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_prufer.py",
+      "size": 2649
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_rewriting.py",
+      "size": 1787
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_schur_number.py",
+      "size": 1727
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_subsets.py",
+      "size": 2635
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_tensor_can.py",
+      "size": 24676
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_testutil.py",
+      "size": 1733
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/tests/test_util.py",
+      "size": 4499
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/testutil.py",
+      "size": 11142
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/combinatorics/util.py",
+      "size": 16296
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/__init__.py",
+      "size": 144
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/delta.py",
+      "size": 9870
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/expr_with_intlimits.py",
+      "size": 11352
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/expr_with_limits.py",
+      "size": 21834
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/gosper.py",
+      "size": 5499
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/guess.py",
+      "size": 17474
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/products.py",
+      "size": 18456
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/summations.py",
+      "size": 55998
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/tests/test_delta.py",
+      "size": 23869
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/tests/test_gosper.py",
+      "size": 7987
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/tests/test_guess.py",
+      "size": 3370
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/tests/test_products.py",
+      "size": 14521
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/concrete/tests/test_sums_products.py",
+      "size": 66390
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/conftest.py",
+      "size": 2775
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/__init__.py",
+      "size": 3123
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/_print_helpers.py",
+      "size": 2388
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/add.py",
+      "size": 43407
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/alphabets.py",
+      "size": 266
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/assumptions.py",
+      "size": 23595
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/assumptions_generated.py",
+      "size": 42817
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/backend.py",
+      "size": 5273
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/basic.py",
+      "size": 76789
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/benchmarks/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/benchmarks/bench_arit.py",
+      "size": 412
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/benchmarks/bench_assumptions.py",
+      "size": 177
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/benchmarks/bench_basic.py",
+      "size": 210
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/benchmarks/bench_expand.py",
+      "size": 427
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/benchmarks/bench_numbers.py",
+      "size": 1135
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/benchmarks/bench_sympify.py",
+      "size": 138
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/cache.py",
+      "size": 6172
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/compatibility.py",
+      "size": 1145
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/containers.py",
+      "size": 11411
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/core.py",
+      "size": 547
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/coreerrors.py",
+      "size": 642
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/decorators.py",
+      "size": 8759
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/evalf.py",
+      "size": 62089
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/expr.py",
+      "size": 143770
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/exprtools.py",
+      "size": 51544
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/facts.py",
+      "size": 19546
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/function.py",
+      "size": 117102
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/intfunc.py",
+      "size": 14219
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/kind.py",
+      "size": 11540
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/logic.py",
+      "size": 10827
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/mod.py",
+      "size": 8363
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/mul.py",
+      "size": 79201
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/multidimensional.py",
+      "size": 4233
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/numbers.py",
+      "size": 136741
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/operations.py",
+      "size": 25828
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/parameters.py",
+      "size": 3854
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/power.py",
+      "size": 73244
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/random.py",
+      "size": 6647
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/relational.py",
+      "size": 51896
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/rules.py",
+      "size": 1496
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/singleton.py",
+      "size": 7115
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/sorting.py",
+      "size": 10827
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/symbol.py",
+      "size": 29820
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/sympify.py",
+      "size": 20546
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_args.py",
+      "size": 184252
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_arit.py",
+      "size": 78611
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_assumptions.py",
+      "size": 41573
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_basic.py",
+      "size": 10230
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_cache.py",
+      "size": 2001
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_compatibility.py",
+      "size": 240
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_complex.py",
+      "size": 21906
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_constructor_postprocessor.py",
+      "size": 2441
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_containers.py",
+      "size": 7432
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_count_ops.py",
+      "size": 5665
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_diff.py",
+      "size": 5421
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_equal.py",
+      "size": 1678
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_eval.py",
+      "size": 2366
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_evalf.py",
+      "size": 28574
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_expand.py",
+      "size": 13886
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_expr.py",
+      "size": 78428
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_exprtools.py",
+      "size": 19021
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_facts.py",
+      "size": 11579
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_function.py",
+      "size": 51450
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_kind.py",
+      "size": 2048
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_logic.py",
+      "size": 5634
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_match.py",
+      "size": 22714
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_multidimensional.py",
+      "size": 848
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_noncommutative.py",
+      "size": 4436
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_numbers.py",
+      "size": 78001
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_operations.py",
+      "size": 2859
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_parameters.py",
+      "size": 3560
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_power.py",
+      "size": 24862
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_priority.py",
+      "size": 3252
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_random.py",
+      "size": 1233
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_relational.py",
+      "size": 43525
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_rules.py",
+      "size": 349
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_singleton.py",
+      "size": 3036
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_sorting.py",
+      "size": 902
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_subs.py",
+      "size": 30106
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_symbol.py",
+      "size": 13043
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_sympify.py",
+      "size": 28195
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_traversal.py",
+      "size": 4311
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_truediv.py",
+      "size": 854
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/tests/test_var.py",
+      "size": 1594
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/trace.py",
+      "size": 348
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/core/traversal.py",
+      "size": 8860
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/crypto/__init__.py",
+      "size": 2158
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/crypto/crypto.py",
+      "size": 89685
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/crypto/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/crypto/tests/test_crypto.py",
+      "size": 19758
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/diffgeom/__init__.py",
+      "size": 991
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/diffgeom/diffgeom.py",
+      "size": 72274
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/diffgeom/rn.py",
+      "size": 6264
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/diffgeom/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/diffgeom/tests/test_class_structure.py",
+      "size": 1048
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/diffgeom/tests/test_diffgeom.py",
+      "size": 14145
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/diffgeom/tests/test_function_diffgeom_book.py",
+      "size": 5254
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/diffgeom/tests/test_hyperbolic_space.py",
+      "size": 2598
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/discrete/__init__.py",
+      "size": 772
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/discrete/convolutions.py",
+      "size": 18341
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/discrete/recurrences.py",
+      "size": 5124
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/discrete/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/discrete/tests/test_convolutions.py",
+      "size": 17856
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/discrete/tests/test_recurrences.py",
+      "size": 3019
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/discrete/tests/test_transforms.py",
+      "size": 5546
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/discrete/transforms.py",
+      "size": 11681
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/__init__.py",
+      "size": 578
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/gmpy.py",
+      "size": 9768
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/importtools.py",
+      "size": 7671
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/ntheory.py",
+      "size": 16555
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/pythonmpq.py",
+      "size": 11259
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/tests/test_autowrap.py",
+      "size": 9759
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/tests/test_codegen.py",
+      "size": 12598
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/tests/test_gmpy.py",
+      "size": 397
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/tests/test_importtools.py",
+      "size": 1394
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/tests/test_ntheory.py",
+      "size": 8881
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/tests/test_numpy.py",
+      "size": 10291
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/tests/test_pythonmpq.py",
+      "size": 5797
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/external/tests/test_scipy.py",
+      "size": 1172
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/__init__.py",
+      "size": 5565
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/combinatorial/__init__.py",
+      "size": 53
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/combinatorial/factorials.py",
+      "size": 39184
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/combinatorial/numbers.py",
+      "size": 101088
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/combinatorial/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/combinatorial/tests/test_comb_factorials.py",
+      "size": 26317
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/combinatorial/tests/test_comb_numbers.py",
+      "size": 47593
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/__init__.py",
+      "size": 50
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/_trigonometric_special.py",
+      "size": 7271
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/benchmarks/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/benchmarks/bench_exp.py",
+      "size": 185
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/complexes.py",
+      "size": 44168
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/exponential.py",
+      "size": 42610
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/hyperbolic.py",
+      "size": 69329
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/integers.py",
+      "size": 22394
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/miscellaneous.py",
+      "size": 27944
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/piecewise.py",
+      "size": 58285
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/tests/test_complexes.py",
+      "size": 34016
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/tests/test_exponential.py",
+      "size": 29733
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/tests/test_hyperbolic.py",
+      "size": 56898
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/tests/test_integers.py",
+      "size": 23266
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/tests/test_interface.py",
+      "size": 2513
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/tests/test_miscellaneous.py",
+      "size": 17148
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/tests/test_piecewise.py",
+      "size": 62876
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/tests/test_trigonometric.py",
+      "size": 90340
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/elementary/trigonometric.py",
+      "size": 115945
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/__init__.py",
+      "size": 59
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/benchmarks/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/benchmarks/bench_special.py",
+      "size": 164
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/bessel.py",
+      "size": 68656
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/beta_functions.py",
+      "size": 12777
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/bsplines.py",
+      "size": 10060
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/delta_functions.py",
+      "size": 19887
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/elliptic_integrals.py",
+      "size": 14921
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/error_functions.py",
+      "size": 79556
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/gamma_functions.py",
+      "size": 42943
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/hyper.py",
+      "size": 38829
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/mathieu_functions.py",
+      "size": 6620
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/polynomials.py",
+      "size": 46753
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/singularity_functions.py",
+      "size": 8346
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/spherical_harmonics.py",
+      "size": 11018
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tensor_functions.py",
+      "size": 12303
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_bessel.py",
+      "size": 37373
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_beta_functions.py",
+      "size": 3786
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_bsplines.py",
+      "size": 7145
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_delta_functions.py",
+      "size": 7138
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_elliptic_integrals.py",
+      "size": 6991
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_error_functions.py",
+      "size": 33565
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_gamma_functions.py",
+      "size": 29908
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_hyper.py",
+      "size": 16694
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_mathieu.py",
+      "size": 1282
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_singularity_functions.py",
+      "size": 6249
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_spec_polynomials.py",
+      "size": 19561
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_spherical_harmonics.py",
+      "size": 3850
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_tensor_functions.py",
+      "size": 5546
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/tests/test_zeta_functions.py",
+      "size": 10474
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/functions/special/zeta_functions.py",
+      "size": 24091
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/galgebra.py",
+      "size": 123
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/__init__.py",
+      "size": 1240
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/curve.py",
+      "size": 10170
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/ellipse.py",
+      "size": 50305
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/entity.py",
+      "size": 20668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/exceptions.py",
+      "size": 131
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/line.py",
+      "size": 80397
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/parabola.py",
+      "size": 10716
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/plane.py",
+      "size": 26770
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/point.py",
+      "size": 36661
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/polygon.py",
+      "size": 82027
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/tests/test_curve.py",
+      "size": 4479
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/tests/test_ellipse.py",
+      "size": 26509
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/tests/test_entity.py",
+      "size": 3896
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/tests/test_geometrysets.py",
+      "size": 1911
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/tests/test_line.py",
+      "size": 38054
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/tests/test_parabola.py",
+      "size": 6150
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/tests/test_plane.py",
+      "size": 12525
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/tests/test_point.py",
+      "size": 16410
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/tests/test_polygon.py",
+      "size": 27602
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/tests/test_util.py",
+      "size": 7044
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/geometry/util.py",
+      "size": 20671
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/holonomic/__init__.py",
+      "size": 784
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/holonomic/holonomic.py",
+      "size": 91887
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/holonomic/holonomicerrors.py",
+      "size": 1193
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/holonomic/numerical.py",
+      "size": 2625
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/holonomic/recurrence.py",
+      "size": 10377
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/holonomic/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/holonomic/tests/test_holonomic.py",
+      "size": 35333
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/holonomic/tests/test_recurrence.py",
+      "size": 1342
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/__init__.py",
+      "size": 1970
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/benchmarks/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/benchmarks/bench_integrate.py",
+      "size": 396
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/benchmarks/bench_trigintegrate.py",
+      "size": 305
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/deltafunctions.py",
+      "size": 7435
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/heurisch.py",
+      "size": 26706
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/integrals.py",
+      "size": 64887
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/intpoly.py",
+      "size": 43266
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/laplace.py",
+      "size": 87038
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/manualintegrate.py",
+      "size": 75721
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/meijerint.py",
+      "size": 80775
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/meijerint_doc.py",
+      "size": 1204
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/prde.py",
+      "size": 52073
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/quadrature.py",
+      "size": 17064
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/rationaltools.py",
+      "size": 11694
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/rde.py",
+      "size": 27393
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/risch.py",
+      "size": 67352
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/singularityfunctions.py",
+      "size": 2235
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_deltafunctions.py",
+      "size": 3709
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_failing_integrals.py",
+      "size": 7438
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_heurisch.py",
+      "size": 14299
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_integrals.py",
+      "size": 81192
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_intpoly.py",
+      "size": 37445
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_laplace.py",
+      "size": 38186
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_lineintegrals.py",
+      "size": 450
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_manual.py",
+      "size": 34551
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_meijerint.py",
+      "size": 32594
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_prde.py",
+      "size": 16360
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_quadrature.py",
+      "size": 19919
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_rationaltools.py",
+      "size": 5669
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_rde.py",
+      "size": 9571
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_risch.py",
+      "size": 38630
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_singularityfunctions.py",
+      "size": 1266
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_transforms.py",
+      "size": 27152
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/tests/test_trigonometry.py",
+      "size": 3869
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/transforms.py",
+      "size": 51750
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/integrals/trigonometry.py",
+      "size": 11083
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/interactive/__init__.py",
+      "size": 251
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/interactive/printing.py",
+      "size": 21562
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/interactive/session.py",
+      "size": 15329
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/interactive/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/interactive/tests/test_interactive.py",
+      "size": 485
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/interactive/tests/test_ipython.py",
+      "size": 11797
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/interactive/traversal.py",
+      "size": 3189
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/__init__.py",
+      "size": 79
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/cartan_matrix.py",
+      "size": 524
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/cartan_type.py",
+      "size": 1790
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/dynkin_diagram.py",
+      "size": 535
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/root_system.py",
+      "size": 6673
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/test_cartan_matrix.py",
+      "size": 303
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/test_cartan_type.py",
+      "size": 339
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/test_dynkin_diagram.py",
+      "size": 260
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/test_root_system.py",
+      "size": 927
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/test_type_A.py",
+      "size": 657
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/test_type_B.py",
+      "size": 642
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/test_type_C.py",
+      "size": 927
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/test_type_D.py",
+      "size": 764
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/test_type_E.py",
+      "size": 987
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/test_type_F.py",
+      "size": 1378
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/test_type_G.py",
+      "size": 548
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/tests/test_weyl_group.py",
+      "size": 1501
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/type_a.py",
+      "size": 4294
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/type_b.py",
+      "size": 4547
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/type_c.py",
+      "size": 4426
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/type_d.py",
+      "size": 4681
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/type_e.py",
+      "size": 8280
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/type_f.py",
+      "size": 4423
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/type_g.py",
+      "size": 2965
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/liealgebras/weyl_group.py",
+      "size": 14557
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/__init__.py",
+      "size": 456
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/algorithms/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/algorithms/dpll.py",
+      "size": 9188
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/algorithms/dpll2.py",
+      "size": 21497
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/algorithms/lra_theory.py",
+      "size": 31769
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/algorithms/minisat22_wrapper.py",
+      "size": 1317
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/algorithms/pycosat_wrapper.py",
+      "size": 1207
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/algorithms/z3_wrapper.py",
+      "size": 3747
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/boolalg.py",
+      "size": 114972
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/inference.py",
+      "size": 8983
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/tests/test_boolalg.py",
+      "size": 49748
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/tests/test_dimacs.py",
+      "size": 3886
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/tests/test_inference.py",
+      "size": 16116
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/tests/test_lra_theory.py",
+      "size": 16834
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/utilities/__init__.py",
+      "size": 55
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/logic/utilities/dimacs.py",
+      "size": 1671
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/__init__.py",
+      "size": 2634
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/benchmarks/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/benchmarks/bench_matrix.py",
+      "size": 306
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/common.py",
+      "size": 95395
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/decompositions.py",
+      "size": 47865
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/dense.py",
+      "size": 30461
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/determinant.py",
+      "size": 34550
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/eigen.py",
+      "size": 39811
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/exceptions.py",
+      "size": 503
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/__init__.py",
+      "size": 1692
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/_shape.py",
+      "size": 3062
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/adjoint.py",
+      "size": 1515
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/applyfunc.py",
+      "size": 6751
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/blockmatrix.py",
+      "size": 31643
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/companion.py",
+      "size": 1705
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/determinant.py",
+      "size": 3281
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/diagonal.py",
+      "size": 6328
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/dotproduct.py",
+      "size": 1911
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/factorizations.py",
+      "size": 1456
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/fourier.py",
+      "size": 2094
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/funcmatrix.py",
+      "size": 3520
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/hadamard.py",
+      "size": 13920
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/inverse.py",
+      "size": 2963
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/kronecker.py",
+      "size": 13404
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/matadd.py",
+      "size": 4773
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/matexpr.py",
+      "size": 27549
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/matmul.py",
+      "size": 15509
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/matpow.py",
+      "size": 5140
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/permutation.py",
+      "size": 8050
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/sets.py",
+      "size": 2033
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/slice.py",
+      "size": 3355
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/special.py",
+      "size": 7499
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_adjoint.py",
+      "size": 1065
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_applyfunc.py",
+      "size": 3522
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_blockmatrix.py",
+      "size": 16541
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_companion.py",
+      "size": 1657
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_derivatives.py",
+      "size": 15991
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_determinant.py",
+      "size": 2067
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_diagonal.py",
+      "size": 4516
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_dotproduct.py",
+      "size": 1171
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_factorizations.py",
+      "size": 786
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_fourier.py",
+      "size": 1638
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_funcmatrix.py",
+      "size": 2230
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_hadamard.py",
+      "size": 4614
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_indexing.py",
+      "size": 12038
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_inverse.py",
+      "size": 2320
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_kronecker.py",
+      "size": 5366
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_matadd.py",
+      "size": 1866
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_matexpr.py",
+      "size": 18441
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_matmul.py",
+      "size": 6187
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_matpow.py",
+      "size": 7308
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_permutation.py",
+      "size": 5607
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_sets.py",
+      "size": 1408
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_slice.py",
+      "size": 2027
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_special.py",
+      "size": 6496
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_trace.py",
+      "size": 3383
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/tests/test_transpose.py",
+      "size": 1987
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/trace.py",
+      "size": 5362
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/expressions/transpose.py",
+      "size": 2645
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/graph.py",
+      "size": 9080
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/immutable.py",
+      "size": 5530
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/inverse.py",
+      "size": 13166
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/kind.py",
+      "size": 2843
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/matrices.py",
+      "size": 23536
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/matrixbase.py",
+      "size": 165154
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/normalforms.py",
+      "size": 4636
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/reductions.py",
+      "size": 12500
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/repmatrix.py",
+      "size": 29914
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/solvers.py",
+      "size": 25163
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/sparse.py",
+      "size": 14673
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/sparsetools.py",
+      "size": 9182
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/subspaces.py",
+      "size": 3761
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_commonmatrix.py",
+      "size": 40772
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_decompositions.py",
+      "size": 14419
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_determinant.py",
+      "size": 9560
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_domains.py",
+      "size": 3276
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_eigen.py",
+      "size": 22722
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_graph.py",
+      "size": 3213
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_immutable.py",
+      "size": 4616
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_interactions.py",
+      "size": 2070
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_matrices.py",
+      "size": 163196
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_matrixbase.py",
+      "size": 168868
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_normalforms.py",
+      "size": 3730
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_reductions.py",
+      "size": 13385
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_repmatrix.py",
+      "size": 2084
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_solvers.py",
+      "size": 22311
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_sparse.py",
+      "size": 23281
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_sparsetools.py",
+      "size": 4877
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/tests/test_subspaces.py",
+      "size": 3465
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/matrices/utilities.py",
+      "size": 2117
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/multipledispatch/__init__.py",
+      "size": 259
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/multipledispatch/conflict.py",
+      "size": 2117
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/multipledispatch/core.py",
+      "size": 2261
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/multipledispatch/dispatcher.py",
+      "size": 12226
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/multipledispatch/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/multipledispatch/tests/test_conflict.py",
+      "size": 1786
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/multipledispatch/tests/test_core.py",
+      "size": 4048
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/multipledispatch/tests/test_dispatcher.py",
+      "size": 6228
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/multipledispatch/utils.py",
+      "size": 3097
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/__init__.py",
+      "size": 2810
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/bbp_pi.py",
+      "size": 5998
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/continued_fraction.py",
+      "size": 10717
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/digits.py",
+      "size": 3831
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/ecm.py",
+      "size": 11793
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/egyptian_fraction.py",
+      "size": 6923
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/elliptic_curve.py",
+      "size": 11544
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/factor_.py",
+      "size": 83551
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/generate.py",
+      "size": 33376
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/modular.py",
+      "size": 8474
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/multinomial.py",
+      "size": 5073
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/partitions_.py",
+      "size": 8995
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/primetest.py",
+      "size": 25423
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/qs.py",
+      "size": 14938
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/residue_ntheory.py",
+      "size": 54359
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_bbp_pi.py",
+      "size": 9486
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_continued_fraction.py",
+      "size": 3583
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_digits.py",
+      "size": 1968
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_ecm.py",
+      "size": 2290
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_egyptian_fraction.py",
+      "size": 2378
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_elliptic_curve.py",
+      "size": 624
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_factor_.py",
+      "size": 26382
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_generate.py",
+      "size": 9868
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_hypothesis.py",
+      "size": 728
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_modular.py",
+      "size": 1425
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_multinomial.py",
+      "size": 2344
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_partitions.py",
+      "size": 1088
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_primetest.py",
+      "size": 9495
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_qs.py",
+      "size": 3956
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/ntheory/tests/test_residue.py",
+      "size": 16809
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/__init__.py",
+      "size": 125
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/ast_parser.py",
+      "size": 2734
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/__init__.py",
+      "size": 3611
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/_antlr/__init__.py",
+      "size": 203
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/_antlr/autolevlexer.py",
+      "size": 13609
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/_antlr/autolevlistener.py",
+      "size": 12821
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/_antlr/autolevparser.py",
+      "size": 106291
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/_build_autolev_antlr.py",
+      "size": 2578
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/_listener_autolev_antlr.py",
+      "size": 104760
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/_parse_autolev_antlr.py",
+      "size": 1736
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/pydy-example-repo/chaos_pendulum.py",
+      "size": 2274
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/pydy-example-repo/double_pendulum.py",
+      "size": 1583
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/pydy-example-repo/mass_spring_damper.py",
+      "size": 1366
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/pydy-example-repo/non_min_pendulum.py",
+      "size": 1503
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/ruletest1.py",
+      "size": 555
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/ruletest10.py",
+      "size": 2726
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/ruletest11.py",
+      "size": 475
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/ruletest12.py",
+      "size": 472
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/ruletest2.py",
+      "size": 820
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/ruletest3.py",
+      "size": 1574
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/ruletest4.py",
+      "size": 682
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/ruletest5.py",
+      "size": 1991
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/ruletest6.py",
+      "size": 1473
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/ruletest7.py",
+      "size": 1696
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/ruletest8.py",
+      "size": 2690
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/ruletest9.py",
+      "size": 1965
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/c/__init__.py",
+      "size": 65
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/c/c_parser.py",
+      "size": 38124
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/fortran/__init__.py",
+      "size": 73
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/fortran/fortran_parser.py",
+      "size": 11483
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/latex/__init__.py",
+      "size": 8968
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/latex/_antlr/__init__.py",
+      "size": 384
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/latex/_antlr/latexlexer.py",
+      "size": 30502
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/latex/_antlr/latexparser.py",
+      "size": 123655
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/latex/_build_latex_antlr.py",
+      "size": 2765
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/latex/_parse_latex_antlr.py",
+      "size": 20712
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/latex/errors.py",
+      "size": 45
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/latex/lark/__init__.py",
+      "size": 120
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/latex/lark/latex_parser.py",
+      "size": 4430
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/latex/lark/transformer.py",
+      "size": 25754
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/mathematica.py",
+      "size": 39614
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/maxima.py",
+      "size": 1835
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/sym_expr.py",
+      "size": 8895
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/sympy_parser.py",
+      "size": 43832
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_ast_parser.py",
+      "size": 803
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_autolev.py",
+      "size": 6647
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_c_parser.py",
+      "size": 155354
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_custom_latex.py",
+      "size": 2060
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_fortran_parser.py",
+      "size": 11828
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_implicit_multiplication_application.py",
+      "size": 7389
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_latex.py",
+      "size": 11765
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_latex_deps.py",
+      "size": 426
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_latex_lark.py",
+      "size": 36059
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_mathematica.py",
+      "size": 13395
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_maxima.py",
+      "size": 1987
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_sym_expr.py",
+      "size": 5668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/tests/test_sympy_parser.py",
+      "size": 12946
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/__init__.py",
+      "size": 220
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/biomechanics/__init__.py",
+      "size": 1520
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/biomechanics/_mixin.py",
+      "size": 1493
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/biomechanics/activation.py",
+      "size": 25522
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/biomechanics/curve.py",
+      "size": 63154
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/biomechanics/musculotendon.py",
+      "size": 58274
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/biomechanics/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/biomechanics/tests/test_activation.py",
+      "size": 13395
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/biomechanics/tests/test_curve.py",
+      "size": 75800
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/biomechanics/tests/test_mixin.py",
+      "size": 1322
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/biomechanics/tests/test_musculotendon.py",
+      "size": 32906
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/continuum_mechanics/__init__.py",
+      "size": 191
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/continuum_mechanics/arch.py",
+      "size": 39243
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/continuum_mechanics/beam.py",
+      "size": 159946
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/continuum_mechanics/cable.py",
+      "size": 31420
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/continuum_mechanics/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/continuum_mechanics/tests/test_arch.py",
+      "size": 2571
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/continuum_mechanics/tests/test_beam.py",
+      "size": 42085
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/continuum_mechanics/tests/test_cable.py",
+      "size": 3832
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/continuum_mechanics/tests/test_truss.py",
+      "size": 3269
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/continuum_mechanics/truss.py",
+      "size": 44962
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/control/__init__.py",
+      "size": 1334
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/control/control_plots.py",
+      "size": 37515
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/control/lti.py",
+      "size": 177322
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/control/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/control/tests/test_control_plots.py",
+      "size": 16899
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/control/tests/test_lti.py",
+      "size": 104043
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/hep/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/hep/gamma_matrices.py",
+      "size": 24253
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/hep/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/hep/tests/test_gamma_matrices.py",
+      "size": 14722
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/hydrogen.py",
+      "size": 7594
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/matrices.py",
+      "size": 3836
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/__init__.py",
+      "size": 2874
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/actuator.py",
+      "size": 43633
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/body.py",
+      "size": 24617
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/body_base.py",
+      "size": 2491
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/functions.py",
+      "size": 25190
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/inertia.py",
+      "size": 6172
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/joint.py",
+      "size": 84621
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/jointsmethod.py",
+      "size": 10415
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/kane.py",
+      "size": 37118
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/lagrange.py",
+      "size": 20202
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/linearize.py",
+      "size": 17242
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/loads.py",
+      "size": 5406
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/method.py",
+      "size": 660
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/models.py",
+      "size": 6463
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/particle.py",
+      "size": 5985
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/pathway.py",
+      "size": 26555
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/rigidbody.py",
+      "size": 10287
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/system.py",
+      "size": 59457
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_actuator.py",
+      "size": 41081
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_body.py",
+      "size": 12067
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_functions.py",
+      "size": 10447
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_inertia.py",
+      "size": 2726
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_joint.py",
+      "size": 57922
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_jointsmethod.py",
+      "size": 10226
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_kane.py",
+      "size": 21545
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_kane2.py",
+      "size": 19256
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_kane3.py",
+      "size": 14959
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_kane4.py",
+      "size": 4709
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_kane5.py",
+      "size": 5693
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_lagrange.py",
+      "size": 10119
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_lagrange2.py",
+      "size": 1402
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_linearity_of_velocity_constraints.py",
+      "size": 1341
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_linearize.py",
+      "size": 13273
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_loads.py",
+      "size": 2698
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_method.py",
+      "size": 154
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_models.py",
+      "size": 5078
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_particle.py",
+      "size": 2682
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_pathway.py",
+      "size": 24944
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_rigidbody.py",
+      "size": 6188
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_system.py",
+      "size": 8700
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_system_class.py",
+      "size": 38219
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/tests/test_wrapping_geometry.py",
+      "size": 10502
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/mechanics/wrapping_geometry.py",
+      "size": 21599
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/optics/__init__.py",
+      "size": 1647
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/optics/gaussopt.py",
+      "size": 20898
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/optics/medium.py",
+      "size": 7124
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/optics/polarization.py",
+      "size": 21434
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/optics/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/optics/tests/test_gaussopt.py",
+      "size": 4222
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/optics/tests/test_medium.py",
+      "size": 2194
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/optics/tests/test_polarization.py",
+      "size": 2605
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/optics/tests/test_utils.py",
+      "size": 8553
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/optics/tests/test_waves.py",
+      "size": 3397
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/optics/utils.py",
+      "size": 22172
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/optics/waves.py",
+      "size": 10042
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/paulialgebra.py",
+      "size": 6002
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/pring.py",
+      "size": 2240
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/qho_1d.py",
+      "size": 2005
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/__init__.py",
+      "size": 1952
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/anticommutator.py",
+      "size": 5072
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/boson.py",
+      "size": 5834
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/cartesian.py",
+      "size": 9092
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/cg.py",
+      "size": 23319
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/circuitplot.py",
+      "size": 11799
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/circuitutils.py",
+      "size": 13882
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/commutator.py",
+      "size": 8139
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/constants.py",
+      "size": 1420
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/dagger.py",
+      "size": 2484
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/density.py",
+      "size": 9546
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/fermion.py",
+      "size": 4983
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/gate.py",
+      "size": 42588
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/grover.py",
+      "size": 10452
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/hilbert.py",
+      "size": 19632
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/identitysearch.py",
+      "size": 27607
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/innerproduct.py",
+      "size": 4303
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/kind.py",
+      "size": 2831
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/matrixcache.py",
+      "size": 3587
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/matrixutils.py",
+      "size": 8214
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/operator.py",
+      "size": 19657
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/operatorordering.py",
+      "size": 10296
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/operatorset.py",
+      "size": 9563
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/pauli.py",
+      "size": 17250
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/piab.py",
+      "size": 1912
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/qapply.py",
+      "size": 9494
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/qasm.py",
+      "size": 6288
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/qexpr.py",
+      "size": 13940
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/qft.py",
+      "size": 6425
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/qubit.py",
+      "size": 25997
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/represent.py",
+      "size": 18729
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/sho1d.py",
+      "size": 20867
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/shor.py",
+      "size": 5504
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/spin.py",
+      "size": 72986
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/state.py",
+      "size": 29971
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tensorproduct.py",
+      "size": 12599
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_anticommutator.py",
+      "size": 1304
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_boson.py",
+      "size": 1676
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_cartesian.py",
+      "size": 4417
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_cg.py",
+      "size": 9159
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_circuitplot.py",
+      "size": 2096
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_circuitutils.py",
+      "size": 13187
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_commutator.py",
+      "size": 2727
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_constants.py",
+      "size": 338
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_dagger.py",
+      "size": 2632
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_density.py",
+      "size": 9718
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_fermion.py",
+      "size": 1636
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_gate.py",
+      "size": 12496
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_grover.py",
+      "size": 3640
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_hilbert.py",
+      "size": 2643
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_identitysearch.py",
+      "size": 17745
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_innerproduct.py",
+      "size": 1483
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_kind.py",
+      "size": 2515
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_matrixutils.py",
+      "size": 4115
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_operator.py",
+      "size": 8417
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_operatorordering.py",
+      "size": 2003
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_operatorset.py",
+      "size": 2628
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_pauli.py",
+      "size": 4940
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_piab.py",
+      "size": 1086
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_printing.py",
+      "size": 30332
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_qapply.py",
+      "size": 6086
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_qasm.py",
+      "size": 2976
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_qexpr.py",
+      "size": 1830
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_qft.py",
+      "size": 1931
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_qubit.py",
+      "size": 9271
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_represent.py",
+      "size": 5177
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_sho1d.py",
+      "size": 6893
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_shor.py",
+      "size": 666
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_spin.py",
+      "size": 345698
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_state.py",
+      "size": 6748
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_tensorproduct.py",
+      "size": 5314
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_trace.py",
+      "size": 3057
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/tests/test_transforms.py",
+      "size": 2346
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/trace.py",
+      "size": 6397
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/quantum/transforms.py",
+      "size": 10929
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/secondquant.py",
+      "size": 90974
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/sho.py",
+      "size": 2480
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/tests/test_clebsch_gordan.py",
+      "size": 9921
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/tests/test_hydrogen.py",
+      "size": 4987
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/tests/test_paulialgebra.py",
+      "size": 1477
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/tests/test_physics_matrices.py",
+      "size": 2948
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/tests/test_pring.py",
+      "size": 1261
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/tests/test_qho_1d.py",
+      "size": 1775
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/tests/test_secondquant.py",
+      "size": 49401
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/tests/test_sho.py",
+      "size": 693
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/__init__.py",
+      "size": 12386
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/definitions/__init__.py",
+      "size": 7470
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/definitions/dimension_definitions.py",
+      "size": 1633
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/definitions/unit_definitions.py",
+      "size": 14680
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/dimensions.py",
+      "size": 20899
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/prefixes.py",
+      "size": 6260
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/quantities.py",
+      "size": 4671
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/systems/__init__.py",
+      "size": 244
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/systems/cgs.py",
+      "size": 3702
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/systems/length_weight_time.py",
+      "size": 7004
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/systems/mks.py",
+      "size": 1546
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/systems/mksa.py",
+      "size": 2002
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/systems/natural.py",
+      "size": 909
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/systems/si.py",
+      "size": 14478
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/tests/test_dimensions.py",
+      "size": 6122
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/tests/test_dimensionsystem.py",
+      "size": 2717
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/tests/test_prefixes.py",
+      "size": 2238
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/tests/test_quantities.py",
+      "size": 19758
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/tests/test_unit_system_cgs_gauss.py",
+      "size": 3173
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/tests/test_unitsystem.py",
+      "size": 3254
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/tests/test_util.py",
+      "size": 9355
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/unitsystem.py",
+      "size": 7593
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/units/util.py",
+      "size": 9885
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/__init__.py",
+      "size": 985
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/dyadic.py",
+      "size": 18042
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/fieldfunctions.py",
+      "size": 8610
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/frame.py",
+      "size": 57260
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/functions.py",
+      "size": 24810
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/point.py",
+      "size": 20569
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/printing.py",
+      "size": 11790
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/tests/test_dyadic.py",
+      "size": 4265
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/tests/test_fieldfunctions.py",
+      "size": 5825
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/tests/test_frame.py",
+      "size": 29683
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/tests/test_functions.py",
+      "size": 21127
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/tests/test_output.py",
+      "size": 2612
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/tests/test_point.py",
+      "size": 12373
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/tests/test_printing.py",
+      "size": 10967
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/tests/test_vector.py",
+      "size": 10259
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/vector/vector.py",
+      "size": 24874
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/physics/wigner.py",
+      "size": 39588
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/__init__.py",
+      "size": 526
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/backends/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/backends/base_backend.py",
+      "size": 14911
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/backends/matplotlibbackend/__init__.py",
+      "size": 162
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/backends/matplotlibbackend/matplotlib.py",
+      "size": 12548
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/backends/textbackend/__init__.py",
+      "size": 92
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/backends/textbackend/text.py",
+      "size": 803
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/experimental_lambdify.py",
+      "size": 22828
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/intervalmath/__init__.py",
+      "size": 479
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/intervalmath/interval_arithmetic.py",
+      "size": 15570
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/intervalmath/interval_membership.py",
+      "size": 2385
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/intervalmath/lib_interval.py",
+      "size": 14809
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/intervalmath/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/intervalmath/tests/test_interval_functions.py",
+      "size": 9862
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/intervalmath/tests/test_interval_membership.py",
+      "size": 4216
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/intervalmath/tests/test_intervalmath.py",
+      "size": 9034
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/plot.py",
+      "size": 40882
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/plot_implicit.py",
+      "size": 7330
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/plotgrid.py",
+      "size": 6115
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/__init__.py",
+      "size": 3732
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/color_scheme.py",
+      "size": 12522
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/managed_window.py",
+      "size": 3072
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot.py",
+      "size": 13352
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot_axes.py",
+      "size": 8655
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot_camera.py",
+      "size": 3928
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot_controller.py",
+      "size": 6941
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot_curve.py",
+      "size": 2838
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot_interval.py",
+      "size": 5431
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot_mode.py",
+      "size": 14156
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot_mode_base.py",
+      "size": 11502
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot_modes.py",
+      "size": 5352
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot_object.py",
+      "size": 330
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot_rotation.py",
+      "size": 1445
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot_surface.py",
+      "size": 3803
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/plot_window.py",
+      "size": 4643
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/tests/test_plotting.py",
+      "size": 2720
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/pygletplot/util.py",
+      "size": 4621
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/series.py",
+      "size": 96568
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/tests/test_experimental_lambdify.py",
+      "size": 3127
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/tests/test_plot.py",
+      "size": 48217
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/tests/test_plot_implicit.py",
+      "size": 5799
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/tests/test_series.py",
+      "size": 65638
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/tests/test_textplot.py",
+      "size": 12761
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/tests/test_utils.py",
+      "size": 3602
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/textplot.py",
+      "size": 5075
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/plotting/utils.py",
+      "size": 12259
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/__init__.py",
+      "size": 5577
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/agca/__init__.py",
+      "size": 130
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/agca/extensions.py",
+      "size": 9388
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/agca/homomorphisms.py",
+      "size": 21937
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/agca/ideals.py",
+      "size": 11073
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/agca/modules.py",
+      "size": 47240
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/agca/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/agca/tests/test_extensions.py",
+      "size": 6455
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/agca/tests/test_homomorphisms.py",
+      "size": 4224
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/agca/tests/test_ideals.py",
+      "size": 3788
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/agca/tests/test_modules.py",
+      "size": 13552
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/appellseqs.py",
+      "size": 8305
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/benchmarks/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/benchmarks/bench_galoispolys.py",
+      "size": 1502
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/benchmarks/bench_groebnertools.py",
+      "size": 803
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/benchmarks/bench_solvers.py",
+      "size": 446778
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/compatibility.py",
+      "size": 58373
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/constructor.py",
+      "size": 11373
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/densearith.py",
+      "size": 34114
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/densebasic.py",
+      "size": 35954
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/densetools.py",
+      "size": 29746
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/dispersion.py",
+      "size": 5740
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/distributedmodules.py",
+      "size": 21827
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domainmatrix.py",
+      "size": 310
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/__init__.py",
+      "size": 1872
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/algebraicfield.py",
+      "size": 23051
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/characteristiczero.py",
+      "size": 382
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/complexfield.py",
+      "size": 6159
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/compositedomain.py",
+      "size": 1642
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/domain.py",
+      "size": 40850
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/domainelement.py",
+      "size": 860
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/expressiondomain.py",
+      "size": 7593
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/expressionrawdomain.py",
+      "size": 1448
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/field.py",
+      "size": 2959
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/finitefield.py",
+      "size": 10654
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/fractionfield.py",
+      "size": 5848
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/gaussiandomains.py",
+      "size": 19598
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/gmpyfinitefield.py",
+      "size": 437
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/gmpyintegerring.py",
+      "size": 3037
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/gmpyrationalfield.py",
+      "size": 3178
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/groundtypes.py",
+      "size": 2102
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/integerring.py",
+      "size": 7442
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/modularinteger.py",
+      "size": 6042
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/mpelements.py",
+      "size": 5042
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/old_fractionfield.py",
+      "size": 6226
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/old_polynomialring.py",
+      "size": 15982
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/polynomialring.py",
+      "size": 6223
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/pythonfinitefield.py",
+      "size": 453
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/pythonintegerring.py",
+      "size": 2962
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/pythonrational.py",
+      "size": 548
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/pythonrationalfield.py",
+      "size": 2295
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/quotientring.py",
+      "size": 5911
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/rationalfield.py",
+      "size": 5982
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/realfield.py",
+      "size": 6456
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/ring.py",
+      "size": 3236
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/simpledomain.py",
+      "size": 369
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/tests/test_domains.py",
+      "size": 51028
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/tests/test_polynomialring.py",
+      "size": 2895
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/domains/tests/test_quotientring.py",
+      "size": 1459
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/euclidtools.py",
+      "size": 41808
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/factortools.py",
+      "size": 43034
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/fglmtools.py",
+      "size": 4298
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/fields.py",
+      "size": 21250
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/galoistools.py",
+      "size": 57238
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/groebnertools.py",
+      "size": 23342
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/heuristicgcd.py",
+      "size": 3732
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/__init__.py",
+      "size": 397
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/_dfm.py",
+      "size": 32971
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/_typing.py",
+      "size": 407
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/ddm.py",
+      "size": 32362
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/dense.py",
+      "size": 23217
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/dfm.py",
+      "size": 1241
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/domainmatrix.py",
+      "size": 115928
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/domainscalar.py",
+      "size": 3778
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/eigen.py",
+      "size": 3015
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/exceptions.py",
+      "size": 1351
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/linsolve.py",
+      "size": 7534
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/lll.py",
+      "size": 3550
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/normalforms.py",
+      "size": 17122
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/rref.py",
+      "size": 15532
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/sdm.py",
+      "size": 64293
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_ddm.py",
+      "size": 16699
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_dense.py",
+      "size": 9516
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_domainmatrix.py",
+      "size": 50006
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_domainscalar.py",
+      "size": 3740
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_eigen.py",
+      "size": 3200
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_fflu.py",
+      "size": 8542
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_inverse.py",
+      "size": 5247
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_linsolve.py",
+      "size": 3373
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_lll.py",
+      "size": 6624
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_normalforms.py",
+      "size": 5106
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_nullspace.py",
+      "size": 5418
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_rref.py",
+      "size": 25982
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_sdm.py",
+      "size": 13415
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/matrices/tests/test_xxm.py",
+      "size": 29778
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/modulargcd.py",
+      "size": 58729
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/monomials.py",
+      "size": 18458
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/multivariate_resultants.py",
+      "size": 15248
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/__init__.py",
+      "size": 538
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/basis.py",
+      "size": 8261
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/exceptions.py",
+      "size": 1594
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/galois_resolvents.py",
+      "size": 25006
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/galoisgroups.py",
+      "size": 20671
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/minpoly.py",
+      "size": 27791
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/modules.py",
+      "size": 69243
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/primes.py",
+      "size": 23984
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/resolvent_lookup.py",
+      "size": 40411
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/subfield.py",
+      "size": 16668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/tests/test_basis.py",
+      "size": 4580
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/tests/test_galoisgroups.py",
+      "size": 5036
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/tests/test_minpoly.py",
+      "size": 23115
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/tests/test_modules.py",
+      "size": 22926
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/tests/test_numbers.py",
+      "size": 5988
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/tests/test_primes.py",
+      "size": 9779
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/tests/test_subfield.py",
+      "size": 12776
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/tests/test_utilities.py",
+      "size": 3661
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/numberfields/utilities.py",
+      "size": 13087
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/orderings.py",
+      "size": 8500
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/orthopolys.py",
+      "size": 10181
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/partfrac.py",
+      "size": 14695
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/polyclasses.py",
+      "size": 96529
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/polyconfig.py",
+      "size": 1598
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/polyerrors.py",
+      "size": 4744
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/polyfuncs.py",
+      "size": 8547
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/polymatrix.py",
+      "size": 9771
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/polyoptions.py",
+      "size": 21806
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/polyquinticconst.py",
+      "size": 96035
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/polyroots.py",
+      "size": 37025
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/polytools.py",
+      "size": 212876
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/polyutils.py",
+      "size": 17248
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/puiseux.py",
+      "size": 26518
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/rationaltools.py",
+      "size": 2838
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/ring_series.py",
+      "size": 59877
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/rings.py",
+      "size": 86080
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/rootisolation.py",
+      "size": 64341
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/rootoftools.py",
+      "size": 43092
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/solvers.py",
+      "size": 13520
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/specialpolys.py",
+      "size": 11038
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/sqfreetools.py",
+      "size": 19876
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/subresultants_qq_zz.py",
+      "size": 88241
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_appellseqs.py",
+      "size": 3820
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_constructor.py",
+      "size": 7220
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_densearith.py",
+      "size": 40827
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_densebasic.py",
+      "size": 21590
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_densetools.py",
+      "size": 26241
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_dispersion.py",
+      "size": 3182
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_distributedmodules.py",
+      "size": 7639
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_euclidtools.py",
+      "size": 19482
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_factortools.py",
+      "size": 24903
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_fields.py",
+      "size": 9869
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_galoistools.py",
+      "size": 28532
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_groebnertools.py",
+      "size": 18584
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_heuristicgcd.py",
+      "size": 4297
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_hypothesis.py",
+      "size": 1109
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_injections.py",
+      "size": 1286
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_modulargcd.py",
+      "size": 9043
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_monomials.py",
+      "size": 11083
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_multivariate_resultants.py",
+      "size": 9501
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_orderings.py",
+      "size": 4254
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_orthopolys.py",
+      "size": 6560
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_partfrac.py",
+      "size": 7838
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_polyclasses.py",
+      "size": 14765
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_polyfuncs.py",
+      "size": 4520
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_polymatrix.py",
+      "size": 7353
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_polyoptions.py",
+      "size": 12416
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_polyroots.py",
+      "size": 26803
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_polytools.py",
+      "size": 139212
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_polyutils.py",
+      "size": 11547
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_puiseux.py",
+      "size": 7304
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_pythonrational.py",
+      "size": 4143
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_rationaltools.py",
+      "size": 2397
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_ring_series.py",
+      "size": 31697
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_rings.py",
+      "size": 48735
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_rootisolation.py",
+      "size": 32724
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_rootoftools.py",
+      "size": 23414
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_solvers.py",
+      "size": 13644
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_specialpolys.py",
+      "size": 5031
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_sqfreetools.py",
+      "size": 4886
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/polys/tests/test_subresultants_qq_zz.py",
+      "size": 13219
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/__init__.py",
+      "size": 2215
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/aesaracode.py",
+      "size": 18921
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/c.py",
+      "size": 27011
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/codeprinter.py",
+      "size": 42371
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/conventions.py",
+      "size": 2586
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/cxx.py",
+      "size": 6123
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/defaults.py",
+      "size": 135
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/dot.py",
+      "size": 8274
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/fortran.py",
+      "size": 28635
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/glsl.py",
+      "size": 20310
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/gtk.py",
+      "size": 466
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/jscode.py",
+      "size": 11981
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/julia.py",
+      "size": 23541
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/lambdarepr.py",
+      "size": 8305
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/latex.py",
+      "size": 123669
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/llvmjitcode.py",
+      "size": 17127
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/maple.py",
+      "size": 10571
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/mathematica.py",
+      "size": 12720
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/mathml.py",
+      "size": 76634
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/numpy.py",
+      "size": 21049
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/octave.py",
+      "size": 25469
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/precedence.py",
+      "size": 5522
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/pretty/__init__.py",
+      "size": 344
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/pretty/pretty.py",
+      "size": 105024
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/pretty/pretty_symbology.py",
+      "size": 24112
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/pretty/stringpict.py",
+      "size": 19158
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/pretty/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/pretty/tests/test_pretty.py",
+      "size": 187716
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/preview.py",
+      "size": 14089
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/printer.py",
+      "size": 15868
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/pycode.py",
+      "size": 27048
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/python.py",
+      "size": 3347
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/pytorch.py",
+      "size": 10620
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/rcode.py",
+      "size": 14101
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/repr.py",
+      "size": 11545
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/rust.py",
+      "size": 20831
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/smtlib.py",
+      "size": 21752
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/str.py",
+      "size": 33239
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tableform.py",
+      "size": 11797
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tensorflow.py",
+      "size": 8161
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_aesaracode.py",
+      "size": 21340
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_c.py",
+      "size": 31227
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_codeprinter.py",
+      "size": 2142
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_conventions.py",
+      "size": 5257
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_cupy.py",
+      "size": 1882
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_cxx.py",
+      "size": 3183
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_dot.py",
+      "size": 4648
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_fortran.py",
+      "size": 35456
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_glsl.py",
+      "size": 28421
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_gtk.py",
+      "size": 500
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_jax.py",
+      "size": 11062
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_jscode.py",
+      "size": 11369
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_julia.py",
+      "size": 14014
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_lambdarepr.py",
+      "size": 6947
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_latex.py",
+      "size": 138061
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_llvmjit.py",
+      "size": 5344
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_maple.py",
+      "size": 13078
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_mathematica.py",
+      "size": 10954
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_mathml.py",
+      "size": 99434
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_numpy.py",
+      "size": 11715
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_octave.py",
+      "size": 18545
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_precedence.py",
+      "size": 4067
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_preview.py",
+      "size": 988
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_pycode.py",
+      "size": 18363
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_python.py",
+      "size": 8128
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_rcode.py",
+      "size": 13781
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_repr.py",
+      "size": 12980
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_rust.py",
+      "size": 11988
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_smtlib.py",
+      "size": 22553
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_str.py",
+      "size": 43523
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_tableform.py",
+      "size": 5692
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_tensorflow.py",
+      "size": 17100
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_theanocode.py",
+      "size": 21394
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_torch.py",
+      "size": 16842
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tests/test_tree.py",
+      "size": 6080
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/theanocode.py",
+      "size": 19094
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/printing/tree.py",
+      "size": 3868
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/release.py",
+      "size": 23
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sandbox/__init__.py",
+      "size": 189
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sandbox/indexed_integrals.py",
+      "size": 2141
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sandbox/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sandbox/tests/test_indexed_integrals.py",
+      "size": 1179
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/__init__.py",
+      "size": 766
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/acceleration.py",
+      "size": 3365
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/approximants.py",
+      "size": 3181
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/aseries.py",
+      "size": 255
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/benchmarks/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/benchmarks/bench_limit.py",
+      "size": 173
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/benchmarks/bench_order.py",
+      "size": 207
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/formal.py",
+      "size": 51668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/fourier.py",
+      "size": 22941
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/gruntz.py",
+      "size": 23497
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/kauers.py",
+      "size": 1720
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/limits.py",
+      "size": 13307
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/limitseq.py",
+      "size": 7752
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/order.py",
+      "size": 19558
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/residues.py",
+      "size": 2213
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/sequences.py",
+      "size": 35543
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/series.py",
+      "size": 1863
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/series_class.py",
+      "size": 2918
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_approximants.py",
+      "size": 1012
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_aseries.py",
+      "size": 2377
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_demidovich.py",
+      "size": 4947
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_formal.py",
+      "size": 22496
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_fourier.py",
+      "size": 5908
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_gruntz.py",
+      "size": 16445
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_kauers.py",
+      "size": 1102
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_limits.py",
+      "size": 48638
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_limitseq.py",
+      "size": 5691
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_lseries.py",
+      "size": 1875
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_nseries.py",
+      "size": 18284
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_order.py",
+      "size": 17901
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_residues.py",
+      "size": 3178
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_sequences.py",
+      "size": 11161
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/series/tests/test_series.py",
+      "size": 17006
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/__init__.py",
+      "size": 1026
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/conditionset.py",
+      "size": 7792
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/contains.py",
+      "size": 1829
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/fancysets.py",
+      "size": 48187
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/handlers/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/handlers/add.py",
+      "size": 1863
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/handlers/comparison.py",
+      "size": 1601
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/handlers/functions.py",
+      "size": 8381
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/handlers/intersection.py",
+      "size": 17514
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/handlers/issubset.py",
+      "size": 4739
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/handlers/mul.py",
+      "size": 1842
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/handlers/power.py",
+      "size": 3186
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/handlers/union.py",
+      "size": 4225
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/ordinals.py",
+      "size": 7641
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/powerset.py",
+      "size": 2913
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/setexpr.py",
+      "size": 3019
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/sets.py",
+      "size": 81202
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/tests/test_conditionset.py",
+      "size": 11370
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/tests/test_contains.py",
+      "size": 1561
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/tests/test_fancysets.py",
+      "size": 51938
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/tests/test_ordinals.py",
+      "size": 2637
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/tests/test_powerset.py",
+      "size": 4805
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/tests/test_setexpr.py",
+      "size": 14797
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/sets/tests/test_sets.py",
+      "size": 68544
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/__init__.py",
+      "size": 1274
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/_cse_diff.py",
+      "size": 10479
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/combsimp.py",
+      "size": 3604
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/cse_main.py",
+      "size": 31310
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/cse_opts.py",
+      "size": 1618
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/epathtools.py",
+      "size": 10122
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/fu.py",
+      "size": 62208
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/gammasimp.py",
+      "size": 18485
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/hyperexpand.py",
+      "size": 84420
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/hyperexpand_doc.py",
+      "size": 521
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/powsimp.py",
+      "size": 26754
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/radsimp.py",
+      "size": 41649
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/ratsimp.py",
+      "size": 7682
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/simplify.py",
+      "size": 73330
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/sqrtdenest.py",
+      "size": 21600
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_combsimp.py",
+      "size": 2958
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_cse.py",
+      "size": 25516
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_cse_diff.py",
+      "size": 7275
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_epathtools.py",
+      "size": 3525
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_fu.py",
+      "size": 19410
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_function.py",
+      "size": 2199
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_gammasimp.py",
+      "size": 5320
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_hyperexpand.py",
+      "size": 41043
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_powsimp.py",
+      "size": 14375
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_radsimp.py",
+      "size": 19128
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_ratsimp.py",
+      "size": 2198
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_rewrite.py",
+      "size": 1127
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_simplify.py",
+      "size": 41928
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_sqrtdenest.py",
+      "size": 7470
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/tests/test_trigsimp.py",
+      "size": 19949
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/traversaltools.py",
+      "size": 409
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/simplify/trigsimp.py",
+      "size": 46857
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/__init__.py",
+      "size": 2333
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/benchmarks/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/benchmarks/bench_solvers.py",
+      "size": 288
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/bivariate.py",
+      "size": 17870
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/decompogen.py",
+      "size": 3757
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/deutils.py",
+      "size": 10315
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/diophantine/__init__.py",
+      "size": 128
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/diophantine/diophantine.py",
+      "size": 122482
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/diophantine/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/diophantine/tests/test_diophantine.py",
+      "size": 43335
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/inequalities.py",
+      "size": 33189
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/__init__.py",
+      "size": 468
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/hypergeometric.py",
+      "size": 10048
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/lie_group.py",
+      "size": 39175
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/nonhomogeneous.py",
+      "size": 17875
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/ode.py",
+      "size": 145379
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/riccati.py",
+      "size": 30736
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/single.py",
+      "size": 109465
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/subscheck.py",
+      "size": 16130
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/systems.py",
+      "size": 71467
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/tests/test_lie_group.py",
+      "size": 5319
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/tests/test_ode.py",
+      "size": 48508
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/tests/test_riccati.py",
+      "size": 29348
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/tests/test_single.py",
+      "size": 100200
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/tests/test_subscheck.py",
+      "size": 12468
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/ode/tests/test_systems.py",
+      "size": 129087
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/pde.py",
+      "size": 34913
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/polysys.py",
+      "size": 27168
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/recurr.py",
+      "size": 25389
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/simplex.py",
+      "size": 35276
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/solvers.py",
+      "size": 138454
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/solveset.py",
+      "size": 151683
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/tests/test_constantsimp.py",
+      "size": 8707
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/tests/test_decompogen.py",
+      "size": 2943
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/tests/test_inequalities.py",
+      "size": 21025
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/tests/test_numeric.py",
+      "size": 4734
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/tests/test_pde.py",
+      "size": 9257
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/tests/test_polysys.py",
+      "size": 15266
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/tests/test_recurr.py",
+      "size": 11418
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/tests/test_simplex.py",
+      "size": 9037
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/tests/test_solvers.py",
+      "size": 107765
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/solvers/tests/test_solveset.py",
+      "size": 148480
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/__init__.py",
+      "size": 8487
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/compound_rv.py",
+      "size": 7965
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/crv.py",
+      "size": 21028
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/crv_types.py",
+      "size": 122371
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/drv.py",
+      "size": 11994
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/drv_types.py",
+      "size": 19865
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/error_prop.py",
+      "size": 3315
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/frv.py",
+      "size": 16874
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/frv_types.py",
+      "size": 23348
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/joint_rv.py",
+      "size": 15963
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/joint_rv_types.py",
+      "size": 30575
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/matrix_distributions.py",
+      "size": 21953
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/random_matrix.py",
+      "size": 1028
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/random_matrix_models.py",
+      "size": 15328
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/rv.py",
+      "size": 54579
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/rv_interface.py",
+      "size": 13935
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/sampling/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/sampling/sample_numpy.py",
+      "size": 4229
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/sampling/sample_pymc.py",
+      "size": 2995
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/sampling/sample_scipy.py",
+      "size": 6329
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/sampling/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/sampling/tests/test_sample_continuous_rv.py",
+      "size": 5708
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/sampling/tests/test_sample_discrete_rv.py",
+      "size": 3360
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/sampling/tests/test_sample_finite_rv.py",
+      "size": 3061
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/stochastic_process.py",
+      "size": 2312
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/stochastic_process_types.py",
+      "size": 88553
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/symbolic_multivariate_probability.py",
+      "size": 10450
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/symbolic_probability.py",
+      "size": 23266
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_compound_rv.py",
+      "size": 6263
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_continuous_rv.py",
+      "size": 56140
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_discrete_rv.py",
+      "size": 11230
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_error_prop.py",
+      "size": 1933
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_finite_rv.py",
+      "size": 20413
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_joint_rv.py",
+      "size": 18653
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_matrix_distributions.py",
+      "size": 8857
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_mix.py",
+      "size": 3991
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_random_matrix.py",
+      "size": 5842
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_rv.py",
+      "size": 12959
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_stochastic_process.py",
+      "size": 39323
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_symbolic_multivariate.py",
+      "size": 5580
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/stats/tests/test_symbolic_probability.py",
+      "size": 9398
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/__init__.py",
+      "size": 1402
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/branch/__init__.py",
+      "size": 356
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/branch/core.py",
+      "size": 2759
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/branch/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/branch/tests/test_core.py",
+      "size": 2246
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/branch/tests/test_tools.py",
+      "size": 942
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/branch/tests/test_traverse.py",
+      "size": 1322
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/branch/tools.py",
+      "size": 357
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/branch/traverse.py",
+      "size": 799
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/core.py",
+      "size": 3956
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/rl.py",
+      "size": 4404
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/tests/test_core.py",
+      "size": 2152
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/tests/test_rl.py",
+      "size": 1949
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/tests/test_tools.py",
+      "size": 875
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/tests/test_traverse.py",
+      "size": 2082
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/tests/test_tree.py",
+      "size": 2400
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/tools.py",
+      "size": 1368
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/traverse.py",
+      "size": 1183
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/tree.py",
+      "size": 3770
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/strategies/util.py",
+      "size": 361
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/__init__.py",
+      "size": 870
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/__init__.py",
+      "size": 8244
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/array_comprehension.py",
+      "size": 12262
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/array_derivatives.py",
+      "size": 4796
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/arrayop.py",
+      "size": 18397
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/dense_ndim_array.py",
+      "size": 6433
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/__init__.py",
+      "size": 7045
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/array_expressions.py",
+      "size": 76961
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/arrayexpr_derivatives.py",
+      "size": 6249
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/conv_array_to_indexed.py",
+      "size": 445
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/conv_array_to_matrix.py",
+      "size": 416
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/conv_indexed_to_array.py",
+      "size": 254
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/conv_matrix_to_array.py",
+      "size": 250
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/from_array_to_indexed.py",
+      "size": 3936
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/from_array_to_matrix.py",
+      "size": 41435
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/from_indexed_to_array.py",
+      "size": 11187
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/from_matrix_to_array.py",
+      "size": 3929
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/tests/test_array_expressions.py",
+      "size": 31262
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/tests/test_arrayexpr_derivatives.py",
+      "size": 2470
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/tests/test_as_explicit.py",
+      "size": 2568
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/tests/test_convert_array_to_indexed.py",
+      "size": 2500
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py",
+      "size": 29311
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/tests/test_convert_indexed_to_array.py",
+      "size": 8615
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/tests/test_convert_matrix_to_array.py",
+      "size": 4595
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/tests/test_deprecated_conv_modules.py",
+      "size": 1216
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/expressions/utils.py",
+      "size": 3939
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/mutable_ndim_array.py",
+      "size": 277
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/ndim_array.py",
+      "size": 19138
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/sparse_ndim_array.py",
+      "size": 6387
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/tests/test_array_comprehension.py",
+      "size": 4529
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/tests/test_array_derivatives.py",
+      "size": 1601
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/tests/test_arrayop.py",
+      "size": 25844
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/tests/test_immutable_ndim_array.py",
+      "size": 15823
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/tests/test_mutable_ndim_array.py",
+      "size": 13070
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/tests/test_ndim_array.py",
+      "size": 2232
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/array/tests/test_ndim_array_conversions.py",
+      "size": 648
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/functions.py",
+      "size": 4168
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/index_methods.py",
+      "size": 15434
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/indexed.py",
+      "size": 24515
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/tensor.py",
+      "size": 181094
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/tests/test_functions.py",
+      "size": 1552
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/tests/test_index_methods.py",
+      "size": 7112
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/tests/test_indexed.py",
+      "size": 16376
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/tests/test_printing.py",
+      "size": 424
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/tests/test_tensor.py",
+      "size": 81236
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/tests/test_tensor_element.py",
+      "size": 908
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/tests/test_tensor_operators.py",
+      "size": 17966
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/tensor/toperators.py",
+      "size": 8840
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/__init__.py",
+      "size": 169
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/matrices.py",
+      "size": 216
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/pytest.py",
+      "size": 13363
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/quality_unicode.py",
+      "size": 3482
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/randtest.py",
+      "size": 562
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/runtests.py",
+      "size": 89921
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/runtests_pytest.py",
+      "size": 17801
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/tests/diagnose_imports.py",
+      "size": 9508
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/tests/test_code_quality.py",
+      "size": 19214
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/tests/test_deprecated.py",
+      "size": 183
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/tests/test_module_imports.py",
+      "size": 1459
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/tests/test_pytest.py",
+      "size": 6778
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/tests/test_runtests_pytest.py",
+      "size": 6083
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/testing/tmpfiles.py",
+      "size": 1042
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/this.py",
+      "size": 550
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/unify/__init__.py",
+      "size": 293
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/unify/core.py",
+      "size": 7037
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/unify/rewrite.py",
+      "size": 1798
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/unify/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/unify/tests/test_rewrite.py",
+      "size": 2002
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/unify/tests/test_sympy.py",
+      "size": 5922
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/unify/tests/test_unify.py",
+      "size": 3029
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/unify/usympy.py",
+      "size": 3964
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/__init__.py",
+      "size": 840
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/_compilation/__init__.py",
+      "size": 751
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/_compilation/availability.py",
+      "size": 2884
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/_compilation/compilation.py",
+      "size": 22156
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/_compilation/runners.py",
+      "size": 10237
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/_compilation/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/_compilation/tests/test_compilation.py",
+      "size": 3189
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/_compilation/util.py",
+      "size": 8611
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/autowrap.py",
+      "size": 42561
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/codegen.py",
+      "size": 81670
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/decorator.py",
+      "size": 11184
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/enumerative.py",
+      "size": 43585
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/exceptions.py",
+      "size": 10570
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/iterables.py",
+      "size": 91103
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/lambdify.py",
+      "size": 57816
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/magic.py",
+      "size": 400
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/matchpy_connector.py",
+      "size": 11948
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/mathml/__init__.py",
+      "size": 3388
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/mathml/data/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/memoization.py",
+      "size": 1838
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/misc.py",
+      "size": 16000
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/pkgdata.py",
+      "size": 935
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/pytest.py",
+      "size": 440
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/randtest.py",
+      "size": 435
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/runtests.py",
+      "size": 451
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/source.py",
+      "size": 1127
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_autowrap.py",
+      "size": 14865
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_codegen.py",
+      "size": 56130
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_codegen_julia.py",
+      "size": 18540
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_codegen_octave.py",
+      "size": 17830
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_codegen_rust.py",
+      "size": 12326
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_decorator.py",
+      "size": 3705
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_deprecated.py",
+      "size": 489
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_enumerative.py",
+      "size": 6097
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_exceptions.py",
+      "size": 716
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_iterables.py",
+      "size": 35288
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_lambdify.py",
+      "size": 73531
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_matchpy_connector.py",
+      "size": 4850
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_mathml.py",
+      "size": 836
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_misc.py",
+      "size": 4643
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_pickling.py",
+      "size": 23600
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_source.py",
+      "size": 289
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_timeutils.py",
+      "size": 337
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_wester.py",
+      "size": 94866
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tests/test_xxe.py",
+      "size": 66
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/timeutils.py",
+      "size": 1941
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/utilities/tmpfiles.py",
+      "size": 450
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/__init__.py",
+      "size": 1969
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/basisdependent.py",
+      "size": 11857
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/coordsysrect.py",
+      "size": 36833
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/deloperator.py",
+      "size": 3191
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/dyadic.py",
+      "size": 8571
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/functions.py",
+      "size": 15454
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/implicitregion.py",
+      "size": 16158
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/integrals.py",
+      "size": 6837
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/kind.py",
+      "size": 1812
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/operators.py",
+      "size": 9579
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/orienters.py",
+      "size": 11798
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/parametricregion.py",
+      "size": 5932
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/point.py",
+      "size": 4488
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/scalar.py",
+      "size": 2024
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/tests/test_coordsysrect.py",
+      "size": 19595
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/tests/test_dyadic.py",
+      "size": 4949
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/tests/test_field_functions.py",
+      "size": 14094
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/tests/test_functions.py",
+      "size": 8050
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/tests/test_implicitregion.py",
+      "size": 4028
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/tests/test_integrals.py",
+      "size": 5087
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/tests/test_operators.py",
+      "size": 1613
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/tests/test_parametricregion.py",
+      "size": 4009
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/tests/test_printing.py",
+      "size": 7708
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/tests/test_vector.py",
+      "size": 10238
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/vector/vector.py",
+      "size": 20322
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_VF.py",
+      "size": 664
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/__config__.py",
+      "size": 574
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/__future__.py",
+      "size": 3185
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/__init__.py",
+      "size": 102960
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_appdirs.py",
+      "size": 26206
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_awaits/__init__.py",
+      "size": 1652
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_classes.py",
+      "size": 1721
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_compile.py",
+      "size": 2011
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_custom_op/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_custom_op/autograd.py",
+      "size": 12083
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_custom_op/impl.py",
+      "size": 27012
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_custom_ops.py",
+      "size": 12824
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_decomp/__init__.py",
+      "size": 19144
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_decomp/decompositions.py",
+      "size": 176426
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_decomp/decompositions_for_jvp.py",
+      "size": 11701
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_decomp/decompositions_for_rng.py",
+      "size": 9178
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_deploy.py",
+      "size": 3457
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dispatch/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dispatch/python.py",
+      "size": 6710
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/__init__.py",
+      "size": 5232
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/_trace_wrapped_higher_order_op.py",
+      "size": 9231
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/backends/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/backends/common.py",
+      "size": 5536
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/backends/cudagraphs.py",
+      "size": 9262
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/backends/debugging.py",
+      "size": 15580
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/backends/distributed.py",
+      "size": 26512
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/backends/inductor.py",
+      "size": 884
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/backends/onnxrt.py",
+      "size": 1541
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/backends/registry.py",
+      "size": 5426
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/backends/tensorrt.py",
+      "size": 406
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/backends/torchxla.py",
+      "size": 1255
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/backends/tvm.py",
+      "size": 7634
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/bytecode_analysis.py",
+      "size": 8525
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/bytecode_transformation.py",
+      "size": 59711
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/cache_size.py",
+      "size": 7908
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/callback.py",
+      "size": 5586
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/code_context.py",
+      "size": 1818
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/codegen.py",
+      "size": 27833
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/compiled_autograd.py",
+      "size": 60443
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/comptime.py",
+      "size": 14212
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/config.py",
+      "size": 27352
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/convert_frame.py",
+      "size": 56860
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/create_parameter_op.py",
+      "size": 2524
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/current_scope_id.py",
+      "size": 1433
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/debug_utils.py",
+      "size": 30356
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/decorators.py",
+      "size": 32805
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/device_interface.py",
+      "size": 17744
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/distributed.py",
+      "size": 1670
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py",
+      "size": 81689
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/exc.py",
+      "size": 23635
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/external_utils.py",
+      "size": 6851
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/funcname_cache.py",
+      "size": 2548
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/graph_break_hints.py",
+      "size": 1327
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/graph_deduplication.py",
+      "size": 17018
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/graph_region_tracker.py",
+      "size": 17500
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/graph_utils.py",
+      "size": 2367
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/guards.py",
+      "size": 145866
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/hooks.py",
+      "size": 867
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/logging.py",
+      "size": 2188
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/metrics_context.py",
+      "size": 8020
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/mutation_guard.py",
+      "size": 5166
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/output_graph.py",
+      "size": 133557
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/package.py",
+      "size": 15955
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/pgo.py",
+      "size": 32144
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/polyfills/__init__.py",
+      "size": 9228
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/polyfills/builtins.py",
+      "size": 1399
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/polyfills/functools.py",
+      "size": 966
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/polyfills/fx.py",
+      "size": 1323
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/polyfills/itertools.py",
+      "size": 5979
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/polyfills/loader.py",
+      "size": 1227
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/polyfills/operator.py",
+      "size": 2924
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/polyfills/os.py",
+      "size": 978
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/polyfills/pytree.py",
+      "size": 15745
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/polyfills/sys.py",
+      "size": 447
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/polyfills/tensor.py",
+      "size": 1404
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/precompile_context.py",
+      "size": 5774
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/profiler.py",
+      "size": 5711
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/replay_record.py",
+      "size": 4290
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/repro/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/repro/after_aot.py",
+      "size": 36314
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/repro/after_dynamo.py",
+      "size": 20572
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/repro/aoti.py",
+      "size": 21190
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/resume_execution.py",
+      "size": 21860
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/side_effects.py",
+      "size": 48180
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/source.py",
+      "size": 33566
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/symbolic_convert.py",
+      "size": 166965
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/tensor_version_op.py",
+      "size": 2399
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/test_case.py",
+      "size": 7258
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/test_dont_skip_tracing_functions.py",
+      "size": 817
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/test_minifier_common.py",
+      "size": 11910
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/testing.py",
+      "size": 17071
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/trace_rules.py",
+      "size": 154004
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/types.py",
+      "size": 4155
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/utils.py",
+      "size": 161146
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/__init__.py",
+      "size": 6640
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/base.py",
+      "size": 23782
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/builder.py",
+      "size": 154898
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/builtin.py",
+      "size": 102371
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/constant.py",
+      "size": 10430
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/ctx_manager.py",
+      "size": 50852
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/dicts.py",
+      "size": 41553
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/distributed.py",
+      "size": 16027
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/functions.py",
+      "size": 88871
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/higher_order_ops.py",
+      "size": 131703
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/iter.py",
+      "size": 23241
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/lazy.py",
+      "size": 7065
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/lists.py",
+      "size": 40116
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/misc.py",
+      "size": 74588
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/nn_module.py",
+      "size": 51881
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/optimizer.py",
+      "size": 16713
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/script_object.py",
+      "size": 3762
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/sdpa.py",
+      "size": 2522
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/tensor.py",
+      "size": 66690
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/torch.py",
+      "size": 71317
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/torch_function.py",
+      "size": 27929
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_dynamo/variables/user_defined.py",
+      "size": 72197
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_environment.py",
+      "size": 42
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/__init__.py",
+      "size": 6487
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/converter.py",
+      "size": 64540
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/__init__.py",
+      "size": 206
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/case.py",
+      "size": 4998
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/__init__.py",
+      "size": 1648
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/assume_constant_result.py",
+      "size": 510
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/autograd_function.py",
+      "size": 578
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/class_method.py",
+      "size": 499
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/cond_branch_class_method.py",
+      "size": 1327
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/cond_branch_nested_function.py",
+      "size": 1302
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/cond_branch_nonlocal_variables.py",
+      "size": 1841
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/cond_closed_over_variable.py",
+      "size": 547
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/cond_operands.py",
+      "size": 799
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/cond_predicate.py",
+      "size": 663
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/constrain_as_size_example.py",
+      "size": 637
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/constrain_as_value_example.py",
+      "size": 689
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/decorator.py",
+      "size": 480
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/dictionary.py",
+      "size": 404
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/dynamic_shape_assert.py",
+      "size": 450
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/dynamic_shape_constructor.py",
+      "size": 396
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/dynamic_shape_if_guard.py",
+      "size": 560
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/dynamic_shape_map.py",
+      "size": 454
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/dynamic_shape_round.py",
+      "size": 525
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/dynamic_shape_slicing.py",
+      "size": 388
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/dynamic_shape_view.py",
+      "size": 444
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/fn_with_kwargs.py",
+      "size": 731
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/list_contains.py",
+      "size": 477
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/list_unpack.py",
+      "size": 568
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/model_attr_mutation.py",
+      "size": 662
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/nested_function.py",
+      "size": 491
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/null_context_manager.py",
+      "size": 478
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/optional_input.py",
+      "size": 455
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/pytree_flatten.py",
+      "size": 376
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/scalar_output.py",
+      "size": 543
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/specialized_attribute.py",
+      "size": 520
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/static_for_loop.py",
+      "size": 385
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/static_if.py",
+      "size": 397
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/tensor_setattr.py",
+      "size": 337
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/type_reflection_method.py",
+      "size": 461
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/unsupported_operator.py",
+      "size": 411
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/examples/user_input_mutation.py",
+      "size": 302
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/gen_example.py",
+      "size": 462
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/db/logging.py",
+      "size": 1651
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/error.py",
+      "size": 1770
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/non_strict_utils.py",
+      "size": 39643
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/pass_base.py",
+      "size": 18268
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/pass_infra/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/pass_infra/node_metadata.py",
+      "size": 771
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/pass_infra/proxy_value.py",
+      "size": 1269
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/__init__.py",
+      "size": 88
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/_node_metadata_hook.py",
+      "size": 2478
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/add_runtime_assertions_for_constraints_pass.py",
+      "size": 10160
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/collect_tracepoints_pass.py",
+      "size": 6548
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/constant_folding.py",
+      "size": 11276
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/functionalize_side_effectful_ops_pass.py",
+      "size": 3279
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/insert_custom_op_guards.py",
+      "size": 2855
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/lift_constants_pass.py",
+      "size": 17458
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/remove_runtime_assertions.py",
+      "size": 1588
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/replace_autocast_with_hop_pass.py",
+      "size": 7216
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/replace_quantized_ops_with_standard_ops_pass.py",
+      "size": 25899
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/replace_set_grad_with_hop_pass.py",
+      "size": 4325
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/replace_view_ops_with_view_copy_ops_pass.py",
+      "size": 2411
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/passes/replace_with_hop_pass_util.py",
+      "size": 7552
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/serde/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/serde/dynamic_shapes.py",
+      "size": 11551
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/serde/schema.py",
+      "size": 14643
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/serde/schema_check.py",
+      "size": 24442
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/serde/serialize.py",
+      "size": 144049
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/serde/union.py",
+      "size": 2026
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/tools.py",
+      "size": 4572
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/utils.py",
+      "size": 55734
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/verifier.py",
+      "size": 19693
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/wrappers.py",
+      "size": 9372
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/__init__.py",
+      "size": 206
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_activation_checkpointing/__init__.py",
+      "size": 206
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_activation_checkpointing/ac_logging_utils.py",
+      "size": 5159
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_activation_checkpointing/graph_info_provider.py",
+      "size": 12766
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_activation_checkpointing/knapsack.py",
+      "size": 3955
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_activation_checkpointing/knapsack_evaluator.py",
+      "size": 11823
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/__init__.py",
+      "size": 206
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/autograd_cache.py",
+      "size": 58030
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/collect_metadata_analysis.py",
+      "size": 42658
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/dispatch_and_compile_graph.py",
+      "size": 12643
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/functional_utils.py",
+      "size": 22690
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/input_output_analysis.py",
+      "size": 17612
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/jit_compile_runtime_wrappers.py",
+      "size": 76516
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/logging_utils.py",
+      "size": 4623
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py",
+      "size": 106137
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/schemas.py",
+      "size": 41588
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/subclass_parametrization.py",
+      "size": 4087
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/subclass_utils.py",
+      "size": 18413
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/traced_function_transforms.py",
+      "size": 45234
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/utils.py",
+      "size": 19218
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/aot_autograd.py",
+      "size": 72659
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/apis.py",
+      "size": 19089
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/autograd_function.py",
+      "size": 28742
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/batch_norm_replacement.py",
+      "size": 857
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/benchmark_utils.py",
+      "size": 6280
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/compile_utils.py",
+      "size": 7682
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/compilers.py",
+      "size": 14049
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/config.py",
+      "size": 13673
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/deprecated.py",
+      "size": 5203
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/eager_transforms.py",
+      "size": 71057
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/functional_call.py",
+      "size": 10578
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/fx_minifier.py",
+      "size": 17363
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/make_functional.py",
+      "size": 22744
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/partitioners.py",
+      "size": 105221
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/pyfunctorch.py",
+      "size": 10676
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/python_key.py",
+      "size": 442
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/pytree_hacks.py",
+      "size": 698
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/top_operators_github_usage.py",
+      "size": 21392
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/utils.py",
+      "size": 1052
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_functorch/vmap.py",
+      "size": 18983
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_guards.py",
+      "size": 39005
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/__init__.py",
+      "size": 2278
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/_invoke_quant.py",
+      "size": 1897
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/aoti_call_delegate.py",
+      "size": 6063
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/associative_scan.py",
+      "size": 18333
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/auto_functionalize.py",
+      "size": 36201
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/base_hop.py",
+      "size": 10537
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/cond.py",
+      "size": 28173
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/effects.py",
+      "size": 10116
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/executorch_call_delegate.py",
+      "size": 5959
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/flat_apply.py",
+      "size": 4369
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/flex_attention.py",
+      "size": 43038
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/foreach_map.py",
+      "size": 663
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/hints_wrap.py",
+      "size": 4837
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/invoke_subgraph.py",
+      "size": 26299
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/map.py",
+      "size": 10053
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/out_dtype.py",
+      "size": 5526
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/run_const_graph.py",
+      "size": 1890
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/scan.py",
+      "size": 38151
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/schema.py",
+      "size": 11128
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/strict_mode.py",
+      "size": 3644
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/torchbind.py",
+      "size": 6252
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/triton_kernel_wrap.py",
+      "size": 82438
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/utils.py",
+      "size": 43459
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/while_loop.py",
+      "size": 17566
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_higher_order_ops/wrap.py",
+      "size": 11222
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/__autotune_main__.py",
+      "size": 913
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/__init__.py",
+      "size": 13516
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/analyze_preserves_zero_mask.py",
+      "size": 5453
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/aoti_eager.py",
+      "size": 11138
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/async_compile.py",
+      "size": 20040
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/autoheuristic/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/autoheuristic/artifacts/_MMRankingA100.py",
+      "size": 28044
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/autoheuristic/artifacts/_MMRankingH100.py",
+      "size": 30668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/autoheuristic/artifacts/_MixedMMA100.py",
+      "size": 7920
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/autoheuristic/artifacts/_MixedMMH100.py",
+      "size": 7882
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/autoheuristic/artifacts/_PadMMA100.py",
+      "size": 4931
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/autoheuristic/artifacts/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/autoheuristic/autoheuristic.py",
+      "size": 11934
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/autoheuristic/autoheuristic_utils.py",
+      "size": 11281
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/autoheuristic/learned_heuristic_controller.py",
+      "size": 4317
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/autoheuristic/learnedheuristic_interface.py",
+      "size": 2852
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/autotune_process.py",
+      "size": 29438
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/bounds.py",
+      "size": 9697
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/choices.py",
+      "size": 17660
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codecache.py",
+      "size": 155537
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/aoti_hipify_utils.py",
+      "size": 1320
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/block_analysis.py",
+      "size": 6679
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/common.py",
+      "size": 95878
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp.py",
+      "size": 223490
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp_bmm_template.py",
+      "size": 9359
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp_flex_attention_template.py",
+      "size": 41024
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp_gemm_template.py",
+      "size": 75880
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp_grouped_gemm_template.py",
+      "size": 20382
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp_micro_gemm.py",
+      "size": 69500
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp_template.py",
+      "size": 4909
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp_template_kernel.py",
+      "size": 25116
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp_utils.py",
+      "size": 27760
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp_wrapper_cpu.py",
+      "size": 119387
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py",
+      "size": 38369
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp_wrapper_gpu.py",
+      "size": 28487
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpp_wrapper_mps.py",
+      "size": 3508
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cpu_device_op_overrides.py",
+      "size": 632
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/cuda_cpp_scheduling.py",
+      "size": 11817
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/cuda_env.py",
+      "size": 1166
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/cuda_kernel.py",
+      "size": 24040
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/cuda_template.py",
+      "size": 11208
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/cutlass_cache.py",
+      "size": 3086
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/cutlass_lib_extensions/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/cutlass_lib_extensions/evt_extensions.py",
+      "size": 9843
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/cutlass_lib_extensions/gemm_operation_extensions.py",
+      "size": 18646
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/cutlass_presets.py",
+      "size": 25506
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/cutlass_python_evt.py",
+      "size": 11734
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/cutlass_utils.py",
+      "size": 17042
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/device_op_overrides.py",
+      "size": 14852
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/gemm_template.py",
+      "size": 74860
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda/serialization.py",
+      "size": 16468
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/cuda_combined_scheduling.py",
+      "size": 5031
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/debug_utils.py",
+      "size": 11251
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/halide.py",
+      "size": 62216
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/memory_planning.py",
+      "size": 25081
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/mps.py",
+      "size": 37827
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/mps_device_op_overrides.py",
+      "size": 671
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/multi_kernel.py",
+      "size": 13609
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/ck_conv_template.py",
+      "size": 24404
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/ck_template.py",
+      "size": 3590
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/ck_tile_template.py",
+      "size": 1486
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py",
+      "size": 36356
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/ck_universal_gemm_template.py",
+      "size": 39510
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/compile_command.py",
+      "size": 4472
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/rocm_benchmark_request.py",
+      "size": 5071
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/rocm_cpp_scheduling.py",
+      "size": 3799
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/rocm_kernel.py",
+      "size": 10373
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/rocm_template.py",
+      "size": 6637
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/rocm_template_buffer.py",
+      "size": 827
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/rocm/rocm_utils.py",
+      "size": 266
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/simd.py",
+      "size": 95661
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/simd_kernel_features.py",
+      "size": 23721
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/subgraph.py",
+      "size": 7422
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/triton.py",
+      "size": 177249
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/triton_combo_kernel.py",
+      "size": 41413
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/triton_split_scan.py",
+      "size": 7243
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/triton_utils.py",
+      "size": 8965
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/wrapper.py",
+      "size": 134938
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/wrapper_fxir.py",
+      "size": 24613
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/xpu/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/codegen/xpu/device_op_overrides.py",
+      "size": 1804
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/comm_analysis.py",
+      "size": 8286
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/comm_lowering.py",
+      "size": 12664
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/comms.py",
+      "size": 42472
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/compile_fx.py",
+      "size": 102927
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/compile_fx_async.py",
+      "size": 6437
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/compile_fx_ext.py",
+      "size": 23144
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/compile_fx_subproc.py",
+      "size": 3197
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/compile_worker/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/compile_worker/__main__.py",
+      "size": 2245
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/compile_worker/subproc_pool.py",
+      "size": 13219
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/compile_worker/tracked_process_pool.py",
+      "size": 3620
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/compile_worker/utils.py",
+      "size": 1506
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/compiler_bisector.py",
+      "size": 22415
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/config.py",
+      "size": 70345
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/constant_folding.py",
+      "size": 15216
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/cpp_builder.py",
+      "size": 67649
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/cpu_vec_isa.py",
+      "size": 14035
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/cudagraph_trees.py",
+      "size": 103554
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/cudagraph_utils.py",
+      "size": 13880
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/custom_graph_pass.py",
+      "size": 3858
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/debug.py",
+      "size": 33032
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/decomposition.py",
+      "size": 36987
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/dependencies.py",
+      "size": 29675
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/dtype_propagation.py",
+      "size": 11497
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/exc.py",
+      "size": 4655
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/extern_node_serializer.py",
+      "size": 830
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/freezing.py",
+      "size": 10876
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/freezing_utils.py",
+      "size": 1268
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fuzzer.py",
+      "size": 36872
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/b2b_gemm.py",
+      "size": 24966
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/binary_folding.py",
+      "size": 19850
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/ddp_fusion.py",
+      "size": 21131
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/decompose_mem_bound_mm.py",
+      "size": 5325
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/dedupe_symint_uses.py",
+      "size": 2517
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/efficient_conv_bn_eval.py",
+      "size": 14078
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/freezing_patterns.py",
+      "size": 9030
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/fuse_attention.py",
+      "size": 35058
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/group_batch_fusion.py",
+      "size": 58707
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/joint_graph.py",
+      "size": 33646
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/micro_pipeline_tp.py",
+      "size": 39007
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/misc_patterns.py",
+      "size": 4787
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/mkldnn_fusion.py",
+      "size": 60071
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/numeric_utils.py",
+      "size": 7278
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/pad_mm.py",
+      "size": 29390
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/post_grad.py",
+      "size": 63002
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/pre_grad.py",
+      "size": 30532
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/quantization.py",
+      "size": 142310
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/reinplace.py",
+      "size": 29842
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/replace_random.py",
+      "size": 4052
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_1.py",
+      "size": 11177
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_10.py",
+      "size": 14216
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_11.py",
+      "size": 13987
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_12.py",
+      "size": 15257
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_13.py",
+      "size": 7862
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_14.py",
+      "size": 14323
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_15.py",
+      "size": 16213
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_16.py",
+      "size": 43596
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_17.py",
+      "size": 17441
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_18.py",
+      "size": 32736
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_19.py",
+      "size": 14046
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_2.py",
+      "size": 11187
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_20.py",
+      "size": 17341
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_21.py",
+      "size": 15066
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_22.py",
+      "size": 15404
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_23.py",
+      "size": 15318
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_3.py",
+      "size": 12447
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_4.py",
+      "size": 12411
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_5.py",
+      "size": 11413
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_6.py",
+      "size": 12641
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_7.py",
+      "size": 15436
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_8.py",
+      "size": 14204
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/_sfdp_pattern_9.py",
+      "size": 15444
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/addmm_pattern.py",
+      "size": 1858
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/bmm_pattern.py",
+      "size": 1272
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/serialized_patterns/mm_pattern.py",
+      "size": 1260
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_passes/split_cat.py",
+      "size": 118330
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/fx_utils.py",
+      "size": 10064
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/graph.py",
+      "size": 103834
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/hooks.py",
+      "size": 639
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/index_propagation.py",
+      "size": 12868
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/inductor_prims.py",
+      "size": 7301
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/ir.py",
+      "size": 304456
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/jagged_lowerings.py",
+      "size": 8966
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/kernel/__init__.py",
+      "size": 40
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/kernel/bmm.py",
+      "size": 9808
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/kernel/conv.py",
+      "size": 21314
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/kernel/flex_attention.py",
+      "size": 100353
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/kernel/flex_decoding.py",
+      "size": 23261
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/kernel/mm.py",
+      "size": 44849
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/kernel/mm_common.py",
+      "size": 8899
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/kernel/mm_plus_mm.py",
+      "size": 5428
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/kernel/mm_scaled_grouped.py",
+      "size": 22387
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/loop_body.py",
+      "size": 24291
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/lowering.py",
+      "size": 232064
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/memory.py",
+      "size": 26080
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/metrics.py",
+      "size": 13871
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/mkldnn_ir.py",
+      "size": 41911
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/mkldnn_lowerings.py",
+      "size": 54213
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/mock_cache.py",
+      "size": 8556
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/ops_handler.py",
+      "size": 35527
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/optimize_indexing.py",
+      "size": 4135
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/output_code.py",
+      "size": 29541
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/package/__init__.py",
+      "size": 67
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/package/build_package.py",
+      "size": 329
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/package/package.py",
+      "size": 4453
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/pattern_matcher.py",
+      "size": 80613
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/quantized_lowerings.py",
+      "size": 5646
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/remote_cache.py",
+      "size": 12796
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/autotune_cache.py",
+      "size": 22736
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/benchmarking.py",
+      "size": 11218
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/cache_dir_utils.py",
+      "size": 1444
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/compile_tasks.py",
+      "size": 2017
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/coordinate_descent_tuner.py",
+      "size": 10046
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/halide_helpers.py",
+      "size": 3542
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/hints.py",
+      "size": 7037
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/runtime_utils.py",
+      "size": 4982
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/static_cuda_launcher.py",
+      "size": 9261
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/triton_compat.py",
+      "size": 4095
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/triton_helpers.py",
+      "size": 23098
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/runtime/triton_heuristics.py",
+      "size": 111499
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/scheduler.py",
+      "size": 195793
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/select_algorithm.py",
+      "size": 116990
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/sizevars.py",
+      "size": 37809
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/standalone_compile.py",
+      "size": 9552
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/subgraph_lowering.py",
+      "size": 7350
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/template_heuristics.py",
+      "size": 44566
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/test_case.py",
+      "size": 1378
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/test_operators.py",
+      "size": 933
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/tiling_utils.py",
+      "size": 25894
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/triton_bundler.py",
+      "size": 16149
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/utils.py",
+      "size": 102710
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/virtualized.py",
+      "size": 14070
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_inductor/wrapper_benchmark.py",
+      "size": 15846
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_jit_internal.py",
+      "size": 53877
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lazy/__init__.py",
+      "size": 1793
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lazy/closure.py",
+      "size": 5572
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lazy/computation.py",
+      "size": 919
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lazy/config.py",
+      "size": 448
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lazy/debug.py",
+      "size": 738
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lazy/device_context.py",
+      "size": 681
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lazy/extract_compiled_graph.py",
+      "size": 8423
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lazy/ir_cache.py",
+      "size": 348
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lazy/metrics.py",
+      "size": 545
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lazy/tensor_factory_functions.py",
+      "size": 1368
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lazy/ts_backend.py",
+      "size": 163
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_library/__init__.py",
+      "size": 269
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_library/autograd.py",
+      "size": 8729
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_library/custom_ops.py",
+      "size": 37539
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_library/fake_class_registry.py",
+      "size": 12781
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_library/fake_impl.py",
+      "size": 8763
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_library/fake_profile.py",
+      "size": 11488
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_library/infer_schema.py",
+      "size": 12588
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_library/simple_registry.py",
+      "size": 2638
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_library/triton.py",
+      "size": 11687
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_library/utils.py",
+      "size": 18299
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_linalg_utils.py",
+      "size": 5164
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lobpcg.py",
+      "size": 43427
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_logging/__init__.py",
+      "size": 799
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_logging/_internal.py",
+      "size": 48803
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_logging/_registrations.py",
+      "size": 7992
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_logging/scribe.py",
+      "size": 2578
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_logging/structured.py",
+      "size": 2927
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_lowrank.py",
+      "size": 10554
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_meta_registrations.py",
+      "size": 251384
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_namedtensor_internals.py",
+      "size": 5290
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/__init__.py",
+      "size": 556
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_binary_ufuncs_impl.py",
+      "size": 1871
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_casting_dicts.py",
+      "size": 42478
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_dtypes.py",
+      "size": 10326
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_dtypes_impl.py",
+      "size": 5907
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_funcs.py",
+      "size": 2097
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_funcs_impl.py",
+      "size": 59239
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_getlimits.py",
+      "size": 269
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_ndarray.py",
+      "size": 16644
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_normalizations.py",
+      "size": 8249
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_reductions_impl.py",
+      "size": 11800
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_ufuncs.py",
+      "size": 8366
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_unary_ufuncs_impl.py",
+      "size": 1161
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/_util.py",
+      "size": 7557
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/fft.py",
+      "size": 2805
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/linalg.py",
+      "size": 5648
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/random.py",
+      "size": 4650
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/testing/__init__.py",
+      "size": 375
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_numpy/testing/utils.py",
+      "size": 76198
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_ops.py",
+      "size": 60538
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_prims/__init__.py",
+      "size": 81333
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_prims/context.py",
+      "size": 6091
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_prims/debug_prims.py",
+      "size": 1889
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_prims/executor.py",
+      "size": 1909
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_prims/rng_prims.py",
+      "size": 14466
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_prims_common/__init__.py",
+      "size": 69668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_prims_common/wrappers.py",
+      "size": 18232
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_python_dispatcher.py",
+      "size": 7137
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_refs/__init__.py",
+      "size": 216413
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_refs/_conversions.py",
+      "size": 3533
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_refs/fft.py",
+      "size": 17967
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_refs/linalg/__init__.py",
+      "size": 11528
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_refs/nn/__init__.py",
+      "size": 24
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_refs/nn/functional/__init__.py",
+      "size": 42484
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_refs/special/__init__.py",
+      "size": 6824
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_size_docs.py",
+      "size": 900
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_sources.py",
+      "size": 4423
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_storage_docs.py",
+      "size": 1335
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_streambase.py",
+      "size": 435
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_strobelight/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_strobelight/cli_function_profiler.py",
+      "size": 11768
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_strobelight/compile_time_profiler.py",
+      "size": 7524
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_subclasses/__init__.py",
+      "size": 375
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_subclasses/_fake_tensor_utils.py",
+      "size": 8845
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_subclasses/fake_impls.py",
+      "size": 37053
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_subclasses/fake_tensor.py",
+      "size": 129522
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_subclasses/fake_utils.py",
+      "size": 10283
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_subclasses/functional_tensor.py",
+      "size": 34271
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_subclasses/meta_utils.py",
+      "size": 87065
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_subclasses/schema_check_mode.py",
+      "size": 8639
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_tensor.py",
+      "size": 72764
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_tensor_docs.py",
+      "size": 144150
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_tensor_str.py",
+      "size": 28513
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_thread_safe_fork.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_torch_docs.py",
+      "size": 426370
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_utils.py",
+      "size": 40418
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_utils_internal.py",
+      "size": 8693
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_vendor/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_vendor/packaging/__init__.py",
+      "size": 496
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_vendor/packaging/_structures.py",
+      "size": 1431
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_vendor/packaging/version.py",
+      "size": 16236
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_vmap_internals.py",
+      "size": 9442
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_weights_only_unpickler.py",
+      "size": 22214
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/accelerator/__init__.py",
+      "size": 8345
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/accelerator/_utils.py",
+      "size": 968
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/amp/__init__.py",
+      "size": 181
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/amp/autocast_mode.py",
+      "size": 25000
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/amp/grad_scaler.py",
+      "size": 30563
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/__init__.py",
+      "size": 678
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/__init__.py",
+      "size": 834
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/__init__.py",
+      "size": 961
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/modules/__init__.py",
+      "size": 655
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/modules/fused.py",
+      "size": 10317
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/qat/__init__.py",
+      "size": 37
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/qat/modules/__init__.py",
+      "size": 547
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/qat/modules/conv_fused.py",
+      "size": 32948
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/qat/modules/linear_fused.py",
+      "size": 6613
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/qat/modules/linear_relu.py",
+      "size": 1686
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/quantized/__init__.py",
+      "size": 236
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/quantized/dynamic/__init__.py",
+      "size": 37
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/quantized/dynamic/modules/__init__.py",
+      "size": 70
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/quantized/dynamic/modules/linear_relu.py",
+      "size": 2027
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/quantized/modules/__init__.py",
+      "size": 409
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/quantized/modules/bn_relu.py",
+      "size": 3285
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/quantized/modules/conv_add.py",
+      "size": 4434
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/quantized/modules/conv_relu.py",
+      "size": 8451
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/intrinsic/quantized/modules/linear_relu.py",
+      "size": 6884
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/qat/__init__.py",
+      "size": 37
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/qat/dynamic/__init__.py",
+      "size": 37
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/qat/dynamic/modules/__init__.py",
+      "size": 50
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/qat/dynamic/modules/linear.py",
+      "size": 1248
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/qat/modules/__init__.py",
+      "size": 228
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/qat/modules/conv.py",
+      "size": 9577
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/qat/modules/embedding_ops.py",
+      "size": 7817
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/qat/modules/linear.py",
+      "size": 3051
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantizable/__init__.py",
+      "size": 37
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantizable/modules/__init__.py",
+      "size": 145
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantizable/modules/activation.py",
+      "size": 23048
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantizable/modules/rnn.py",
+      "size": 21607
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/__init__.py",
+      "size": 686
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/dynamic/__init__.py",
+      "size": 37
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/dynamic/modules/__init__.py",
+      "size": 413
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/dynamic/modules/conv.py",
+      "size": 18190
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/dynamic/modules/linear.py",
+      "size": 6350
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/dynamic/modules/rnn.py",
+      "size": 51348
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/functional.py",
+      "size": 29589
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/modules/__init__.py",
+      "size": 4521
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/modules/activation.py",
+      "size": 11608
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/modules/batchnorm.py",
+      "size": 4427
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/modules/conv.py",
+      "size": 43414
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/modules/dropout.py",
+      "size": 806
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/modules/embedding_ops.py",
+      "size": 14676
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/modules/functional_modules.py",
+      "size": 9222
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/modules/linear.py",
+      "size": 13609
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/modules/normalization.py",
+      "size": 9539
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/modules/rnn.py",
+      "size": 1822
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/modules/utils.py",
+      "size": 4695
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/reference/__init__.py",
+      "size": 284
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/reference/modules/__init__.py",
+      "size": 494
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/reference/modules/conv.py",
+      "size": 15389
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/reference/modules/linear.py",
+      "size": 2273
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/reference/modules/rnn.py",
+      "size": 29682
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/reference/modules/sparse.py",
+      "size": 4673
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/quantized/reference/modules/utils.py",
+      "size": 15346
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/sparse/__init__.py",
+      "size": 24
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/sparse/quantized/__init__.py",
+      "size": 168
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/sparse/quantized/dynamic/__init__.py",
+      "size": 57
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/sparse/quantized/dynamic/linear.py",
+      "size": 6328
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/sparse/quantized/linear.py",
+      "size": 9017
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/nn/sparse/quantized/utils.py",
+      "size": 2080
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/_numeric_suite.py",
+      "size": 20076
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/_numeric_suite_fx.py",
+      "size": 41358
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/fx/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/fx/graph_matcher.py",
+      "size": 19278
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/fx/graph_passes.py",
+      "size": 44351
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/fx/mappings.py",
+      "size": 18300
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/fx/n_shadows_utils.py",
+      "size": 51181
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/fx/ns_types.py",
+      "size": 2327
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/fx/pattern_utils.py",
+      "size": 8369
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/fx/qconfig_multi_mapping.py",
+      "size": 10183
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/fx/utils.py",
+      "size": 20643
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/ns/fx/weight_utils.py",
+      "size": 11382
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/__init__.py",
+      "size": 640
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/activation_sparsifier/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/activation_sparsifier/activation_sparsifier.py",
+      "size": 19072
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/data_scheduler/__init__.py",
+      "size": 92
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/data_scheduler/base_data_scheduler.py",
+      "size": 7665
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/data_sparsifier/__init__.py",
+      "size": 174
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/data_sparsifier/base_data_sparsifier.py",
+      "size": 13435
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/data_sparsifier/data_norm_sparsifier.py",
+      "size": 7760
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/data_sparsifier/lightning/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/data_sparsifier/lightning/callbacks/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/data_sparsifier/lightning/callbacks/_data_sparstity_utils.py",
+      "size": 1636
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/data_sparsifier/lightning/callbacks/data_sparsity.py",
+      "size": 6611
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/data_sparsifier/quantization_utils.py",
+      "size": 5890
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/pruner/FPGM_pruner.py",
+      "size": 3456
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/pruner/__init__.py",
+      "size": 260
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/pruner/base_structured_sparsifier.py",
+      "size": 10936
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/pruner/lstm_saliency_pruner.py",
+      "size": 2141
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/pruner/match_utils.py",
+      "size": 1981
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/pruner/parametrization.py",
+      "size": 1844
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/pruner/prune_functions.py",
+      "size": 19095
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_experimental/pruner/saliency_pruner.py",
+      "size": 1400
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/_mappings.py",
+      "size": 597
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/scheduler/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/scheduler/base_scheduler.py",
+      "size": 6526
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/scheduler/cubic_scheduler.py",
+      "size": 3844
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/scheduler/lambda_scheduler.py",
+      "size": 2114
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/sparsifier/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/sparsifier/base_sparsifier.py",
+      "size": 13732
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/sparsifier/nearly_diagonal_sparsifier.py",
+      "size": 2266
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/sparsifier/utils.py",
+      "size": 4802
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/pruning/sparsifier/weight_norm_sparsifier.py",
+      "size": 9296
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/__init__.py",
+      "size": 7319
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/_correct_bias.py",
+      "size": 5427
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/_equalize.py",
+      "size": 9468
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/_learnable_fake_quantize.py",
+      "size": 7910
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/__init__.py",
+      "size": 915
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/_common_operator_config_utils.py",
+      "size": 27512
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/_qnnpack_pt2e.py",
+      "size": 6431
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/backend_config.py",
+      "size": 31661
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/executorch.py",
+      "size": 16924
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/fbgemm.py",
+      "size": 4208
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/native.py",
+      "size": 8242
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/observation_type.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/onednn.py",
+      "size": 19083
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/qnnpack.py",
+      "size": 5400
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/tensorrt.py",
+      "size": 3021
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/utils.py",
+      "size": 12433
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/backend_config/x86.py",
+      "size": 3869
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fake_quantize.py",
+      "size": 22887
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fuse_modules.py",
+      "size": 6825
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fuser_method_mappings.py",
+      "size": 10375
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/__init__.py",
+      "size": 81
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/_decomposed.py",
+      "size": 42445
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/_equalize.py",
+      "size": 37917
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/_lower_to_native_backend.py",
+      "size": 54631
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/_model_report/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/_model_report/detector.py",
+      "size": 76399
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/_model_report/model_report.py",
+      "size": 29641
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/_model_report/model_report_observer.py",
+      "size": 12084
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/_model_report/model_report_visualizer.py",
+      "size": 32548
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/convert.py",
+      "size": 57746
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/custom_config.py",
+      "size": 21861
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/fuse.py",
+      "size": 7256
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/fuse_handler.py",
+      "size": 4645
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/graph_module.py",
+      "size": 6644
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/lower_to_fbgemm.py",
+      "size": 602
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/lower_to_qnnpack.py",
+      "size": 527
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/lstm_utils.py",
+      "size": 10316
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/match_utils.py",
+      "size": 8860
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/pattern_utils.py",
+      "size": 3668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/prepare.py",
+      "size": 87550
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/qconfig_mapping_utils.py",
+      "size": 15359
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/quantize_handler.py",
+      "size": 7280
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/tracer.py",
+      "size": 1688
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/fx/utils.py",
+      "size": 37615
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/observer.py",
+      "size": 79254
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/_affine_quantization.py",
+      "size": 34025
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/_numeric_debugger.py",
+      "size": 12134
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/duplicate_dq_pass.py",
+      "size": 3148
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/export_utils.py",
+      "size": 7990
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/graph_utils.py",
+      "size": 6385
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/lowering.py",
+      "size": 1904
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/port_metadata_pass.py",
+      "size": 9219
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/prepare.py",
+      "size": 21552
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/qat_utils.py",
+      "size": 36686
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/representation/__init__.py",
+      "size": 110
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/representation/rewrite.py",
+      "size": 28375
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/pt2e/utils.py",
+      "size": 23235
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/qconfig.py",
+      "size": 24337
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/qconfig_mapping.py",
+      "size": 14811
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quant_type.py",
+      "size": 760
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantization_mappings.py",
+      "size": 13816
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantize.py",
+      "size": 31011
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantize_fx.py",
+      "size": 32653
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantize_jit.py",
+      "size": 14595
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantize_pt2e.py",
+      "size": 9473
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantizer/__init__.py",
+      "size": 455
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantizer/composable_quantizer.py",
+      "size": 3012
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantizer/embedding_quantizer.py",
+      "size": 3457
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantizer/quantizer.py",
+      "size": 6624
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantizer/utils.py",
+      "size": 3225
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantizer/x86_inductor_quantizer.py",
+      "size": 64874
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantizer/xnnpack_quantizer.py",
+      "size": 16310
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantizer/xnnpack_quantizer_utils.py",
+      "size": 40659
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/quantizer/xpu_inductor_quantizer.py",
+      "size": 3875
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/stubs.py",
+      "size": 2298
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/ao/quantization/utils.py",
+      "size": 28921
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/__init__.py",
+      "size": 25424
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/_functions/__init__.py",
+      "size": 36
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/_functions/tensor.py",
+      "size": 2203
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/_functions/utils.py",
+      "size": 2017
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/anomaly_mode.py",
+      "size": 4951
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/forward_ad.py",
+      "size": 7639
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/function.py",
+      "size": 33147
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/functional.py",
+      "size": 52600
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/grad_mode.py",
+      "size": 13318
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/gradcheck.py",
+      "size": 90560
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/graph.py",
+      "size": 30452
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/profiler.py",
+      "size": 48935
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/profiler_legacy.py",
+      "size": 11506
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/profiler_util.py",
+      "size": 41359
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/autograd/variable.py",
+      "size": 391
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/__init__.py",
+      "size": 1777
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/_coreml/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/_coreml/preprocess.py",
+      "size": 4301
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/_nnapi/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/_nnapi/prepare.py",
+      "size": 6559
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/_nnapi/serializer.py",
+      "size": 82895
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/cpu/__init__.py",
+      "size": 314
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/cuda/__init__.py",
+      "size": 19087
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/cudnn/__init__.py",
+      "size": 6603
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/cudnn/rnn.py",
+      "size": 2061
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/cusparselt/__init__.py",
+      "size": 1246
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/kleidiai/__init__.py",
+      "size": 162
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/mha/__init__.py",
+      "size": 718
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/mkl/__init__.py",
+      "size": 1782
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/mkldnn/__init__.py",
+      "size": 3589
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/mps/__init__.py",
+      "size": 1642
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/nnpack/__init__.py",
+      "size": 837
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/openmp/__init__.py",
+      "size": 157
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/opt_einsum/__init__.py",
+      "size": 3882
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/quantized/__init__.py",
+      "size": 1861
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/xeon/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/xeon/run_cpu.py",
+      "size": 37537
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/backends/xnnpack/__init__.py",
+      "size": 702
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/compiler/__init__.py",
+      "size": 23392
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/compiler/_cache.py",
+      "size": 10911
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/compiler/config.py",
+      "size": 3629
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/contrib/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/contrib/_tensorboard_vis.py",
+      "size": 5875
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cpu/__init__.py",
+      "size": 4847
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cpu/amp/__init__.py",
+      "size": 72
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cpu/amp/autocast_mode.py",
+      "size": 1521
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cpu/amp/grad_scaler.py",
+      "size": 958
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/__init__.py",
+      "size": 64719
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/_gpu_trace.py",
+      "size": 2377
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/_memory_viz.py",
+      "size": 25848
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/_pin_memory_utils.py",
+      "size": 747
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/_sanitizer.py",
+      "size": 24199
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/_utils.py",
+      "size": 12463
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/amp/__init__.py",
+      "size": 267
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/amp/autocast_mode.py",
+      "size": 2819
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/amp/common.py",
+      "size": 230
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/amp/grad_scaler.py",
+      "size": 1073
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/comm.py",
+      "size": 344
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/error.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/gds.py",
+      "size": 5806
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/graphs.py",
+      "size": 24226
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/jiterator.py",
+      "size": 6828
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/memory.py",
+      "size": 46762
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/nccl.py",
+      "size": 4577
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/nvtx.py",
+      "size": 3537
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/profiler.py",
+      "size": 2401
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/random.py",
+      "size": 5441
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/sparse.py",
+      "size": 67
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/streams.py",
+      "size": 9547
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/cuda/tunable.py",
+      "size": 31301
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/__init__.py",
+      "size": 5031
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_checkpointable.py",
+      "size": 1305
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_composable/__init__.py",
+      "size": 125
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_composable/checkpoint_activation.py",
+      "size": 4725
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_composable/contract.py",
+      "size": 10376
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_composable/fsdp/__init__.py",
+      "size": 169
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_composable/fsdp/fully_shard.py",
+      "size": 240
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_composable/replicate.py",
+      "size": 9302
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_composable_state.py",
+      "size": 1394
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_functional_collectives.py",
+      "size": 44441
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_functional_collectives_impl.py",
+      "size": 3223
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_serialization.py",
+      "size": 4472
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/__init__.py",
+      "size": 87
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/_utils.py",
+      "size": 1070
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/api.py",
+      "size": 12396
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/checkpoint/__init__.py",
+      "size": 584
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/common_op_utils.py",
+      "size": 2179
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/metadata.py",
+      "size": 2215
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/op_registry_utils.py",
+      "size": 1031
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_optim/__init__.py",
+      "size": 1869
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_optim/api.py",
+      "size": 4277
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/__init__.py",
+      "size": 19254
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/_ops/__init__.py",
+      "size": 498
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/_ops/_common.py",
+      "size": 4196
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/_ops/binary_cmp.py",
+      "size": 2736
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/_ops/init.py",
+      "size": 5486
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/_ops/misc_ops.py",
+      "size": 497
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/_ops/tensor_ops.py",
+      "size": 7711
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/api.py",
+      "size": 54668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/logger.py",
+      "size": 1084
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/logging_handlers.py",
+      "size": 359
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/metadata.py",
+      "size": 2998
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/reshard.py",
+      "size": 10726
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/shard.py",
+      "size": 2361
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharded_tensor/utils.py",
+      "size": 11667
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharder.py",
+      "size": 901
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharding_plan/__init__.py",
+      "size": 47
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharding_plan/api.py",
+      "size": 3649
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharding_spec/__init__.py",
+      "size": 291
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharding_spec/_internals.py",
+      "size": 8407
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharding_spec/api.py",
+      "size": 9821
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharding_spec/chunk_sharding_spec.py",
+      "size": 9251
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/_common.py",
+      "size": 13029
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py",
+      "size": 11209
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding_bag.py",
+      "size": 18319
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_sharded_tensor/__init__.py",
+      "size": 617
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_sharding_spec/__init__.py",
+      "size": 646
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_state_dict_utils.py",
+      "size": 29277
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_symmetric_memory/__init__.py",
+      "size": 61868
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_symmetric_memory/_nvshmem_triton.py",
+      "size": 5539
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tensor/__init__.py",
+      "size": 969
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tensor/api.py",
+      "size": 300
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tensor/placement_types.py",
+      "size": 384
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tools/__init__.py",
+      "size": 327
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tools/common_utils.py",
+      "size": 1188
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tools/fake_collectives.py",
+      "size": 11859
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tools/fsdp2_mem_tracker.py",
+      "size": 23750
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tools/ilp_utils.py",
+      "size": 10100
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tools/mem_tracker.py",
+      "size": 42836
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tools/memory_tracker.py",
+      "size": 11658
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tools/mod_tracker.py",
+      "size": 10028
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tools/runtime_estimator.py",
+      "size": 21147
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tools/sac_estimator.py",
+      "size": 42286
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/_tools/sac_ilp.py",
+      "size": 11321
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/__init__.py",
+      "size": 43
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/_checkpoint/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py",
+      "size": 12299
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/_comm_hooks/__init__.py",
+      "size": 131
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/_comm_hooks/default_hooks.py",
+      "size": 7653
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/_optimizer_overlap/__init__.py",
+      "size": 52
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/_optimizer_overlap/optimizer_overlap.py",
+      "size": 3753
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/_quantization/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/_quantization/quantization.py",
+      "size": 5610
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/ddp_comm_hooks/__init__.py",
+      "size": 3597
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/ddp_comm_hooks/ddp_zero_hook.py",
+      "size": 19718
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/ddp_comm_hooks/debugging_hooks.py",
+      "size": 1115
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py",
+      "size": 7776
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/ddp_comm_hooks/mixed_precision_hooks.py",
+      "size": 3254
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/ddp_comm_hooks/optimizer_overlap_hooks.py",
+      "size": 6125
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/ddp_comm_hooks/post_localSGD_hook.py",
+      "size": 5150
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py",
+      "size": 40414
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/ddp_comm_hooks/quantization_hooks.py",
+      "size": 8234
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/join.py",
+      "size": 13386
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/model_averaging/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/model_averaging/averagers.py",
+      "size": 5455
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/model_averaging/hierarchical_model_averager.py",
+      "size": 9794
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/algorithms/model_averaging/utils.py",
+      "size": 3161
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/argparse_util.py",
+      "size": 3903
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/autograd/__init__.py",
+      "size": 1647
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/c10d_logger.py",
+      "size": 3125
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/__init__.py",
+      "size": 694
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_async_executor.py",
+      "size": 1097
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_async_process_executor.py",
+      "size": 12385
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_async_thread_executor.py",
+      "size": 1365
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_checkpointer.py",
+      "size": 3656
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_dedup_save_plans.py",
+      "size": 2681
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_dedup_tensors.py",
+      "size": 1991
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_extension.py",
+      "size": 7703
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_fsspec_filesystem.py",
+      "size": 5583
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_hf_utils.py",
+      "size": 2840
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_nested_dict.py",
+      "size": 2273
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_sharded_tensor_utils.py",
+      "size": 4144
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_state_dict_stager.py",
+      "size": 13520
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_storage_utils.py",
+      "size": 1408
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_traverse.py",
+      "size": 6876
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/_version.py",
+      "size": 122
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/api.py",
+      "size": 1417
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/default_planner.py",
+      "size": 26212
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/filesystem.py",
+      "size": 34192
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/format_utils.py",
+      "size": 10234
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/hf_storage.py",
+      "size": 12941
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/logger.py",
+      "size": 3549
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/logging_handlers.py",
+      "size": 220
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/metadata.py",
+      "size": 5597
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/optimizer.py",
+      "size": 13153
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/planner.py",
+      "size": 16263
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/planner_helpers.py",
+      "size": 16517
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/resharding.py",
+      "size": 2275
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/staging.py",
+      "size": 4958
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/state_dict.py",
+      "size": 56348
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/state_dict_loader.py",
+      "size": 12428
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/state_dict_saver.py",
+      "size": 14138
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/stateful.py",
+      "size": 1061
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/storage.py",
+      "size": 9725
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/checkpoint/utils.py",
+      "size": 16073
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/collective_utils.py",
+      "size": 7273
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/constants.py",
+      "size": 1229
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/device_mesh.py",
+      "size": 51169
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py",
+      "size": 222365
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/__init__.py",
+      "size": 3654
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/agent/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/agent/server/__init__.py",
+      "size": 1401
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/agent/server/api.py",
+      "size": 37496
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/agent/server/health_check_server.py",
+      "size": 1679
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/agent/server/local_elastic_agent.py",
+      "size": 16591
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/control_plane.py",
+      "size": 1181
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/events/__init__.py",
+      "size": 5376
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/events/api.py",
+      "size": 3247
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/events/handlers.py",
+      "size": 556
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/metrics/__init__.py",
+      "size": 4902
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/metrics/api.py",
+      "size": 5676
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/__init__.py",
+      "size": 7378
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/api.py",
+      "size": 33742
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py",
+      "size": 14491
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/errors/error_handler.py",
+      "size": 6600
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/errors/handlers.py",
+      "size": 464
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/redirects.py",
+      "size": 2764
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/subprocess_handler/__init__.py",
+      "size": 523
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/subprocess_handler/handlers.py",
+      "size": 726
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/subprocess_handler/subprocess_handler.py",
+      "size": 2436
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/multiprocessing/tail_log.py",
+      "size": 4947
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/rendezvous/__init__.py",
+      "size": 6269
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/rendezvous/_etcd_stub.py",
+      "size": 2014
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/rendezvous/api.py",
+      "size": 13094
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py",
+      "size": 10900
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py",
+      "size": 49425
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/rendezvous/etcd_rendezvous.py",
+      "size": 43530
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py",
+      "size": 7409
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/rendezvous/etcd_server.py",
+      "size": 8437
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/rendezvous/etcd_store.py",
+      "size": 7255
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/rendezvous/registry.py",
+      "size": 3023
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py",
+      "size": 3665
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/rendezvous/utils.py",
+      "size": 8390
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/timer/__init__.py",
+      "size": 1750
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/timer/api.py",
+      "size": 9586
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/timer/debug_info_logging.py",
+      "size": 610
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/timer/file_based_local_timer.py",
+      "size": 16449
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/timer/local_timer.py",
+      "size": 4285
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/utils/__init__.py",
+      "size": 318
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/utils/api.py",
+      "size": 1705
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/utils/data/__init__.py",
+      "size": 372
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/utils/data/cycling_iterator.py",
+      "size": 1643
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/utils/data/elastic_distributed_sampler.py",
+      "size": 3034
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/utils/distributed.py",
+      "size": 5923
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/utils/log_level.py",
+      "size": 339
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/utils/logging.py",
+      "size": 2271
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/elastic/utils/store.py",
+      "size": 7278
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/__init__.py",
+      "size": 1740
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_common_utils.py",
+      "size": 22394
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_debug_utils.py",
+      "size": 5694
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_dynamo_utils.py",
+      "size": 2631
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_exec_order_utils.py",
+      "size": 16073
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_flat_param.py",
+      "size": 123630
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fsdp_extensions.py",
+      "size": 4956
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/__init__.py",
+      "size": 376
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/_fsdp_api.py",
+      "size": 3347
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py",
+      "size": 26800
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/_fsdp_common.py",
+      "size": 5680
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/_fsdp_init.py",
+      "size": 9142
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/_fsdp_param.py",
+      "size": 41522
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py",
+      "size": 35452
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/_fsdp_state.py",
+      "size": 17794
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_fully_shard/_fully_shard.py",
+      "size": 30118
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_init_utils.py",
+      "size": 46223
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_limiter_utils.py",
+      "size": 1086
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_optim_utils.py",
+      "size": 86620
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_runtime_utils.py",
+      "size": 66525
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_shard_utils.py",
+      "size": 4623
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_state_dict_utils.py",
+      "size": 34293
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_trace_utils.py",
+      "size": 10752
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_traversal_utils.py",
+      "size": 4610
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_unshard_param_utils.py",
+      "size": 11524
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/_wrap_utils.py",
+      "size": 10895
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/api.py",
+      "size": 18975
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py",
+      "size": 100272
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/sharded_grad_scaler.py",
+      "size": 16164
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/fsdp/wrap.py",
+      "size": 22615
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/launch.py",
+      "size": 7595
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/launcher/__init__.py",
+      "size": 349
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/launcher/api.py",
+      "size": 11452
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/logging_handlers.py",
+      "size": 359
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/nn/__init__.py",
+      "size": 145
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/nn/api/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/nn/api/remote_module.py",
+      "size": 31286
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/nn/functional.py",
+      "size": 15215
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/nn/jit/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/nn/jit/instantiator.py",
+      "size": 5510
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/nn/jit/templates/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/nn/jit/templates/remote_module_template.py",
+      "size": 3463
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/__init__.py",
+      "size": 1440
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/_deprecation_warning.py",
+      "size": 547
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/apply_optimizer_in_backward.py",
+      "size": 5214
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/functional_adadelta.py",
+      "size": 3954
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/functional_adagrad.py",
+      "size": 4304
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/functional_adam.py",
+      "size": 7425
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/functional_adamax.py",
+      "size": 4651
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/functional_adamw.py",
+      "size": 7545
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/functional_rmsprop.py",
+      "size": 4684
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/functional_rprop.py",
+      "size": 3838
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/functional_sgd.py",
+      "size": 5938
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/named_optimizer.py",
+      "size": 13985
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/optimizer.py",
+      "size": 9771
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/post_localSGD_optimizer.py",
+      "size": 4467
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/utils.py",
+      "size": 2238
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/optim/zero_redundancy_optimizer.py",
+      "size": 72000
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/pipelining/_IR.py",
+      "size": 49244
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/pipelining/__init__.py",
+      "size": 641
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/pipelining/_backward.py",
+      "size": 15866
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/pipelining/_debug.py",
+      "size": 608
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/pipelining/_schedule_visualizer.py",
+      "size": 6922
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/pipelining/_unflatten.py",
+      "size": 952
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/pipelining/_utils.py",
+      "size": 3787
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/pipelining/microbatch.py",
+      "size": 16198
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/pipelining/schedules.py",
+      "size": 113840
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/pipelining/stage.py",
+      "size": 61677
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/remote_device.py",
+      "size": 4600
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rendezvous.py",
+      "size": 10185
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rpc/__init__.py",
+      "size": 9945
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rpc/_testing/__init__.py",
+      "size": 479
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rpc/_testing/faulty_agent_backend_registry.py",
+      "size": 1639
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rpc/_utils.py",
+      "size": 1649
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rpc/api.py",
+      "size": 37004
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rpc/backend_registry.py",
+      "size": 16253
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rpc/constants.py",
+      "size": 804
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rpc/functions.py",
+      "size": 7272
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rpc/internal.py",
+      "size": 11112
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rpc/options.py",
+      "size": 7231
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rpc/rref_proxy.py",
+      "size": 2673
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/rpc/server_process_global_profiler.py",
+      "size": 8445
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/run.py",
+      "size": 31915
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/__init__.py",
+      "size": 2169
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_api.py",
+      "size": 57059
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_collective_utils.py",
+      "size": 14006
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_dispatch.py",
+      "size": 19547
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_dtensor_spec.py",
+      "size": 10309
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_op_schema.py",
+      "size": 20482
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_ops/__init__.py",
+      "size": 380
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_ops/_common_rules.py",
+      "size": 11805
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_ops/_conv_ops.py",
+      "size": 3521
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_ops/_einsum_strategy.py",
+      "size": 6383
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_ops/_embedding_ops.py",
+      "size": 10154
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_ops/_math_ops.py",
+      "size": 41211
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_ops/_matrix_ops.py",
+      "size": 35956
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_ops/_pointwise_ops.py",
+      "size": 21385
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_ops/_random_ops.py",
+      "size": 1087
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_ops/_tensor_ops.py",
+      "size": 35307
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_ops/_view_ops.py",
+      "size": 25609
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_ops/utils.py",
+      "size": 10743
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_random.py",
+      "size": 16206
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_redistribute.py",
+      "size": 16274
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_sharding_prop.py",
+      "size": 22956
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_shards_wrapper.py",
+      "size": 13480
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_tp_conv.py",
+      "size": 10154
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/_utils.py",
+      "size": 16353
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/debug/__init__.py",
+      "size": 850
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/debug/_comm_mode.py",
+      "size": 28762
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/debug/_op_coverage.py",
+      "size": 3142
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/debug/_visualize_sharding.py",
+      "size": 7549
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/device_mesh.py",
+      "size": 190
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/experimental/__init__.py",
+      "size": 1424
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/experimental/_attention.py",
+      "size": 51076
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/experimental/_func_map.py",
+      "size": 12185
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/experimental/_register_sharding.py",
+      "size": 5666
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/experimental/_tp_transform.py",
+      "size": 20280
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/parallel/__init__.py",
+      "size": 643
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/parallel/_data_parallel_utils.py",
+      "size": 1510
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/parallel/_utils.py",
+      "size": 2313
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/parallel/api.py",
+      "size": 6013
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/parallel/ddp.py",
+      "size": 3734
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/parallel/fsdp.py",
+      "size": 13668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/parallel/input_reshard.py",
+      "size": 3756
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/parallel/loss.py",
+      "size": 17793
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/parallel/style.py",
+      "size": 37226
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/tensor/placement_types.py",
+      "size": 29590
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributed/utils.py",
+      "size": 13354
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/__init__.py",
+      "size": 6111
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/bernoulli.py",
+      "size": 4613
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/beta.py",
+      "size": 3976
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/binomial.py",
+      "size": 6318
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/categorical.py",
+      "size": 6063
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/cauchy.py",
+      "size": 3172
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/chi2.py",
+      "size": 1153
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/constraint_registry.py",
+      "size": 10306
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/constraints.py",
+      "size": 21602
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/continuous_bernoulli.py",
+      "size": 9107
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/dirichlet.py",
+      "size": 4413
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/distribution.py",
+      "size": 12605
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/exp_family.py",
+      "size": 2437
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/exponential.py",
+      "size": 2695
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/fishersnedecor.py",
+      "size": 3678
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/gamma.py",
+      "size": 3908
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/generalized_pareto.py",
+      "size": 5757
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/geometric.py",
+      "size": 5053
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/gumbel.py",
+      "size": 3015
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/half_cauchy.py",
+      "size": 2608
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/half_normal.py",
+      "size": 2373
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/independent.py",
+      "size": 4982
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/inverse_gamma.py",
+      "size": 2747
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/kl.py",
+      "size": 31737
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/kumaraswamy.py",
+      "size": 3652
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/laplace.py",
+      "size": 3503
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/lkj_cholesky.py",
+      "size": 6556
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/log_normal.py",
+      "size": 2200
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/logistic_normal.py",
+      "size": 2216
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/lowrank_multivariate_normal.py",
+      "size": 10126
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/mixture_same_family.py",
+      "size": 8652
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/multinomial.py",
+      "size": 5640
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/multivariate_normal.py",
+      "size": 11093
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/negative_binomial.py",
+      "size": 5045
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/normal.py",
+      "size": 3866
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/one_hot_categorical.py",
+      "size": 4991
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/pareto.py",
+      "size": 2498
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/poisson.py",
+      "size": 2447
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/relaxed_bernoulli.py",
+      "size": 5956
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/relaxed_categorical.py",
+      "size": 5641
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/studentT.py",
+      "size": 4150
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/transformed_distribution.py",
+      "size": 8874
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/transforms.py",
+      "size": 42417
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/uniform.py",
+      "size": 3361
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/utils.py",
+      "size": 8027
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/von_mises.py",
+      "size": 6325
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/weibull.py",
+      "size": 3384
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/distributions/wishart.py",
+      "size": 13711
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/__init__.py",
+      "size": 23523
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/_draft_export.py",
+      "size": 19263
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/_remove_auto_functionalized_pass.py",
+      "size": 1951
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/_remove_effect_tokens_pass.py",
+      "size": 6335
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/_safeguard.py",
+      "size": 1956
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/_swap.py",
+      "size": 17579
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/_trace.py",
+      "size": 88303
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/_tree_utils.py",
+      "size": 2262
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/_unlift.py",
+      "size": 17528
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/_wrapper_utils.py",
+      "size": 271
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/custom_obj.py",
+      "size": 296
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/custom_ops.py",
+      "size": 960
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/decomp_utils.py",
+      "size": 5518
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/dynamic_shapes.py",
+      "size": 53430
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/experimental/__init__.py",
+      "size": 12698
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/exported_program.py",
+      "size": 67025
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/graph_signature.py",
+      "size": 24816
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/passes/__init__.py",
+      "size": 2262
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/pt2_archive/__init__.py",
+      "size": 144
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/pt2_archive/_package.py",
+      "size": 24457
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/pt2_archive/_package_weights.py",
+      "size": 3414
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/pt2_archive/constants.py",
+      "size": 1504
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/export/unflatten.py",
+      "size": 66052
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fft/__init__.py",
+      "size": 55337
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/func/__init__.py",
+      "size": 656
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/functional.py",
+      "size": 88875
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/futures/__init__.py",
+      "size": 14496
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/__init__.py",
+      "size": 4163
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/_compatibility.py",
+      "size": 1081
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/_graph_pickler.py",
+      "size": 21722
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/_lazy_graph_module.py",
+      "size": 7158
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/_pytree.py",
+      "size": 3587
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/_symbolic_trace.py",
+      "size": 50818
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/_utils.py",
+      "size": 1736
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/annotate.py",
+      "size": 1256
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/config.py",
+      "size": 328
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/_backward_state.py",
+      "size": 967
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/_config.py",
+      "size": 4710
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/_constant_symnode.py",
+      "size": 1522
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/_dynamism.py",
+      "size": 4501
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/accelerator_partitioner.py",
+      "size": 47767
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/const_fold.py",
+      "size": 12574
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/debug.py",
+      "size": 811
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/graph_gradual_typechecker.py",
+      "size": 34087
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/merge_matmul.py",
+      "size": 6063
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/meta_tracer.py",
+      "size": 10577
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/migrate_gradual_types/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/migrate_gradual_types/constraint.py",
+      "size": 17222
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/migrate_gradual_types/constraint_generator.py",
+      "size": 51032
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/migrate_gradual_types/constraint_transformation.py",
+      "size": 41000
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/migrate_gradual_types/operation.py",
+      "size": 287
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/migrate_gradual_types/transform_to_z3.py",
+      "size": 16370
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/migrate_gradual_types/util.py",
+      "size": 1365
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/migrate_gradual_types/z3_types.py",
+      "size": 807
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/normalize.py",
+      "size": 5492
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/optimization.py",
+      "size": 17686
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/partitioner_utils.py",
+      "size": 12295
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/proxy_tensor.py",
+      "size": 90911
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/recording.py",
+      "size": 19923
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/refinement_types.py",
+      "size": 451
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/rewriter.py",
+      "size": 5468
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/schema_type_annotation.py",
+      "size": 5379
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/sym_node.py",
+      "size": 60254
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/symbolic_shapes.py",
+      "size": 334461
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/__init__.py",
+      "size": 196
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/core.py",
+      "size": 2754
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/dispatch.py",
+      "size": 193
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/match.py",
+      "size": 3414
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/more.py",
+      "size": 2962
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/multipledispatch/__init__.py",
+      "size": 139
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/multipledispatch/conflict.py",
+      "size": 4210
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/multipledispatch/core.py",
+      "size": 2568
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/multipledispatch/dispatcher.py",
+      "size": 13884
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/multipledispatch/utils.py",
+      "size": 3760
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/multipledispatch/variadic.py",
+      "size": 2962
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/unification_tools.py",
+      "size": 10567
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/utils.py",
+      "size": 2937
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unification/variable.py",
+      "size": 2065
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/unify_refinements.py",
+      "size": 3151
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/experimental/validator.py",
+      "size": 34006
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/graph.py",
+      "size": 76317
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/graph_module.py",
+      "size": 42260
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/immutable_collections.py",
+      "size": 3269
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/interpreter.py",
+      "size": 23170
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/node.py",
+      "size": 34216
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/operator_schemas.py",
+      "size": 21854
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/__init__.py",
+      "size": 240
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/_tensorify_python_scalars.py",
+      "size": 16090
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/annotate_getitem_nodes.py",
+      "size": 2761
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/backends/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/backends/cudagraphs.py",
+      "size": 2083
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/dialect/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/dialect/common/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/dialect/common/cse_pass.py",
+      "size": 5248
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/fake_tensor_prop.py",
+      "size": 4200
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/graph_drawer.py",
+      "size": 19112
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/graph_manipulation.py",
+      "size": 3964
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/graph_transform_observer.py",
+      "size": 7392
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/infra/__init__.py",
+      "size": 27
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/infra/partitioner.py",
+      "size": 16459
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/infra/pass_base.py",
+      "size": 2501
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/infra/pass_manager.py",
+      "size": 10345
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/net_min_base.py",
+      "size": 36570
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/operator_support.py",
+      "size": 7632
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/param_fetch.py",
+      "size": 3714
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/pass_manager.py",
+      "size": 7058
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/reinplace.py",
+      "size": 34529
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/runtime_assert.py",
+      "size": 29065
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/shape_prop.py",
+      "size": 8324
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/split_module.py",
+      "size": 26769
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/split_utils.py",
+      "size": 11473
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/splitter_base.py",
+      "size": 33809
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/tests/test_pass_manager.py",
+      "size": 1873
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/tools_common.py",
+      "size": 11202
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/utils/__init__.py",
+      "size": 74
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/utils/common.py",
+      "size": 3107
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/utils/fuser_utils.py",
+      "size": 9788
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/utils/matcher_utils.py",
+      "size": 17242
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/utils/matcher_with_name_node_map_utils.py",
+      "size": 4197
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/passes/utils/source_matcher_utils.py",
+      "size": 5768
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/proxy.py",
+      "size": 28504
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/subgraph_rewriter.py",
+      "size": 15905
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/tensor_type.py",
+      "size": 3009
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/fx/traceback.py",
+      "size": 7325
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/hub.py",
+      "size": 33459
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/__init__.py",
+      "size": 8344
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_async.py",
+      "size": 3827
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_await.py",
+      "size": 852
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_builtins.py",
+      "size": 6791
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_check.py",
+      "size": 9386
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_dataclass_impls.py",
+      "size": 6672
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_decomposition_utils.py",
+      "size": 404
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_decompositions.py",
+      "size": 4374
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_freeze.py",
+      "size": 9503
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_fuser.py",
+      "size": 7083
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_ir_utils.py",
+      "size": 886
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_logging.py",
+      "size": 257
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_monkeytype_config.py",
+      "size": 7288
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_passes/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_passes/_property_propagation.py",
+      "size": 1438
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_pickle.py",
+      "size": 1168
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_recursive.py",
+      "size": 42373
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_script.py",
+      "size": 65303
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_serialization.py",
+      "size": 9687
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_shape_functions.py",
+      "size": 45269
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_state.py",
+      "size": 3759
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/_trace.py",
+      "size": 58377
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/annotations.py",
+      "size": 17882
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/frontend.py",
+      "size": 45233
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/generate_bytecode.py",
+      "size": 1042
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/mobile/__init__.py",
+      "size": 8517
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/quantized.py",
+      "size": 3193
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/supported_ops.py",
+      "size": 10267
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/jit/unsupported_tensor_ops.py",
+      "size": 1987
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/library.py",
+      "size": 62649
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/linalg/__init__.py",
+      "size": 114871
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/masked/__init__.py",
+      "size": 928
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/masked/_docs.py",
+      "size": 49468
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/masked/_ops.py",
+      "size": 66202
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/masked/maskedtensor/__init__.py",
+      "size": 344
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/masked/maskedtensor/_ops_refs.py",
+      "size": 17556
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/masked/maskedtensor/binary.py",
+      "size": 5496
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/masked/maskedtensor/core.py",
+      "size": 12822
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/masked/maskedtensor/creation.py",
+      "size": 605
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/masked/maskedtensor/passthrough.py",
+      "size": 1447
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/masked/maskedtensor/reductions.py",
+      "size": 5585
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/masked/maskedtensor/unary.py",
+      "size": 4197
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/monitor/__init__.py",
+      "size": 1278
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/mps/__init__.py",
+      "size": 6281
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/mps/event.py",
+      "size": 1730
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/mps/profiler.py",
+      "size": 3278
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/mtia/__init__.py",
+      "size": 13452
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/mtia/_utils.py",
+      "size": 1597
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/mtia/memory.py",
+      "size": 1757
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/multiprocessing/__init__.py",
+      "size": 3456
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/multiprocessing/_atfork.py",
+      "size": 790
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/multiprocessing/pool.py",
+      "size": 1743
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/multiprocessing/queue.py",
+      "size": 1477
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/multiprocessing/reductions.py",
+      "size": 23140
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/multiprocessing/spawn.py",
+      "size": 12804
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nested/__init__.py",
+      "size": 21914
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nested/_internal/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nested/_internal/nested_int.py",
+      "size": 3190
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nested/_internal/nested_tensor.py",
+      "size": 24735
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nested/_internal/ops.py",
+      "size": 97622
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nested/_internal/sdpa.py",
+      "size": 34484
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/__init__.py",
+      "size": 2425
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/_reduction.py",
+      "size": 1625
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/attention/__init__.py",
+      "size": 5917
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/attention/_utils.py",
+      "size": 2039
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/attention/bias.py",
+      "size": 13425
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/attention/experimental/__init__.py",
+      "size": 110
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/attention/experimental/_paged_attention.py",
+      "size": 12037
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/attention/flex_attention.py",
+      "size": 58217
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/backends/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/backends/thnn.py",
+      "size": 146
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/common_types.py",
+      "size": 2186
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/cpp.py",
+      "size": 3017
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/functional.py",
+      "size": 243853
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/grad.py",
+      "size": 9910
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/init.py",
+      "size": 25743
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/__init__.py",
+      "size": 697
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/modules/__init__.py",
+      "size": 517
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/modules/fused.py",
+      "size": 563
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/qat/__init__.py",
+      "size": 59
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/qat/modules/__init__.py",
+      "size": 637
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/qat/modules/conv_fused.py",
+      "size": 854
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/qat/modules/linear_fused.py",
+      "size": 455
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/qat/modules/linear_relu.py",
+      "size": 455
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/quantized/__init__.py",
+      "size": 336
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/quantized/dynamic/__init__.py",
+      "size": 73
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/quantized/dynamic/modules/__init__.py",
+      "size": 114
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/quantized/dynamic/modules/linear_relu.py",
+      "size": 97
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/quantized/modules/__init__.py",
+      "size": 379
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/quantized/modules/bn_relu.py",
+      "size": 111
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/quantized/modules/conv_relu.py",
+      "size": 149
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/intrinsic/quantized/modules/linear_relu.py",
+      "size": 89
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/__init__.py",
+      "size": 6494
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/_functions.py",
+      "size": 11995
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/activation.py",
+      "size": 58405
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/adaptive.py",
+      "size": 12435
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/batchnorm.py",
+      "size": 38394
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/channelshuffle.py",
+      "size": 1548
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/container.py",
+      "size": 36951
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/conv.py",
+      "size": 76163
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/distance.py",
+      "size": 3262
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/dropout.py",
+      "size": 11187
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/flatten.py",
+      "size": 5537
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/fold.py",
+      "size": 12959
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/instancenorm.py",
+      "size": 20319
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/lazy.py",
+      "size": 11611
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/linear.py",
+      "size": 11269
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/loss.py",
+      "size": 93834
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/module.py",
+      "size": 126775
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/normalization.py",
+      "size": 14954
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/padding.py",
+      "size": 30947
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/pixelshuffle.py",
+      "size": 3680
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/pooling.py",
+      "size": 59534
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/rnn.py",
+      "size": 74511
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/sparse.py",
+      "size": 24084
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/transformer.py",
+      "size": 51864
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/upsampling.py",
+      "size": 11541
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/modules/utils.py",
+      "size": 2579
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/parallel/__init__.py",
+      "size": 760
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/parallel/_functions.py",
+      "size": 4949
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/parallel/comm.py",
+      "size": 10893
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/parallel/data_parallel.py",
+      "size": 11761
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/parallel/distributed.py",
+      "size": 109136
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/parallel/parallel_apply.py",
+      "size": 4464
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/parallel/replicate.py",
+      "size": 7020
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/parallel/scatter_gather.py",
+      "size": 4983
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/parameter.py",
+      "size": 11378
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/qat/__init__.py",
+      "size": 365
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/qat/dynamic/__init__.py",
+      "size": 208
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/qat/dynamic/modules/__init__.py",
+      "size": 78
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/qat/dynamic/modules/linear.py",
+      "size": 416
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/qat/modules/__init__.py",
+      "size": 501
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/qat/modules/conv.py",
+      "size": 406
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/qat/modules/embedding_ops.py",
+      "size": 458
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/qat/modules/linear.py",
+      "size": 392
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantizable/__init__.py",
+      "size": 57
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantizable/modules/__init__.py",
+      "size": 207
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantizable/modules/activation.py",
+      "size": 440
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantizable/modules/rnn.py",
+      "size": 429
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/__init__.py",
+      "size": 771
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/_reference/__init__.py",
+      "size": 66
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/_reference/modules/__init__.py",
+      "size": 1018
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/_reference/modules/conv.py",
+      "size": 579
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/_reference/modules/linear.py",
+      "size": 450
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/_reference/modules/rnn.py",
+      "size": 524
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/_reference/modules/sparse.py",
+      "size": 467
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/_reference/modules/utils.py",
+      "size": 590
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/dynamic/__init__.py",
+      "size": 58
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/dynamic/modules/__init__.py",
+      "size": 993
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/dynamic/modules/conv.py",
+      "size": 669
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/dynamic/modules/linear.py",
+      "size": 448
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/dynamic/modules/rnn.py",
+      "size": 740
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/functional.py",
+      "size": 276
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/modules/__init__.py",
+      "size": 2101
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/modules/activation.py",
+      "size": 528
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/modules/batchnorm.py",
+      "size": 437
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/modules/conv.py",
+      "size": 666
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/modules/dropout.py",
+      "size": 442
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/modules/embedding_ops.py",
+      "size": 547
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/modules/functional_modules.py",
+      "size": 554
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/modules/linear.py",
+      "size": 481
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/modules/normalization.py",
+      "size": 626
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/modules/rnn.py",
+      "size": 411
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/quantized/modules/utils.py",
+      "size": 539
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/__init__.py",
+      "size": 1242
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_deprecation_utils.py",
+      "size": 1675
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_expanded_weights/__init__.py",
+      "size": 452
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_expanded_weights/conv_expanded_weights.py",
+      "size": 2816
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_expanded_weights/conv_utils.py",
+      "size": 10729
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_expanded_weights/embedding_expanded_weights.py",
+      "size": 2850
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_expanded_weights/expanded_weights_impl.py",
+      "size": 6280
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_expanded_weights/expanded_weights_utils.py",
+      "size": 7582
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_expanded_weights/group_norm_expanded_weights.py",
+      "size": 3450
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_expanded_weights/instance_norm_expanded_weights.py",
+      "size": 3729
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_expanded_weights/layer_norm_expanded_weights.py",
+      "size": 3246
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_expanded_weights/linear_expanded_weights.py",
+      "size": 2216
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_named_member_accessor.py",
+      "size": 14163
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/_per_sample_grad.py",
+      "size": 5775
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/clip_grad.py",
+      "size": 11151
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/convert_parameters.py",
+      "size": 3244
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/fusion.py",
+      "size": 6434
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/init.py",
+      "size": 2250
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/memory_format.py",
+      "size": 8204
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/parametrizations.py",
+      "size": 25666
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/parametrize.py",
+      "size": 36222
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/prune.py",
+      "size": 58091
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/rnn.py",
+      "size": 23231
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/spectral_norm.py",
+      "size": 14914
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/stateless.py",
+      "size": 11696
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/nn/utils/weight_norm.py",
+      "size": 5882
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/__init__.py",
+      "size": 21747
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_constants.py",
+      "size": 531
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_experimental.py",
+      "size": 1033
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_flags.py",
+      "size": 1235
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_globals.py",
+      "size": 2772
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/_exporter_legacy.py",
+      "size": 19593
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/_lazy_import.py",
+      "size": 1228
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_analysis.py",
+      "size": 8859
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_building.py",
+      "size": 30810
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_capture_strategies.py",
+      "size": 9737
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_compat.py",
+      "size": 7560
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_constants.py",
+      "size": 378
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_core.py",
+      "size": 67299
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_decomp.py",
+      "size": 2837
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_dispatching.py",
+      "size": 14800
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_dynamic_shapes.py",
+      "size": 14009
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_errors.py",
+      "size": 535
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_flags.py",
+      "size": 642
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_fx_passes.py",
+      "size": 1724
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_ir_passes.py",
+      "size": 5854
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_isolated.py",
+      "size": 1816
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_onnx_program.py",
+      "size": 18178
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_registration.py",
+      "size": 12433
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_reporting.py",
+      "size": 7396
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_schemas.py",
+      "size": 20597
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_tensors.py",
+      "size": 2467
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_testing.py",
+      "size": 3328
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_torchlib/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_torchlib/_tensor_typing.py",
+      "size": 2042
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_torchlib/_torchlib_registry.py",
+      "size": 2722
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_torchlib/ops/__init__.py",
+      "size": 180
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_torchlib/ops/core.py",
+      "size": 1543
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_torchlib/ops/hop.py",
+      "size": 5309
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_torchlib/ops/nn.py",
+      "size": 10469
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_torchlib/ops/symbolic.py",
+      "size": 4722
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_torchlib/ops/symops.py",
+      "size": 1147
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_type_casting.py",
+      "size": 1161
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/exporter/_verification.py",
+      "size": 12563
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/__init__.py",
+      "size": 172
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/_pass.py",
+      "size": 8590
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/decomposition_table.py",
+      "size": 5100
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/dynamo_graph_extractor.py",
+      "size": 8285
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/fx_onnx_interpreter.py",
+      "size": 31204
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/onnxfunction_dispatcher.py",
+      "size": 30407
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/passes/__init__.py",
+      "size": 552
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/passes/_utils.py",
+      "size": 4197
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/passes/decomp.py",
+      "size": 3546
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/passes/functionalization.py",
+      "size": 6261
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/passes/modularization.py",
+      "size": 34021
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/passes/readability.py",
+      "size": 5483
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/passes/type_promotion.py",
+      "size": 64579
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/passes/virtualization.py",
+      "size": 3813
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/patcher.py",
+      "size": 6039
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/registration.py",
+      "size": 2984
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/serialization.py",
+      "size": 11618
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/fx/type_utils.py",
+      "size": 5837
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/io_adapter.py",
+      "size": 23046
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/jit_utils.py",
+      "size": 14129
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/onnx_proto_utils.py",
+      "size": 9199
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/onnxruntime.py",
+      "size": 52944
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_internal/registration.py",
+      "size": 11121
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_onnx_supported_ops.py",
+      "size": 3319
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/_type_utils.py",
+      "size": 13940
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/errors.py",
+      "size": 3464
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/operators.py",
+      "size": 1185
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/ops/__init__.py",
+      "size": 20944
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/ops/_dtype_mappings.py",
+      "size": 836
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/ops/_impl.py",
+      "size": 13890
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/ops/_symbolic_impl.py",
+      "size": 11781
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_caffe2.py",
+      "size": 10971
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_helper.py",
+      "size": 82311
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset10.py",
+      "size": 37428
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset11.py",
+      "size": 53342
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset12.py",
+      "size": 15659
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset13.py",
+      "size": 41254
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset14.py",
+      "size": 9473
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset15.py",
+      "size": 2872
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset16.py",
+      "size": 6410
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset17.py",
+      "size": 8039
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset18.py",
+      "size": 8092
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset19.py",
+      "size": 536
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset20.py",
+      "size": 2446
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset7.py",
+      "size": 2118
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset8.py",
+      "size": 14992
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/symbolic_opset9.py",
+      "size": 225245
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/utils.py",
+      "size": 74867
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/onnx/verification.py",
+      "size": 70529
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/__init__.py",
+      "size": 2118
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/_adafactor.py",
+      "size": 27988
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/_functional.py",
+      "size": 3242
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/_multi_tensor/__init__.py",
+      "size": 1027
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/adadelta.py",
+      "size": 16681
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/adagrad.py",
+      "size": 20820
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/adam.py",
+      "size": 39250
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/adamax.py",
+      "size": 17345
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/adamw.py",
+      "size": 7344
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/asgd.py",
+      "size": 16290
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/lbfgs.py",
+      "size": 18154
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/lr_scheduler.py",
+      "size": 84169
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/nadam.py",
+      "size": 26455
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/optimizer.py",
+      "size": 49829
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/radam.py",
+      "size": 24685
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/rmsprop.py",
+      "size": 20436
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/rprop.py",
+      "size": 17533
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/sgd.py",
+      "size": 20064
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/sparse_adam.py",
+      "size": 7958
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/optim/swa_utils.py",
+      "size": 19169
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/overrides.py",
+      "size": 105216
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/__init__.py",
+      "size": 388
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/_digraph.py",
+      "size": 5630
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/_directory_reader.py",
+      "size": 1915
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/_importlib.py",
+      "size": 2998
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/_mangling.py",
+      "size": 1891
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/_mock.py",
+      "size": 2866
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/_package_pickler.py",
+      "size": 4988
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/_package_unpickler.py",
+      "size": 992
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/_stdlib.py",
+      "size": 4067
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/analyze/__init__.py",
+      "size": 130
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/analyze/find_first_use_of_broken_modules.py",
+      "size": 1035
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/analyze/is_from_package.py",
+      "size": 404
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/analyze/trace_dependencies.py",
+      "size": 2235
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/file_structure_representation.py",
+      "size": 4753
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/find_file_dependencies.py",
+      "size": 3979
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/glob_group.py",
+      "size": 3665
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/importer.py",
+      "size": 8892
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/package_exporter.py",
+      "size": 50862
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/package/package_importer.py",
+      "size": 31668
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/profiler/__init__.py",
+      "size": 1578
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/profiler/_memory_profiler.py",
+      "size": 48164
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/profiler/_pattern_matcher.py",
+      "size": 24738
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/profiler/_utils.py",
+      "size": 13937
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/profiler/itt.py",
+      "size": 1782
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/profiler/profiler.py",
+      "size": 45224
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/profiler/python_tracer.py",
+      "size": 476
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/__init__.py",
+      "size": 2654
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/_numeric_suite.py",
+      "size": 779
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/_numeric_suite_fx.py",
+      "size": 752
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/_quantized_conversions.py",
+      "size": 4321
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fake_quantize.py",
+      "size": 1015
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fuse_modules.py",
+      "size": 732
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fuser_method_mappings.py",
+      "size": 511
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fx/__init__.py",
+      "size": 594
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fx/_equalize.py",
+      "size": 1250
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fx/convert.py",
+      "size": 386
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fx/fuse.py",
+      "size": 380
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fx/fusion_patterns.py",
+      "size": 415
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fx/graph_module.py",
+      "size": 573
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fx/match_utils.py",
+      "size": 456
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fx/pattern_utils.py",
+      "size": 1298
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fx/prepare.py",
+      "size": 386
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fx/quantization_patterns.py",
+      "size": 2087
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fx/quantization_types.py",
+      "size": 395
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/fx/utils.py",
+      "size": 723
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/observer.py",
+      "size": 1078
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/qconfig.py",
+      "size": 910
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/quant_type.py",
+      "size": 399
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/quantization_mappings.py",
+      "size": 1147
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/quantize.py",
+      "size": 804
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/quantize_fx.py",
+      "size": 736
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/quantize_jit.py",
+      "size": 714
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/stubs.py",
+      "size": 392
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quantization/utils.py",
+      "size": 833
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/quasirandom.py",
+      "size": 7948
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/random.py",
+      "size": 7197
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/return_types.py",
+      "size": 1485
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/serialization.py",
+      "size": 84881
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/signal/__init__.py",
+      "size": 46
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/signal/windows/__init__.py",
+      "size": 383
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/signal/windows/windows.py",
+      "size": 22654
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/sparse/__init__.py",
+      "size": 25518
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/sparse/_semi_structured_conversions.py",
+      "size": 14016
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/sparse/_semi_structured_ops.py",
+      "size": 6372
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/sparse/_triton_ops.py",
+      "size": 86150
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/sparse/_triton_ops_meta.py",
+      "size": 500784
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/sparse/semi_structured.py",
+      "size": 28043
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/special/__init__.py",
+      "size": 32735
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/storage.py",
+      "size": 52353
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/__init__.py",
+      "size": 187
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_comparison.py",
+      "size": 66077
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_creation.py",
+      "size": 12198
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/autocast_test_lists.py",
+      "size": 28391
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/autograd_function_db.py",
+      "size": 19613
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/check_kernel_launches.py",
+      "size": 6027
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/codegen/__init__.py",
+      "size": 22
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_cuda.py",
+      "size": 14728
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_device_type.py",
+      "size": 72905
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_dist_composable.py",
+      "size": 3577
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_distributed.py",
+      "size": 64637
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_dtype.py",
+      "size": 4864
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_fsdp.py",
+      "size": 58019
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_jit.py",
+      "size": 15847
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_methods_invocations.py",
+      "size": 1206661
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_mkldnn.py",
+      "size": 2286
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_modules.py",
+      "size": 216587
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_mps.py",
+      "size": 37664
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_nn.py",
+      "size": 172511
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_optimizers.py",
+      "size": 82356
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_pruning.py",
+      "size": 13655
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_quantization.py",
+      "size": 115782
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_quantized.py",
+      "size": 17713
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_subclass.py",
+      "size": 12194
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/common_utils.py",
+      "size": 236933
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/composite_compliance.py",
+      "size": 26025
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/custom_op_db.py",
+      "size": 19645
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/custom_tensor.py",
+      "size": 5220
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/data/__init__.py",
+      "size": 22
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/data/network1.py",
+      "size": 169
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/data/network2.py",
+      "size": 199
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/dist_utils.py",
+      "size": 7255
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/_shard/__init__.py",
+      "size": 27
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py",
+      "size": 3204
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/_shard/sharded_tensor/_test_ops_common.py",
+      "size": 4011
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/_shard/sharded_tensor/_test_st_common.py",
+      "size": 1618
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/_shard/test_common.py",
+      "size": 1219
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/_tensor/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/_tensor/common_dtensor.py",
+      "size": 21769
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/checkpoint_utils.py",
+      "size": 5136
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/common_state_dict.py",
+      "size": 6705
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/ddp_under_dist_autograd_test.py",
+      "size": 26953
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/distributed_test.py",
+      "size": 437044
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/distributed_utils.py",
+      "size": 1947
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/fake_pg.py",
+      "size": 1033
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/multi_threaded_pg.py",
+      "size": 19302
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/nn/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/nn/api/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/nn/api/remote_module_test.py",
+      "size": 29727
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/dist_autograd_test.py",
+      "size": 107082
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/dist_optimizer_test.py",
+      "size": 10574
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/examples/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/examples/parameter_server_test.py",
+      "size": 4555
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/examples/reinforcement_learning_rpc_test.py",
+      "size": 9255
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/faulty_agent_rpc_test.py",
+      "size": 14239
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/faulty_rpc_agent_test_fixture.py",
+      "size": 2142
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/jit/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/jit/dist_autograd_test.py",
+      "size": 4172
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/jit/rpc_test.py",
+      "size": 46880
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/jit/rpc_test_faulty.py",
+      "size": 7974
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/rpc_agent_test_fixture.py",
+      "size": 1874
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/rpc_test.py",
+      "size": 226049
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc/tensorpipe_rpc_agent_test_fixture.py",
+      "size": 974
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/distributed/rpc_utils.py",
+      "size": 6615
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/dynamo_test_failures.py",
+      "size": 5440
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/fake_config_module.py",
+      "size": 1253
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/fake_config_module2.py",
+      "size": 343
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/fake_config_module3.py",
+      "size": 218
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/generated/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/generated/annotated_fn_args.py",
+      "size": 550494
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/hop_db.py",
+      "size": 13923
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/hypothesis_utils.py",
+      "size": 14622
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/inductor_utils.py",
+      "size": 11138
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/jit_metaprogramming_utils.py",
+      "size": 34057
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/jit_utils.py",
+      "size": 33951
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/logging_tensor.py",
+      "size": 6646
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/logging_utils.py",
+      "size": 8205
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/opinfo/__init__.py",
+      "size": 116
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/opinfo/core.py",
+      "size": 123946
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/opinfo/definitions/__init__.py",
+      "size": 452
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/opinfo/definitions/_masked.py",
+      "size": 46439
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/opinfo/definitions/fft.py",
+      "size": 29445
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/opinfo/definitions/linalg.py",
+      "size": 83990
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/opinfo/definitions/nested.py",
+      "size": 59720
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/opinfo/definitions/signal.py",
+      "size": 15342
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/opinfo/definitions/sparse.py",
+      "size": 33781
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/opinfo/definitions/special.py",
+      "size": 27544
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/opinfo/refs.py",
+      "size": 8039
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/opinfo/utils.py",
+      "size": 8722
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/optests/__init__.py",
+      "size": 372
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/optests/aot_autograd.py",
+      "size": 6434
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/optests/autograd_registration.py",
+      "size": 5692
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/optests/fake_tensor.py",
+      "size": 257
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/optests/generate_tests.py",
+      "size": 31776
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/optests/make_fx.py",
+      "size": 3268
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/quantization_torch_package_models.py",
+      "size": 951
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/static_module.py",
+      "size": 893
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/subclasses.py",
+      "size": 2530
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/test_module/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/test_module/future_div.py",
+      "size": 114
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/test_module/no_future_div.py",
+      "size": 145
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/torchbind_impls.py",
+      "size": 5256
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/triton_utils.py",
+      "size": 29342
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_internal/two_tensor.py",
+      "size": 3601
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/testing/_utils.py",
+      "size": 2039
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/torch_version.py",
+      "size": 2530
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/types.py",
+      "size": 3687
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/__init__.py",
+      "size": 4061
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_appending_byte_serializer.py",
+      "size": 3657
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_backport_slots.py",
+      "size": 4605
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_config_module.py",
+      "size": 29801
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_content_store.py",
+      "size": 9222
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_contextlib.py",
+      "size": 6026
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_cpp_embed_headers.py",
+      "size": 1806
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_cpp_extension_versioner.py",
+      "size": 1938
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_cxx_pytree.py",
+      "size": 38302
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_device.py",
+      "size": 3709
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_dtype_abbrs.py",
+      "size": 755
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_exposed_in.py",
+      "size": 693
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_filelock.py",
+      "size": 1567
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_foreach_utils.py",
+      "size": 2427
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_freeze.py",
+      "size": 9996
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_functools.py",
+      "size": 1423
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_get_clean_triton.py",
+      "size": 6968
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_helion.py",
+      "size": 364
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_import_utils.py",
+      "size": 1329
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_mode_utils.py",
+      "size": 255
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_ordered_set.py",
+      "size": 5512
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_python_dispatch.py",
+      "size": 28557
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_pytree.py",
+      "size": 71788
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_stats.py",
+      "size": 1014
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_strobelight/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_strobelight/cli_function_profiler.py",
+      "size": 11341
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_sympy/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_sympy/functions.py",
+      "size": 50787
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_sympy/interp.py",
+      "size": 7141
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_sympy/numbers.py",
+      "size": 11401
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_sympy/printers.py",
+      "size": 20555
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_sympy/reference.py",
+      "size": 13604
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_sympy/singleton_int.py",
+      "size": 2967
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_sympy/solve.py",
+      "size": 6509
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_sympy/symbol.py",
+      "size": 3719
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_sympy/value_ranges.py",
+      "size": 35220
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_thunk.py",
+      "size": 625
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_traceback.py",
+      "size": 10248
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_triton.py",
+      "size": 4348
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_typing_utils.py",
+      "size": 378
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/_zip.py",
+      "size": 2455
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/backcompat/__init__.py",
+      "size": 662
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/backend_registration.py",
+      "size": 19485
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/__init__.py",
+      "size": 411
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/examples/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/examples/compare.py",
+      "size": 2915
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/examples/fuzzer.py",
+      "size": 2650
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/examples/op_benchmark.py",
+      "size": 4227
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/examples/simple_timeit.py",
+      "size": 541
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/examples/spectral_ops_fuzz_test.py",
+      "size": 4779
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/op_fuzzers/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/op_fuzzers/binary.py",
+      "size": 4136
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/op_fuzzers/sparse_binary.py",
+      "size": 4218
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/op_fuzzers/sparse_unary.py",
+      "size": 3246
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/op_fuzzers/spectral.py",
+      "size": 3624
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/op_fuzzers/unary.py",
+      "size": 3146
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/utils/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/utils/_stubs.py",
+      "size": 999
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/utils/common.py",
+      "size": 13660
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/utils/compare.py",
+      "size": 13270
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/utils/compile.py",
+      "size": 7602
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/utils/cpp_jit.py",
+      "size": 6805
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/utils/fuzzer.py",
+      "size": 18367
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/utils/sparse_fuzzer.py",
+      "size": 5160
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/utils/timer.py",
+      "size": 21199
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/utils/valgrind_wrapper/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py",
+      "size": 37262
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/bottleneck/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/bottleneck/__main__.py",
+      "size": 7190
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/bundled_inputs.py",
+      "size": 22582
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/checkpoint.py",
+      "size": 68071
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/collect_env.py",
+      "size": 24503
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/cpp_backtrace.py",
+      "size": 483
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/cpp_extension.py",
+      "size": 132431
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/__init__.py",
+      "size": 1654
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/_utils/__init__.py",
+      "size": 1625
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/_utils/collate.py",
+      "size": 15964
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/_utils/fetch.py",
+      "size": 1953
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/_utils/pin_memory.py",
+      "size": 4451
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/_utils/signal_handling.py",
+      "size": 3171
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/_utils/worker.py",
+      "size": 13800
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/backward_compatibility.py",
+      "size": 309
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/dataloader.py",
+      "size": 79585
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/__init__.py",
+      "size": 88
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/_decorator.py",
+      "size": 7832
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/_hook_iterator.py",
+      "size": 11949
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/_typing.py",
+      "size": 16294
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/dataframe/__init__.py",
+      "size": 331
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/dataframe/dataframe_wrapper.py",
+      "size": 3293
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/dataframe/dataframes.py",
+      "size": 13468
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/dataframe/datapipes.py",
+      "size": 4537
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/dataframe/structures.py",
+      "size": 662
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/datapipe.py",
+      "size": 16796
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/gen_pyi.py",
+      "size": 11818
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/iter/__init__.py",
+      "size": 1815
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/iter/callable.py",
+      "size": 9065
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/iter/combinatorics.py",
+      "size": 6460
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/iter/combining.py",
+      "size": 27318
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/iter/filelister.py",
+      "size": 2596
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/iter/fileopener.py",
+      "size": 2823
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/iter/grouping.py",
+      "size": 12354
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/iter/routeddecoder.py",
+      "size": 2731
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/iter/selecting.py",
+      "size": 3313
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/iter/sharding.py",
+      "size": 3510
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/iter/streamreader.py",
+      "size": 1560
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/iter/utils.py",
+      "size": 1809
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/map/__init__.py",
+      "size": 667
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/map/callable.py",
+      "size": 1860
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/map/combinatorics.py",
+      "size": 4191
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/map/combining.py",
+      "size": 3699
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/map/grouping.py",
+      "size": 2457
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/map/utils.py",
+      "size": 1575
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/utils/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/utils/common.py",
+      "size": 13700
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/utils/decoder.py",
+      "size": 11887
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/datapipes/utils/snapshot.py",
+      "size": 3103
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/dataset.py",
+      "size": 19467
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/distributed.py",
+      "size": 6125
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/graph.py",
+      "size": 5799
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/graph_settings.py",
+      "size": 5540
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/data/sampler.py",
+      "size": 12836
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/deterministic.py",
+      "size": 611
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/dlpack.py",
+      "size": 4509
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/file_baton.py",
+      "size": 2040
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/flop_counter.py",
+      "size": 28775
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/hipify/__init__.py",
+      "size": 33
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/hipify/constants.py",
+      "size": 1174
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/hipify/cuda_to_hip_mappings.py",
+      "size": 358399
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/hipify/hipify_python.py",
+      "size": 47054
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/hipify/version.py",
+      "size": 22
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/hooks.py",
+      "size": 9982
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/jit/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/jit/log_extract.py",
+      "size": 3751
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/mkldnn.py",
+      "size": 7908
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/mobile_optimizer.py",
+      "size": 6430
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/model_dump/__init__.py",
+      "size": 16782
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/model_dump/__main__.py",
+      "size": 79
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/model_zoo.py",
+      "size": 117
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/module_tracker.py",
+      "size": 5385
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/serialization/__init__.py",
+      "size": 21
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/serialization/config.py",
+      "size": 658
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/show_pickle.py",
+      "size": 5391
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/tensorboard/__init__.py",
+      "size": 480
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/tensorboard/_convert_np.py",
+      "size": 734
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/tensorboard/_embedding.py",
+      "size": 3224
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/tensorboard/_onnx_graph.py",
+      "size": 1887
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/tensorboard/_proto_graph.py",
+      "size": 1758
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/tensorboard/_pytorch_graph.py",
+      "size": 13692
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/tensorboard/_utils.py",
+      "size": 4187
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/tensorboard/summary.py",
+      "size": 34462
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/tensorboard/writer.py",
+      "size": 46659
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/throughput_benchmark.py",
+      "size": 6502
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/viz/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/viz/_cycles.py",
+      "size": 16740
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/utils/weak.py",
+      "size": 11166
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/version.py",
+      "size": 277
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/xpu/__init__.py",
+      "size": 17938
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/xpu/_gpu_trace.py",
+      "size": 2355
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/xpu/_utils.py",
+      "size": 1591
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/xpu/memory.py",
+      "size": 8028
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/xpu/random.py",
+      "size": 5239
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/xpu/streams.py",
+      "size": 5858
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/__init__.py",
+      "size": 348
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/aoti/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/aoti/fallback_ops.py",
+      "size": 7483
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/autograd.py",
+      "size": 38959
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/cpp.py",
+      "size": 16279
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/dispatcher.py",
+      "size": 3479
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/functionalization.py",
+      "size": 7566
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/lazy.py",
+      "size": 17053
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/meta.py",
+      "size": 483
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/native.py",
+      "size": 5205
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/python.py",
+      "size": 59687
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/structured.py",
+      "size": 6115
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/translate.py",
+      "size": 19297
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/types/__init__.py",
+      "size": 144
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/types/signatures.py",
+      "size": 15722
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/types/types.py",
+      "size": 6139
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/types/types_base.py",
+      "size": 7184
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/ufunc.py",
+      "size": 6693
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/api/unboxing.py",
+      "size": 9381
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/code_template.py",
+      "size": 3211
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/context.py",
+      "size": 4056
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/dest/__init__.py",
+      "size": 805
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/dest/lazy_ir.py",
+      "size": 28990
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/dest/lazy_ts_lowering.py",
+      "size": 1831
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/dest/native_functions.py",
+      "size": 3171
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/dest/register_dispatch_key.py",
+      "size": 41484
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/dest/ufunc.py",
+      "size": 17837
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/gen.py",
+      "size": 113467
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/gen_aoti_c_shim.py",
+      "size": 25798
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/gen_backend_stubs.py",
+      "size": 22400
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/gen_functionalization_type.py",
+      "size": 38235
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/gen_lazy_tensor.py",
+      "size": 22730
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/gen_schema_utils.py",
+      "size": 3317
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/gen_vmap_plumbing.py",
+      "size": 9395
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/local.py",
+      "size": 2167
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/model.py",
+      "size": 114399
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/native_function_generation.py",
+      "size": 29765
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/operator_versions/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/operator_versions/gen_mobile_upgraders.py",
+      "size": 12388
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/operator_versions/gen_mobile_upgraders_constant.py",
+      "size": 243
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/context.py",
+      "size": 945
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/gen_annotated_fn_args.py",
+      "size": 4476
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/gen_autograd.py",
+      "size": 4617
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/gen_autograd_functions.py",
+      "size": 38108
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/gen_inplace_or_view_type.py",
+      "size": 22721
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/gen_python_functions.py",
+      "size": 46359
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/gen_trace_type.py",
+      "size": 18974
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/gen_variable_factories.py",
+      "size": 4479
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/gen_variable_type.py",
+      "size": 83821
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/gen_view_funcs.py",
+      "size": 11589
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/load_derivatives.py",
+      "size": 40338
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/selective_build/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/selective_build/operator.py",
+      "size": 6509
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/selective_build/selector.py",
+      "size": 12666
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/static_runtime/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/static_runtime/config.py",
+      "size": 14487
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/static_runtime/gen_static_runtime_ops.py",
+      "size": 7408
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/static_runtime/generator.py",
+      "size": 27116
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/utils.py",
+      "size": 18584
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/yaml_utils.py",
+      "size": 1080
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/typing_extensions.py",
+      "size": 160429
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/__init__.py",
+      "size": 183
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/__main__.py",
+      "size": 3221
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/activation/__init__.py",
+      "size": 464
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/activation/activator.py",
+      "size": 1419
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/activation/bash/__init__.py",
+      "size": 648
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/activation/batch/__init__.py",
+      "size": 756
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/activation/cshell/__init__.py",
+      "size": 336
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/activation/fish/__init__.py",
+      "size": 555
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/activation/nushell/__init__.py",
+      "size": 1464
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/activation/powershell/__init__.py",
+      "size": 823
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/activation/python/__init__.py",
+      "size": 830
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/activation/python/activate_this.py",
+      "size": 1305
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/activation/via_template.py",
+      "size": 3209
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/app_data/__init__.py",
+      "size": 1467
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/app_data/base.py",
+      "size": 2083
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/app_data/na.py",
+      "size": 1500
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/app_data/read_only.py",
+      "size": 1113
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/app_data/via_disk_folder.py",
+      "size": 5469
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/app_data/via_tempdir.py",
+      "size": 811
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/config/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/config/cli/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/config/cli/parser.py",
+      "size": 4644
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/config/convert.py",
+      "size": 2792
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/config/env_var.py",
+      "size": 748
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/config/ini.py",
+      "size": 2706
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/creator.py",
+      "size": 9205
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/debug.py",
+      "size": 3149
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/describe.py",
+      "size": 3154
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/pyenv_cfg.py",
+      "size": 1825
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/_virtualenv.py",
+      "size": 5347
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/api.py",
+      "size": 4523
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/builtin/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/builtin/builtin_way.py",
+      "size": 520
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/builtin/cpython/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/builtin/cpython/common.py",
+      "size": 2653
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/builtin/cpython/cpython3.py",
+      "size": 6427
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/builtin/cpython/mac_os.py",
+      "size": 11669
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/builtin/graalpy/__init__.py",
+      "size": 2986
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/builtin/pypy/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/builtin/pypy/common.py",
+      "size": 1716
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/builtin/pypy/pypy3.py",
+      "size": 2494
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/builtin/ref.py",
+      "size": 5433
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/builtin/via_global_self_do.py",
+      "size": 4430
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/store.py",
+      "size": 667
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/create/via_global_ref/venv.py",
+      "size": 3688
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/discovery/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/discovery/builtin.py",
+      "size": 9728
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/discovery/cached_py_info.py",
+      "size": 6984
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/discovery/discover.py",
+      "size": 1173
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/discovery/py_info.py",
+      "size": 28663
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/discovery/py_spec.py",
+      "size": 5034
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/discovery/windows/__init__.py",
+      "size": 1889
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/discovery/windows/pep514.py",
+      "size": 5644
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/info.py",
+      "size": 2290
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/report.py",
+      "size": 1354
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/run/__init__.py",
+      "size": 6484
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/run/plugin/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/run/plugin/activators.py",
+      "size": 2235
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/run/plugin/base.py",
+      "size": 2096
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/run/plugin/creators.py",
+      "size": 3626
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/run/plugin/discovery.py",
+      "size": 1395
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/run/plugin/seeders.py",
+      "size": 1050
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/run/session.py",
+      "size": 2487
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/embed/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/embed/base_embed.py",
+      "size": 5229
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/embed/pip_invoke.py",
+      "size": 2237
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/embed/via_app_data/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/embed/via_app_data/pip_install/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/embed/via_app_data/pip_install/base.py",
+      "size": 8323
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/embed/via_app_data/pip_install/copy.py",
+      "size": 1226
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/embed/via_app_data/pip_install/symlink.py",
+      "size": 2015
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/embed/via_app_data/via_app_data.py",
+      "size": 5910
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/seeder.py",
+      "size": 1155
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/wheels/__init__.py",
+      "size": 204
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/wheels/acquire.py",
+      "size": 4617
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/wheels/bundle.py",
+      "size": 1863
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/wheels/embed/__init__.py",
+      "size": 1624
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/wheels/periodic_update.py",
+      "size": 15586
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/seed/wheels/util.py",
+      "size": 3962
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/util/__init__.py",
+      "size": 0
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/util/error.py",
+      "size": 323
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/util/lock.py",
+      "size": 5023
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/util/path/__init__.py",
+      "size": 340
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/util/path/_permission.py",
+      "size": 665
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/util/path/_sync.py",
+      "size": 2116
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/util/path/_win.py",
+      "size": 803
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/util/subprocess/__init__.py",
+      "size": 735
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/util/zipapp.py",
+      "size": 1232
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv/version.py",
+      "size": 708
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/__init__.py",
+      "size": 12311
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/composer.py",
+      "size": 4883
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/constructor.py",
+      "size": 28639
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/cyaml.py",
+      "size": 3851
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/dumper.py",
+      "size": 2837
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/emitter.py",
+      "size": 43006
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/error.py",
+      "size": 2533
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/events.py",
+      "size": 2445
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/loader.py",
+      "size": 2061
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/nodes.py",
+      "size": 1440
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/parser.py",
+      "size": 25495
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/reader.py",
+      "size": 6794
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/representer.py",
+      "size": 14190
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/resolver.py",
+      "size": 9004
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/scanner.py",
+      "size": 51279
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/serializer.py",
+      "size": 4165
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/yaml/tokens.py",
+      "size": 2573
+    },
+    {
+      "path": "agents/codex_client/codex_client/__init__.py",
+      "size": 121
+    },
+    {
+      "path": "agents/codex_client/codex_client/bridge.py",
+      "size": 4177
+    },
+    {
+      "path": "agents/codex_client/codex_client/config.py",
+      "size": 787
+    },
+    {
+      "path": "agents/codex_client/codex_client/demo_plan_and_call.py",
+      "size": 2716
+    },
+    {
+      "path": "agents/codex_client/codex_client/models.py",
+      "size": 1144
+    },
+    {
+      "path": "agents/codex_client/tests/test_config.py",
+      "size": 976
+    },
+    {
+      "path": "agents/msp_client.py",
+      "size": 7367
+    },
+    {
+      "path": "analysis/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "analysis/audit_pipeline.py",
+      "size": 3091
+    },
+    {
+      "path": "analysis/intuitive_aptitude.py",
+      "size": 27837
+    },
+    {
+      "path": "analysis/metrics.py",
+      "size": 441
+    },
+    {
+      "path": "analysis/parsers.py",
+      "size": 586
+    },
+    {
+      "path": "analysis/providers.py",
+      "size": 424
+    },
+    {
+      "path": "analysis/registry.py",
+      "size": 402
+    },
+    {
+      "path": "analysis/tests_docs_links_audit.py",
+      "size": 13440
+    },
+    {
+      "path": "build_helpers_manifest.py",
+      "size": 1786
+    },
+    {
+      "path": "cli/__init__.py",
+      "size": 116
+    },
+    {
+      "path": "cli/ast_upgrade.py",
+      "size": 52047
+    },
+    {
+      "path": "cli/audit_runner_root.py",
+      "size": 880
+    },
+    {
+      "path": "cli/patch_runner.py",
+      "size": 8679
+    },
+    {
+      "path": "cli/script_polish.py",
+      "size": 25550
+    },
+    {
+      "path": "cli/setup.py",
+      "size": 11761
+    },
+    {
+      "path": "cli/status_audit.py",
+      "size": 4936
+    },
+    {
+      "path": "cli/task_sequence.py",
+      "size": 36678
+    },
+    {
+      "path": "cli/train_schema_demo.py",
+      "size": 1184
+    },
+    {
+      "path": "cli/update_runner.py",
+      "size": 20931
+    },
+    {
+      "path": "cli/workflow.py",
+      "size": 17723
+    },
+    {
+      "path": "codex_addons/metrics/collector.py",
+      "size": 15629
+    },
+    {
+      "path": "codex_addons/registry.py",
+      "size": 5572
+    },
+    {
+      "path": "codex_addons/registry_names.py",
+      "size": 2686
+    },
+    {
+      "path": "codex_addons/spectral.py",
+      "size": 10178
+    },
+    {
+      "path": "codex_addons/vector_stores/__init__.py",
+      "size": 319
+    },
+    {
+      "path": "codex_addons/vector_stores/pgvector_stub.py",
+      "size": 828
+    },
+    {
+      "path": "codex_addons/vector_stores/weaviate_stub.py",
+      "size": 855
+    },
+    {
+      "path": "codex_digest/__init__.py",
+      "size": 225
+    },
+    {
+      "path": "codex_digest/cli.py",
+      "size": 1511
+    },
+    {
+      "path": "codex_digest/error_capture.py",
+      "size": 1581
+    },
+    {
+      "path": "codex_digest/mapper.py",
+      "size": 1854
+    },
+    {
+      "path": "codex_digest/pipeline.py",
+      "size": 2507
+    },
+    {
+      "path": "codex_digest/semparser.py",
+      "size": 1660
+    },
+    {
+      "path": "codex_digest/tokenizer.py",
+      "size": 2073
+    },
+    {
+      "path": "codex_digest/utils.py",
+      "size": 642
+    },
+    {
+      "path": "codex_digest/workflow.py",
+      "size": 984
+    },
+    {
+      "path": "codex_ml/__init__.py",
+      "size": 1031
+    },
+    {
+      "path": "codex_ml/__main__.py",
+      "size": 583
+    },
+    {
+      "path": "codex_ml/_package_main.py",
+      "size": 882
+    },
+    {
+      "path": "codex_ml/cli/main.py",
+      "size": 980
+    },
+    {
+      "path": "codex_ml/data/checksums.py",
+      "size": 1256
+    },
+    {
+      "path": "codex_ml/pipeline.py",
+      "size": 1034
+    },
+    {
+      "path": "codex_ml/tracking/mlflow_utils.py",
+      "size": 843
+    },
+    {
+      "path": "codex_ml/tracking/writers.py",
+      "size": 2686
+    },
+    {
+      "path": "codex_ml/utils/checkpointing.py",
+      "size": 810
+    },
+    {
+      "path": "codex_task_executor.py",
+      "size": 39865
+    },
+    {
+      "path": "codex_task_sequence.py",
+      "size": 1036
+    },
+    {
+      "path": "codex_utils/__init__.py",
+      "size": 620
+    },
+    {
+      "path": "codex_utils/cli/ndjson_summary.py",
+      "size": 11211
+    },
+    {
+      "path": "codex_utils/json_report.py",
+      "size": 18196
+    },
+    {
+      "path": "codex_utils/logging_setup.py",
+      "size": 4094
+    },
+    {
+      "path": "codex_utils/mlflow_offline.py",
+      "size": 4171
+    },
+    {
+      "path": "codex_utils/ndjson.py",
+      "size": 2599
+    },
+    {
+      "path": "codex_utils/regex_patterns.py",
+      "size": 637
+    },
+    {
+      "path": "codex_utils/repro.py",
+      "size": 6332
+    },
+    {
+      "path": "codex_utils/tracking/__init__.py",
+      "size": 312
+    },
+    {
+      "path": "codex_utils/tracking/guards.py",
+      "size": 2503
+    },
+    {
+      "path": "configs/__init__.py",
+      "size": 17
+    },
+    {
+      "path": "configs/base/base_config.py",
+      "size": 641
+    },
+    {
+      "path": "configs/development/noxfile.py",
+      "size": 29231
+    },
+    {
+      "path": "configs/schemas/__init__.py",
+      "size": 1381
+    },
+    {
+      "path": "conftest.py",
+      "size": 7701
+    },
+    {
+      "path": "deploy/__init__.py",
+      "size": 80
+    },
+    {
+      "path": "deploy/deploy_codex_pipeline.py",
+      "size": 7996
+    },
+    {
+      "path": "docs/examples/codex_symbolic_pipeline.py",
+      "size": 9396
+    },
+    {
+      "path": "examples/__init__.py",
+      "size": 71
+    },
+    {
+      "path": "examples/chat_finetune.py",
+      "size": 1168
+    },
+    {
+      "path": "examples/evaluate_toy.py",
+      "size": 530
+    },
+    {
+      "path": "examples/mlflow_offline.py",
+      "size": 4306
+    },
+    {
+      "path": "examples/plugins/__init__.py",
+      "size": 63
+    },
+    {
+      "path": "examples/plugins/broken.py",
+      "size": 70
+    },
+    {
+      "path": "examples/plugins/hello_plugin.py",
+      "size": 324
+    },
+    {
+      "path": "examples/plugins/metrics_token_accuracy_plugin.py",
+      "size": 398
+    },
+    {
+      "path": "examples/plugins/toy_data_loader/__init__.py",
+      "size": 295
+    },
+    {
+      "path": "examples/plugins/toy_metric/__init__.py",
+      "size": 304
+    },
+    {
+      "path": "examples/plugins/toy_model/__init__.py",
+      "size": 456
+    },
+    {
+      "path": "examples/plugins/toy_tokenizer/__init__.py",
+      "size": 641
+    },
+    {
+      "path": "examples/plugins/toy_trainer/__init__.py",
+      "size": 504
+    },
+    {
+      "path": "examples/tokenize.py",
+      "size": 614
+    },
+    {
+      "path": "examples/train_toy.py",
+      "size": 810
+    },
+    {
+      "path": "hydra/__init__.py",
+      "size": 7878
+    },
+    {
+      "path": "hydra/errors.py",
+      "size": 692
+    },
+    {
+      "path": "interfaces/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "interfaces/tokenizer.py",
+      "size": 430
+    },
+    {
+      "path": "models/__init__.py",
+      "size": 181
+    },
+    {
+      "path": "models/chat_model.py",
+      "size": 5708
+    },
+    {
+      "path": "models/lora/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "models/lora/_test_utils.py",
+      "size": 4018
+    },
+    {
+      "path": "models/peft_utils.py",
+      "size": 1185
+    },
+    {
+      "path": "monitoring/system_metrics.py",
+      "size": 1778
+    },
+    {
+      "path": "nox_sessions/audit.py",
+      "size": 373
+    },
+    {
+      "path": "nox_sessions/docs_validation.py",
+      "size": 2316
+    },
+    {
+      "path": "nox_sessions/fence_tests.py",
+      "size": 449
+    },
+    {
+      "path": "noxfile.py",
+      "size": 11415
+    },
+    {
+      "path": "omegaconf/__init__.py",
+      "size": 8162
+    },
+    {
+      "path": "scripts/__init__.py",
+      "size": 323
+    },
+    {
+      "path": "scripts/agent/probe_env.py",
+      "size": 2208
+    },
+    {
+      "path": "scripts/analysis/ast_signature_similarity.py",
+      "size": 4287
+    },
+    {
+      "path": "scripts/apply_session_logging_workflow.py",
+      "size": 17944
+    },
+    {
+      "path": "scripts/archival/check_archival_compliance.py",
+      "size": 4842
+    },
+    {
+      "path": "scripts/archive/__init__.py",
+      "size": 62
+    },
+    {
+      "path": "scripts/archive/select_and_compress.py",
+      "size": 4511
+    },
+    {
+      "path": "scripts/archive/trend_aggregate.py",
+      "size": 2671
+    },
+    {
+      "path": "scripts/archive/validate_prefixes.py",
+      "size": 2452
+    },
+    {
+      "path": "scripts/audit/build_integrity_chain.py",
+      "size": 2762
+    },
+    {
+      "path": "scripts/automation/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "scripts/automation/sync_issues_to_report.py",
+      "size": 1579
+    },
+    {
+      "path": "scripts/baseline/rotate_baselines.py",
+      "size": 1069
+    },
+    {
+      "path": "scripts/benchmark_logging.py",
+      "size": 2502
+    },
+    {
+      "path": "scripts/canonicalize_artifacts.py",
+      "size": 1643
+    },
+    {
+      "path": "scripts/check_licenses.py",
+      "size": 1091
+    },
+    {
+      "path": "scripts/cli/__init__.py",
+      "size": 26
+    },
+    {
+      "path": "scripts/cli/viewer.py",
+      "size": 1120
+    },
+    {
+      "path": "scripts/codex_end_to_end.py",
+      "size": 1535
+    },
+    {
+      "path": "scripts/codex_offline_audit.py",
+      "size": 28246
+    },
+    {
+      "path": "scripts/codex_orchestrate.py",
+      "size": 6378
+    },
+    {
+      "path": "scripts/codex_ready_execution.py",
+      "size": 6098
+    },
+    {
+      "path": "scripts/codex_ready_task_runner.py",
+      "size": 15778
+    },
+    {
+      "path": "scripts/config/__init__.py",
+      "size": 54
+    },
+    {
+      "path": "scripts/config/parse_knobs.py",
+      "size": 10955
+    },
+    {
+      "path": "scripts/config/schema_validate.py",
+      "size": 2573
+    },
+    {
+      "path": "scripts/connectors/__init__.py",
+      "size": 51
+    },
+    {
+      "path": "scripts/connectors/prune_rate_limit_history.py",
+      "size": 1511
+    },
+    {
+      "path": "scripts/connectors/ratelimit_to_status.py",
+      "size": 1626
+    },
+    {
+      "path": "scripts/content_filter/__init__.py",
+      "size": 68
+    },
+    {
+      "path": "scripts/content_filter/apply_filter.py",
+      "size": 7894
+    },
+    {
+      "path": "scripts/dashboards/__init__.py",
+      "size": 53
+    },
+    {
+      "path": "scripts/dashboards/build_ratelimit_tile.py",
+      "size": 3850
+    },
+    {
+      "path": "scripts/dashboards/build_tiles_index.py",
+      "size": 1293
+    },
+    {
+      "path": "scripts/dashboards/render_ratelimit_tile_html.py",
+      "size": 4570
+    },
+    {
+      "path": "scripts/data/hash_dataset_files.py",
+      "size": 1023
+    },
+    {
+      "path": "scripts/deep_research_task_process.py",
+      "size": 41506
+    },
+    {
+      "path": "scripts/deepresearch/__init__.py",
+      "size": 49
+    },
+    {
+      "path": "scripts/deepresearch/generate_context_manifest.py",
+      "size": 1728
+    },
+    {
+      "path": "scripts/env/export_env_json.py",
+      "size": 1825
+    },
+    {
+      "path": "scripts/env/export_env_snapshot.py",
+      "size": 580
+    },
+    {
+      "path": "scripts/env/print_env_info.py",
+      "size": 1279
+    },
+    {
+      "path": "scripts/environment_snapshot.py",
+      "size": 8221
+    },
+    {
+      "path": "scripts/export_env.py",
+      "size": 2033
+    },
+    {
+      "path": "scripts/export_env_info.py",
+      "size": 580
+    },
+    {
+      "path": "scripts/fix_markdown_fences.py",
+      "size": 1682
+    },
+    {
+      "path": "scripts/fix_md_fences.py",
+      "size": 2664
+    },
+    {
+      "path": "scripts/generate_capability_report.py",
+      "size": 6107
+    },
+    {
+      "path": "scripts/generate_desired_state.py",
+      "size": 1760
+    },
+    {
+      "path": "scripts/generate_preflight.py",
+      "size": 4428
+    },
+    {
+      "path": "scripts/init_sample_db.py",
+      "size": 2913
+    },
+    {
+      "path": "scripts/make_quickstart_notebook.py",
+      "size": 4116
+    },
+    {
+      "path": "scripts/metrics/token_similarity.py",
+      "size": 3358
+    },
+    {
+      "path": "scripts/multi_repo/federated_index.py",
+      "size": 3217
+    },
+    {
+      "path": "scripts/ops/__init__.py",
+      "size": 109
+    },
+    {
+      "path": "scripts/ops/bootstrap_self_hosted_runner.py",
+      "size": 4050
+    },
+    {
+      "path": "scripts/ops/codex_mint_tokens_per_run.py",
+      "size": 16063
+    },
+    {
+      "path": "scripts/ops/codex_repo_admin_bootstrap.py",
+      "size": 19766
+    },
+    {
+      "path": "scripts/refresh_requirements_lock.py",
+      "size": 10172
+    },
+    {
+      "path": "scripts/repo_audit.py",
+      "size": 5589
+    },
+    {
+      "path": "scripts/run_codex_tasks.py",
+      "size": 4752
+    },
+    {
+      "path": "scripts/run_sweep.py",
+      "size": 4741
+    },
+    {
+      "path": "scripts/sbom_cyclonedx.py",
+      "size": 8516
+    },
+    {
+      "path": "scripts/security/classify_severity.py",
+      "size": 3112
+    },
+    {
+      "path": "scripts/security/enforce_policy.py",
+      "size": 3454
+    },
+    {
+      "path": "scripts/security/secret_context_correlate.py",
+      "size": 4506
+    },
+    {
+      "path": "scripts/security/secret_entropy_scan.py",
+      "size": 2454
+    },
+    {
+      "path": "scripts/space_traversal/__init__.py",
+      "size": 435
+    },
+    {
+      "path": "scripts/space_traversal/audit_runner.py",
+      "size": 39987
+    },
+    {
+      "path": "scripts/space_traversal/capability_scoring.py",
+      "size": 1854
+    },
+    {
+      "path": "scripts/space_traversal/coverage_ingest.py",
+      "size": 2597
+    },
+    {
+      "path": "scripts/space_traversal/detectors/ci_cd_pipeline.py",
+      "size": 2720
+    },
+    {
+      "path": "scripts/space_traversal/detectors/code_quality_tooling.py",
+      "size": 3181
+    },
+    {
+      "path": "scripts/space_traversal/detectors/deployment_infrastructure.py",
+      "size": 2568
+    },
+    {
+      "path": "scripts/space_traversal/detectors/detector_duplication.py",
+      "size": 993
+    },
+    {
+      "path": "scripts/space_traversal/detectors/detector_peft.py",
+      "size": 1324
+    },
+    {
+      "path": "scripts/space_traversal/detectors/detector_safeguards.py",
+      "size": 1632
+    },
+    {
+      "path": "scripts/space_traversal/detectors/documentation_system.py",
+      "size": 2233
+    },
+    {
+      "path": "scripts/space_traversal/detectors/experiment_management.py",
+      "size": 2233
+    },
+    {
+      "path": "scripts/space_traversal/detectors/inference_serving.py",
+      "size": 1323
+    },
+    {
+      "path": "scripts/space_traversal/detectors/reproducibility.py",
+      "size": 2597
+    },
+    {
+      "path": "scripts/space_traversal/detectors/testing_infrastructure.py",
+      "size": 1907
+    },
+    {
+      "path": "scripts/space_traversal/detectors/unified_training.py",
+      "size": 911
+    },
+    {
+      "path": "scripts/space_traversal/detectors/vector_store_detector.py",
+      "size": 879
+    },
+    {
+      "path": "scripts/space_traversal/dup_similarity.py",
+      "size": 2912
+    },
+    {
+      "path": "scripts/space_traversal/status_update_report.py",
+      "size": 7373
+    },
+    {
+      "path": "scripts/space_traversal/synonym_loader.py",
+      "size": 3413
+    },
+    {
+      "path": "scripts/space_traversal/validators.py",
+      "size": 2153
+    },
+    {
+      "path": "scripts/status/collect_schema_results.py",
+      "size": 1869
+    },
+    {
+      "path": "scripts/status/generate_capability_matrix_md.py",
+      "size": 1481
+    },
+    {
+      "path": "scripts/status/render_full_markdown_report.py",
+      "size": 3805
+    },
+    {
+      "path": "scripts/status/render_html_report.py",
+      "size": 7763
+    },
+    {
+      "path": "scripts/status/render_markdown_report.py",
+      "size": 1142
+    },
+    {
+      "path": "scripts/status/render_monthly_html.py",
+      "size": 3937
+    },
+    {
+      "path": "scripts/status/screenshot_html.py",
+      "size": 1156
+    },
+    {
+      "path": "scripts/status/validate_and_publish.py",
+      "size": 1990
+    },
+    {
+      "path": "scripts/sync_zendesk_docs.py",
+      "size": 1038
+    },
+    {
+      "path": "scripts/torch_policy_check.py",
+      "size": 2703
+    },
+    {
+      "path": "scripts/train.py",
+      "size": 4803
+    },
+    {
+      "path": "scripts/validate_coverage_gates.py",
+      "size": 5150
+    },
+    {
+      "path": "scripts/zendesk_docs_catalog.py",
+      "size": 1033
+    },
+    {
+      "path": "scripts/zendesk_docs_fetch.py",
+      "size": 2722
+    },
+    {
+      "path": "sentencepiece/__init__.py",
+      "size": 1318
+    },
+    {
+      "path": "services/__init__.py",
+      "size": 28
+    },
+    {
+      "path": "services/api/__init__.py",
+      "size": 41
+    },
+    {
+      "path": "services/api/main.py",
+      "size": 19295
+    },
+    {
+      "path": "services/ita/app/__init__.py",
+      "size": 88
+    },
+    {
+      "path": "services/ita/app/git_ops.py",
+      "size": 1728
+    },
+    {
+      "path": "services/ita/app/hygiene.py",
+      "size": 3544
+    },
+    {
+      "path": "services/ita/app/knowledge_base.py",
+      "size": 2361
+    },
+    {
+      "path": "services/ita/app/main.py",
+      "size": 4834
+    },
+    {
+      "path": "services/ita/app/models.py",
+      "size": 3638
+    },
+    {
+      "path": "services/ita/app/security.py",
+      "size": 3429
+    },
+    {
+      "path": "services/ita/app/tests_runner.py",
+      "size": 2400
+    },
+    {
+      "path": "services/ita/scripts/issue_api_key.py",
+      "size": 763
+    },
+    {
+      "path": "services/ita/tests/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "services/ita/tests/test_contract.py",
+      "size": 2004
+    },
+    {
+      "path": "services/ita/tests/test_endpoints.py",
+      "size": 3003
+    },
+    {
+      "path": "services/msp_gateway/__init__.py",
+      "size": 90
+    },
+    {
+      "path": "services/msp_gateway/app.py",
+      "size": 3911
+    },
+    {
+      "path": "services/msp_gateway/config.py",
+      "size": 7790
+    },
+    {
+      "path": "services/msp_gateway/main.py",
+      "size": 954
+    },
+    {
+      "path": "services/msp_gateway/middleware/__init__.py",
+      "size": 285
+    },
+    {
+      "path": "services/msp_gateway/middleware/rate_limit.py",
+      "size": 12012
+    },
+    {
+      "path": "services/msp_gateway/middleware/tenant_context.py",
+      "size": 17161
+    },
+    {
+      "path": "services/msp_gateway/providers/__init__.py",
+      "size": 338
+    },
+    {
+      "path": "services/msp_gateway/providers/model_adapter.py",
+      "size": 5770
+    },
+    {
+      "path": "services/msp_gateway/providers/retrieval_adapter.py",
+      "size": 2457
+    },
+    {
+      "path": "services/msp_gateway/routers/__init__.py",
+      "size": 231
+    },
+    {
+      "path": "services/msp_gateway/routers/admin.py",
+      "size": 7134
+    },
+    {
+      "path": "services/msp_gateway/routers/infer.py",
+      "size": 8514
+    },
+    {
+      "path": "services/msp_gateway/routers/kb.py",
+      "size": 4874
+    },
+    {
+      "path": "services/msp_gateway/schemas/__init__.py",
+      "size": 607
+    },
+    {
+      "path": "services/msp_gateway/schemas/requests.py",
+      "size": 2591
+    },
+    {
+      "path": "services/msp_gateway/schemas/responses.py",
+      "size": 4145
+    },
+    {
+      "path": "services/msp_gateway/security.py",
+      "size": 6365
+    },
+    {
+      "path": "sitecustomize.py",
+      "size": 2833
+    },
+    {
+      "path": "src/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "src/cli.py",
+      "size": 7946
+    },
+    {
+      "path": "src/codex/__init__.py",
+      "size": 187
+    },
+    {
+      "path": "src/codex/_version.py",
+      "size": 324
+    },
+    {
+      "path": "src/codex/api/__init__.py",
+      "size": 97
+    },
+    {
+      "path": "src/codex/api/app.py",
+      "size": 887
+    },
+    {
+      "path": "src/codex/archive/__init__.py",
+      "size": 237
+    },
+    {
+      "path": "src/codex/archive/api.py",
+      "size": 4722
+    },
+    {
+      "path": "src/codex/archive/backend.py",
+      "size": 21372
+    },
+    {
+      "path": "src/codex/archive/batch.py",
+      "size": 7061
+    },
+    {
+      "path": "src/codex/archive/cli.py",
+      "size": 24266
+    },
+    {
+      "path": "src/codex/archive/config.py",
+      "size": 13852
+    },
+    {
+      "path": "src/codex/archive/consolidate.py",
+      "size": 6279
+    },
+    {
+      "path": "src/codex/archive/dal.py",
+      "size": 35671
+    },
+    {
+      "path": "src/codex/archive/detect.py",
+      "size": 1753
+    },
+    {
+      "path": "src/codex/archive/evidence_schema.py",
+      "size": 4065
+    },
+    {
+      "path": "src/codex/archive/logging_config.py",
+      "size": 5615
+    },
+    {
+      "path": "src/codex/archive/perf.py",
+      "size": 1929
+    },
+    {
+      "path": "src/codex/archive/plan.py",
+      "size": 2449
+    },
+    {
+      "path": "src/codex/archive/retry.py",
+      "size": 2566
+    },
+    {
+      "path": "src/codex/archive/schema.py",
+      "size": 9354
+    },
+    {
+      "path": "src/codex/archive/score.py",
+      "size": 618
+    },
+    {
+      "path": "src/codex/archive/service.py",
+      "size": 13038
+    },
+    {
+      "path": "src/codex/archive/shims.py",
+      "size": 1434
+    },
+    {
+      "path": "src/codex/archive/sigstore_client.py",
+      "size": 4573
+    },
+    {
+      "path": "src/codex/archive/similarity.py",
+      "size": 2738
+    },
+    {
+      "path": "src/codex/archive/standardization.py",
+      "size": 6157
+    },
+    {
+      "path": "src/codex/archive/stub.py",
+      "size": 752
+    },
+    {
+      "path": "src/codex/archive/util.py",
+      "size": 5091
+    },
+    {
+      "path": "src/codex/chat.py",
+      "size": 3110
+    },
+    {
+      "path": "src/codex/cli.py",
+      "size": 22248
+    },
+    {
+      "path": "src/codex/cli_archive.py",
+      "size": 12831
+    },
+    {
+      "path": "src/codex/cli_knowledge.py",
+      "size": 2482
+    },
+    {
+      "path": "src/codex/cli_maps.py",
+      "size": 640
+    },
+    {
+      "path": "src/codex/cli_qa.py",
+      "size": 1103
+    },
+    {
+      "path": "src/codex/cli_release.py",
+      "size": 2486
+    },
+    {
+      "path": "src/codex/cli_roles.py",
+      "size": 1415
+    },
+    {
+      "path": "src/codex/cli_zendesk.py",
+      "size": 26621
+    },
+    {
+      "path": "src/codex/db/sqlite_patch.py",
+      "size": 5973
+    },
+    {
+      "path": "src/codex/diagram/__init__.py",
+      "size": 141
+    },
+    {
+      "path": "src/codex/diagram/flows.py",
+      "size": 2110
+    },
+    {
+      "path": "src/codex/dynamics/__init__.py",
+      "size": 102
+    },
+    {
+      "path": "src/codex/dynamics/apply_logging.py",
+      "size": 3764
+    },
+    {
+      "path": "src/codex/dynamics/cli_d365.py",
+      "size": 4992
+    },
+    {
+      "path": "src/codex/dynamics/model/__init__.py",
+      "size": 225
+    },
+    {
+      "path": "src/codex/dynamics/model/choice.py",
+      "size": 924
+    },
+    {
+      "path": "src/codex/dynamics/model/role.py",
+      "size": 1055
+    },
+    {
+      "path": "src/codex/dynamics/role_matrix.py",
+      "size": 1299
+    },
+    {
+      "path": "src/codex/dynamics/solution_xml.py",
+      "size": 6789
+    },
+    {
+      "path": "src/codex/evidence.py",
+      "size": 1717
+    },
+    {
+      "path": "src/codex/evidence/__init__.py",
+      "size": 938
+    },
+    {
+      "path": "src/codex/evidence/core.py",
+      "size": 1053
+    },
+    {
+      "path": "src/codex/knowledge/__init__.py",
+      "size": 526
+    },
+    {
+      "path": "src/codex/knowledge/build.py",
+      "size": 4652
+    },
+    {
+      "path": "src/codex/knowledge/chunk.py",
+      "size": 1926
+    },
+    {
+      "path": "src/codex/knowledge/dedup.py",
+      "size": 1500
+    },
+    {
+      "path": "src/codex/knowledge/normalize.py",
+      "size": 1757
+    },
+    {
+      "path": "src/codex/knowledge/pii.py",
+      "size": 923
+    },
+    {
+      "path": "src/codex/knowledge/schema.py",
+      "size": 759
+    },
+    {
+      "path": "src/codex/logging/__init__.py",
+      "size": 556
+    },
+    {
+      "path": "src/codex/logging/config.py",
+      "size": 360
+    },
+    {
+      "path": "src/codex/logging/conversation_logger.py",
+      "size": 2961
+    },
+    {
+      "path": "src/codex/logging/db_utils.py",
+      "size": 4897
+    },
+    {
+      "path": "src/codex/logging/export.py",
+      "size": 4189
+    },
+    {
+      "path": "src/codex/logging/fetch_messages.py",
+      "size": 4560
+    },
+    {
+      "path": "src/codex/logging/import_ndjson.py",
+      "size": 8999
+    },
+    {
+      "path": "src/codex/logging/query_logs.py",
+      "size": 9234
+    },
+    {
+      "path": "src/codex/logging/session_hooks.py",
+      "size": 7647
+    },
+    {
+      "path": "src/codex/logging/session_logger.py",
+      "size": 14560
+    },
+    {
+      "path": "src/codex/logging/session_query.py",
+      "size": 7390
+    },
+    {
+      "path": "src/codex/logging/viewer.py",
+      "size": 8720
+    },
+    {
+      "path": "src/codex/mapping/__init__.py",
+      "size": 306
+    },
+    {
+      "path": "src/codex/mapping/load.py",
+      "size": 3031
+    },
+    {
+      "path": "src/codex/mapping/models.py",
+      "size": 720
+    },
+    {
+      "path": "src/codex/monitoring/__init__.py",
+      "size": 2432
+    },
+    {
+      "path": "src/codex/monkeypatch/log_adapters.py",
+      "size": 1877
+    },
+    {
+      "path": "src/codex/qa/__init__.py",
+      "size": 113
+    },
+    {
+      "path": "src/codex/qa/rubric.py",
+      "size": 2656
+    },
+    {
+      "path": "src/codex/rag/__init__.py",
+      "size": 333
+    },
+    {
+      "path": "src/codex/rag/postprocess.py",
+      "size": 5638
+    },
+    {
+      "path": "src/codex/rag/prompt.py",
+      "size": 11178
+    },
+    {
+      "path": "src/codex/release/__init__.py",
+      "size": 75
+    },
+    {
+      "path": "src/codex/release/api.py",
+      "size": 9726
+    },
+    {
+      "path": "src/codex/release/manifest.py",
+      "size": 3116
+    },
+    {
+      "path": "src/codex/retrieval/__init__.py",
+      "size": 449
+    },
+    {
+      "path": "src/codex/retrieval/embed.py",
+      "size": 4829
+    },
+    {
+      "path": "src/codex/retrieval/search.py",
+      "size": 5359
+    },
+    {
+      "path": "src/codex/retrieval/stores/__init__.py",
+      "size": 224
+    },
+    {
+      "path": "src/codex/retrieval/stores/faiss_store.py",
+      "size": 5460
+    },
+    {
+      "path": "src/codex/retrieval/stores/pgvector_store.py",
+      "size": 1453
+    },
+    {
+      "path": "src/codex/retrieval/stores/weaviate_store.py",
+      "size": 1465
+    },
+    {
+      "path": "src/codex/search/__init__.py",
+      "size": 278
+    },
+    {
+      "path": "src/codex/search/providers.py",
+      "size": 3903
+    },
+    {
+      "path": "src/codex/training.py",
+      "size": 38470
+    },
+    {
+      "path": "src/codex/utils/__init__.py",
+      "size": 33
+    },
+    {
+      "path": "src/codex/utils/context_discovery.py",
+      "size": 4755
+    },
+    {
+      "path": "src/codex/utils/session_cache.py",
+      "size": 5542
+    },
+    {
+      "path": "src/codex/utils/subprocess.py",
+      "size": 719
+    },
+    {
+      "path": "src/codex/utils/validators.py",
+      "size": 7071
+    },
+    {
+      "path": "src/codex/versioning.py",
+      "size": 2434
+    },
+    {
+      "path": "src/codex/zendesk/__init__.py",
+      "size": 321
+    },
+    {
+      "path": "src/codex/zendesk/apply.py",
+      "size": 16765
+    },
+    {
+      "path": "src/codex/zendesk/model/__init__.py",
+      "size": 1077
+    },
+    {
+      "path": "src/codex/zendesk/model/app.py",
+      "size": 1150
+    },
+    {
+      "path": "src/codex/zendesk/model/field.py",
+      "size": 2260
+    },
+    {
+      "path": "src/codex/zendesk/model/group.py",
+      "size": 1752
+    },
+    {
+      "path": "src/codex/zendesk/model/guide.py",
+      "size": 1177
+    },
+    {
+      "path": "src/codex/zendesk/model/macro.py",
+      "size": 1532
+    },
+    {
+      "path": "src/codex/zendesk/model/role.py",
+      "size": 986
+    },
+    {
+      "path": "src/codex/zendesk/model/routing.py",
+      "size": 2134
+    },
+    {
+      "path": "src/codex/zendesk/model/sla.py",
+      "size": 1020
+    },
+    {
+      "path": "src/codex/zendesk/model/talk.py",
+      "size": 2352
+    },
+    {
+      "path": "src/codex/zendesk/model/trigger.py",
+      "size": 3160
+    },
+    {
+      "path": "src/codex/zendesk/model/view.py",
+      "size": 1375
+    },
+    {
+      "path": "src/codex/zendesk/model/webhook.py",
+      "size": 1680
+    },
+    {
+      "path": "src/codex/zendesk/model/widget.py",
+      "size": 1199
+    },
+    {
+      "path": "src/codex/zendesk/monitoring/__init__.py",
+      "size": 180
+    },
+    {
+      "path": "src/codex/zendesk/monitoring/registry.py",
+      "size": 309
+    },
+    {
+      "path": "src/codex/zendesk/monitoring/zendesk_metrics.py",
+      "size": 1509
+    },
+    {
+      "path": "src/codex/zendesk/plan/__init__.py",
+      "size": 235
+    },
+    {
+      "path": "src/codex/zendesk/plan/diff_engine.py",
+      "size": 6488
+    },
+    {
+      "path": "src/codex/zendesk/plan/validators.py",
+      "size": 2651
+    },
+    {
+      "path": "src/codex_bridge/__init__.py",
+      "size": 13
+    },
+    {
+      "path": "src/codex_bridge/github_client.py",
+      "size": 3479
+    },
+    {
+      "path": "src/codex_cli/__init__.py",
+      "size": 84
+    },
+    {
+      "path": "src/codex_cli/app.py",
+      "size": 15195
+    },
+    {
+      "path": "src/codex_crm/__init__.py",
+      "size": 241
+    },
+    {
+      "path": "src/codex_crm/cdm/__init__.py",
+      "size": 123
+    },
+    {
+      "path": "src/codex_crm/cdm/loader.py",
+      "size": 2635
+    },
+    {
+      "path": "src/codex_crm/cli.py",
+      "size": 3953
+    },
+    {
+      "path": "src/codex_crm/convert/__init__.py",
+      "size": 330
+    },
+    {
+      "path": "src/codex_crm/convert/rules.py",
+      "size": 2953
+    },
+    {
+      "path": "src/codex_crm/d365_admin/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "src/codex_crm/d365_admin/generate.py",
+      "size": 2083
+    },
+    {
+      "path": "src/codex_crm/diagram/__init__.py",
+      "size": 220
+    },
+    {
+      "path": "src/codex_crm/diagram/flows.py",
+      "size": 1389
+    },
+    {
+      "path": "src/codex_crm/evidence/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "src/codex_crm/evidence/emit.py",
+      "size": 1815
+    },
+    {
+      "path": "src/codex_crm/pa_legacy/__init__.py",
+      "size": 262
+    },
+    {
+      "path": "src/codex_crm/pa_legacy/reader.py",
+      "size": 1769
+    },
+    {
+      "path": "src/codex_crm/zaf_legacy/__init__.py",
+      "size": 258
+    },
+    {
+      "path": "src/codex_crm/zaf_legacy/reader.py",
+      "size": 5306
+    },
+    {
+      "path": "src/codex_crm/zd_admin/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "src/codex_crm/zd_admin/generate.py",
+      "size": 1718
+    },
+    {
+      "path": "src/codex_ml/__init__.py",
+      "size": 5384
+    },
+    {
+      "path": "src/codex_ml/__main__.py",
+      "size": 181
+    },
+    {
+      "path": "src/codex_ml/_package_main.py",
+      "size": 882
+    },
+    {
+      "path": "src/codex_ml/analysis/__init__.py",
+      "size": 157
+    },
+    {
+      "path": "src/codex_ml/analysis/extractors.py",
+      "size": 4354
+    },
+    {
+      "path": "src/codex_ml/analysis/metrics.py",
+      "size": 614
+    },
+    {
+      "path": "src/codex_ml/analysis/parsers.py",
+      "size": 1430
+    },
+    {
+      "path": "src/codex_ml/analysis/providers.py",
+      "size": 10422
+    },
+    {
+      "path": "src/codex_ml/analysis/registry.py",
+      "size": 1041
+    },
+    {
+      "path": "src/codex_ml/callbacks/__init__.py",
+      "size": 376
+    },
+    {
+      "path": "src/codex_ml/callbacks/base.py",
+      "size": 3750
+    },
+    {
+      "path": "src/codex_ml/callbacks/ndjson_logger.py",
+      "size": 787
+    },
+    {
+      "path": "src/codex_ml/callbacks/system_metrics.py",
+      "size": 2442
+    },
+    {
+      "path": "src/codex_ml/checkpointing/__init__.py",
+      "size": 189
+    },
+    {
+      "path": "src/codex_ml/checkpointing/atomic_io.py",
+      "size": 1902
+    },
+    {
+      "path": "src/codex_ml/checkpointing/checkpoint_core.py",
+      "size": 3301
+    },
+    {
+      "path": "src/codex_ml/checkpointing/compat.py",
+      "size": 949
+    },
+    {
+      "path": "src/codex_ml/checkpointing/schema_v2.py",
+      "size": 3232
+    },
+    {
+      "path": "src/codex_ml/cli/__init__.py",
+      "size": 9267
+    },
+    {
+      "path": "src/codex_ml/cli/__main__.py",
+      "size": 123
+    },
+    {
+      "path": "src/codex_ml/cli/audit_pipeline.py",
+      "size": 8513
+    },
+    {
+      "path": "src/codex_ml/cli/checkpoint_validate.py",
+      "size": 6191
+    },
+    {
+      "path": "src/codex_ml/cli/codex_cli.py",
+      "size": 17692
+    },
+    {
+      "path": "src/codex_ml/cli/config.py",
+      "size": 7315
+    },
+    {
+      "path": "src/codex_ml/cli/deploy.py",
+      "size": 3017
+    },
+    {
+      "path": "src/codex_ml/cli/detectors.py",
+      "size": 810
+    },
+    {
+      "path": "src/codex_ml/cli/entrypoints.py",
+      "size": 8885
+    },
+    {
+      "path": "src/codex_ml/cli/evaluate.py",
+      "size": 10235
+    },
+    {
+      "path": "src/codex_ml/cli/generate.py",
+      "size": 5811
+    },
+    {
+      "path": "src/codex_ml/cli/hydra_audit.py",
+      "size": 13227
+    },
+    {
+      "path": "src/codex_ml/cli/hydra_entry.py",
+      "size": 5532
+    },
+    {
+      "path": "src/codex_ml/cli/hydra_main.py",
+      "size": 9845
+    },
+    {
+      "path": "src/codex_ml/cli/infer.py",
+      "size": 8898
+    },
+    {
+      "path": "src/codex_ml/cli/list_plugins.py",
+      "size": 8043
+    },
+    {
+      "path": "src/codex_ml/cli/main.py",
+      "size": 26722
+    },
+    {
+      "path": "src/codex_ml/cli/manifest.py",
+      "size": 2193
+    },
+    {
+      "path": "src/codex_ml/cli/metrics_cli.py",
+      "size": 19361
+    },
+    {
+      "path": "src/codex_ml/cli/ndjson_summary.py",
+      "size": 13134
+    },
+    {
+      "path": "src/codex_ml/cli/offline_bootstrap.py",
+      "size": 4365
+    },
+    {
+      "path": "src/codex_ml/cli/plugins_cli.py",
+      "size": 5194
+    },
+    {
+      "path": "src/codex_ml/cli/repo_map.py",
+      "size": 10375
+    },
+    {
+      "path": "src/codex_ml/cli/simple_cli.py",
+      "size": 4777
+    },
+    {
+      "path": "src/codex_ml/cli/status_report.py",
+      "size": 2149
+    },
+    {
+      "path": "src/codex_ml/cli/tokenizer.py",
+      "size": 3907
+    },
+    {
+      "path": "src/codex_ml/cli/tracking_cli.py",
+      "size": 3419
+    },
+    {
+      "path": "src/codex_ml/cli/tracking_decide.py",
+      "size": 5358
+    },
+    {
+      "path": "src/codex_ml/cli/train.py",
+      "size": 16745
+    },
+    {
+      "path": "src/codex_ml/cli/validate.py",
+      "size": 7230
+    },
+    {
+      "path": "src/codex_ml/codex_structured_logging.py",
+      "size": 13091
+    },
+    {
+      "path": "src/codex_ml/config/__init__.py",
+      "size": 31439
+    },
+    {
+      "path": "src/codex_ml/config/settings.py",
+      "size": 1499
+    },
+    {
+      "path": "src/codex_ml/config_schema.py",
+      "size": 8782
+    },
+    {
+      "path": "src/codex_ml/configs/__init__.py",
+      "size": 384
+    },
+    {
+      "path": "src/codex_ml/configs/training/__init__.py",
+      "size": 59
+    },
+    {
+      "path": "src/codex_ml/connectors/__init__.py",
+      "size": 292
+    },
+    {
+      "path": "src/codex_ml/connectors/base.py",
+      "size": 4779
+    },
+    {
+      "path": "src/codex_ml/connectors/local.py",
+      "size": 548
+    },
+    {
+      "path": "src/codex_ml/connectors/registry.py",
+      "size": 674
+    },
+    {
+      "path": "src/codex_ml/connectors/remote.py",
+      "size": 3995
+    },
+    {
+      "path": "src/codex_ml/data/__init__.py",
+      "size": 1347
+    },
+    {
+      "path": "src/codex_ml/data/cache.py",
+      "size": 5051
+    },
+    {
+      "path": "src/codex_ml/data/checksums.py",
+      "size": 1526
+    },
+    {
+      "path": "src/codex_ml/data/cli.py",
+      "size": 1497
+    },
+    {
+      "path": "src/codex_ml/data/datamodule.py",
+      "size": 5997
+    },
+    {
+      "path": "src/codex_ml/data/dataset_wrapper.py",
+      "size": 2341
+    },
+    {
+      "path": "src/codex_ml/data/hf_datasets.py",
+      "size": 1982
+    },
+    {
+      "path": "src/codex_ml/data/integrity.py",
+      "size": 944
+    },
+    {
+      "path": "src/codex_ml/data/jsonl_loader.py",
+      "size": 1955
+    },
+    {
+      "path": "src/codex_ml/data/jsonl_stream.py",
+      "size": 1669
+    },
+    {
+      "path": "src/codex_ml/data/loader.py",
+      "size": 17103
+    },
+    {
+      "path": "src/codex_ml/data/loaders.py",
+      "size": 21134
+    },
+    {
+      "path": "src/codex_ml/data/loaders/csv.py",
+      "size": 3566
+    },
+    {
+      "path": "src/codex_ml/data/loaders/jsonl.py",
+      "size": 4347
+    },
+    {
+      "path": "src/codex_ml/data/local_files.py",
+      "size": 4608
+    },
+    {
+      "path": "src/codex_ml/data/make_splits.py",
+      "size": 2157
+    },
+    {
+      "path": "src/codex_ml/data/reasoning_manifest.py",
+      "size": 10063
+    },
+    {
+      "path": "src/codex_ml/data/registry.py",
+      "size": 11576
+    },
+    {
+      "path": "src/codex_ml/data/sharding.py",
+      "size": 342
+    },
+    {
+      "path": "src/codex_ml/data/split.py",
+      "size": 7174
+    },
+    {
+      "path": "src/codex_ml/data/split_utils.py",
+      "size": 5036
+    },
+    {
+      "path": "src/codex_ml/data/splits.py",
+      "size": 2207
+    },
+    {
+      "path": "src/codex_ml/data/streaming.py",
+      "size": 1770
+    },
+    {
+      "path": "src/codex_ml/data_utils.py",
+      "size": 6622
+    },
+    {
+      "path": "src/codex_ml/deployment/__init__.py",
+      "size": 142
+    },
+    {
+      "path": "src/codex_ml/deployment/cloud.py",
+      "size": 2621
+    },
+    {
+      "path": "src/codex_ml/detectors/__init__.py",
+      "size": 197
+    },
+    {
+      "path": "src/codex_ml/detectors/aggregate.py",
+      "size": 760
+    },
+    {
+      "path": "src/codex_ml/detectors/core.py",
+      "size": 344
+    },
+    {
+      "path": "src/codex_ml/detectors/unified_training.py",
+      "size": 349
+    },
+    {
+      "path": "src/codex_ml/distributed/__init__.py",
+      "size": 296
+    },
+    {
+      "path": "src/codex_ml/distributed/minimal.py",
+      "size": 4944
+    },
+    {
+      "path": "src/codex_ml/eval/__init__.py",
+      "size": 607
+    },
+    {
+      "path": "src/codex_ml/eval/datasets.py",
+      "size": 9197
+    },
+    {
+      "path": "src/codex_ml/eval/eval_runner.py",
+      "size": 6208
+    },
+    {
+      "path": "src/codex_ml/eval/evaluator.py",
+      "size": 54047
+    },
+    {
+      "path": "src/codex_ml/eval/fallback.py",
+      "size": 3564
+    },
+    {
+      "path": "src/codex_ml/eval/metrics.py",
+      "size": 12913
+    },
+    {
+      "path": "src/codex_ml/eval/run_eval.py",
+      "size": 3061
+    },
+    {
+      "path": "src/codex_ml/eval/runner.py",
+      "size": 33401
+    },
+    {
+      "path": "src/codex_ml/hf_loader.py",
+      "size": 11313
+    },
+    {
+      "path": "src/codex_ml/ingest.py",
+      "size": 9933
+    },
+    {
+      "path": "src/codex_ml/interfaces/__init__.py",
+      "size": 2312
+    },
+    {
+      "path": "src/codex_ml/interfaces/peft_hooks.py",
+      "size": 2273
+    },
+    {
+      "path": "src/codex_ml/interfaces/registry.py",
+      "size": 5019
+    },
+    {
+      "path": "src/codex_ml/interfaces/reward_model.py",
+      "size": 6499
+    },
+    {
+      "path": "src/codex_ml/interfaces/rl.py",
+      "size": 5739
+    },
+    {
+      "path": "src/codex_ml/interfaces/tokenizer.py",
+      "size": 25409
+    },
+    {
+      "path": "src/codex_ml/interfaces/tokenizer_hf.py",
+      "size": 486
+    },
+    {
+      "path": "src/codex_ml/io/atomic.py",
+      "size": 2321
+    },
+    {
+      "path": "src/codex_ml/logging/__init__.py",
+      "size": 1242
+    },
+    {
+      "path": "src/codex_ml/logging/file_logger.py",
+      "size": 3587
+    },
+    {
+      "path": "src/codex_ml/logging/ndjson_logger.py",
+      "size": 7612
+    },
+    {
+      "path": "src/codex_ml/logging/run_logger.py",
+      "size": 8270
+    },
+    {
+      "path": "src/codex_ml/logging/run_metadata.py",
+      "size": 3710
+    },
+    {
+      "path": "src/codex_ml/logging/session_logger.py",
+      "size": 1661
+    },
+    {
+      "path": "src/codex_ml/logging/structured.py",
+      "size": 1557
+    },
+    {
+      "path": "src/codex_ml/main.py",
+      "size": 2946
+    },
+    {
+      "path": "src/codex_ml/metrics.py",
+      "size": 269
+    },
+    {
+      "path": "src/codex_ml/metrics/__init__.py",
+      "size": 331
+    },
+    {
+      "path": "src/codex_ml/metrics/_optional_bleu_rouge.py",
+      "size": 3281
+    },
+    {
+      "path": "src/codex_ml/metrics/api.py",
+      "size": 455
+    },
+    {
+      "path": "src/codex_ml/metrics/curves.py",
+      "size": 795
+    },
+    {
+      "path": "src/codex_ml/metrics/evaluator.py",
+      "size": 1930
+    },
+    {
+      "path": "src/codex_ml/metrics/registry.py",
+      "size": 14432
+    },
+    {
+      "path": "src/codex_ml/metrics/sinks.py",
+      "size": 2678
+    },
+    {
+      "path": "src/codex_ml/metrics/text.py",
+      "size": 967
+    },
+    {
+      "path": "src/codex_ml/metrics/writers.py",
+      "size": 3747
+    },
+    {
+      "path": "src/codex_ml/metrics_base.py",
+      "size": 2070
+    },
+    {
+      "path": "src/codex_ml/model_registry.py",
+      "size": 12352
+    },
+    {
+      "path": "src/codex_ml/modeling/__init__.py",
+      "size": 1933
+    },
+    {
+      "path": "src/codex_ml/modeling/codex_model.py",
+      "size": 7450
+    },
+    {
+      "path": "src/codex_ml/modeling/codex_model_loader.py",
+      "size": 5391
+    },
+    {
+      "path": "src/codex_ml/modeling/factory.py",
+      "size": 3206
+    },
+    {
+      "path": "src/codex_ml/models/__init__.py",
+      "size": 2460
+    },
+    {
+      "path": "src/codex_ml/models/activations.py",
+      "size": 887
+    },
+    {
+      "path": "src/codex_ml/models/decoder_only.py",
+      "size": 8879
+    },
+    {
+      "path": "src/codex_ml/models/factory.py",
+      "size": 5921
+    },
+    {
+      "path": "src/codex_ml/models/generate.py",
+      "size": 2174
+    },
+    {
+      "path": "src/codex_ml/models/loader_registry.py",
+      "size": 1495
+    },
+    {
+      "path": "src/codex_ml/models/minilm.py",
+      "size": 3103
+    },
+    {
+      "path": "src/codex_ml/models/offline_tiny.py",
+      "size": 1779
+    },
+    {
+      "path": "src/codex_ml/models/peft_hooks.py",
+      "size": 1102
+    },
+    {
+      "path": "src/codex_ml/models/reasoning.py",
+      "size": 11658
+    },
+    {
+      "path": "src/codex_ml/models/registry.py",
+      "size": 9937
+    },
+    {
+      "path": "src/codex_ml/models/utils/__init__.py",
+      "size": 150
+    },
+    {
+      "path": "src/codex_ml/models/utils/peft.py",
+      "size": 1815
+    },
+    {
+      "path": "src/codex_ml/monitoring/__init__.py",
+      "size": 339
+    },
+    {
+      "path": "src/codex_ml/monitoring/_logger_types.py",
+      "size": 1687
+    },
+    {
+      "path": "src/codex_ml/monitoring/async_writer.py",
+      "size": 4338
+    },
+    {
+      "path": "src/codex_ml/monitoring/cli.py",
+      "size": 2855
+    },
+    {
+      "path": "src/codex_ml/monitoring/codex_logging.py",
+      "size": 28186
+    },
+    {
+      "path": "src/codex_ml/monitoring/health.py",
+      "size": 4090
+    },
+    {
+      "path": "src/codex_ml/monitoring/metrics_export.py",
+      "size": 1310
+    },
+    {
+      "path": "src/codex_ml/monitoring/microhelpers.py",
+      "size": 4585
+    },
+    {
+      "path": "src/codex_ml/monitoring/mlflow_utils.py",
+      "size": 2388
+    },
+    {
+      "path": "src/codex_ml/monitoring/prometheus.py",
+      "size": 3628
+    },
+    {
+      "path": "src/codex_ml/monitoring/prometheus_metrics.py",
+      "size": 5240
+    },
+    {
+      "path": "src/codex_ml/monitoring/schema.py",
+      "size": 1660
+    },
+    {
+      "path": "src/codex_ml/monitoring/system_metrics.py",
+      "size": 25952
+    },
+    {
+      "path": "src/codex_ml/monitoring/tb_writer.py",
+      "size": 1509
+    },
+    {
+      "path": "src/codex_ml/monitoring/tracking.py",
+      "size": 3992
+    },
+    {
+      "path": "src/codex_ml/peft/__init__.py",
+      "size": 12
+    },
+    {
+      "path": "src/codex_ml/peft/peft_adapter.py",
+      "size": 5527
+    },
+    {
+      "path": "src/codex_ml/perf/__init__.py",
+      "size": 147
+    },
+    {
+      "path": "src/codex_ml/perf/bench.py",
+      "size": 5415
+    },
+    {
+      "path": "src/codex_ml/perf/profiler.py",
+      "size": 1537
+    },
+    {
+      "path": "src/codex_ml/pipeline.py",
+      "size": 26251
+    },
+    {
+      "path": "src/codex_ml/plugins/__init__.py",
+      "size": 4481
+    },
+    {
+      "path": "src/codex_ml/plugins/base.py",
+      "size": 900
+    },
+    {
+      "path": "src/codex_ml/plugins/loader.py",
+      "size": 3216
+    },
+    {
+      "path": "src/codex_ml/plugins/programmatic.py",
+      "size": 3135
+    },
+    {
+      "path": "src/codex_ml/plugins/registries.py",
+      "size": 25186
+    },
+    {
+      "path": "src/codex_ml/plugins/registry.py",
+      "size": 6879
+    },
+    {
+      "path": "src/codex_ml/registry.py",
+      "size": 236
+    },
+    {
+      "path": "src/codex_ml/registry/__init__.py",
+      "size": 4632
+    },
+    {
+      "path": "src/codex_ml/registry/base.py",
+      "size": 7784
+    },
+    {
+      "path": "src/codex_ml/registry/data_loaders.py",
+      "size": 459
+    },
+    {
+      "path": "src/codex_ml/registry/metrics.py",
+      "size": 265
+    },
+    {
+      "path": "src/codex_ml/registry/models.py",
+      "size": 255
+    },
+    {
+      "path": "src/codex_ml/registry/token_cache.py",
+      "size": 1467
+    },
+    {
+      "path": "src/codex_ml/registry/tokenizers.py",
+      "size": 10323
+    },
+    {
+      "path": "src/codex_ml/registry/trainers.py",
+      "size": 1356
+    },
+    {
+      "path": "src/codex_ml/reward_models/__init__.py",
+      "size": 310
+    },
+    {
+      "path": "src/codex_ml/reward_models/rlhf.py",
+      "size": 9472
+    },
+    {
+      "path": "src/codex_ml/reward_models/simple.py",
+      "size": 1208
+    },
+    {
+      "path": "src/codex_ml/rl/__init__.py",
+      "size": 172
+    },
+    {
+      "path": "src/codex_ml/rl/scripted_agent.py",
+      "size": 2239
+    },
+    {
+      "path": "src/codex_ml/rl/simple_agent.py",
+      "size": 781
+    },
+    {
+      "path": "src/codex_ml/safety/__init__.py",
+      "size": 1392
+    },
+    {
+      "path": "src/codex_ml/safety/filters.py",
+      "size": 35807
+    },
+    {
+      "path": "src/codex_ml/safety/moderation.py",
+      "size": 10690
+    },
+    {
+      "path": "src/codex_ml/safety/redaction.py",
+      "size": 3067
+    },
+    {
+      "path": "src/codex_ml/safety/risk_score.py",
+      "size": 1858
+    },
+    {
+      "path": "src/codex_ml/safety/sandbox.py",
+      "size": 2683
+    },
+    {
+      "path": "src/codex_ml/safety/sanitizers.py",
+      "size": 3890
+    },
+    {
+      "path": "src/codex_ml/symbolic_pipeline.py",
+      "size": 17373
+    },
+    {
+      "path": "src/codex_ml/telemetry/__init__.py",
+      "size": 333
+    },
+    {
+      "path": "src/codex_ml/telemetry/metrics.py",
+      "size": 1243
+    },
+    {
+      "path": "src/codex_ml/telemetry/server.py",
+      "size": 948
+    },
+    {
+      "path": "src/codex_ml/tokenization/__init__.py",
+      "size": 515
+    },
+    {
+      "path": "src/codex_ml/tokenization/adapter.py",
+      "size": 19030
+    },
+    {
+      "path": "src/codex_ml/tokenization/api.py",
+      "size": 5027
+    },
+    {
+      "path": "src/codex_ml/tokenization/cli.py",
+      "size": 4789
+    },
+    {
+      "path": "src/codex_ml/tokenization/compat.py",
+      "size": 731
+    },
+    {
+      "path": "src/codex_ml/tokenization/hf_adapter.py",
+      "size": 2757
+    },
+    {
+      "path": "src/codex_ml/tokenization/hf_tokenizer.py",
+      "size": 12052
+    },
+    {
+      "path": "src/codex_ml/tokenization/offline_vocab.py",
+      "size": 2177
+    },
+    {
+      "path": "src/codex_ml/tokenization/pipeline.py",
+      "size": 8151
+    },
+    {
+      "path": "src/codex_ml/tokenization/sentencepiece_adapter.py",
+      "size": 9149
+    },
+    {
+      "path": "src/codex_ml/tokenization/sp_trainer.py",
+      "size": 6554
+    },
+    {
+      "path": "src/codex_ml/tokenization/train_tokenizer.py",
+      "size": 1648
+    },
+    {
+      "path": "src/codex_ml/tracking/__init__.py",
+      "size": 1257
+    },
+    {
+      "path": "src/codex_ml/tracking/cli.py",
+      "size": 999
+    },
+    {
+      "path": "src/codex_ml/tracking/git_tag.py",
+      "size": 1115
+    },
+    {
+      "path": "src/codex_ml/tracking/guards.py",
+      "size": 8886
+    },
+    {
+      "path": "src/codex_ml/tracking/init_experiment.py",
+      "size": 12205
+    },
+    {
+      "path": "src/codex_ml/tracking/init_offline.py",
+      "size": 884
+    },
+    {
+      "path": "src/codex_ml/tracking/mlflow_guard.py",
+      "size": 8653
+    },
+    {
+      "path": "src/codex_ml/tracking/mlflow_utils.py",
+      "size": 15552
+    },
+    {
+      "path": "src/codex_ml/tracking/offline.py",
+      "size": 5011
+    },
+    {
+      "path": "src/codex_ml/tracking/writers.py",
+      "size": 26848
+    },
+    {
+      "path": "src/codex_ml/train_loop.py",
+      "size": 78412
+    },
+    {
+      "path": "src/codex_ml/training.py",
+      "size": 2271
+    },
+    {
+      "path": "src/codex_ml/training/__init__.py",
+      "size": 1702
+    },
+    {
+      "path": "src/codex_ml/training/callbacks.py",
+      "size": 1307
+    },
+    {
+      "path": "src/codex_ml/training/dataloader_utils.py",
+      "size": 1180
+    },
+    {
+      "path": "src/codex_ml/training/dp_config.py",
+      "size": 2288
+    },
+    {
+      "path": "src/codex_ml/training/engine.py",
+      "size": 7771
+    },
+    {
+      "path": "src/codex_ml/training/eval.py",
+      "size": 3392
+    },
+    {
+      "path": "src/codex_ml/training/functional_training.py",
+      "size": 20302
+    },
+    {
+      "path": "src/codex_ml/training/legacy_api.py",
+      "size": 59827
+    },
+    {
+      "path": "src/codex_ml/training/strategies.py",
+      "size": 17238
+    },
+    {
+      "path": "src/codex_ml/training/toy_trainer.py",
+      "size": 1913
+    },
+    {
+      "path": "src/codex_ml/training/unified_training.py",
+      "size": 16362
+    },
+    {
+      "path": "src/codex_ml/utils/__init__.py",
+      "size": 1131
+    },
+    {
+      "path": "src/codex_ml/utils/artifacts.py",
+      "size": 1558
+    },
+    {
+      "path": "src/codex_ml/utils/atomic_io.py",
+      "size": 1422
+    },
+    {
+      "path": "src/codex_ml/utils/checkpoint.py",
+      "size": 19288
+    },
+    {
+      "path": "src/codex_ml/utils/checkpoint_core.py",
+      "size": 18791
+    },
+    {
+      "path": "src/codex_ml/utils/checkpoint_event.py",
+      "size": 1915
+    },
+    {
+      "path": "src/codex_ml/utils/checkpoint_integrity.py",
+      "size": 7437
+    },
+    {
+      "path": "src/codex_ml/utils/checkpoint_manager.py",
+      "size": 2238
+    },
+    {
+      "path": "src/codex_ml/utils/checkpoint_retention.py",
+      "size": 2973
+    },
+    {
+      "path": "src/codex_ml/utils/checkpointing.py",
+      "size": 44431
+    },
+    {
+      "path": "src/codex_ml/utils/checksum.py",
+      "size": 1074
+    },
+    {
+      "path": "src/codex_ml/utils/checksums.py",
+      "size": 501
+    },
+    {
+      "path": "src/codex_ml/utils/config_loader.py",
+      "size": 12018
+    },
+    {
+      "path": "src/codex_ml/utils/determinism.py",
+      "size": 4141
+    },
+    {
+      "path": "src/codex_ml/utils/env.py",
+      "size": 1476
+    },
+    {
+      "path": "src/codex_ml/utils/error_log.py",
+      "size": 1579
+    },
+    {
+      "path": "src/codex_ml/utils/errors.py",
+      "size": 856
+    },
+    {
+      "path": "src/codex_ml/utils/experiment_tracking_mlflow.py",
+      "size": 5329
+    },
+    {
+      "path": "src/codex_ml/utils/hf_pinning.py",
+      "size": 3421
+    },
+    {
+      "path": "src/codex_ml/utils/hf_revision.py",
+      "size": 677
+    },
+    {
+      "path": "src/codex_ml/utils/jsonio.py",
+      "size": 899
+    },
+    {
+      "path": "src/codex_ml/utils/jsonl.py",
+      "size": 411
+    },
+    {
+      "path": "src/codex_ml/utils/logging_mlflow.py",
+      "size": 1811
+    },
+    {
+      "path": "src/codex_ml/utils/logging_wandb.py",
+      "size": 1996
+    },
+    {
+      "path": "src/codex_ml/utils/mlflow_entrypoints.py",
+      "size": 573
+    },
+    {
+      "path": "src/codex_ml/utils/modeling.py",
+      "size": 16081
+    },
+    {
+      "path": "src/codex_ml/utils/opt_import.py",
+      "size": 110
+    },
+    {
+      "path": "src/codex_ml/utils/optional.py",
+      "size": 1029
+    },
+    {
+      "path": "src/codex_ml/utils/optional_dependencies.py",
+      "size": 1005
+    },
+    {
+      "path": "src/codex_ml/utils/provenance.py",
+      "size": 11262
+    },
+    {
+      "path": "src/codex_ml/utils/repro.py",
+      "size": 2870
+    },
+    {
+      "path": "src/codex_ml/utils/retention.py",
+      "size": 5274
+    },
+    {
+      "path": "src/codex_ml/utils/run_metadata.py",
+      "size": 1721
+    },
+    {
+      "path": "src/codex_ml/utils/runmeta.py",
+      "size": 2363
+    },
+    {
+      "path": "src/codex_ml/utils/seed.py",
+      "size": 1181
+    },
+    {
+      "path": "src/codex_ml/utils/seeding.py",
+      "size": 1966
+    },
+    {
+      "path": "src/codex_ml/utils/subproc.py",
+      "size": 3560
+    },
+    {
+      "path": "src/codex_ml/utils/system_metrics.py",
+      "size": 2681
+    },
+    {
+      "path": "src/codex_ml/utils/tensorboard_logger.py",
+      "size": 2965
+    },
+    {
+      "path": "src/codex_ml/utils/torch_checks.py",
+      "size": 3985
+    },
+    {
+      "path": "src/codex_ml/utils/torch_det.py",
+      "size": 288
+    },
+    {
+      "path": "src/codex_ml/utils/tracking_bootstrap.py",
+      "size": 1659
+    },
+    {
+      "path": "src/codex_ml/utils/train_helpers.py",
+      "size": 3193
+    },
+    {
+      "path": "src/codex_ml/utils/yaml_support.py",
+      "size": 2030
+    },
+    {
+      "path": "src/codex_utils/__init__.py",
+      "size": 1232
+    },
+    {
+      "path": "src/codex_utils/regex_patterns.py",
+      "size": 244
+    },
+    {
+      "path": "src/codex_utils/tracking/__init__.py",
+      "size": 394
+    },
+    {
+      "path": "src/codex_utils/tracking/guards.py",
+      "size": 402
+    },
+    {
+      "path": "src/common/__init__.py",
+      "size": 56
+    },
+    {
+      "path": "src/common/hooks.py",
+      "size": 4743
+    },
+    {
+      "path": "src/common/mlflow_guard.py",
+      "size": 4469
+    },
+    {
+      "path": "src/common/ndjson_tools.py",
+      "size": 2498
+    },
+    {
+      "path": "src/common/provenance.py",
+      "size": 4260
+    },
+    {
+      "path": "src/common/randomness.py",
+      "size": 2318
+    },
+    {
+      "path": "src/common/registry.py",
+      "size": 1561
+    },
+    {
+      "path": "src/common/validate.py",
+      "size": 2898
+    },
+    {
+      "path": "src/data/__init__.py",
+      "size": 523
+    },
+    {
+      "path": "src/data/datasets.py",
+      "size": 9485
+    },
+    {
+      "path": "src/data/loaders.py",
+      "size": 1071
+    },
+    {
+      "path": "src/data/manifest.py",
+      "size": 3624
+    },
+    {
+      "path": "src/data/registry.py",
+      "size": 4877
+    },
+    {
+      "path": "src/evaluation/__init__.py",
+      "size": 366
+    },
+    {
+      "path": "src/evaluation/metrics.py",
+      "size": 3355
+    },
+    {
+      "path": "src/evaluation/writers.py",
+      "size": 1818
+    },
+    {
+      "path": "src/experiments/__init__.py",
+      "size": 37
+    },
+    {
+      "path": "src/experiments/manager.py",
+      "size": 976
+    },
+    {
+      "path": "src/hhg_logistics/__init__.py",
+      "size": 115
+    },
+    {
+      "path": "src/hhg_logistics/data/prepare.py",
+      "size": 4043
+    },
+    {
+      "path": "src/hhg_logistics/eval/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "src/hhg_logistics/eval/harness.py",
+      "size": 2278
+    },
+    {
+      "path": "src/hhg_logistics/main.py",
+      "size": 729
+    },
+    {
+      "path": "src/hhg_logistics/model/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "src/hhg_logistics/model/adapters.py",
+      "size": 797
+    },
+    {
+      "path": "src/hhg_logistics/model/peft_utils.py",
+      "size": 6718
+    },
+    {
+      "path": "src/hhg_logistics/monitor/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "src/hhg_logistics/monitor/data_gate.py",
+      "size": 1268
+    },
+    {
+      "path": "src/hhg_logistics/monitor/data_report.py",
+      "size": 3210
+    },
+    {
+      "path": "src/hhg_logistics/monitor/serve_report.py",
+      "size": 2982
+    },
+    {
+      "path": "src/hhg_logistics/monitor/snapshot.py",
+      "size": 1344
+    },
+    {
+      "path": "src/hhg_logistics/pipeline.py",
+      "size": 5077
+    },
+    {
+      "path": "src/hhg_logistics/pipeline_nodes/__init__.py",
+      "size": 3313
+    },
+    {
+      "path": "src/hhg_logistics/pipeline_nodes/clean.py",
+      "size": 1739
+    },
+    {
+      "path": "src/hhg_logistics/pipeline_nodes/features.py",
+      "size": 898
+    },
+    {
+      "path": "src/hhg_logistics/pipeline_nodes/ingest.py",
+      "size": 653
+    },
+    {
+      "path": "src/hhg_logistics/plugins/__init__.py",
+      "size": 553
+    },
+    {
+      "path": "src/hhg_logistics/plugins/example_plugin.py",
+      "size": 711
+    },
+    {
+      "path": "src/hhg_logistics/registry/__init__.py",
+      "size": 1241
+    },
+    {
+      "path": "src/hhg_logistics/serve/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "src/hhg_logistics/serve/app.py",
+      "size": 16025
+    },
+    {
+      "path": "src/hhg_logistics/serve/smoke.py",
+      "size": 1750
+    },
+    {
+      "path": "src/hhg_logistics/train.py",
+      "size": 10923
+    },
+    {
+      "path": "src/hydra_extra/__init__.py",
+      "size": 1932
+    },
+    {
+      "path": "src/ingestion/__init__.py",
+      "size": 10657
+    },
+    {
+      "path": "src/ingestion/csv_ingestor.py",
+      "size": 796
+    },
+    {
+      "path": "src/ingestion/encoding_detect.py",
+      "size": 5409
+    },
+    {
+      "path": "src/ingestion/file_ingestor.py",
+      "size": 604
+    },
+    {
+      "path": "src/ingestion/io_text.py",
+      "size": 5401
+    },
+    {
+      "path": "src/ingestion/json_ingestor.py",
+      "size": 640
+    },
+    {
+      "path": "src/ingestion/split.py",
+      "size": 1526
+    },
+    {
+      "path": "src/ingestion/utils.py",
+      "size": 12513
+    },
+    {
+      "path": "src/integrations/github_app_auth.py",
+      "size": 5647
+    },
+    {
+      "path": "src/logging_config.py",
+      "size": 485
+    },
+    {
+      "path": "src/logging_utils.py",
+      "size": 13112
+    },
+    {
+      "path": "src/metrics.py",
+      "size": 1490
+    },
+    {
+      "path": "src/modeling.py",
+      "size": 14003
+    },
+    {
+      "path": "src/security/__init__.py",
+      "size": 1137
+    },
+    {
+      "path": "src/security/audit_logger.py",
+      "size": 2297
+    },
+    {
+      "path": "src/security/content_filters.py",
+      "size": 1723
+    },
+    {
+      "path": "src/security/core.py",
+      "size": 8199
+    },
+    {
+      "path": "src/security/encryption.py",
+      "size": 2541
+    },
+    {
+      "path": "src/security/secrets.py",
+      "size": 3565
+    },
+    {
+      "path": "src/tokenization/__init__.py",
+      "size": 742
+    },
+    {
+      "path": "src/tokenization/api.py",
+      "size": 3028
+    },
+    {
+      "path": "src/tokenization/cli.py",
+      "size": 19886
+    },
+    {
+      "path": "src/tokenization/sentencepiece_adapter.py",
+      "size": 1611
+    },
+    {
+      "path": "src/tokenization/train_tokenizer.py",
+      "size": 9031
+    },
+    {
+      "path": "src/tokenizer/__init__.py",
+      "size": 46
+    },
+    {
+      "path": "src/tokenizer/fast_tokenizer.py",
+      "size": 4349
+    },
+    {
+      "path": "src/tools/archive_pr_checklist.py",
+      "size": 7159
+    },
+    {
+      "path": "src/tools/codeowners_validate.py",
+      "size": 3671
+    },
+    {
+      "path": "src/training/__init__.py",
+      "size": 470
+    },
+    {
+      "path": "src/training/checkpointing.py",
+      "size": 10149
+    },
+    {
+      "path": "src/training/simple_trainer.py",
+      "size": 2475
+    },
+    {
+      "path": "src/training/trainer.py",
+      "size": 25908
+    },
+    {
+      "path": "src/utils/__init__.py",
+      "size": 275
+    },
+    {
+      "path": "src/utils/checkpoint.py",
+      "size": 13228
+    },
+    {
+      "path": "src/utils/checkpointing.py",
+      "size": 4650
+    },
+    {
+      "path": "src/utils/error_logging.py",
+      "size": 1855
+    },
+    {
+      "path": "src/utils/logging_factory.py",
+      "size": 1794
+    },
+    {
+      "path": "src/utils/trackers.py",
+      "size": 951
+    },
+    {
+      "path": "src/utils/training_callbacks.py",
+      "size": 1160
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/agents/codex_client/client/openai_tools.py",
+      "size": 932
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/agents/codex_client/codex_client/demo_plan_and_call.py",
+      "size": 2376
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/agents/codex_client/codex_client/openai_wrapper.py",
+      "size": 1773
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/mcp/server/main.py",
+      "size": 260
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/mcp/server/server.py",
+      "size": 705
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/app/auth.py",
+      "size": 602
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/app/main.py",
+      "size": 1998
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/app/routers/gitops.py",
+      "size": 1081
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/app/routers/kb.py",
+      "size": 745
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/app/routers/repo.py",
+      "size": 769
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/app/routers/tests.py",
+      "size": 862
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/app/utils/github_app.py",
+      "size": 1829
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/app/utils/security.py",
+      "size": 425
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/scripts/issue_api_key.py",
+      "size": 49
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/tests/test_contract.py",
+      "size": 123
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/tests/test_endpoints.py",
+      "size": 329
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/tools/codex_safety/openai_wrapper.py",
+      "size": 78
+    },
+    {
+      "path": "tests/__init__.py",
+      "size": 31
+    },
+    {
+      "path": "tests/_codex_introspect.py",
+      "size": 3818
+    },
+    {
+      "path": "tests/addons/test_metrics_collector_mlflow.py",
+      "size": 2686
+    },
+    {
+      "path": "tests/analysis/test_ast_similarity.py",
+      "size": 1945
+    },
+    {
+      "path": "tests/analysis/test_audit_pipeline.py",
+      "size": 682
+    },
+    {
+      "path": "tests/analysis/test_docs_links_audit.py",
+      "size": 2397
+    },
+    {
+      "path": "tests/analysis/test_external_search.py",
+      "size": 1502
+    },
+    {
+      "path": "tests/analysis/test_external_web_search.py",
+      "size": 5708
+    },
+    {
+      "path": "tests/analysis/test_providers.py",
+      "size": 975
+    },
+    {
+      "path": "tests/archival/test_archival_tombstone_required.py",
+      "size": 4208
+    },
+    {
+      "path": "tests/archive/test_archive_hygiene.py",
+      "size": 5038
+    },
+    {
+      "path": "tests/archive/test_archive_plan_apply.py",
+      "size": 6808
+    },
+    {
+      "path": "tests/archive/test_auto_compress.py",
+      "size": 1761
+    },
+    {
+      "path": "tests/archive/test_backend_retention.py",
+      "size": 5782
+    },
+    {
+      "path": "tests/archive/test_batch_restore.py",
+      "size": 3257
+    },
+    {
+      "path": "tests/archive/test_config.py",
+      "size": 3109
+    },
+    {
+      "path": "tests/archive/test_consolidation_flow.py",
+      "size": 3128
+    },
+    {
+      "path": "tests/archive/test_evidence_log.py",
+      "size": 2466
+    },
+    {
+      "path": "tests/archive/test_improvements_integration.py",
+      "size": 2969
+    },
+    {
+      "path": "tests/archive/test_logging_config.py",
+      "size": 3592
+    },
+    {
+      "path": "tests/archive/test_multi_backend_integration.py",
+      "size": 1569
+    },
+    {
+      "path": "tests/archive/test_perf_metrics.py",
+      "size": 757
+    },
+    {
+      "path": "tests/archive/test_plan_and_store.py",
+      "size": 1508
+    },
+    {
+      "path": "tests/archive/test_prefix_auto_validation.py",
+      "size": 1220
+    },
+    {
+      "path": "tests/archive/test_prefix_enforcement.py",
+      "size": 1113
+    },
+    {
+      "path": "tests/archive/test_purge_shared_artifact.py",
+      "size": 3339
+    },
+    {
+      "path": "tests/archive/test_referent_pg_mariadb.py",
+      "size": 1298
+    },
+    {
+      "path": "tests/archive/test_restore_validation.py",
+      "size": 8448
+    },
+    {
+      "path": "tests/archive/test_retry.py",
+      "size": 1722
+    },
+    {
+      "path": "tests/archive/test_sql_identifier_safety.py",
+      "size": 828
+    },
+    {
+      "path": "tests/archive/test_standardization.py",
+      "size": 4523
+    },
+    {
+      "path": "tests/archive/test_stub_text.py",
+      "size": 437
+    },
+    {
+      "path": "tests/archive/test_trend_aggregate.py",
+      "size": 952
+    },
+    {
+      "path": "tests/audit/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/audit/test_context_and_facets.py",
+      "size": 734
+    },
+    {
+      "path": "tests/audit/test_gaps_analyze.py",
+      "size": 1052
+    },
+    {
+      "path": "tests/breadcrumbs/test_bundle_and_integrity.py",
+      "size": 1147
+    },
+    {
+      "path": "tests/breadcrumbs/test_catalog_db.py",
+      "size": 884
+    },
+    {
+      "path": "tests/breadcrumbs/test_compaction.py",
+      "size": 453
+    },
+    {
+      "path": "tests/breadcrumbs/test_ledger.py",
+      "size": 848
+    },
+    {
+      "path": "tests/callbacks/test_default_callbacks.py",
+      "size": 1495
+    },
+    {
+      "path": "tests/callbacks/test_ndjson_logger.py",
+      "size": 682
+    },
+    {
+      "path": "tests/capabilities/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/capabilities/test_autodiscovery.py",
+      "size": 612
+    },
+    {
+      "path": "tests/checkpoint/test_checkpoint_integrity_tolerant.py",
+      "size": 722
+    },
+    {
+      "path": "tests/checkpoint/test_checkpoint_integrity_wiring.py",
+      "size": 1296
+    },
+    {
+      "path": "tests/checkpoint/test_checkpoint_load_roundtrip.py",
+      "size": 367
+    },
+    {
+      "path": "tests/checkpoint/test_checkpoint_peft_state.py",
+      "size": 2122
+    },
+    {
+      "path": "tests/checkpoint/test_checkpoint_schema.py",
+      "size": 545
+    },
+    {
+      "path": "tests/checkpoint/test_integrity_snapshot.py",
+      "size": 2021
+    },
+    {
+      "path": "tests/checkpoint/test_no_direct_atomic_write_usage.py",
+      "size": 697
+    },
+    {
+      "path": "tests/checkpoint/test_run_metadata_sidecar.py",
+      "size": 533
+    },
+    {
+      "path": "tests/checkpoint/test_runmeta_enrichment.py",
+      "size": 719
+    },
+    {
+      "path": "tests/checkpoint/test_state_providers.py",
+      "size": 2127
+    },
+    {
+      "path": "tests/checkpointing/__init__.py",
+      "size": 45
+    },
+    {
+      "path": "tests/checkpointing/test_atomic_io.py",
+      "size": 434
+    },
+    {
+      "path": "tests/checkpointing/test_atomic_write.py",
+      "size": 403
+    },
+    {
+      "path": "tests/checkpointing/test_atomicity_and_resume.py",
+      "size": 602
+    },
+    {
+      "path": "tests/checkpointing/test_best_not_pruned.py",
+      "size": 497
+    },
+    {
+      "path": "tests/checkpointing/test_best_promotion.py",
+      "size": 537
+    },
+    {
+      "path": "tests/checkpointing/test_canonical_json.py",
+      "size": 653
+    },
+    {
+      "path": "tests/checkpointing/test_checkpoint_core_io.py",
+      "size": 783
+    },
+    {
+      "path": "tests/checkpointing/test_checkpoint_json_event.py",
+      "size": 877
+    },
+    {
+      "path": "tests/checkpointing/test_checkpoint_retention.py",
+      "size": 656
+    },
+    {
+      "path": "tests/checkpointing/test_checkpoint_schema_and_compat.py",
+      "size": 1597
+    },
+    {
+      "path": "tests/checkpointing/test_checkpointing_compat.py",
+      "size": 717
+    },
+    {
+      "path": "tests/checkpointing/test_corrupt_checkpoint_load.py",
+      "size": 814
+    },
+    {
+      "path": "tests/checkpointing/test_load_latest.py",
+      "size": 2710
+    },
+    {
+      "path": "tests/checkpointing/test_meta_schema.py",
+      "size": 716
+    },
+    {
+      "path": "tests/checkpointing/test_periodic_and_trim.py",
+      "size": 533
+    },
+    {
+      "path": "tests/checkpointing/test_resume_optimizer_rng_equivalence.py",
+      "size": 909
+    },
+    {
+      "path": "tests/checkpointing/test_retention_and_digest.py",
+      "size": 1140
+    },
+    {
+      "path": "tests/checkpointing/test_retention_local.py",
+      "size": 1051
+    },
+    {
+      "path": "tests/checkpointing/test_rng_state_checkpoint.py",
+      "size": 1169
+    },
+    {
+      "path": "tests/checkpointing/test_rng_state_roundtrip.py",
+      "size": 369
+    },
+    {
+      "path": "tests/checkpointing/test_roundtrip.py",
+      "size": 1425
+    },
+    {
+      "path": "tests/checkpointing/test_schema_v2_basic.py",
+      "size": 1456
+    },
+    {
+      "path": "tests/checkpointing/test_schema_v2_jcs_numbers.py",
+      "size": 648
+    },
+    {
+      "path": "tests/checkpointing/test_schema_v2_upgrade.py",
+      "size": 733
+    },
+    {
+      "path": "tests/ci/test_workflow_validation.py",
+      "size": 703
+    },
+    {
+      "path": "tests/cli/conftest.py",
+      "size": 652
+    },
+    {
+      "path": "tests/cli/test_cli_checkpoint_validate.py",
+      "size": 1605
+    },
+    {
+      "path": "tests/cli/test_cli_hydra_entry_smoke.py",
+      "size": 915
+    },
+    {
+      "path": "tests/cli/test_cli_manifest.py",
+      "size": 1381
+    },
+    {
+      "path": "tests/cli/test_cli_manifest_init.py",
+      "size": 800
+    },
+    {
+      "path": "tests/cli/test_cli_manifest_validate.py",
+      "size": 1555
+    },
+    {
+      "path": "tests/cli/test_cli_offline_bootstrap.py",
+      "size": 1244
+    },
+    {
+      "path": "tests/cli/test_cli_schemas.py",
+      "size": 1658
+    },
+    {
+      "path": "tests/cli/test_cli_structured_logging.py",
+      "size": 584
+    },
+    {
+      "path": "tests/cli/test_cli_tracking_decide.py",
+      "size": 1836
+    },
+    {
+      "path": "tests/cli/test_cli_viewer.py",
+      "size": 677
+    },
+    {
+      "path": "tests/cli/test_codex_cli.py",
+      "size": 266
+    },
+    {
+      "path": "tests/cli/test_codex_export_env.py",
+      "size": 774
+    },
+    {
+      "path": "tests/cli/test_codex_ml_cli_guard.py",
+      "size": 845
+    },
+    {
+      "path": "tests/cli/test_codex_train_cli.py",
+      "size": 1386
+    },
+    {
+      "path": "tests/cli/test_codexml_cli_fallback.py",
+      "size": 1550
+    },
+    {
+      "path": "tests/cli/test_config_audit.py",
+      "size": 1397
+    },
+    {
+      "path": "tests/cli/test_eval_probe_json_schema.py",
+      "size": 1218
+    },
+    {
+      "path": "tests/cli/test_evaluation_cli.py",
+      "size": 2383
+    },
+    {
+      "path": "tests/cli/test_generate_safety.py",
+      "size": 3509
+    },
+    {
+      "path": "tests/cli/test_hydra_audit.py",
+      "size": 1402
+    },
+    {
+      "path": "tests/cli/test_hydra_missing_probe_json.py",
+      "size": 743
+    },
+    {
+      "path": "tests/cli/test_infer_cli_lora.py",
+      "size": 1634
+    },
+    {
+      "path": "tests/cli/test_metrics_cli_duckdb_missing_dependency.py",
+      "size": 992
+    },
+    {
+      "path": "tests/cli/test_metrics_ingest.py",
+      "size": 2365
+    },
+    {
+      "path": "tests/cli/test_metrics_store_duckdb_modes.py",
+      "size": 1953
+    },
+    {
+      "path": "tests/cli/test_metrics_store_sqlite_chunked.py",
+      "size": 2126
+    },
+    {
+      "path": "tests/cli/test_metrics_table_name_validation.py",
+      "size": 1608
+    },
+    {
+      "path": "tests/cli/test_metrics_validate_tail_badge.py",
+      "size": 1491
+    },
+    {
+      "path": "tests/cli/test_monitoring_cli.py",
+      "size": 2331
+    },
+    {
+      "path": "tests/cli/test_ndjson_summary_cli.py",
+      "size": 1731
+    },
+    {
+      "path": "tests/cli/test_offline_bootstrap.py",
+      "size": 697
+    },
+    {
+      "path": "tests/cli/test_plugins_cli.py",
+      "size": 3097
+    },
+    {
+      "path": "tests/cli/test_repo_cli.py",
+      "size": 1354
+    },
+    {
+      "path": "tests/cli/test_status_audit.py",
+      "size": 3909
+    },
+    {
+      "path": "tests/cli/test_subcommands.py",
+      "size": 412
+    },
+    {
+      "path": "tests/cli/test_tokenizer_cli.py",
+      "size": 4964
+    },
+    {
+      "path": "tests/cli/test_tracking_bootstrap_cli.py",
+      "size": 998
+    },
+    {
+      "path": "tests/cli/test_train_probe_json_schema.py",
+      "size": 1138
+    },
+    {
+      "path": "tests/code_quality/test_black_formatting.py",
+      "size": 329
+    },
+    {
+      "path": "tests/code_quality/test_import_sorting.py",
+      "size": 332
+    },
+    {
+      "path": "tests/code_quality/test_mypy_type_coverage.py",
+      "size": 1192
+    },
+    {
+      "path": "tests/code_quality/test_ruff_linting.py",
+      "size": 315
+    },
+    {
+      "path": "tests/code_quality/test_semgrep_rules.py",
+      "size": 375
+    },
+    {
+      "path": "tests/codex_crm/test_diagram_flows.py",
+      "size": 974
+    },
+    {
+      "path": "tests/codex_ml/data/test_jsonl_loader.py",
+      "size": 1136
+    },
+    {
+      "path": "tests/codex_ml/test_cli_train_config_bridge.py",
+      "size": 4734
+    },
+    {
+      "path": "tests/codex_ml/test_model_factory.py",
+      "size": 3927
+    },
+    {
+      "path": "tests/config/conftest.py",
+      "size": 76
+    },
+    {
+      "path": "tests/config/test_config_schema.py",
+      "size": 1643
+    },
+    {
+      "path": "tests/config/test_config_settings.py",
+      "size": 1167
+    },
+    {
+      "path": "tests/config/test_depth_gating.py",
+      "size": 1532
+    },
+    {
+      "path": "tests/config/test_hydra_defaults.py",
+      "size": 659
+    },
+    {
+      "path": "tests/config/test_hydra_defaults_tree.py",
+      "size": 1175
+    },
+    {
+      "path": "tests/config/test_knob_parsing.py",
+      "size": 10090
+    },
+    {
+      "path": "tests/config/test_knobs_summary.py",
+      "size": 794
+    },
+    {
+      "path": "tests/config/test_override_propagation.py",
+      "size": 1004
+    },
+    {
+      "path": "tests/config/test_provenance_snapshot.py",
+      "size": 501
+    },
+    {
+      "path": "tests/config/test_schema.py",
+      "size": 588
+    },
+    {
+      "path": "tests/config/test_schema_validate.py",
+      "size": 585
+    },
+    {
+      "path": "tests/config/test_sweep_expand.py",
+      "size": 995
+    },
+    {
+      "path": "tests/config/test_training_config_negative.py",
+      "size": 409
+    },
+    {
+      "path": "tests/config/test_training_config_yaml.py",
+      "size": 430
+    },
+    {
+      "path": "tests/config/test_validate_config.py",
+      "size": 1332
+    },
+    {
+      "path": "tests/configs/test_defaults_exist_and_load.py",
+      "size": 425
+    },
+    {
+      "path": "tests/configs/test_hydra_structured_config.py",
+      "size": 842
+    },
+    {
+      "path": "tests/configs/test_training_configs_validate.py",
+      "size": 610
+    },
+    {
+      "path": "tests/configuration/test_config_audit_helpers.py",
+      "size": 2319
+    },
+    {
+      "path": "tests/configuration/test_hydra_override_propagation.py",
+      "size": 3193
+    },
+    {
+      "path": "tests/configuration/test_hydra_validation.py",
+      "size": 4349
+    },
+    {
+      "path": "tests/configuration/test_yaml_under_configs_parse.py",
+      "size": 1485
+    },
+    {
+      "path": "tests/conftest.py",
+      "size": 10372
+    },
+    {
+      "path": "tests/connectors/__init__.py",
+      "size": 19
+    },
+    {
+      "path": "tests/connectors/conftest.py",
+      "size": 53
+    },
+    {
+      "path": "tests/connectors/test_github_connector_check.py",
+      "size": 704
+    },
+    {
+      "path": "tests/connectors/test_local_connector.py",
+      "size": 761
+    },
+    {
+      "path": "tests/connectors/test_registry.py",
+      "size": 772
+    },
+    {
+      "path": "tests/connectors/test_remote.py",
+      "size": 2588
+    },
+    {
+      "path": "tests/crm/__init__.py",
+      "size": 26
+    },
+    {
+      "path": "tests/crm/test_cdm_loader.py",
+      "size": 701
+    },
+    {
+      "path": "tests/crm/test_cli.py",
+      "size": 1915
+    },
+    {
+      "path": "tests/crm/test_cli_smoke.py",
+      "size": 573
+    },
+    {
+      "path": "tests/crm/test_conversion_fidelity.py",
+      "size": 188
+    },
+    {
+      "path": "tests/crm/test_conversion_truths.py",
+      "size": 1035
+    },
+    {
+      "path": "tests/crm/test_diagram_flows.py",
+      "size": 551
+    },
+    {
+      "path": "tests/crm/test_pa_legacy_reader.py",
+      "size": 1753
+    },
+    {
+      "path": "tests/crm/test_pa_reader.py",
+      "size": 359
+    },
+    {
+      "path": "tests/crm/test_rules_conversion.py",
+      "size": 1090
+    },
+    {
+      "path": "tests/crm/test_zaf_legacy_reader.py",
+      "size": 1098
+    },
+    {
+      "path": "tests/crm/test_zaf_reader.py",
+      "size": 222
+    },
+    {
+      "path": "tests/d365/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/d365/test_apply_stubs.py",
+      "size": 1895
+    },
+    {
+      "path": "tests/d365/test_mapping_loaders.py",
+      "size": 1128
+    },
+    {
+      "path": "tests/d365/test_solution_xml.py",
+      "size": 1018
+    },
+    {
+      "path": "tests/dashboards/test_build_ratelimit_tile.py",
+      "size": 1484
+    },
+    {
+      "path": "tests/dashboards/test_ratelimit_tile_schema.py",
+      "size": 1276
+    },
+    {
+      "path": "tests/dashboards/test_render_ratelimit_tile_html.py",
+      "size": 1190
+    },
+    {
+      "path": "tests/data/test_cache.py",
+      "size": 2511
+    },
+    {
+      "path": "tests/data/test_cache_flush_threshold.py",
+      "size": 749
+    },
+    {
+      "path": "tests/data/test_cache_roundtrip.py",
+      "size": 975
+    },
+    {
+      "path": "tests/data/test_data_cache.py",
+      "size": 1174
+    },
+    {
+      "path": "tests/data/test_data_shard_integrity.py",
+      "size": 793
+    },
+    {
+      "path": "tests/data/test_datamodule_determinism.py",
+      "size": 683
+    },
+    {
+      "path": "tests/data/test_dataset_determinism.py",
+      "size": 1931
+    },
+    {
+      "path": "tests/data/test_datasets_module.py",
+      "size": 1979
+    },
+    {
+      "path": "tests/data/test_hf_factory_compat.py",
+      "size": 677
+    },
+    {
+      "path": "tests/data/test_load_dataset.py",
+      "size": 593
+    },
+    {
+      "path": "tests/data/test_loaders.py",
+      "size": 3445
+    },
+    {
+      "path": "tests/data/test_local_files.py",
+      "size": 4430
+    },
+    {
+      "path": "tests/data/test_make_splits.py",
+      "size": 809
+    },
+    {
+      "path": "tests/data/test_manifest.py",
+      "size": 945
+    },
+    {
+      "path": "tests/data/test_pipeline_validation.py",
+      "size": 911
+    },
+    {
+      "path": "tests/data/test_prepare_data_reproducible.py",
+      "size": 2314
+    },
+    {
+      "path": "tests/data/test_registry_manifest.py",
+      "size": 1519
+    },
+    {
+      "path": "tests/data/test_safety_filter.py",
+      "size": 402
+    },
+    {
+      "path": "tests/data/test_safety_filter_split.py",
+      "size": 248
+    },
+    {
+      "path": "tests/data/test_samples.py",
+      "size": 1483
+    },
+    {
+      "path": "tests/data/test_shard_integrity.py",
+      "size": 798
+    },
+    {
+      "path": "tests/data/test_split_dataset.py",
+      "size": 298
+    },
+    {
+      "path": "tests/data/test_split_dataset_checksum.py",
+      "size": 342
+    },
+    {
+      "path": "tests/data/test_split_dataset_deterministic.py",
+      "size": 291
+    },
+    {
+      "path": "tests/data/test_split_manifest.py",
+      "size": 682
+    },
+    {
+      "path": "tests/data/test_split_seed.py",
+      "size": 694
+    },
+    {
+      "path": "tests/data/test_streaming_datamodule.py",
+      "size": 1943
+    },
+    {
+      "path": "tests/data/test_streaming_memory.py",
+      "size": 598
+    },
+    {
+      "path": "tests/deepresearch/test_context_manifest.py",
+      "size": 757
+    },
+    {
+      "path": "tests/deployment/test_api_integration.py",
+      "size": 611
+    },
+    {
+      "path": "tests/deployment/test_blue_green_deployment.py",
+      "size": 230
+    },
+    {
+      "path": "tests/deployment/test_cloud.py",
+      "size": 1648
+    },
+    {
+      "path": "tests/deployment/test_container_security.py",
+      "size": 353
+    },
+    {
+      "path": "tests/deployment/test_docker_build.py",
+      "size": 672
+    },
+    {
+      "path": "tests/deployment/test_dockerfiles_reproducible.py",
+      "size": 1388
+    },
+    {
+      "path": "tests/deployment/test_helm_chart.py",
+      "size": 639
+    },
+    {
+      "path": "tests/deployment/test_helm_chart_schema_basic.py",
+      "size": 1192
+    },
+    {
+      "path": "tests/deployment/test_helm_values.py",
+      "size": 868
+    },
+    {
+      "path": "tests/deployment/test_k8s_manifests.py",
+      "size": 949
+    },
+    {
+      "path": "tests/deployment/test_rollback_scenario.py",
+      "size": 282
+    },
+    {
+      "path": "tests/deployment/test_secret_injection.py",
+      "size": 210
+    },
+    {
+      "path": "tests/deployment/test_volume_mounts.py",
+      "size": 233
+    },
+    {
+      "path": "tests/detectors/test_aggregate.py",
+      "size": 707
+    },
+    {
+      "path": "tests/detectors/test_core.py",
+      "size": 395
+    },
+    {
+      "path": "tests/detectors/test_integration_card.py",
+      "size": 421
+    },
+    {
+      "path": "tests/detectors/test_unified_training.py",
+      "size": 303
+    },
+    {
+      "path": "tests/diagram/test_flow_to_mermaid_smoke.py",
+      "size": 417
+    },
+    {
+      "path": "tests/distributed/test_ddp_env_optin_smoke.py",
+      "size": 863
+    },
+    {
+      "path": "tests/distributed/test_minimal_distributed.py",
+      "size": 474
+    },
+    {
+      "path": "tests/docs/test_api_docs_build.py",
+      "size": 3175
+    },
+    {
+      "path": "tests/docs/test_link_audit.py",
+      "size": 610
+    },
+    {
+      "path": "tests/docs/test_status_update_template.py",
+      "size": 4583
+    },
+    {
+      "path": "tests/e2e_offline/test_diff_and_apply.py",
+      "size": 750
+    },
+    {
+      "path": "tests/eval/conftest.py",
+      "size": 77
+    },
+    {
+      "path": "tests/eval/test_bleu_rouge_fallbacks.py",
+      "size": 1678
+    },
+    {
+      "path": "tests/eval/test_datasets_hf_disk.py",
+      "size": 1543
+    },
+    {
+      "path": "tests/eval/test_eval_cli.py",
+      "size": 421
+    },
+    {
+      "path": "tests/eval/test_eval_cli_passthrough.py",
+      "size": 566
+    },
+    {
+      "path": "tests/eval/test_eval_contract.py",
+      "size": 258
+    },
+    {
+      "path": "tests/eval/test_eval_provenance_capture.py",
+      "size": 2967
+    },
+    {
+      "path": "tests/eval/test_eval_runner_max_samples.py",
+      "size": 444
+    },
+    {
+      "path": "tests/eval/test_eval_runner_smoke.py",
+      "size": 951
+    },
+    {
+      "path": "tests/eval/test_evaluate_dataloader_helper.py",
+      "size": 3024
+    },
+    {
+      "path": "tests/eval/test_evaluation_reproducible.py",
+      "size": 2850
+    },
+    {
+      "path": "tests/eval/test_hf_dataset_loader.py",
+      "size": 7612
+    },
+    {
+      "path": "tests/eval/test_metric_registry_registration.py",
+      "size": 656
+    },
+    {
+      "path": "tests/eval/test_metrics.py",
+      "size": 506
+    },
+    {
+      "path": "tests/eval/test_metrics_correctness.py",
+      "size": 752
+    },
+    {
+      "path": "tests/eval/test_metrics_text_values.py",
+      "size": 740
+    },
+    {
+      "path": "tests/eval/test_registry_determinism.py",
+      "size": 686
+    },
+    {
+      "path": "tests/eval/test_run_unit_tests.py",
+      "size": 628
+    },
+    {
+      "path": "tests/eval/test_schema_compat.py",
+      "size": 1687
+    },
+    {
+      "path": "tests/eval/test_synthetic_alignment.py",
+      "size": 569
+    },
+    {
+      "path": "tests/evaluation/test_metrics.py",
+      "size": 4650
+    },
+    {
+      "path": "tests/evaluation/test_metrics_registry.py",
+      "size": 1683
+    },
+    {
+      "path": "tests/evaluators/test_codex_evaluator.py",
+      "size": 1443
+    },
+    {
+      "path": "tests/evaluators/test_evaluator_optional_deps.py",
+      "size": 998
+    },
+    {
+      "path": "tests/evaluators/test_validate_fences_sample.py",
+      "size": 1011
+    },
+    {
+      "path": "tests/fixtures/__init__.py",
+      "size": 56
+    },
+    {
+      "path": "tests/fixtures/zaf_legacy.py",
+      "size": 720
+    },
+    {
+      "path": "tests/gates/conftest.py",
+      "size": 77
+    },
+    {
+      "path": "tests/gates/test_quality_gates.py",
+      "size": 3491
+    },
+    {
+      "path": "tests/github/test_app_token.py",
+      "size": 999
+    },
+    {
+      "path": "tests/github/test_app_token_cli.py",
+      "size": 1468
+    },
+    {
+      "path": "tests/github/test_gh_api_pagination_cache.py",
+      "size": 2195
+    },
+    {
+      "path": "tests/github/test_gh_api_wrapper.py",
+      "size": 890
+    },
+    {
+      "path": "tests/guards/test_selection_guard.py",
+      "size": 3628
+    },
+    {
+      "path": "tests/helpers/__init__.py",
+      "size": 43
+    },
+    {
+      "path": "tests/helpers/optional_dependencies.py",
+      "size": 1328
+    },
+    {
+      "path": "tests/hf_loader/test_amp_dtype_map.py",
+      "size": 520
+    },
+    {
+      "path": "tests/hf_loader/test_bf16_probe.py",
+      "size": 801
+    },
+    {
+      "path": "tests/hhg_logistics/serve/test_app.py",
+      "size": 9105
+    },
+    {
+      "path": "tests/inference/test_ita_openapi_exists.py",
+      "size": 565
+    },
+    {
+      "path": "tests/inference/test_services_api_import.py",
+      "size": 586
+    },
+    {
+      "path": "tests/ingestion/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/ingestion/test_io_text.py",
+      "size": 1568
+    },
+    {
+      "path": "tests/ingestion/test_split.py",
+      "size": 1933
+    },
+    {
+      "path": "tests/integration/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/integration/test_build_api_docs_integration.py",
+      "size": 6721
+    },
+    {
+      "path": "tests/integration/test_cli_smoke.py",
+      "size": 912
+    },
+    {
+      "path": "tests/integration/test_code_quality_pipeline.py",
+      "size": 836
+    },
+    {
+      "path": "tests/integration/test_data_gate.py",
+      "size": 2124
+    },
+    {
+      "path": "tests/integration/test_data_report.py",
+      "size": 1128
+    },
+    {
+      "path": "tests/integration/test_distributed_init.py",
+      "size": 6665
+    },
+    {
+      "path": "tests/integration/test_eval_wrapper.py",
+      "size": 908
+    },
+    {
+      "path": "tests/integration/test_ge_pipeline.py",
+      "size": 963
+    },
+    {
+      "path": "tests/integration/test_mlflow_offline.py",
+      "size": 870
+    },
+    {
+      "path": "tests/integration/test_monitor_report.py",
+      "size": 1259
+    },
+    {
+      "path": "tests/integration/test_toy_trainer.py",
+      "size": 413
+    },
+    {
+      "path": "tests/integration/test_toy_trainer_perf_snapshot.py",
+      "size": 755
+    },
+    {
+      "path": "tests/interfaces/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/interfaces/conftest.py",
+      "size": 77
+    },
+    {
+      "path": "tests/interfaces/test_apply_config.py",
+      "size": 1209
+    },
+    {
+      "path": "tests/interfaces/test_env_tokenizer_component.py",
+      "size": 564
+    },
+    {
+      "path": "tests/interfaces/test_get_component_env_var.py",
+      "size": 434
+    },
+    {
+      "path": "tests/interfaces/test_loader_tokenizer_env.py",
+      "size": 747
+    },
+    {
+      "path": "tests/interfaces/test_registry_degradation.py",
+      "size": 946
+    },
+    {
+      "path": "tests/interfaces/test_registry_loader.py",
+      "size": 903
+    },
+    {
+      "path": "tests/interfaces/test_tokenizer_hf.py",
+      "size": 9574
+    },
+    {
+      "path": "tests/interfaces/test_tokenizer_loader_env.py",
+      "size": 550
+    },
+    {
+      "path": "tests/knowledge/test_archive_manifest_side_effects.py",
+      "size": 1297
+    },
+    {
+      "path": "tests/knowledge/test_build_kb.py",
+      "size": 555
+    },
+    {
+      "path": "tests/knowledge/test_dedup.py",
+      "size": 701
+    },
+    {
+      "path": "tests/knowledge/test_normalize.py",
+      "size": 286
+    },
+    {
+      "path": "tests/logging/test_capture_exceptions_systemexit.py",
+      "size": 563
+    },
+    {
+      "path": "tests/logging/test_file_logger.py",
+      "size": 956
+    },
+    {
+      "path": "tests/logging/test_logging_utils_module.py",
+      "size": 2146
+    },
+    {
+      "path": "tests/logging/test_public_api_docstrings.py",
+      "size": 941
+    },
+    {
+      "path": "tests/logging/test_public_docstrings.py",
+      "size": 1024
+    },
+    {
+      "path": "tests/logging/test_run_schema.py",
+      "size": 3775
+    },
+    {
+      "path": "tests/logging/test_session_logger_structured.py",
+      "size": 992
+    },
+    {
+      "path": "tests/logging/test_structured_logging.py",
+      "size": 917
+    },
+    {
+      "path": "tests/manifest/test_warning_aggregation.py",
+      "size": 1691
+    },
+    {
+      "path": "tests/metrics/test_bleu_rouge.py",
+      "size": 7909
+    },
+    {
+      "path": "tests/metrics/test_classification_metrics.py",
+      "size": 661
+    },
+    {
+      "path": "tests/metrics/test_metrics_jsonschema.py",
+      "size": 1427
+    },
+    {
+      "path": "tests/metrics/test_record_metrics_local.py",
+      "size": 809
+    },
+    {
+      "path": "tests/metrics/test_scoring_integration.py",
+      "size": 2433
+    },
+    {
+      "path": "tests/metrics/test_token_similarity.py",
+      "size": 1378
+    },
+    {
+      "path": "tests/metrics/test_writers.py",
+      "size": 1075
+    },
+    {
+      "path": "tests/modeling/conftest.py",
+      "size": 80
+    },
+    {
+      "path": "tests/modeling/test_codex_model.py",
+      "size": 3238
+    },
+    {
+      "path": "tests/modeling/test_decoder_only.py",
+      "size": 2575
+    },
+    {
+      "path": "tests/modeling/test_lora_minimal.py",
+      "size": 3919
+    },
+    {
+      "path": "tests/modeling/test_model_registry.py",
+      "size": 225
+    },
+    {
+      "path": "tests/modeling/test_modeling_module.py",
+      "size": 4552
+    },
+    {
+      "path": "tests/models/conftest.py",
+      "size": 80
+    },
+    {
+      "path": "tests/models/test_chat_model.py",
+      "size": 2726
+    },
+    {
+      "path": "tests/models/test_lora_integration.py",
+      "size": 1060
+    },
+    {
+      "path": "tests/models/test_models_registry_api.py",
+      "size": 2554
+    },
+    {
+      "path": "tests/models/test_peft_optional.py",
+      "size": 321
+    },
+    {
+      "path": "tests/models/test_peft_smoke.py",
+      "size": 1081
+    },
+    {
+      "path": "tests/models/test_peft_utils.py",
+      "size": 537
+    },
+    {
+      "path": "tests/models/test_registry_dtype.py",
+      "size": 2039
+    },
+    {
+      "path": "tests/monitoring/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/monitoring/conftest.py",
+      "size": 77
+    },
+    {
+      "path": "tests/monitoring/test_async_writer_rotation.py",
+      "size": 537
+    },
+    {
+      "path": "tests/monitoring/test_codex_logging_bootstrap.py",
+      "size": 725
+    },
+    {
+      "path": "tests/monitoring/test_codex_logging_cfg.py",
+      "size": 1432
+    },
+    {
+      "path": "tests/monitoring/test_codex_logging_degraded_warning.py",
+      "size": 637
+    },
+    {
+      "path": "tests/monitoring/test_codex_logging_offline.py",
+      "size": 1226
+    },
+    {
+      "path": "tests/monitoring/test_engine_bootstrap.py",
+      "size": 2237
+    },
+    {
+      "path": "tests/monitoring/test_logging_bootstrap_initialization.py",
+      "size": 1396
+    },
+    {
+      "path": "tests/monitoring/test_logging_bootstrap_real.py",
+      "size": 790
+    },
+    {
+      "path": "tests/monitoring/test_metrics_export_helpers.py",
+      "size": 304
+    },
+    {
+      "path": "tests/monitoring/test_mlflow_monitoring_utils.py",
+      "size": 2638
+    },
+    {
+      "path": "tests/monitoring/test_monitoring_mlflow_utils.py",
+      "size": 2638
+    },
+    {
+      "path": "tests/monitoring/test_nvml_optional.py",
+      "size": 1251
+    },
+    {
+      "path": "tests/monitoring/test_prometheus_fallback.py",
+      "size": 1473
+    },
+    {
+      "path": "tests/monitoring/test_prometheus_metrics_registry.py",
+      "size": 1706
+    },
+    {
+      "path": "tests/monitoring/test_sampler_multi_gpu.py",
+      "size": 942
+    },
+    {
+      "path": "tests/monitoring/test_schema_and_redaction.py",
+      "size": 558
+    },
+    {
+      "path": "tests/monitoring/test_system_metrics.py",
+      "size": 1137
+    },
+    {
+      "path": "tests/monitoring/test_system_metrics_cpu_fallback.py",
+      "size": 1712
+    },
+    {
+      "path": "tests/monitoring/test_system_metrics_nvml_missing.py",
+      "size": 604
+    },
+    {
+      "path": "tests/monitoring/test_system_snapshot.py",
+      "size": 1058
+    },
+    {
+      "path": "tests/multi_repo/test_federated_index.py",
+      "size": 1637
+    },
+    {
+      "path": "tests/multilingual/conftest.py",
+      "size": 88
+    },
+    {
+      "path": "tests/multilingual/test_data_loader.py",
+      "size": 572
+    },
+    {
+      "path": "tests/multilingual/test_tokenizer.py",
+      "size": 360
+    },
+    {
+      "path": "tests/ops/__init__.py",
+      "size": 46
+    },
+    {
+      "path": "tests/ops/test_archive_pr_checklist.py",
+      "size": 5379
+    },
+    {
+      "path": "tests/ops/test_codeowners_validation.py",
+      "size": 980
+    },
+    {
+      "path": "tests/ops/test_codex_mint_tokens_contract.py",
+      "size": 2697
+    },
+    {
+      "path": "tests/ops/test_codex_repo_admin_bootstrap.py",
+      "size": 622
+    },
+    {
+      "path": "tests/ops/test_repo_admin_bootstrap.py",
+      "size": 407
+    },
+    {
+      "path": "tests/ops/test_repo_admin_bootstrap_v2.py",
+      "size": 1702
+    },
+    {
+      "path": "tests/ops/test_runner_common_parse.py",
+      "size": 1752
+    },
+    {
+      "path": "tests/peft/test_apply_lora.py",
+      "size": 832
+    },
+    {
+      "path": "tests/perf/test_perf_smoke.py",
+      "size": 329
+    },
+    {
+      "path": "tests/perf/test_performance_profiler.py",
+      "size": 791
+    },
+    {
+      "path": "tests/perf/test_smoke.py",
+      "size": 1445
+    },
+    {
+      "path": "tests/pipeline/conftest.py",
+      "size": 170
+    },
+    {
+      "path": "tests/pipeline/test_pipeline_config.py",
+      "size": 4127
+    },
+    {
+      "path": "tests/pipeline/test_pipeline_smoke.py",
+      "size": 3250
+    },
+    {
+      "path": "tests/plugins/_sandbox_pkg/codex_dummy_plugin/__init__.py",
+      "size": 186
+    },
+    {
+      "path": "tests/plugins/test_entry_point_collision.py",
+      "size": 950
+    },
+    {
+      "path": "tests/plugins/test_entry_point_discovery.py",
+      "size": 1185
+    },
+    {
+      "path": "tests/plugins/test_entry_point_loader_function.py",
+      "size": 534
+    },
+    {
+      "path": "tests/plugins/test_entrypoint_discovery_json_cli.py",
+      "size": 1082
+    },
+    {
+      "path": "tests/plugins/test_factory_registry.py",
+      "size": 6847
+    },
+    {
+      "path": "tests/plugins/test_factory_vs_class.py",
+      "size": 551
+    },
+    {
+      "path": "tests/plugins/test_list_plugins_cli_flags.py",
+      "size": 492
+    },
+    {
+      "path": "tests/plugins/test_list_plugins_cli_json.py",
+      "size": 970
+    },
+    {
+      "path": "tests/plugins/test_list_plugins_cli_json_stdout_only.py",
+      "size": 1297
+    },
+    {
+      "path": "tests/plugins/test_list_plugins_cli_smoke.py",
+      "size": 1602
+    },
+    {
+      "path": "tests/plugins/test_list_plugins_cli_stdout_stderr.py",
+      "size": 427
+    },
+    {
+      "path": "tests/plugins/test_list_plugins_degrade.py",
+      "size": 1792
+    },
+    {
+      "path": "tests/plugins/test_metric_plugin_loading.py",
+      "size": 3592
+    },
+    {
+      "path": "tests/plugins/test_registry_basic.py",
+      "size": 484
+    },
+    {
+      "path": "tests/plugins/test_registry_entries.py",
+      "size": 5062
+    },
+    {
+      "path": "tests/plugins/test_registry_programmatic.py",
+      "size": 465
+    },
+    {
+      "path": "tests/plugins/test_tokenization_deprecation_shims.py",
+      "size": 902
+    },
+    {
+      "path": "tests/privacy/conftest.py",
+      "size": 44
+    },
+    {
+      "path": "tests/privacy/test_dp_training.py",
+      "size": 2415
+    },
+    {
+      "path": "tests/registry/test_registry_documentation.py",
+      "size": 526
+    },
+    {
+      "path": "tests/release/test_release_dal.py",
+      "size": 2350
+    },
+    {
+      "path": "tests/release/test_release_dal_pg_mariadb.py",
+      "size": 1555
+    },
+    {
+      "path": "tests/release/test_release_pack_verify.py",
+      "size": 2142
+    },
+    {
+      "path": "tests/release/test_release_unpack.py",
+      "size": 2640
+    },
+    {
+      "path": "tests/repro/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/repro/test_determinism.py",
+      "size": 307
+    },
+    {
+      "path": "tests/reproducibility/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/reproducibility/test_deterministic_seeding.py",
+      "size": 7564
+    },
+    {
+      "path": "tests/reward_models/test_length_reward_model.py",
+      "size": 463
+    },
+    {
+      "path": "tests/safety/test_filters.py",
+      "size": 761
+    },
+    {
+      "path": "tests/safety/test_filters_regressions.py",
+      "size": 2361
+    },
+    {
+      "path": "tests/safety/test_filters_runtime.py",
+      "size": 634
+    },
+    {
+      "path": "tests/safety/test_license_checker.py",
+      "size": 695
+    },
+    {
+      "path": "tests/safety/test_risk_score.py",
+      "size": 203
+    },
+    {
+      "path": "tests/safety/test_safety_filter_integration.py",
+      "size": 1516
+    },
+    {
+      "path": "tests/safety/test_secret_redactor.py",
+      "size": 927
+    },
+    {
+      "path": "tests/samples/test_samples_exist.py",
+      "size": 1005
+    },
+    {
+      "path": "tests/schemas/test_schema_validate.py",
+      "size": 1984
+    },
+    {
+      "path": "tests/scripts/test_prune_rate_limit_history.py",
+      "size": 809
+    },
+    {
+      "path": "tests/scripts/test_train_script.py",
+      "size": 1386
+    },
+    {
+      "path": "tests/security/test_audit_logging.py",
+      "size": 305
+    },
+    {
+      "path": "tests/security/test_content_filters.py",
+      "size": 563
+    },
+    {
+      "path": "tests/security/test_csrf_protection.py",
+      "size": 271
+    },
+    {
+      "path": "tests/security/test_encryption.py",
+      "size": 1754
+    },
+    {
+      "path": "tests/security/test_enforce_policy.py",
+      "size": 962
+    },
+    {
+      "path": "tests/security/test_injection_prevention.py",
+      "size": 4480
+    },
+    {
+      "path": "tests/security/test_input_validation.py",
+      "size": 1251
+    },
+    {
+      "path": "tests/security/test_log_redaction.py",
+      "size": 1562
+    },
+    {
+      "path": "tests/security/test_offline_scans.py",
+      "size": 805
+    },
+    {
+      "path": "tests/security/test_path_traversal.py",
+      "size": 385
+    },
+    {
+      "path": "tests/security/test_pii_filter.py",
+      "size": 2773
+    },
+    {
+      "path": "tests/security/test_rate_limiting.py",
+      "size": 424
+    },
+    {
+      "path": "tests/security/test_safety_filters.py",
+      "size": 692
+    },
+    {
+      "path": "tests/security/test_secret_context_correlate.py",
+      "size": 1683
+    },
+    {
+      "path": "tests/security/test_secret_entropy.py",
+      "size": 2033
+    },
+    {
+      "path": "tests/security/test_secret_entropy_scan.py",
+      "size": 721
+    },
+    {
+      "path": "tests/security/test_secret_rotation.py",
+      "size": 474
+    },
+    {
+      "path": "tests/security/test_security_severity.py",
+      "size": 1312
+    },
+    {
+      "path": "tests/security/test_semgrep_rules.py",
+      "size": 1244
+    },
+    {
+      "path": "tests/security/test_session_hijacking.py",
+      "size": 720
+    },
+    {
+      "path": "tests/security/test_verify_pins.py",
+      "size": 357
+    },
+    {
+      "path": "tests/selection/test_selection_report_smoke.py",
+      "size": 1013
+    },
+    {
+      "path": "tests/self_mgmt/test_noxfile_parse.py",
+      "size": 968
+    },
+    {
+      "path": "tests/self_mgmt/test_requirements_dev.py",
+      "size": 403
+    },
+    {
+      "path": "tests/services/api/test_infer_limits.py",
+      "size": 3060
+    },
+    {
+      "path": "tests/services/api/test_main_utils.py",
+      "size": 2918
+    },
+    {
+      "path": "tests/services/api/test_middleware_security.py",
+      "size": 1331
+    },
+    {
+      "path": "tests/services/api/test_rate_limit_middleware.py",
+      "size": 2236
+    },
+    {
+      "path": "tests/smoke/conftest.py",
+      "size": 76
+    },
+    {
+      "path": "tests/smoke/test_artifacts_hash.py",
+      "size": 528
+    },
+    {
+      "path": "tests/smoke/test_checkpoint_hashing.py",
+      "size": 987
+    },
+    {
+      "path": "tests/smoke/test_cli_determinism_wiring.py",
+      "size": 520
+    },
+    {
+      "path": "tests/smoke/test_config_validate_cli.py",
+      "size": 710
+    },
+    {
+      "path": "tests/smoke/test_determinism.py",
+      "size": 1466
+    },
+    {
+      "path": "tests/smoke/test_hf_trainer_hello.py",
+      "size": 1728
+    },
+    {
+      "path": "tests/smoke/test_logging_flags_end_to_end.py",
+      "size": 1657
+    },
+    {
+      "path": "tests/smoke/test_mlflow_utils_noop.py",
+      "size": 507
+    },
+    {
+      "path": "tests/smoke/test_plugin_registry.py",
+      "size": 1002
+    },
+    {
+      "path": "tests/space_traversal/test_detector_duplication.py",
+      "size": 1615
+    },
+    {
+      "path": "tests/space_traversal/test_detector_peft.py",
+      "size": 1546
+    },
+    {
+      "path": "tests/space_traversal/test_detector_safeguards.py",
+      "size": 1518
+    },
+    {
+      "path": "tests/space_traversal/test_synonym_loader.py",
+      "size": 1887
+    },
+    {
+      "path": "tests/space_traversal/test_validators.py",
+      "size": 3045
+    },
+    {
+      "path": "tests/specs/_workflow_config_utils.py",
+      "size": 622
+    },
+    {
+      "path": "tests/specs/test_audit_diff_cli.py",
+      "size": 1283
+    },
+    {
+      "path": "tests/specs/test_audit_explain_cli.py",
+      "size": 1505
+    },
+    {
+      "path": "tests/specs/test_audit_manifest_fields.py",
+      "size": 1677
+    },
+    {
+      "path": "tests/specs/test_audit_meta_in_report.py",
+      "size": 2352
+    },
+    {
+      "path": "tests/specs/test_cli_normalization.py",
+      "size": 1110
+    },
+    {
+      "path": "tests/specs/test_component_caps_clamp.py",
+      "size": 2441
+    },
+    {
+      "path": "tests/specs/test_detector_inference_serving.py",
+      "size": 710
+    },
+    {
+      "path": "tests/specs/test_docs_score_synonyms.py",
+      "size": 1081
+    },
+    {
+      "path": "tests/specs/test_dup_similarity.py",
+      "size": 1789
+    },
+    {
+      "path": "tests/specs/test_metrics_schema.py",
+      "size": 1102
+    },
+    {
+      "path": "tests/specs/test_regex_props.py",
+      "size": 777
+    },
+    {
+      "path": "tests/specs/test_smt_policy.py",
+      "size": 1011
+    },
+    {
+      "path": "tests/status/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/status/test_render_monthly_html.py",
+      "size": 1280
+    },
+    {
+      "path": "tests/status/test_status_gate_from_statusrc.py",
+      "size": 1009
+    },
+    {
+      "path": "tests/status/test_status_report.py",
+      "size": 1001
+    },
+    {
+      "path": "tests/status/test_status_report_smoke.py",
+      "size": 1195
+    },
+    {
+      "path": "tests/status/test_status_report_verbose.py",
+      "size": 852
+    },
+    {
+      "path": "tests/stub_packages/hydra/__init__.py",
+      "size": 93
+    },
+    {
+      "path": "tests/stub_packages/numpy/__init__.py",
+      "size": 151
+    },
+    {
+      "path": "tests/stub_packages/omegaconf/__init__.py",
+      "size": 315
+    },
+    {
+      "path": "tests/stub_packages/sentencepiece/__init__.py",
+      "size": 110
+    },
+    {
+      "path": "tests/stub_packages/torch/__init__.py",
+      "size": 318
+    },
+    {
+      "path": "tests/stub_packages/torch/utils/__init__.py",
+      "size": 32
+    },
+    {
+      "path": "tests/stub_packages/torch/utils/data/__init__.py",
+      "size": 62
+    },
+    {
+      "path": "tests/stub_packages/transformers/__init__.py",
+      "size": 112
+    },
+    {
+      "path": "tests/stub_packages/yaml/__init__.py",
+      "size": 93
+    },
+    {
+      "path": "tests/telemetry/test_instrumentation.py",
+      "size": 395
+    },
+    {
+      "path": "tests/telemetry/test_json_disable_env.py",
+      "size": 601
+    },
+    {
+      "path": "tests/telemetry/test_metrics_server.py",
+      "size": 576
+    },
+    {
+      "path": "tests/telemetry/test_ndjson_disable_env.py",
+      "size": 986
+    },
+    {
+      "path": "tests/telemetry/test_sample_rate_gate.py",
+      "size": 980
+    },
+    {
+      "path": "tests/telemetry/test_telemetry_event_schema.py",
+      "size": 1619
+    },
+    {
+      "path": "tests/templates/__init__.py",
+      "size": 40
+    },
+    {
+      "path": "tests/templates/test_status_template.py",
+      "size": 17311
+    },
+    {
+      "path": "tests/templates/test_template_discovery.py",
+      "size": 2454
+    },
+    {
+      "path": "tests/templates/test_template_structure.py",
+      "size": 3081
+    },
+    {
+      "path": "tests/test_accelerate_shim.py",
+      "size": 2447
+    },
+    {
+      "path": "tests/test_actions_server_smoke.py",
+      "size": 668
+    },
+    {
+      "path": "tests/test_activations.py",
+      "size": 255
+    },
+    {
+      "path": "tests/test_api_infer.py",
+      "size": 617
+    },
+    {
+      "path": "tests/test_api_infer_masking.py",
+      "size": 1174
+    },
+    {
+      "path": "tests/test_api_infer_tokenizer.py",
+      "size": 847
+    },
+    {
+      "path": "tests/test_api_rate_limit.py",
+      "size": 602
+    },
+    {
+      "path": "tests/test_api_secret_filter.py",
+      "size": 414
+    },
+    {
+      "path": "tests/test_batch_metrics_shim.py",
+      "size": 763
+    },
+    {
+      "path": "tests/test_bestk_retention.py",
+      "size": 1120
+    },
+    {
+      "path": "tests/test_callbacks.py",
+      "size": 3041
+    },
+    {
+      "path": "tests/test_chat_env_cleanup.py",
+      "size": 504
+    },
+    {
+      "path": "tests/test_chat_session.py",
+      "size": 3210
+    },
+    {
+      "path": "tests/test_chat_session_exit.py",
+      "size": 1138
+    },
+    {
+      "path": "tests/test_checkpoint_bundle.py",
+      "size": 1006
+    },
+    {
+      "path": "tests/test_checkpoint_checksum.py",
+      "size": 6213
+    },
+    {
+      "path": "tests/test_checkpoint_checksum_and_retention.py",
+      "size": 1951
+    },
+    {
+      "path": "tests/test_checkpoint_commit_meta.py",
+      "size": 762
+    },
+    {
+      "path": "tests/test_checkpoint_corrupt_load.py",
+      "size": 1101
+    },
+    {
+      "path": "tests/test_checkpoint_corruption.py",
+      "size": 669
+    },
+    {
+      "path": "tests/test_checkpoint_integrity.py",
+      "size": 658
+    },
+    {
+      "path": "tests/test_checkpoint_integrity_corruption.py",
+      "size": 1051
+    },
+    {
+      "path": "tests/test_checkpoint_manager.py",
+      "size": 1518
+    },
+    {
+      "path": "tests/test_checkpoint_metadata.py",
+      "size": 859
+    },
+    {
+      "path": "tests/test_checkpoint_provenance.py",
+      "size": 662
+    },
+    {
+      "path": "tests/test_checkpoint_restore_rng_torch.py",
+      "size": 1733
+    },
+    {
+      "path": "tests/test_checkpoint_roundtrip.py",
+      "size": 2878
+    },
+    {
+      "path": "tests/test_checkpoint_save_resume.py",
+      "size": 1015
+    },
+    {
+      "path": "tests/test_checkpoint_sha_rng.py",
+      "size": 1313
+    },
+    {
+      "path": "tests/test_checkpoint_system_meta.py",
+      "size": 324
+    },
+    {
+      "path": "tests/test_checkpoint_util.py",
+      "size": 1265
+    },
+    {
+      "path": "tests/test_checkpointing.py",
+      "size": 1985
+    },
+    {
+      "path": "tests/test_checkpointing_utils_extra.py",
+      "size": 768
+    },
+    {
+      "path": "tests/test_checksum_sha256.py",
+      "size": 698
+    },
+    {
+      "path": "tests/test_ci_smoke.py",
+      "size": 352
+    },
+    {
+      "path": "tests/test_cli.py",
+      "size": 5852
+    },
+    {
+      "path": "tests/test_cli_entrypoint.py",
+      "size": 999
+    },
+    {
+      "path": "tests/test_cli_help.py",
+      "size": 606
+    },
+    {
+      "path": "tests/test_cli_help_paths.py",
+      "size": 1625
+    },
+    {
+      "path": "tests/test_cli_hydra_validation.py",
+      "size": 1932
+    },
+    {
+      "path": "tests/test_cli_pool.py",
+      "size": 1214
+    },
+    {
+      "path": "tests/test_cli_simple.py",
+      "size": 2412
+    },
+    {
+      "path": "tests/test_cli_smoke.py",
+      "size": 528
+    },
+    {
+      "path": "tests/test_cli_train_command.py",
+      "size": 1156
+    },
+    {
+      "path": "tests/test_cli_train_engine.py",
+      "size": 2268
+    },
+    {
+      "path": "tests/test_codex_best_effort.py",
+      "size": 3037
+    },
+    {
+      "path": "tests/test_codex_cli.py",
+      "size": 798
+    },
+    {
+      "path": "tests/test_codex_maintenance.py",
+      "size": 767
+    },
+    {
+      "path": "tests/test_codex_ml_cli_version.py",
+      "size": 439
+    },
+    {
+      "path": "tests/test_codex_run_tasks.py",
+      "size": 5756
+    },
+    {
+      "path": "tests/test_codex_sequence_validations.py",
+      "size": 5334
+    },
+    {
+      "path": "tests/test_codexml_cli.py",
+      "size": 2427
+    },
+    {
+      "path": "tests/test_config_validation.py",
+      "size": 2040
+    },
+    {
+      "path": "tests/test_container_smoke.py",
+      "size": 1104
+    },
+    {
+      "path": "tests/test_conversation_logger.py",
+      "size": 700
+    },
+    {
+      "path": "tests/test_crc32_file.py",
+      "size": 341
+    },
+    {
+      "path": "tests/test_data_cache_sharding.py",
+      "size": 297
+    },
+    {
+      "path": "tests/test_data_loader.py",
+      "size": 2306
+    },
+    {
+      "path": "tests/test_data_loaders.py",
+      "size": 1211
+    },
+    {
+      "path": "tests/test_data_loaders_extended.py",
+      "size": 1391
+    },
+    {
+      "path": "tests/test_data_registry.py",
+      "size": 1513
+    },
+    {
+      "path": "tests/test_data_split_utils.py",
+      "size": 1851
+    },
+    {
+      "path": "tests/test_data_splits.py",
+      "size": 1302
+    },
+    {
+      "path": "tests/test_data_utils.py",
+      "size": 1437
+    },
+    {
+      "path": "tests/test_dataset_checksums.py",
+      "size": 464
+    },
+    {
+      "path": "tests/test_dataset_manifest.py",
+      "size": 1013
+    },
+    {
+      "path": "tests/test_dataset_wrapper.py",
+      "size": 1090
+    },
+    {
+      "path": "tests/test_datasets_determinism.py",
+      "size": 1016
+    },
+    {
+      "path": "tests/test_datasets_module.py",
+      "size": 2155
+    },
+    {
+      "path": "tests/test_db_utils.py",
+      "size": 1608
+    },
+    {
+      "path": "tests/test_db_utils_table_name.py",
+      "size": 759
+    },
+    {
+      "path": "tests/test_deep_research_task_process.py",
+      "size": 1167
+    },
+    {
+      "path": "tests/test_deploy_codex_pipeline.py",
+      "size": 3396
+    },
+    {
+      "path": "tests/test_determinism.py",
+      "size": 404
+    },
+    {
+      "path": "tests/test_deterministic_split.py",
+      "size": 1195
+    },
+    {
+      "path": "tests/test_docs_examples_paths.py",
+      "size": 543
+    },
+    {
+      "path": "tests/test_engine_hf_trainer.py",
+      "size": 12949
+    },
+    {
+      "path": "tests/test_engine_hf_trainer_grad_accum.py",
+      "size": 629
+    },
+    {
+      "path": "tests/test_engine_hf_trainer_lora.py",
+      "size": 4063
+    },
+    {
+      "path": "tests/test_env_logging.py",
+      "size": 2154
+    },
+    {
+      "path": "tests/test_error_log.py",
+      "size": 314
+    },
+    {
+      "path": "tests/test_eval_fallback.py",
+      "size": 948
+    },
+    {
+      "path": "tests/test_eval_loop_cpu.py",
+      "size": 3141
+    },
+    {
+      "path": "tests/test_eval_loop_minimal.py",
+      "size": 1139
+    },
+    {
+      "path": "tests/test_eval_loop_resilience.py",
+      "size": 1728
+    },
+    {
+      "path": "tests/test_eval_metrics_continual.py",
+      "size": 896
+    },
+    {
+      "path": "tests/test_eval_runner.py",
+      "size": 715
+    },
+    {
+      "path": "tests/test_eval_with_metrics.py",
+      "size": 2398
+    },
+    {
+      "path": "tests/test_eval_writers.py",
+      "size": 775
+    },
+    {
+      "path": "tests/test_evaluate_cli.py",
+      "size": 1328
+    },
+    {
+      "path": "tests/test_evaluation.py",
+      "size": 5699
+    },
+    {
+      "path": "tests/test_export.py",
+      "size": 1605
+    },
+    {
+      "path": "tests/test_factory_registry.py",
+      "size": 9610
+    },
+    {
+      "path": "tests/test_fences_tool.py",
+      "size": 944
+    },
+    {
+      "path": "tests/test_fetch_messages.py",
+      "size": 11279
+    },
+    {
+      "path": "tests/test_fetch_messages_missing_db.py",
+      "size": 718
+    },
+    {
+      "path": "tests/test_git_tag.py",
+      "size": 5606
+    },
+    {
+      "path": "tests/test_github_client.py",
+      "size": 156
+    },
+    {
+      "path": "tests/test_grad_accumulation_path.py",
+      "size": 1817
+    },
+    {
+      "path": "tests/test_gradient_accumulation_equivalence.py",
+      "size": 4298
+    },
+    {
+      "path": "tests/test_gradient_accumulation_tail_flush.py",
+      "size": 4292
+    },
+    {
+      "path": "tests/test_hf_loader_amp.py",
+      "size": 622
+    },
+    {
+      "path": "tests/test_hf_loader_peft_guard.py",
+      "size": 1311
+    },
+    {
+      "path": "tests/test_hf_loader_registry.py",
+      "size": 1256
+    },
+    {
+      "path": "tests/test_hf_tokenizer_padding.py",
+      "size": 1063
+    },
+    {
+      "path": "tests/test_hf_trainer_lora_config.py",
+      "size": 2306
+    },
+    {
+      "path": "tests/test_hydra_cli.py",
+      "size": 664
+    },
+    {
+      "path": "tests/test_hydra_compose.py",
+      "size": 1600
+    },
+    {
+      "path": "tests/test_import_codex.py",
+      "size": 72
+    },
+    {
+      "path": "tests/test_import_ndjson.py",
+      "size": 2215
+    },
+    {
+      "path": "tests/test_import_ndjson_cli.py",
+      "size": 1963
+    },
+    {
+      "path": "tests/test_import_ndjson_dedup.py",
+      "size": 1365
+    },
+    {
+      "path": "tests/test_ingestion_auto_encoding.py",
+      "size": 576
+    },
+    {
+      "path": "tests/test_ingestion_encoding_coverage.py",
+      "size": 2095
+    },
+    {
+      "path": "tests/test_ingestion_encodings_matrix.py",
+      "size": 681
+    },
+    {
+      "path": "tests/test_ingestion_family_encoding.py",
+      "size": 1188
+    },
+    {
+      "path": "tests/test_ingestion_io.py",
+      "size": 1948
+    },
+    {
+      "path": "tests/test_ingestion_read_text.py",
+      "size": 485
+    },
+    {
+      "path": "tests/test_ingestion_seeded_shuffle.py",
+      "size": 271
+    },
+    {
+      "path": "tests/test_ingestion_split_cache.py",
+      "size": 798
+    },
+    {
+      "path": "tests/test_interface_loader_env.py",
+      "size": 540
+    },
+    {
+      "path": "tests/test_interfaces_compat.py",
+      "size": 4038
+    },
+    {
+      "path": "tests/test_interfaces_hf_tokenizer.py",
+      "size": 743
+    },
+    {
+      "path": "tests/test_iter_jsonl.py",
+      "size": 777
+    },
+    {
+      "path": "tests/test_json_report.py",
+      "size": 2922
+    },
+    {
+      "path": "tests/test_jsonl_writer.py",
+      "size": 504
+    },
+    {
+      "path": "tests/test_label_policy_lint.py",
+      "size": 2717
+    },
+    {
+      "path": "tests/test_loader_registry.py",
+      "size": 2585
+    },
+    {
+      "path": "tests/test_loaders.py",
+      "size": 2006
+    },
+    {
+      "path": "tests/test_local_ci_script.py",
+      "size": 1844
+    },
+    {
+      "path": "tests/test_log_adapters.py",
+      "size": 528
+    },
+    {
+      "path": "tests/test_logging_bootstrap.py",
+      "size": 1130
+    },
+    {
+      "path": "tests/test_logging_utils.py",
+      "size": 2105
+    },
+    {
+      "path": "tests/test_logging_utils_module.py",
+      "size": 2052
+    },
+    {
+      "path": "tests/test_logging_viewer_cli.py",
+      "size": 2265
+    },
+    {
+      "path": "tests/test_make_generator_worker_seed.py",
+      "size": 894
+    },
+    {
+      "path": "tests/test_metric_curves.py",
+      "size": 391
+    },
+    {
+      "path": "tests/test_metric_registry.py",
+      "size": 4022
+    },
+    {
+      "path": "tests/test_metrics.py",
+      "size": 2105
+    },
+    {
+      "path": "tests/test_metrics_cli_duckdb.py",
+      "size": 1337
+    },
+    {
+      "path": "tests/test_metrics_correctness.py",
+      "size": 1512
+    },
+    {
+      "path": "tests/test_metrics_generative.py",
+      "size": 6052
+    },
+    {
+      "path": "tests/test_metrics_logging.py",
+      "size": 881
+    },
+    {
+      "path": "tests/test_metrics_perplexity.py",
+      "size": 676
+    },
+    {
+      "path": "tests/test_metrics_registry_alias.py",
+      "size": 271
+    },
+    {
+      "path": "tests/test_metrics_sinks.py",
+      "size": 986
+    },
+    {
+      "path": "tests/test_metrics_tb.py",
+      "size": 745
+    },
+    {
+      "path": "tests/test_metrics_token_accuracy.py",
+      "size": 612
+    },
+    {
+      "path": "tests/test_microhelpers.py",
+      "size": 1372
+    },
+    {
+      "path": "tests/test_minilm_forward.py",
+      "size": 1017
+    },
+    {
+      "path": "tests/test_mlflow_adapter.py",
+      "size": 821
+    },
+    {
+      "path": "tests/test_mlflow_step_logging.py",
+      "size": 5868
+    },
+    {
+      "path": "tests/test_mlflow_utils.py",
+      "size": 8158
+    },
+    {
+      "path": "tests/test_mlflow_utils_root.py",
+      "size": 4351
+    },
+    {
+      "path": "tests/test_model_factory.py",
+      "size": 2713
+    },
+    {
+      "path": "tests/test_model_forward.py",
+      "size": 455
+    },
+    {
+      "path": "tests/test_model_loader.py",
+      "size": 8399
+    },
+    {
+      "path": "tests/test_model_registry.py",
+      "size": 4356
+    },
+    {
+      "path": "tests/test_model_registry_helpers.py",
+      "size": 3707
+    },
+    {
+      "path": "tests/test_model_registry_invalid.py",
+      "size": 471
+    },
+    {
+      "path": "tests/test_modeling_module.py",
+      "size": 4138
+    },
+    {
+      "path": "tests/test_modeling_utils.py",
+      "size": 3232
+    },
+    {
+      "path": "tests/test_monitoring.py",
+      "size": 2874
+    },
+    {
+      "path": "tests/test_monitoring_cli.py",
+      "size": 3075
+    },
+    {
+      "path": "tests/test_monitoring_thread.py",
+      "size": 830
+    },
+    {
+      "path": "tests/test_most_recent_branch_remote.py",
+      "size": 329
+    },
+    {
+      "path": "tests/test_msp_infer_api.py",
+      "size": 7388
+    },
+    {
+      "path": "tests/test_ndjson_db_parity.py",
+      "size": 1291
+    },
+    {
+      "path": "tests/test_ndjson_logger.py",
+      "size": 787
+    },
+    {
+      "path": "tests/test_ndjson_logging.py",
+      "size": 540
+    },
+    {
+      "path": "tests/test_ndjson_writer.py",
+      "size": 447
+    },
+    {
+      "path": "tests/test_nox_tests_delegation.py",
+      "size": 764
+    },
+    {
+      "path": "tests/test_offline_repo_auditor.py",
+      "size": 1115
+    },
+    {
+      "path": "tests/test_packaging_metadata.py",
+      "size": 2655
+    },
+    {
+      "path": "tests/test_parse_when.py",
+      "size": 511
+    },
+    {
+      "path": "tests/test_peft_adapter.py",
+      "size": 2221
+    },
+    {
+      "path": "tests/test_peft_gating.py",
+      "size": 272
+    },
+    {
+      "path": "tests/test_peft_hooks.py",
+      "size": 1756
+    },
+    {
+      "path": "tests/test_peft_integration.py",
+      "size": 418
+    },
+    {
+      "path": "tests/test_perf_sampler.py",
+      "size": 222
+    },
+    {
+      "path": "tests/test_perf_summary.py",
+      "size": 487
+    },
+    {
+      "path": "tests/test_pipeline.py",
+      "size": 372
+    },
+    {
+      "path": "tests/test_plugin_loader.py",
+      "size": 1968
+    },
+    {
+      "path": "tests/test_plugins_cli.py",
+      "size": 3187
+    },
+    {
+      "path": "tests/test_policy_enforcement.py",
+      "size": 4076
+    },
+    {
+      "path": "tests/test_precommit_config_exists.py",
+      "size": 214
+    },
+    {
+      "path": "tests/test_pyproject_metadata.py",
+      "size": 1100
+    },
+    {
+      "path": "tests/test_pyproject_scripts_present.py",
+      "size": 1221
+    },
+    {
+      "path": "tests/test_pyproject_toml_parse.py",
+      "size": 1098
+    },
+    {
+      "path": "tests/test_query_logs_build_query.py",
+      "size": 17260
+    },
+    {
+      "path": "tests/test_query_logs_tail.py",
+      "size": 1286
+    },
+    {
+      "path": "tests/test_readme_examples.py",
+      "size": 831
+    },
+    {
+      "path": "tests/test_readme_has_quickstart.py",
+      "size": 834
+    },
+    {
+      "path": "tests/test_registry.py",
+      "size": 4595
+    },
+    {
+      "path": "tests/test_repo_option_a.py",
+      "size": 725
+    },
+    {
+      "path": "tests/test_repo_option_b.py",
+      "size": 561
+    },
+    {
+      "path": "tests/test_repro_branches.py",
+      "size": 755
+    },
+    {
+      "path": "tests/test_repro_capture.py",
+      "size": 598
+    },
+    {
+      "path": "tests/test_repro_cli.py",
+      "size": 1112
+    },
+    {
+      "path": "tests/test_repro_determinism.py",
+      "size": 716
+    },
+    {
+      "path": "tests/test_repro_helper.py",
+      "size": 478
+    },
+    {
+      "path": "tests/test_repro_rng_roundtrip.py",
+      "size": 1545
+    },
+    {
+      "path": "tests/test_repro_seed_consistency.py",
+      "size": 913
+    },
+    {
+      "path": "tests/test_reproducibility.py",
+      "size": 472
+    },
+    {
+      "path": "tests/test_requirements_lock.py",
+      "size": 1076
+    },
+    {
+      "path": "tests/test_resume.py",
+      "size": 2190
+    },
+    {
+      "path": "tests/test_resume_training.py",
+      "size": 3787
+    },
+    {
+      "path": "tests/test_retrieval_pipeline.py",
+      "size": 4386
+    },
+    {
+      "path": "tests/test_reward_models_rlhf.py",
+      "size": 1476
+    },
+    {
+      "path": "tests/test_run_eval_cli.py",
+      "size": 756
+    },
+    {
+      "path": "tests/test_run_functional_training_tokenizer.py",
+      "size": 1048
+    },
+    {
+      "path": "tests/test_runner_doctor.py",
+      "size": 517
+    },
+    {
+      "path": "tests/test_safety.py",
+      "size": 3757
+    },
+    {
+      "path": "tests/test_safety_filters_integration.py",
+      "size": 2802
+    },
+    {
+      "path": "tests/test_safety_import_no_crash.py",
+      "size": 331
+    },
+    {
+      "path": "tests/test_search_providers.py",
+      "size": 947
+    },
+    {
+      "path": "tests/test_secrets_scanner.py",
+      "size": 902
+    },
+    {
+      "path": "tests/test_seeded_shuffle.py",
+      "size": 257
+    },
+    {
+      "path": "tests/test_semparser.py",
+      "size": 354
+    },
+    {
+      "path": "tests/test_sentencepiece_adapter.py",
+      "size": 20694
+    },
+    {
+      "path": "tests/test_session_hooks.py",
+      "size": 4978
+    },
+    {
+      "path": "tests/test_session_hooks_warnings.py",
+      "size": 793
+    },
+    {
+      "path": "tests/test_session_logger_log_adapters.py",
+      "size": 1453
+    },
+    {
+      "path": "tests/test_session_logger_wal.py",
+      "size": 1175
+    },
+    {
+      "path": "tests/test_session_logging.py",
+      "size": 11290
+    },
+    {
+      "path": "tests/test_session_logging_mirror.py",
+      "size": 641
+    },
+    {
+      "path": "tests/test_session_query_cli.py",
+      "size": 2555
+    },
+    {
+      "path": "tests/test_session_query_smoke.py",
+      "size": 1405
+    },
+    {
+      "path": "tests/test_setup_sync_groups.py",
+      "size": 1364
+    },
+    {
+      "path": "tests/test_simple_cli_seeding.py",
+      "size": 562
+    },
+    {
+      "path": "tests/test_split_indices.py",
+      "size": 727
+    },
+    {
+      "path": "tests/test_splits.py",
+      "size": 1090
+    },
+    {
+      "path": "tests/test_sqlite_pool.py",
+      "size": 1266
+    },
+    {
+      "path": "tests/test_sqlite_pool_close.py",
+      "size": 1466
+    },
+    {
+      "path": "tests/test_sqlite_sanitize.py",
+      "size": 347
+    },
+    {
+      "path": "tests/test_sqlite_wal.py",
+      "size": 798
+    },
+    {
+      "path": "tests/test_static_code_analysis_step.py",
+      "size": 531
+    },
+    {
+      "path": "tests/test_structured_logger.py",
+      "size": 215
+    },
+    {
+      "path": "tests/test_symbolic_pipeline.py",
+      "size": 4588
+    },
+    {
+      "path": "tests/test_system_metrics_logging.py",
+      "size": 7796
+    },
+    {
+      "path": "tests/test_system_metrics_sampler.py",
+      "size": 1182
+    },
+    {
+      "path": "tests/test_tb_writer_noop.py",
+      "size": 826
+    },
+    {
+      "path": "tests/test_telemetry_degrade.py",
+      "size": 400
+    },
+    {
+      "path": "tests/test_token_cache.py",
+      "size": 2490
+    },
+    {
+      "path": "tests/test_tokenization.py",
+      "size": 832
+    },
+    {
+      "path": "tests/test_tokenization_roundtrip.py",
+      "size": 2781
+    },
+    {
+      "path": "tests/test_tokenizer.py",
+      "size": 5120
+    },
+    {
+      "path": "tests/test_tokenizer_batch_encode.py",
+      "size": 6867
+    },
+    {
+      "path": "tests/test_tokenizer_cli_refresh.py",
+      "size": 538
+    },
+    {
+      "path": "tests/test_tokenizer_encode_decode.py",
+      "size": 523
+    },
+    {
+      "path": "tests/test_tokenizer_ids.py",
+      "size": 305
+    },
+    {
+      "path": "tests/test_tokenizer_roundtrip.py",
+      "size": 1593
+    },
+    {
+      "path": "tests/test_tokenizer_sp.py",
+      "size": 983
+    },
+    {
+      "path": "tests/test_tokenizer_wrapper.py",
+      "size": 891
+    },
+    {
+      "path": "tests/test_tracking_mlflow_smoke.py",
+      "size": 500
+    },
+    {
+      "path": "tests/test_train_helpers.py",
+      "size": 325
+    },
+    {
+      "path": "tests/test_train_loop.py",
+      "size": 7898
+    },
+    {
+      "path": "tests/test_train_loop_import_sideeffects.py",
+      "size": 1562
+    },
+    {
+      "path": "tests/test_train_loop_smoke.py",
+      "size": 3922
+    },
+    {
+      "path": "tests/test_train_smoke.py",
+      "size": 2197
+    },
+    {
+      "path": "tests/test_train_tokenizer.py",
+      "size": 1147
+    },
+    {
+      "path": "tests/test_trainer_extended.py",
+      "size": 5354
+    },
+    {
+      "path": "tests/test_trainer_reward_registry.py",
+      "size": 1315
+    },
+    {
+      "path": "tests/test_training_arguments_flags.py",
+      "size": 591
+    },
+    {
+      "path": "tests/test_training_callbacks.py",
+      "size": 802
+    },
+    {
+      "path": "tests/test_training_config_yaml.py",
+      "size": 789
+    },
+    {
+      "path": "tests/test_training_continual_strategy.py",
+      "size": 3813
+    },
+    {
+      "path": "tests/test_training_engine.py",
+      "size": 3097
+    },
+    {
+      "path": "tests/test_training_eval.py",
+      "size": 1496
+    },
+    {
+      "path": "tests/test_training_integration_flags.py",
+      "size": 12860
+    },
+    {
+      "path": "tests/test_training_lr_history_and_eval.py",
+      "size": 1127
+    },
+    {
+      "path": "tests/test_training_metadata_logging.py",
+      "size": 1819
+    },
+    {
+      "path": "tests/test_training_resume.py",
+      "size": 1256
+    },
+    {
+      "path": "tests/test_trainloop_grad_accum.py",
+      "size": 168
+    },
+    {
+      "path": "tests/test_utils_training_callbacks.py",
+      "size": 613
+    },
+    {
+      "path": "tests/test_validate_fences.py",
+      "size": 2473
+    },
+    {
+      "path": "tests/test_validate_fences_md.py",
+      "size": 1175
+    },
+    {
+      "path": "tests/test_vector_store_stub.py",
+      "size": 483
+    },
+    {
+      "path": "tests/test_vendor_audit_scripts.py",
+      "size": 11811
+    },
+    {
+      "path": "tests/test_wandb_shim.py",
+      "size": 1970
+    },
+    {
+      "path": "tests/test_zendesk_validators.py",
+      "size": 2474
+    },
+    {
+      "path": "tests/tokenization/conftest.py",
+      "size": 14123
+    },
+    {
+      "path": "tests/tokenization/test_adapter.py",
+      "size": 525
+    },
+    {
+      "path": "tests/tokenization/test_api_import_warning_once.py",
+      "size": 407
+    },
+    {
+      "path": "tests/tokenization/test_cli_inspect_export.py",
+      "size": 1058
+    },
+    {
+      "path": "tests/tokenization/test_deprecation.py",
+      "size": 1625
+    },
+    {
+      "path": "tests/tokenization/test_encode_decode_roundtrip.py",
+      "size": 833
+    },
+    {
+      "path": "tests/tokenization/test_hf_adapter_canonical.py",
+      "size": 370
+    },
+    {
+      "path": "tests/tokenization/test_hf_tokenizer_adapter.py",
+      "size": 819
+    },
+    {
+      "path": "tests/tokenization/test_load_tokenizer_use_fast.py",
+      "size": 1804
+    },
+    {
+      "path": "tests/tokenization/test_padding_truncation_ext.py",
+      "size": 3263
+    },
+    {
+      "path": "tests/tokenization/test_roundtrip.py",
+      "size": 5180
+    },
+    {
+      "path": "tests/tokenization/test_roundtrip_basic.py",
+      "size": 3390
+    },
+    {
+      "path": "tests/tokenization/test_sentencepiece_adapter.py",
+      "size": 1782
+    },
+    {
+      "path": "tests/tokenization/test_sentencepiece_adapter_edges.py",
+      "size": 1759
+    },
+    {
+      "path": "tests/tokenization/test_sentencepiece_adapter_prefix.py",
+      "size": 1004
+    },
+    {
+      "path": "tests/tokenization/test_sentencepiece_adapter_stub.py",
+      "size": 5253
+    },
+    {
+      "path": "tests/tokenization/test_sentencepiece_adapter_train.py",
+      "size": 2626
+    },
+    {
+      "path": "tests/tokenization/test_sentencepiece_roundtrip.py",
+      "size": 4813
+    },
+    {
+      "path": "tests/tokenization/test_sentencepiece_tokenizer.py",
+      "size": 5997
+    },
+    {
+      "path": "tests/tokenization/test_sp_fixture_roundtrip.py",
+      "size": 1030
+    },
+    {
+      "path": "tests/tokenization/test_streaming_ingest.py",
+      "size": 2890
+    },
+    {
+      "path": "tests/tokenization/test_tiny_vocab_roundtrip.py",
+      "size": 1076
+    },
+    {
+      "path": "tests/tokenization/test_tokenization_api_and_deprecation.py",
+      "size": 1769
+    },
+    {
+      "path": "tests/tokenization/test_tokenization_compat.py",
+      "size": 787
+    },
+    {
+      "path": "tests/tokenization/test_tokenization_deprecation.py",
+      "size": 326
+    },
+    {
+      "path": "tests/tokenization/test_tokenization_roundtrip.py",
+      "size": 648
+    },
+    {
+      "path": "tests/tokenization/test_tokenizer_basic.py",
+      "size": 753
+    },
+    {
+      "path": "tests/tokenization/test_tokenizer_cli.py",
+      "size": 1904
+    },
+    {
+      "path": "tests/tokenization/test_tokenizer_parity.py",
+      "size": 827
+    },
+    {
+      "path": "tests/tokenization/test_tokenizer_training_streaming_equivalence.py",
+      "size": 3146
+    },
+    {
+      "path": "tests/tokenization/test_train_tokenizer_smoke.py",
+      "size": 832
+    },
+    {
+      "path": "tests/tokenization/test_train_tokenizer_streaming.py",
+      "size": 4885
+    },
+    {
+      "path": "tests/tools/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/tools/test_cli_ndjson_summary.py",
+      "size": 1432
+    },
+    {
+      "path": "tests/tools/test_cli_ndjson_summary_prop.py",
+      "size": 1171
+    },
+    {
+      "path": "tests/tools/test_env_snapshot.py",
+      "size": 451
+    },
+    {
+      "path": "tests/tools/test_export_security.py",
+      "size": 1115
+    },
+    {
+      "path": "tests/tools/test_link_id_crossref.py",
+      "size": 730
+    },
+    {
+      "path": "tests/tools/test_ndjson_to_csv.py",
+      "size": 579
+    },
+    {
+      "path": "tests/tools/test_patch_apply.py",
+      "size": 791
+    },
+    {
+      "path": "tests/tools/test_perf_snapshot.py",
+      "size": 962
+    },
+    {
+      "path": "tests/tools/test_post_check_validation.py",
+      "size": 559
+    },
+    {
+      "path": "tests/tools/test_report_merge.py",
+      "size": 731
+    },
+    {
+      "path": "tests/tools/test_sarif_aggregate.py",
+      "size": 1016
+    },
+    {
+      "path": "tests/tools/test_schema_validate_cli.py",
+      "size": 697
+    },
+    {
+      "path": "tests/tools/test_template_lint.py",
+      "size": 635
+    },
+    {
+      "path": "tests/tools/test_validate_configs.py",
+      "size": 1130
+    },
+    {
+      "path": "tests/tools/test_validate_fences.py",
+      "size": 1223
+    },
+    {
+      "path": "tests/tools/test_validate_fences_samples.py",
+      "size": 677
+    },
+    {
+      "path": "tests/tracking/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/tracking/test_composite_writer_degrades.py",
+      "size": 1326
+    },
+    {
+      "path": "tests/tracking/test_default_file_backend.py",
+      "size": 627
+    },
+    {
+      "path": "tests/tracking/test_file_uri_normalization.py",
+      "size": 515
+    },
+    {
+      "path": "tests/tracking/test_git_tag.py",
+      "size": 564
+    },
+    {
+      "path": "tests/tracking/test_git_tag_decode.py",
+      "size": 219
+    },
+    {
+      "path": "tests/tracking/test_guards_offline_matrix.py",
+      "size": 468
+    },
+    {
+      "path": "tests/tracking/test_init_experiment_tags.py",
+      "size": 1139
+    },
+    {
+      "path": "tests/tracking/test_mlflow_defaults_and_noop.py",
+      "size": 997
+    },
+    {
+      "path": "tests/tracking/test_mlflow_entrypoints.py",
+      "size": 1137
+    },
+    {
+      "path": "tests/tracking/test_mlflow_guard.py",
+      "size": 7362
+    },
+    {
+      "path": "tests/tracking/test_mlflow_init.py",
+      "size": 1710
+    },
+    {
+      "path": "tests/tracking/test_mlflow_noop_default.py",
+      "size": 1076
+    },
+    {
+      "path": "tests/tracking/test_mlflow_offline_cli.py",
+      "size": 3389
+    },
+    {
+      "path": "tests/tracking/test_mlflow_offline_guard.py",
+      "size": 2381
+    },
+    {
+      "path": "tests/tracking/test_ndjson_logger_core.py",
+      "size": 1777
+    },
+    {
+      "path": "tests/tracking/test_ndjson_summarizer.py",
+      "size": 3020
+    },
+    {
+      "path": "tests/tracking/test_ndjson_writer.py",
+      "size": 1957
+    },
+    {
+      "path": "tests/tracking/test_noop_logger.py",
+      "size": 466
+    },
+    {
+      "path": "tests/tracking/test_offline_decision.py",
+      "size": 577
+    },
+    {
+      "path": "tests/tracking/test_offline_helpers.py",
+      "size": 819
+    },
+    {
+      "path": "tests/tracking/test_offline_ndjson_logger.py",
+      "size": 526
+    },
+    {
+      "path": "tests/tracking/test_seed_snapshot_local.py",
+      "size": 383
+    },
+    {
+      "path": "tests/tracking/test_tracking_bootstrap.py",
+      "size": 795
+    },
+    {
+      "path": "tests/tracking/test_tracking_guard_matrix.py",
+      "size": 1342
+    },
+    {
+      "path": "tests/tracking/test_tracking_guards.py",
+      "size": 1919
+    },
+    {
+      "path": "tests/tracking/test_tracking_ndjson_summary.py",
+      "size": 1032
+    },
+    {
+      "path": "tests/tracking/test_tracking_summary_rotation.py",
+      "size": 2255
+    },
+    {
+      "path": "tests/tracking/test_tracking_writers_offline.py",
+      "size": 7469
+    },
+    {
+      "path": "tests/tracking/test_writers_roundtrip.py",
+      "size": 1716
+    },
+    {
+      "path": "tests/train/test_hydra_degrade.py",
+      "size": 418
+    },
+    {
+      "path": "tests/train/test_hydra_main_exit_path.py",
+      "size": 492
+    },
+    {
+      "path": "tests/train_loop/test_bf16_matmul_guard.py",
+      "size": 889
+    },
+    {
+      "path": "tests/train_loop/test_bf16_require_flag.py",
+      "size": 642
+    },
+    {
+      "path": "tests/train_loop/test_dataset_cast_policy_event.py",
+      "size": 1068
+    },
+    {
+      "path": "tests/train_loop/test_dtype_logging_and_dataset_gate.py",
+      "size": 852
+    },
+    {
+      "path": "tests/train_loop/test_resolve_dtype_and_device.py",
+      "size": 1187
+    },
+    {
+      "path": "tests/train_loop/test_telemetry_rollover.py",
+      "size": 1192
+    },
+    {
+      "path": "tests/training/conftest.py",
+      "size": 2046
+    },
+    {
+      "path": "tests/training/test_base_config.py",
+      "size": 709
+    },
+    {
+      "path": "tests/training/test_callbacks.py",
+      "size": 450
+    },
+    {
+      "path": "tests/training/test_checkpoint_integrity.py",
+      "size": 2164
+    },
+    {
+      "path": "tests/training/test_checkpoint_manager_basic.py",
+      "size": 864
+    },
+    {
+      "path": "tests/training/test_checkpoint_manager_callback.py",
+      "size": 951
+    },
+    {
+      "path": "tests/training/test_checkpoint_manifest.py",
+      "size": 1037
+    },
+    {
+      "path": "tests/training/test_checkpoint_resume.py",
+      "size": 2083
+    },
+    {
+      "path": "tests/training/test_checkpoint_rng_restore.py",
+      "size": 851
+    },
+    {
+      "path": "tests/training/test_config_loading.py",
+      "size": 2761
+    },
+    {
+      "path": "tests/training/test_cuda_determinism_guard.py",
+      "size": 886
+    },
+    {
+      "path": "tests/training/test_custom_loop_overfit.py",
+      "size": 903
+    },
+    {
+      "path": "tests/training/test_distributed_init_fallback.py",
+      "size": 4121
+    },
+    {
+      "path": "tests/training/test_engine_hf_trainer_lora_cfg.py",
+      "size": 1876
+    },
+    {
+      "path": "tests/training/test_evaluate_module.py",
+      "size": 1949
+    },
+    {
+      "path": "tests/training/test_extended_trainer.py",
+      "size": 5953
+    },
+    {
+      "path": "tests/training/test_functional_training_evaluation.py",
+      "size": 3347
+    },
+    {
+      "path": "tests/training/test_functional_training_main.py",
+      "size": 5572
+    },
+    {
+      "path": "tests/training/test_lora_optional.py",
+      "size": 1379
+    },
+    {
+      "path": "tests/training/test_lora_toggles.py",
+      "size": 786
+    },
+    {
+      "path": "tests/training/test_mid_epoch_naming.py",
+      "size": 390
+    },
+    {
+      "path": "tests/training/test_mid_epoch_resume_equivalence.py",
+      "size": 2576
+    },
+    {
+      "path": "tests/training/test_offline_wandb.py",
+      "size": 312
+    },
+    {
+      "path": "tests/training/test_overfit_smoke.py",
+      "size": 1122
+    },
+    {
+      "path": "tests/training/test_resume_and_retention.py",
+      "size": 3899
+    },
+    {
+      "path": "tests/training/test_run_custom_trainer_metadata.py",
+      "size": 2415
+    },
+    {
+      "path": "tests/training/test_run_functional_training_resume.py",
+      "size": 5952
+    },
+    {
+      "path": "tests/training/test_scheduler_amp_resume_parity.py",
+      "size": 1928
+    },
+    {
+      "path": "tests/training/test_seed_util.py",
+      "size": 727
+    },
+    {
+      "path": "tests/training/test_seed_utils.py",
+      "size": 709
+    },
+    {
+      "path": "tests/training/test_split_determinism.py",
+      "size": 322
+    },
+    {
+      "path": "tests/training/test_strict_determinism.py",
+      "size": 4153
+    },
+    {
+      "path": "tests/training/test_tiny_overfit.py",
+      "size": 2143
+    },
+    {
+      "path": "tests/training/test_trainer_auto_resume.py",
+      "size": 1632
+    },
+    {
+      "path": "tests/training/test_training_config_module.py",
+      "size": 1838
+    },
+    {
+      "path": "tests/training/test_unified_training_parity.py",
+      "size": 642
+    },
+    {
+      "path": "tests/training/test_unified_training_parity_and_resume.py",
+      "size": 3370
+    },
+    {
+      "path": "tests/training/test_unified_training_resume.py",
+      "size": 573
+    },
+    {
+      "path": "tests/training/test_unified_training_warnings.py",
+      "size": 768
+    },
+    {
+      "path": "tests/typer_cli/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tests/typer_cli/test_detectors_cli.py",
+      "size": 445
+    },
+    {
+      "path": "tests/unit/__init__.py",
+      "size": 66
+    },
+    {
+      "path": "tests/unit/test_adapters.py",
+      "size": 235
+    },
+    {
+      "path": "tests/unit/test_apply_ops_normalization.py",
+      "size": 833
+    },
+    {
+      "path": "tests/unit/test_attach_artifacts.py",
+      "size": 511
+    },
+    {
+      "path": "tests/unit/test_build_api_docs.py",
+      "size": 10581
+    },
+    {
+      "path": "tests/unit/test_cli_prompt_sanitisation.py",
+      "size": 2562
+    },
+    {
+      "path": "tests/unit/test_config_compose.py",
+      "size": 1208
+    },
+    {
+      "path": "tests/unit/test_coverage_toml_floor.py",
+      "size": 873
+    },
+    {
+      "path": "tests/unit/test_data_cache_locking.py",
+      "size": 649
+    },
+    {
+      "path": "tests/unit/test_datasets_module.py",
+      "size": 1218
+    },
+    {
+      "path": "tests/unit/test_deploy_cli.py",
+      "size": 2684
+    },
+    {
+      "path": "tests/unit/test_evaluate_cli_flags.py",
+      "size": 3898
+    },
+    {
+      "path": "tests/unit/test_evaluate_cli_metrics_log.py",
+      "size": 2920
+    },
+    {
+      "path": "tests/unit/test_hooks_manager.py",
+      "size": 490
+    },
+    {
+      "path": "tests/unit/test_logging_utils_module.py",
+      "size": 2654
+    },
+    {
+      "path": "tests/unit/test_mlflow_guard.py",
+      "size": 539
+    },
+    {
+      "path": "tests/unit/test_modeling_module.py",
+      "size": 2474
+    },
+    {
+      "path": "tests/unit/test_ndjson_tools.py",
+      "size": 660
+    },
+    {
+      "path": "tests/unit/test_peft_utils.py",
+      "size": 764
+    },
+    {
+      "path": "tests/unit/test_pipeline_nodes.py",
+      "size": 1343
+    },
+    {
+      "path": "tests/unit/test_plugin_loader.py",
+      "size": 317
+    },
+    {
+      "path": "tests/unit/test_prepare_split.py",
+      "size": 317
+    },
+    {
+      "path": "tests/unit/test_provenance.py",
+      "size": 2760
+    },
+    {
+      "path": "tests/unit/test_randomness.py",
+      "size": 553
+    },
+    {
+      "path": "tests/unit/test_registry_basic.py",
+      "size": 296
+    },
+    {
+      "path": "tests/unit/test_repo_map.py",
+      "size": 2198
+    },
+    {
+      "path": "tests/unit/test_repo_map_command.py",
+      "size": 1039
+    },
+    {
+      "path": "tests/unit/test_repo_map_reasoning.py",
+      "size": 2540
+    },
+    {
+      "path": "tests/unit/test_sanity.py",
+      "size": 249
+    },
+    {
+      "path": "tests/unit/test_session_utilities.py",
+      "size": 4096
+    },
+    {
+      "path": "tests/unit/test_tokenizer_cli_feature_flag.py",
+      "size": 1595
+    },
+    {
+      "path": "tests/unit/test_train_entrypoint.py",
+      "size": 1201
+    },
+    {
+      "path": "tests/unit/test_trainer_module.py",
+      "size": 3496
+    },
+    {
+      "path": "tests/unit/test_validate_patch.py",
+      "size": 3744
+    },
+    {
+      "path": "tests/unit/test_validators.py",
+      "size": 6463
+    },
+    {
+      "path": "tests/unit/test_zaf_legacy_reader.py",
+      "size": 2300
+    },
+    {
+      "path": "tests/unit/test_zendesk_models.py",
+      "size": 1810
+    },
+    {
+      "path": "tests/utils/cli_runner.py",
+      "size": 753
+    },
+    {
+      "path": "tests/utils/test_checkpoint_rng.py",
+      "size": 753
+    },
+    {
+      "path": "tests/utils/test_checkpointing.py",
+      "size": 634
+    },
+    {
+      "path": "tests/utils/test_checkpointing_core.py",
+      "size": 1549
+    },
+    {
+      "path": "tests/utils/test_checkpointing_safe_load.py",
+      "size": 2731
+    },
+    {
+      "path": "tests/utils/test_codex_utils_offline.py",
+      "size": 8016
+    },
+    {
+      "path": "tests/utils/test_error_log.py",
+      "size": 968
+    },
+    {
+      "path": "tests/utils/test_modeling.py",
+      "size": 1702
+    },
+    {
+      "path": "tests/utils/test_provenance_export.py",
+      "size": 2083
+    },
+    {
+      "path": "tests/utils/test_repro_rng.py",
+      "size": 1367
+    },
+    {
+      "path": "tests/utils/test_rng_state.py",
+      "size": 1644
+    },
+    {
+      "path": "tests/utils/test_seed.py",
+      "size": 1238
+    },
+    {
+      "path": "tests/visual/__init__.py",
+      "size": 26
+    },
+    {
+      "path": "tests/visual/test_status_html_render.py",
+      "size": 1637
+    },
+    {
+      "path": "tests/visual/test_visual_compare.py",
+      "size": 1169
+    },
+    {
+      "path": "tests/visual/test_visual_compare_config.py",
+      "size": 1309
+    },
+    {
+      "path": "tests/zd/test_evidence_parity.py",
+      "size": 1253
+    },
+    {
+      "path": "tokenization/__init__.py",
+      "size": 1113
+    },
+    {
+      "path": "tokenization/api.py",
+      "size": 444
+    },
+    {
+      "path": "tokenization/cli.py",
+      "size": 1335
+    },
+    {
+      "path": "tokenization/loader.py",
+      "size": 600
+    },
+    {
+      "path": "tokenization/sentencepiece_adapter.py",
+      "size": 412
+    },
+    {
+      "path": "tools/__init__.py",
+      "size": 32
+    },
+    {
+      "path": "tools/actions_cli.py",
+      "size": 3775
+    },
+    {
+      "path": "tools/actions_server.py",
+      "size": 5450
+    },
+    {
+      "path": "tools/allowlist_args.py",
+      "size": 606
+    },
+    {
+      "path": "tools/answer_codex_questions.py",
+      "size": 2212
+    },
+    {
+      "path": "tools/apply_branchA_all.py",
+      "size": 23803
+    },
+    {
+      "path": "tools/apply_ci_precommit.py",
+      "size": 10762
+    },
+    {
+      "path": "tools/apply_codex_audit_tasks.py",
+      "size": 16111
+    },
+    {
+      "path": "tools/apply_container_api.py",
+      "size": 12983
+    },
+    {
+      "path": "tools/apply_data_loaders.py",
+      "size": 4375
+    },
+    {
+      "path": "tools/apply_docs.py",
+      "size": 13201
+    },
+    {
+      "path": "tools/apply_hydra_scaffold.py",
+      "size": 7743
+    },
+    {
+      "path": "tools/apply_interfaces.py",
+      "size": 16436
+    },
+    {
+      "path": "tools/apply_ml_metrics.py",
+      "size": 15414
+    },
+    {
+      "path": "tools/apply_mlflow_tracking.py",
+      "size": 11287
+    },
+    {
+      "path": "tools/apply_patch_safely.py",
+      "size": 5620
+    },
+    {
+      "path": "tools/apply_pyproject_packaging.py",
+      "size": 24137
+    },
+    {
+      "path": "tools/apply_safety.py",
+      "size": 2867
+    },
+    {
+      "path": "tools/apply_stack_polish.py",
+      "size": 20096
+    },
+    {
+      "path": "tools/archive_manager/archive_manager.py",
+      "size": 32035
+    },
+    {
+      "path": "tools/assets/build_manifest.py",
+      "size": 1115
+    },
+    {
+      "path": "tools/assets/verify_manifest.py",
+      "size": 1397
+    },
+    {
+      "path": "tools/audit_builder.py",
+      "size": 3757
+    },
+    {
+      "path": "tools/audit_runner.py",
+      "size": 1556
+    },
+    {
+      "path": "tools/auto_analyze_errors.py",
+      "size": 3499
+    },
+    {
+      "path": "tools/bench_tokenizer.py",
+      "size": 2433
+    },
+    {
+      "path": "tools/bench_unified_training.py",
+      "size": 3558
+    },
+    {
+      "path": "tools/build_api_docs.py",
+      "size": 9805
+    },
+    {
+      "path": "tools/build_sqlite_snapshot.py",
+      "size": 921
+    },
+    {
+      "path": "tools/bundle_run.py",
+      "size": 1589
+    },
+    {
+      "path": "tools/capability_autodiscover.py",
+      "size": 2282
+    },
+    {
+      "path": "tools/capability_score.py",
+      "size": 1505
+    },
+    {
+      "path": "tools/catalog_db.py",
+      "size": 4770
+    },
+    {
+      "path": "tools/check_imports.py",
+      "size": 861
+    },
+    {
+      "path": "tools/ci_guard.py",
+      "size": 528
+    },
+    {
+      "path": "tools/cli/__init__.py",
+      "size": 0
+    },
+    {
+      "path": "tools/cli/codex_tools.py",
+      "size": 1866
+    },
+    {
+      "path": "tools/codemods/codemod_chmod_user_exec.py",
+      "size": 1037
+    },
+    {
+      "path": "tools/codemods/codemod_hf_pinning.py",
+      "size": 1126
+    },
+    {
+      "path": "tools/codemods/codemod_urlopen_to_safe.py",
+      "size": 1394
+    },
+    {
+      "path": "tools/codemods/codemod_xml_defused.py",
+      "size": 969
+    },
+    {
+      "path": "tools/codex_agents_workflow.py",
+      "size": 9879
+    },
+    {
+      "path": "tools/codex_apply_modeling_monitoring_api.py",
+      "size": 22075
+    },
+    {
+      "path": "tools/codex_cli.py",
+      "size": 4684
+    },
+    {
+      "path": "tools/codex_coverage_booster.py",
+      "size": 16744
+    },
+    {
+      "path": "tools/codex_db.py",
+      "size": 2037
+    },
+    {
+      "path": "tools/codex_evaluator.py",
+      "size": 4295
+    },
+    {
+      "path": "tools/codex_exec.py",
+      "size": 4192
+    },
+    {
+      "path": "tools/codex_execute_audit.py",
+      "size": 11922
+    },
+    {
+      "path": "tools/codex_import_normalizer.py",
+      "size": 11954
+    },
+    {
+      "path": "tools/codex_ingest_md.py",
+      "size": 3741
+    },
+    {
+      "path": "tools/codex_ingestion_workflow.py",
+      "size": 14545
+    },
+    {
+      "path": "tools/codex_logging_workflow.py",
+      "size": 16854
+    },
+    {
+      "path": "tools/codex_maintenance.py",
+      "size": 2528
+    },
+    {
+      "path": "tools/codex_make_smoke_tests.py",
+      "size": 9564
+    },
+    {
+      "path": "tools/codex_patch_exec.py",
+      "size": 9781
+    },
+    {
+      "path": "tools/codex_patch_session_logging.py",
+      "size": 10903
+    },
+    {
+      "path": "tools/codex_precommit_bootstrap.py",
+      "size": 13035
+    },
+    {
+      "path": "tools/codex_run.py",
+      "size": 5024
+    },
+    {
+      "path": "tools/codex_run_tasks.py",
+      "size": 13465
+    },
+    {
+      "path": "tools/codex_safety/__init__.py",
+      "size": 60
+    },
+    {
+      "path": "tools/codex_safety/openai_wrapper.py",
+      "size": 3536
+    },
+    {
+      "path": "tools/codex_seq_runner.py",
+      "size": 12644
+    },
+    {
+      "path": "tools/codex_session_logging_workflow.py",
+      "size": 14387
+    },
+    {
+      "path": "tools/codex_sqlite_align.py",
+      "size": 17875
+    },
+    {
+      "path": "tools/codex_src_consolidation.py",
+      "size": 14648
+    },
+    {
+      "path": "tools/codex_supplied_task_runner.py",
+      "size": 12547
+    },
+    {
+      "path": "tools/codex_task_runner.py",
+      "size": 14022
+    },
+    {
+      "path": "tools/codex_workflow.py",
+      "size": 3387
+    },
+    {
+      "path": "tools/codex_workflow_executor.py",
+      "size": 5480
+    },
+    {
+      "path": "tools/codex_workflow_session_query.py",
+      "size": 1337
+    },
+    {
+      "path": "tools/commit_msg_lint.py",
+      "size": 2485
+    },
+    {
+      "path": "tools/compact_ledger_to_parquet.py",
+      "size": 1432
+    },
+    {
+      "path": "tools/configs/list_groups.py",
+      "size": 3033
+    },
+    {
+      "path": "tools/configs/schema_guard.py",
+      "size": 4151
+    },
+    {
+      "path": "tools/coverage_extract.py",
+      "size": 1660
+    },
+    {
+      "path": "tools/data_drift_check.py",
+      "size": 1492
+    },
+    {
+      "path": "tools/disable_remote_ci.py",
+      "size": 6066
+    },
+    {
+      "path": "tools/docs/gen_open_questions.py",
+      "size": 1479
+    },
+    {
+      "path": "tools/docs/harvest_open_questions.py",
+      "size": 1381
+    },
+    {
+      "path": "tools/docs/link_audit.py",
+      "size": 1391
+    },
+    {
+      "path": "tools/docs/scan_links.py",
+      "size": 1925
+    },
+    {
+      "path": "tools/env/export_env_json.py",
+      "size": 1209
+    },
+    {
+      "path": "tools/env_snapshot.py",
+      "size": 1453
+    },
+    {
+      "path": "tools/export_to_parquet.py",
+      "size": 3243
+    },
+    {
+      "path": "tools/extract_validation_errors.py",
+      "size": 6971
+    },
+    {
+      "path": "tools/file_integrity_audit.py",
+      "size": 4964
+    },
+    {
+      "path": "tools/fix_code_fences.py",
+      "size": 2389
+    },
+    {
+      "path": "tools/gaps_analyze.py",
+      "size": 3202
+    },
+    {
+      "path": "tools/gen_tiny_spm.py",
+      "size": 1287
+    },
+    {
+      "path": "tools/git/branch_selector.py",
+      "size": 846
+    },
+    {
+      "path": "tools/git/changed_paths.py",
+      "size": 267
+    },
+    {
+      "path": "tools/git/most_recent_branch.py",
+      "size": 410
+    },
+    {
+      "path": "tools/git_patch_parser_complete.py",
+      "size": 29399
+    },
+    {
+      "path": "tools/github/app_token.py",
+      "size": 4208
+    },
+    {
+      "path": "tools/github/gh_api.py",
+      "size": 13998
+    },
+    {
+      "path": "tools/import_contracts_summary.py",
+      "size": 961
+    },
+    {
+      "path": "tools/install_codex_hooks.py",
+      "size": 2917
+    },
+    {
+      "path": "tools/label_policy_lint.py",
+      "size": 2787
+    },
+    {
+      "path": "tools/ledger.py",
+      "size": 3740
+    },
+    {
+      "path": "tools/link_id_crossref.py",
+      "size": 2890
+    },
+    {
+      "path": "tools/lint_policy_probe.py",
+      "size": 1395
+    },
+    {
+      "path": "tools/llm_auto_fix.py",
+      "size": 6046
+    },
+    {
+      "path": "tools/llm_bridge.py",
+      "size": 4433
+    },
+    {
+      "path": "tools/logging/structured_logger.py",
+      "size": 368
+    },
+    {
+      "path": "tools/make_spm_fixture.py",
+      "size": 1861
+    },
+    {
+      "path": "tools/metrics/generate_repo_metrics.py",
+      "size": 11606
+    },
+    {
+      "path": "tools/mkdocs_repair.py",
+      "size": 1479
+    },
+    {
+      "path": "tools/monitoring_integrate.py",
+      "size": 17667
+    },
+    {
+      "path": "tools/ndjson_to_csv.py",
+      "size": 2670
+    },
+    {
+      "path": "tools/notebooks/check_load.py",
+      "size": 1641
+    },
+    {
+      "path": "tools/offline_repo_auditor.py",
+      "size": 15339
+    },
+    {
+      "path": "tools/package_functional_training.py",
+      "size": 1115
+    },
+    {
+      "path": "tools/patch_apply.py",
+      "size": 2769
+    },
+    {
+      "path": "tools/perf/sampler.py",
+      "size": 1336
+    },
+    {
+      "path": "tools/perf/summarize.py",
+      "size": 991
+    },
+    {
+      "path": "tools/perf/summarize_perf.py",
+      "size": 1400
+    },
+    {
+      "path": "tools/perf_snapshot.py",
+      "size": 2887
+    },
+    {
+      "path": "tools/pip_audit_prewarm.py",
+      "size": 669
+    },
+    {
+      "path": "tools/pip_audit_wrapper.py",
+      "size": 2282
+    },
+    {
+      "path": "tools/post_check_validation.py",
+      "size": 14461
+    },
+    {
+      "path": "tools/pr_snippet.py",
+      "size": 2269
+    },
+    {
+      "path": "tools/precommit_block_large.py",
+      "size": 810
+    },
+    {
+      "path": "tools/preflight_minimal_labels.py",
+      "size": 4869
+    },
+    {
+      "path": "tools/prepare_commit_msg.py",
+      "size": 2275
+    },
+    {
+      "path": "tools/prepare_reasoning_corpora.py",
+      "size": 8706
+    },
+    {
+      "path": "tools/prepare_reasoning_streams.py",
+      "size": 7684
+    },
+    {
+      "path": "tools/prepush_tests.py",
+      "size": 3446
+    },
+    {
+      "path": "tools/purge_session_logs.py",
+      "size": 3084
+    },
+    {
+      "path": "tools/pytest_repair.py",
+      "size": 1599
+    },
+    {
+      "path": "tools/python_shim.py",
+      "size": 753
+    },
+    {
+      "path": "tools/repo_mapper.py",
+      "size": 2430
+    },
+    {
+      "path": "tools/report_merge.py",
+      "size": 1509
+    },
+    {
+      "path": "tools/revert_or_restore(other).py",
+      "size": 3506
+    },
+    {
+      "path": "tools/revert_or_restore.py",
+      "size": 3649
+    },
+    {
+      "path": "tools/run_codex_improvements.py",
+      "size": 1478
+    },
+    {
+      "path": "tools/run_precommit.py",
+      "size": 1452
+    },
+    {
+      "path": "tools/run_supplied_task.py",
+      "size": 13175
+    },
+    {
+      "path": "tools/run_tests.py",
+      "size": 1983
+    },
+    {
+      "path": "tools/runner_doctor.py",
+      "size": 3457
+    },
+    {
+      "path": "tools/scan_config_references.py",
+      "size": 1037
+    },
+    {
+      "path": "tools/scan_secrets.py",
+      "size": 8110
+    },
+    {
+      "path": "tools/schema_diff.py",
+      "size": 1953
+    },
+    {
+      "path": "tools/schema_results_to_status.py",
+      "size": 1132
+    },
+    {
+      "path": "tools/schema_validate.py",
+      "size": 2140
+    },
+    {
+      "path": "tools/security/dep_snapshot.py",
+      "size": 771
+    },
+    {
+      "path": "tools/security/license_audit.py",
+      "size": 655
+    },
+    {
+      "path": "tools/security/net.py",
+      "size": 1789
+    },
+    {
+      "path": "tools/security/offline_scans.py",
+      "size": 1455
+    },
+    {
+      "path": "tools/security/permissions.py",
+      "size": 271
+    },
+    {
+      "path": "tools/security/scan_repo.py",
+      "size": 1393
+    },
+    {
+      "path": "tools/select_precommit.py",
+      "size": 992
+    },
+    {
+      "path": "tools/selection_guard.py",
+      "size": 9869
+    },
+    {
+      "path": "tools/selection_report.py",
+      "size": 14146
+    },
+    {
+      "path": "tools/shebang_exec_guard.py",
+      "size": 1882
+    },
+    {
+      "path": "tools/status/capability_autodiscovery.py",
+      "size": 1507
+    },
+    {
+      "path": "tools/status/codex_status_cli.py",
+      "size": 941
+    },
+    {
+      "path": "tools/status/evidence_scan.py",
+      "size": 406
+    },
+    {
+      "path": "tools/status/generate_status_update.py",
+      "size": 42325
+    },
+    {
+      "path": "tools/status/migrate_v1_1_to_v1_2.py",
+      "size": 1228
+    },
+    {
+      "path": "tools/status/remediation_workflow.py",
+      "size": 1800
+    },
+    {
+      "path": "tools/status/render_md.py",
+      "size": 1032
+    },
+    {
+      "path": "tools/status/status_update_executor.py",
+      "size": 9661
+    },
+    {
+      "path": "tools/status/validate_codex_status.py",
+      "size": 2354
+    },
+    {
+      "path": "tools/status/validate_status_update.py",
+      "size": 1844
+    },
+    {
+      "path": "tools/status_gate_from_statusrc.py",
+      "size": 1509
+    },
+    {
+      "path": "tools/status_report.py",
+      "size": 12733
+    },
+    {
+      "path": "tools/survey/normalize_survey_md.py",
+      "size": 3983
+    },
+    {
+      "path": "tools/survey_sanitize.py",
+      "size": 2057
+    },
+    {
+      "path": "tools/template_lint.py",
+      "size": 1283
+    },
+    {
+      "path": "tools/test_auto_analyze_errors.py",
+      "size": 2205
+    },
+    {
+      "path": "tools/unify_logging_canonical.py",
+      "size": 11382
+    },
+    {
+      "path": "tools/update_docs_nav_and_links.py",
+      "size": 2252
+    },
+    {
+      "path": "tools/validate.py",
+      "size": 8524
+    },
+    {
+      "path": "tools/validate_api_docs.py",
+      "size": 6069
+    },
+    {
+      "path": "tools/validate_checkpoint.py",
+      "size": 3066
+    },
+    {
+      "path": "tools/validate_configs.py",
+      "size": 3936
+    },
+    {
+      "path": "tools/validate_fences.py",
+      "size": 12026
+    },
+    {
+      "path": "tools/validate_patch.py",
+      "size": 6640
+    },
+    {
+      "path": "tools/validate_readiness.py",
+      "size": 3465
+    },
+    {
+      "path": "tools/validate_status_report.py",
+      "size": 7577
+    },
+    {
+      "path": "tools/verify_data_paths.py",
+      "size": 998
+    },
+    {
+      "path": "tools/verify_pins.py",
+      "size": 722
+    },
+    {
+      "path": "tools/visual_baseline_rotate.py",
+      "size": 1633
+    },
+    {
+      "path": "tools/visual_compare.py",
+      "size": 2968
+    },
+    {
+      "path": "tools/visual_compare_config.py",
+      "size": 2382
+    },
+    {
+      "path": "tools/workflow_merge.py",
+      "size": 11761
+    },
+    {
+      "path": "tools/worm_ship.py",
+      "size": 990
+    },
+    {
+      "path": "torch/__init__.py",
+      "size": 2689
+    },
+    {
+      "path": "torch/nn/__init__.py",
+      "size": 393
+    },
+    {
+      "path": "training/__init__.py",
+      "size": 362
+    },
+    {
+      "path": "training/accelerate_init_guard.py",
+      "size": 6935
+    },
+    {
+      "path": "training/cache.py",
+      "size": 2500
+    },
+    {
+      "path": "training/checkpoint_manager.py",
+      "size": 16646
+    },
+    {
+      "path": "training/config.py",
+      "size": 7447
+    },
+    {
+      "path": "training/data_utils.py",
+      "size": 11959
+    },
+    {
+      "path": "training/datasets.py",
+      "size": 2791
+    },
+    {
+      "path": "training/engine_hf_trainer.py",
+      "size": 43935
+    },
+    {
+      "path": "training/evaluate.py",
+      "size": 4289
+    },
+    {
+      "path": "training/functional_training.py",
+      "size": 34264
+    },
+    {
+      "path": "training/offline_wandb.py",
+      "size": 307
+    },
+    {
+      "path": "training/seed.py",
+      "size": 1117
+    },
+    {
+      "path": "training/seed_utils.py",
+      "size": 2852
+    },
+    {
+      "path": "training/streaming.py",
+      "size": 1203
+    },
+    {
+      "path": "transformers/__init__.py",
+      "size": 2523
+    },
+    {
+      "path": "typer/testing.py",
+      "size": 154
+    },
+    {
+      "path": "validate_fences.py",
+      "size": 617
+    },
+    {
+      "path": "yaml/__init__.py",
+      "size": 4027
+    }
+  ],
+  ".toml": [
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/resources/empty_template_Cargo.toml",
+      "size": 96
+    },
+    {
+      "path": "agents/codex_client/pyproject.toml",
+      "size": 559
+    },
+    {
+      "path": "pyproject.toml",
+      "size": 8527
+    },
+    {
+      "path": "services/ita/pyproject.toml",
+      "size": 702
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/agents/codex_client/pyproject.toml",
+      "size": 225
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/mcp/server/pyproject.toml",
+      "size": 101
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/pyproject.toml",
+      "size": 329
+    },
+    {
+      "path": "tests/plugins/_sandbox_pkg/pyproject.toml",
+      "size": 341
+    }
+  ],
+  ".txt": [
+    {
+      "path": ".codex/DO_NOT_ACTIVATE_ACTIONS.txt",
+      "size": 42
+    },
+    {
+      "path": ".codex/GATES_REPORT.txt",
+      "size": 129
+    },
+    {
+      "path": ".codex/inventory.txt",
+      "size": 5111
+    },
+    {
+      "path": ".codex/reports/file_migration_summary_20251024.txt",
+      "size": 2743
+    },
+    {
+      "path": ".codex/reports/merge_summary_archive_policy_20251024.txt",
+      "size": 2538
+    },
+    {
+      "path": ".codex/status.post.txt",
+      "size": 26
+    },
+    {
+      "path": ".codex/status.pre.txt",
+      "size": 25
+    },
+    {
+      "path": ".codex/status/apply_log.txt",
+      "size": 259
+    },
+    {
+      "path": ".codex/status/diff-S0_to_S1.txt",
+      "size": 43
+    },
+    {
+      "path": ".codex/status/log-S0_to_S1.txt",
+      "size": 43
+    },
+    {
+      "path": ".codex/validation/20250910T052842Z/post_filelist.txt",
+      "size": 25545
+    },
+    {
+      "path": ".codex/validation/20250910T052842Z/pre_filelist.txt",
+      "size": 25025
+    },
+    {
+      "path": ".codex/validation/20250910T052842Z/pre_head.txt",
+      "size": 8
+    },
+    {
+      "path": ".codex/validation/20250910T071257Z/post_filelist.txt",
+      "size": 25720
+    },
+    {
+      "path": ".codex/validation/20250910T071257Z/pre_filelist.txt",
+      "size": 25720
+    },
+    {
+      "path": ".codex/validation/20250910T071257Z/pre_head.txt",
+      "size": 8
+    },
+    {
+      "path": ".codex/validation/20250910T071257Z/test_status_compare.txt",
+      "size": 170
+    },
+    {
+      "path": ".codex/validation/20250910T080054Z/post_filelist.txt",
+      "size": 26301
+    },
+    {
+      "path": ".codex/validation/20250910T080054Z/pre_filelist.txt",
+      "size": 26301
+    },
+    {
+      "path": ".codex/validation/20250910T080054Z/pre_head.txt",
+      "size": 8
+    },
+    {
+      "path": ".codex/validation/20250910T113918Z/post_filelist.txt",
+      "size": 26955
+    },
+    {
+      "path": ".codex/validation/20250910T113918Z/pre_filelist.txt",
+      "size": 26955
+    },
+    {
+      "path": ".codex/validation/20250910T135035Z/pre_filelist.txt",
+      "size": 27333
+    },
+    {
+      "path": ".codex/validation/20250910T135035Z/pre_head.txt",
+      "size": 8
+    },
+    {
+      "path": ".codex/validation/20250910T151757Z/post_filelist.txt",
+      "size": 27909
+    },
+    {
+      "path": ".codex/validation/20250910T151757Z/pre_filelist.txt",
+      "size": 27909
+    },
+    {
+      "path": ".codex/validation/20250910T151757Z/pre_head.txt",
+      "size": 8
+    },
+    {
+      "path": ".codex/validation/20250910T210555Z/post_filelist.txt",
+      "size": 28254
+    },
+    {
+      "path": ".codex/validation/20250910T210555Z/pre_filelist.txt",
+      "size": 28254
+    },
+    {
+      "path": ".mypy-baseline.txt",
+      "size": 115
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/MarkupSafe-2.1.5.dist-info/top_level.txt",
+      "size": 11
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/cfgv-3.4.0.dist-info/top_level.txt",
+      "size": 5
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib-0.4.0.dist-info/LICENSE.txt",
+      "size": 14531
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/distlib-0.4.0.dist-info/top_level.txt",
+      "size": 8
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/identify-2.6.15.dist-info/entry_points.txt",
+      "size": 51
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/identify-2.6.15.dist-info/top_level.txt",
+      "size": 9
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2-3.1.6.dist-info/entry_points.txt",
+      "size": 58
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/jinja2-3.1.6.dist-info/licenses/LICENSE.txt",
+      "size": 1475
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/mpmath-1.3.0.dist-info/top_level.txt",
+      "size": 7
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx-3.5.dist-info/entry_points.txt",
+      "size": 94
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx-3.5.dist-info/licenses/LICENSE.txt",
+      "size": 1763
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/networkx-3.5.dist-info/top_level.txt",
+      "size": 9
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/nodeenv-1.9.1.dist-info/entry_points.txt",
+      "size": 41
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/nodeenv-1.9.1.dist-info/top_level.txt",
+      "size": 8
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip-25.3.dist-info/entry_points.txt",
+      "size": 84
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip-25.3.dist-info/licenses/AUTHORS.txt",
+      "size": 11503
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip-25.3.dist-info/licenses/LICENSE.txt",
+      "size": 1093
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip-25.3.dist-info/licenses/src/pip/_vendor/cachecontrol/LICENSE.txt",
+      "size": 558
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip-25.3.dist-info/licenses/src/pip/_vendor/dependency_groups/LICENSE.txt",
+      "size": 1099
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip-25.3.dist-info/licenses/src/pip/_vendor/distlib/LICENSE.txt",
+      "size": 14531
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip-25.3.dist-info/licenses/src/pip/_vendor/urllib3/LICENSE.txt",
+      "size": 1115
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/cachecontrol/LICENSE.txt",
+      "size": 558
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/dependency_groups/LICENSE.txt",
+      "size": 1099
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/distlib/LICENSE.txt",
+      "size": 14531
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/urllib3/LICENSE.txt",
+      "size": 1115
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pip/_vendor/vendor.txt",
+      "size": 343
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit-4.3.0.dist-info/entry_points.txt",
+      "size": 52
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit-4.3.0.dist-info/top_level.txt",
+      "size": 11
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pyyaml-6.0.3.dist-info/top_level.txt",
+      "size": 11
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools-70.2.0.dist-info/entry_points.txt",
+      "size": 2733
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/setuptools-70.2.0.dist-info/top_level.txt",
+      "size": 41
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy-1.14.0.dist-info/entry_points.txt",
+      "size": 39
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy-1.14.0.dist-info/top_level.txt",
+      "size": 13
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/autolev/test-examples/README.txt",
+      "size": 528
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/sympy/parsing/latex/LICENSE.txt",
+      "size": 1075
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch-2.8.0+cpu.dist-info/entry_points.txt",
+      "size": 199
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch-2.8.0+cpu.dist-info/top_level.txt",
+      "size": 25
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/virtualenv-20.35.4.dist-info/entry_points.txt",
+      "size": 1434
+    },
+    {
+      "path": "archive/removed/todo_resolution_plans_10-6_to_10-7.txt",
+      "size": 541
+    },
+    {
+      "path": "artifacts/coverage/summary.txt",
+      "size": 42646
+    },
+    {
+      "path": "artifacts/env/hw.txt",
+      "size": 77
+    },
+    {
+      "path": "artifacts/env/os.txt",
+      "size": 254
+    },
+    {
+      "path": "artifacts/env/pip-freeze.txt",
+      "size": 5288
+    },
+    {
+      "path": "artifacts/env/python.txt",
+      "size": 18
+    },
+    {
+      "path": "artifacts/guardrails/no-gh-actions-scan.txt",
+      "size": 7946
+    },
+    {
+      "path": "artifacts/security/bandit.txt",
+      "size": 117571
+    },
+    {
+      "path": "artifacts/security/detect-secrets.txt",
+      "size": 4397483
+    },
+    {
+      "path": "artifacts/security/safety.txt",
+      "size": 204
+    },
+    {
+      "path": "codex_digest/requirements.txt",
+      "size": 46
+    },
+    {
+      "path": "configs/development/artifacts/sbom/packages.txt",
+      "size": 16243
+    },
+    {
+      "path": "data/offline/tiny_corpus.txt",
+      "size": 44
+    },
+    {
+      "path": "docs/requirements.txt",
+      "size": 93
+    },
+    {
+      "path": "docs/status_updates/repo_map_reasoning.txt",
+      "size": 2079
+    },
+    {
+      "path": "requirements-dev.txt",
+      "size": 284
+    },
+    {
+      "path": "requirements-optional.txt",
+      "size": 836
+    },
+    {
+      "path": "requirements/base.txt",
+      "size": 460
+    },
+    {
+      "path": "requirements/dev.txt",
+      "size": 357
+    },
+    {
+      "path": "requirements/docker.txt",
+      "size": 216
+    },
+    {
+      "path": "requirements/lock.txt",
+      "size": 24665
+    },
+    {
+      "path": "services/api/requirements.txt",
+      "size": 73
+    },
+    {
+      "path": "tests/assets/corpus_tiny.txt",
+      "size": 239
+    }
+  ],
+  ".yaml": [
+    {
+      "path": ".codex/hydra_last/config.yaml",
+      "size": 279
+    },
+    {
+      "path": ".copilot-space/workflow.yaml",
+      "size": 1978
+    },
+    {
+      "path": ".pre-commit-config.yaml",
+      "size": 6272
+    },
+    {
+      "path": ".pre-commit-hybrid.yaml",
+      "size": 1285
+    },
+    {
+      "path": ".pre-commit-ruff.yaml",
+      "size": 1148
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/resources/empty_template_pubspec.yaml",
+      "size": 78
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torch/_export/serde/schema.yaml",
+      "size": 9497
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/ATen/native/native_functions.yaml",
+      "size": 606478
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/ATen/native/tags.yaml",
+      "size": 5284
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/deprecated.yaml",
+      "size": 6250
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/torchgen/packaged/autograd/derivatives.yaml",
+      "size": 181563
+    },
+    {
+      "path": "actions/openapi.yaml",
+      "size": 2308
+    },
+    {
+      "path": "bandit.yaml",
+      "size": 10
+    },
+    {
+      "path": "codex_ready_task_sequence.yaml",
+      "size": 6074
+    },
+    {
+      "path": "config/sample-sbom-config.yaml",
+      "size": 61
+    },
+    {
+      "path": "configs/base/app.yaml",
+      "size": 1255
+    },
+    {
+      "path": "configs/base/base.yaml",
+      "size": 575
+    },
+    {
+      "path": "configs/base/default.yaml",
+      "size": 1065
+    },
+    {
+      "path": "configs/base/defaults.yaml",
+      "size": 538
+    },
+    {
+      "path": "configs/base/deterministic.yaml",
+      "size": 109
+    },
+    {
+      "path": "configs/base/environment/ubuntu.yaml",
+      "size": 145
+    },
+    {
+      "path": "configs/base/hydra.yaml",
+      "size": 720
+    },
+    {
+      "path": "configs/base/logging/base.yaml",
+      "size": 134
+    },
+    {
+      "path": "configs/base/offline/catalogue.yaml",
+      "size": 925
+    },
+    {
+      "path": "configs/base/offline/tiny_fixtures.yaml",
+      "size": 1254
+    },
+    {
+      "path": "configs/base/params.yaml",
+      "size": 148
+    },
+    {
+      "path": "configs/base/safety/policy.yaml",
+      "size": 2854
+    },
+    {
+      "path": "configs/deploy/reasoning_pod.yaml",
+      "size": 1119
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/config.yaml",
+      "size": 2420
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/data/default.yaml",
+      "size": 414
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/env/ubuntu.yaml",
+      "size": 73
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/eval/default.yaml",
+      "size": 333
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/hooks/default.yaml",
+      "size": 229
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/model/baseline.yaml",
+      "size": 102
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/model/hf_llm.yaml",
+      "size": 337
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/monitor/default.yaml",
+      "size": 1073
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/pipeline/clean.yaml",
+      "size": 274
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/pipeline/features.yaml",
+      "size": 261
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/pipeline/ingest.yaml",
+      "size": 224
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/plugins/default.yaml",
+      "size": 80
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/serve/local.yaml",
+      "size": 506
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/train/default.yaml",
+      "size": 133
+    },
+    {
+      "path": "configs/deployment/hhg_logistics/train/lora.yaml",
+      "size": 363
+    },
+    {
+      "path": "configs/deployment/interfaces.example.yaml",
+      "size": 377
+    },
+    {
+      "path": "configs/deployment/interfaces.yaml",
+      "size": 296
+    },
+    {
+      "path": "configs/deployment/interfaces/offline.yaml",
+      "size": 712
+    },
+    {
+      "path": "configs/deployment/plugins/default.yaml",
+      "size": 120
+    },
+    {
+      "path": "configs/evaluation/base.yaml",
+      "size": 408
+    },
+    {
+      "path": "configs/evaluation/default.yaml",
+      "size": 437
+    },
+    {
+      "path": "configs/evaluation/metrics/offline/weighted_accuracy.yaml",
+      "size": 514
+    },
+    {
+      "path": "configs/evaluation/offline.yaml",
+      "size": 52
+    },
+    {
+      "path": "configs/evaluation/reasoning/base.yaml",
+      "size": 1224
+    },
+    {
+      "path": "configs/evaluation/reasoning/default.yaml",
+      "size": 63
+    },
+    {
+      "path": "configs/evaluation/reasoning/local_ci.yaml",
+      "size": 766
+    },
+    {
+      "path": "configs/evaluation/reasoning/math.yaml",
+      "size": 436
+    },
+    {
+      "path": "configs/evaluation/reasoning/proof.yaml",
+      "size": 441
+    },
+    {
+      "path": "configs/evaluation/reasoning/tools.yaml",
+      "size": 431
+    },
+    {
+      "path": "configs/experimental/config_minimal.yaml",
+      "size": 410
+    },
+    {
+      "path": "configs/experimental/experiment.yaml",
+      "size": 51
+    },
+    {
+      "path": "configs/msp/gateway.yaml",
+      "size": 654
+    },
+    {
+      "path": "configs/msp/retrieval.yaml",
+      "size": 925
+    },
+    {
+      "path": "configs/msp/safety.yaml",
+      "size": 1000
+    },
+    {
+      "path": "configs/schemas/data.schema.yaml",
+      "size": 568
+    },
+    {
+      "path": "configs/schemas/model.schema.yaml",
+      "size": 692
+    },
+    {
+      "path": "configs/schemas/training.schema.yaml",
+      "size": 807
+    },
+    {
+      "path": "configs/simple/train.yaml",
+      "size": 657
+    },
+    {
+      "path": "configs/training/base.yaml",
+      "size": 1626
+    },
+    {
+      "path": "configs/training/continual/base.yaml",
+      "size": 164
+    },
+    {
+      "path": "configs/training/continual/difficulty_curriculum.yaml",
+      "size": 1419
+    },
+    {
+      "path": "configs/training/continual/difficulty_scaling.yaml",
+      "size": 948
+    },
+    {
+      "path": "configs/training/continual/interleaved_rehearsal.yaml",
+      "size": 1405
+    },
+    {
+      "path": "configs/training/continual/rehearsal.yaml",
+      "size": 1418
+    },
+    {
+      "path": "configs/training/data/base.yaml",
+      "size": 437
+    },
+    {
+      "path": "configs/training/data/offline/tiny_corpus.yaml",
+      "size": 433
+    },
+    {
+      "path": "configs/training/data/tiny.yaml",
+      "size": 524
+    },
+    {
+      "path": "configs/training/functional_base.yaml",
+      "size": 590
+    },
+    {
+      "path": "configs/training/legacy/trainer_base.yaml",
+      "size": 414
+    },
+    {
+      "path": "configs/training/model/base.yaml",
+      "size": 839
+    },
+    {
+      "path": "configs/training/model/offline/gpt2.yaml",
+      "size": 484
+    },
+    {
+      "path": "configs/training/model/offline/tiny_sequence.yaml",
+      "size": 368
+    },
+    {
+      "path": "configs/training/model/offline/tinyllama.yaml",
+      "size": 510
+    },
+    {
+      "path": "configs/training/model/toy.yaml",
+      "size": 109
+    },
+    {
+      "path": "configs/training/offline/functional.yaml",
+      "size": 881
+    },
+    {
+      "path": "configs/training/offline/tiny_functional.yaml",
+      "size": 941
+    },
+    {
+      "path": "configs/training/pipeline_inputs/smoke.yaml",
+      "size": 1760
+    },
+    {
+      "path": "configs/training/profiles/default.yaml",
+      "size": 1325
+    },
+    {
+      "path": "configs/training/profiles/small.yaml",
+      "size": 146
+    },
+    {
+      "path": "configs/training/reasoning/baseline.yaml",
+      "size": 2019
+    },
+    {
+      "path": "configs/training/reasoning/chain_of_thought.yaml",
+      "size": 493
+    },
+    {
+      "path": "configs/training/reasoning/curricula/first_principles.yaml",
+      "size": 465
+    },
+    {
+      "path": "configs/training/reasoning/curricula/starter.yaml",
+      "size": 468
+    },
+    {
+      "path": "configs/training/reasoning/tool_execution.yaml",
+      "size": 667
+    },
+    {
+      "path": "configs/training/sweep_example.yaml",
+      "size": 278
+    },
+    {
+      "path": "configs/training/sweeps/basics.yaml",
+      "size": 166
+    },
+    {
+      "path": "configs/training/sweeps/sweep_offline.yaml",
+      "size": 774
+    },
+    {
+      "path": "configs/training/tokenization/base.yaml",
+      "size": 544
+    },
+    {
+      "path": "configs/training/tokenizer/multilingual.yaml",
+      "size": 142
+    },
+    {
+      "path": "configs/training/tokenizer/offline/gpt2.yaml",
+      "size": 449
+    },
+    {
+      "path": "configs/training/tokenizer/offline/tiny_vocab.yaml",
+      "size": 371
+    },
+    {
+      "path": "configs/training/tokenizer/offline/tinyllama.yaml",
+      "size": 476
+    },
+    {
+      "path": "configs/training/tokenizer/train_tokenizer.yaml",
+      "size": 148
+    },
+    {
+      "path": "configs/training/tracking/base.yaml",
+      "size": 90
+    },
+    {
+      "path": "configs/training/tracking/offline.yaml",
+      "size": 281
+    },
+    {
+      "path": "deploy/helm/Chart.yaml",
+      "size": 106
+    },
+    {
+      "path": "deploy/helm/values.yaml",
+      "size": 789
+    },
+    {
+      "path": "docs/ops/mkdocs_nav_snippet.yaml",
+      "size": 695
+    },
+    {
+      "path": "docs/templates/status/codex_status_template.schema.yaml",
+      "size": 7114
+    },
+    {
+      "path": "docs/templates/status/codex_status_template.schema_v1.2.yaml",
+      "size": 55238
+    },
+    {
+      "path": "dvc.yaml",
+      "size": 654
+    },
+    {
+      "path": "examples/safety/policy_bypass_example.yaml",
+      "size": 638
+    },
+    {
+      "path": "policies/denylist.yaml",
+      "size": 1733
+    },
+    {
+      "path": "policies/safelist.yaml",
+      "size": 804
+    },
+    {
+      "path": "scripts/task_sequences/zendesk_first_cycle.yaml",
+      "size": 4973
+    },
+    {
+      "path": "semgrep_rules/python-security.yaml",
+      "size": 1806
+    },
+    {
+      "path": "services/ita/openapi.yaml",
+      "size": 6703
+    },
+    {
+      "path": "src/codex_ml/configs/training/functional_base.yaml",
+      "size": 536
+    },
+    {
+      "path": "temp/bridge_codex_copilot_bridge/services/ita/openapi.yaml",
+      "size": 3493
+    }
+  ],
+  ".yml": [
+    {
+      "path": ".bandit.yml",
+      "size": 450
+    },
+    {
+      "path": ".codex/disabled_workflows/_policy.yml",
+      "size": 360
+    },
+    {
+      "path": ".codex/disabled_workflows/lint.yml",
+      "size": 628
+    },
+    {
+      "path": ".codex/disabled_workflows/manual_ci.yml",
+      "size": 408
+    },
+    {
+      "path": ".codex/disabled_workflows/release-upload.yml",
+      "size": 711
+    },
+    {
+      "path": ".codex/flags.yml",
+      "size": 41
+    },
+    {
+      "path": ".codex/policies/allowlists.yml",
+      "size": 455
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/bug_report.yml",
+      "size": 2549
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/config.yml",
+      "size": 775
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/feature_request.yml",
+      "size": 2436
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/security.yml",
+      "size": 2702
+    },
+    {
+      "path": ".github/OWNER_APPROVAL.example.yml",
+      "size": 669
+    },
+    {
+      "path": ".github/OWNER_APPROVAL.yml",
+      "size": 321
+    },
+    {
+      "path": ".github/_workflows_disabled/_policy.yml",
+      "size": 360
+    },
+    {
+      "path": ".github/_workflows_disabled/docker-build-push.marketplace.yml",
+      "size": 10940
+    },
+    {
+      "path": ".github/_workflows_disabled/lint.yml",
+      "size": 628
+    },
+    {
+      "path": ".github/_workflows_disabled/manual_ci.yml",
+      "size": 408
+    },
+    {
+      "path": ".github/_workflows_disabled/release-upload.yml",
+      "size": 711
+    },
+    {
+      "path": ".github/dependabot.yml",
+      "size": 2063
+    },
+    {
+      "path": ".github/labeler.yml",
+      "size": 368
+    },
+    {
+      "path": ".github/release-drafter.yml",
+      "size": 502
+    },
+    {
+      "path": ".github/workflows/audit_chain.yml",
+      "size": 887
+    },
+    {
+      "path": ".github/workflows/automation_ingest.yml",
+      "size": 1155
+    },
+    {
+      "path": ".github/workflows/capability-audit.yml",
+      "size": 1961
+    },
+    {
+      "path": ".github/workflows/coverage_report.yml",
+      "size": 989
+    },
+    {
+      "path": ".github/workflows/daily_status_cron.yml",
+      "size": 548
+    },
+    {
+      "path": ".github/workflows/daily_status_enrich.yml",
+      "size": 1078
+    },
+    {
+      "path": ".github/workflows/data_validation.yml",
+      "size": 1196
+    },
+    {
+      "path": ".github/workflows/docker-build-push.yml",
+      "size": 9858
+    },
+    {
+      "path": ".github/workflows/docs.yml",
+      "size": 1521
+    },
+    {
+      "path": ".github/workflows/draft-audit-pr.yml",
+      "size": 1656
+    },
+    {
+      "path": ".github/workflows/github_connector_check.yml",
+      "size": 431
+    },
+    {
+      "path": ".github/workflows/html_visual_baseline.yml",
+      "size": 1677
+    },
+    {
+      "path": ".github/workflows/html_visual_regression.yml",
+      "size": 1201
+    },
+    {
+      "path": ".github/workflows/labeler.yml",
+      "size": 351
+    },
+    {
+      "path": ".github/workflows/nox_gates.yml",
+      "size": 753
+    },
+    {
+      "path": ".github/workflows/publish_dashboard_release.yml",
+      "size": 843
+    },
+    {
+      "path": ".github/workflows/ratelimit_history_prune.yml",
+      "size": 435
+    },
+    {
+      "path": ".github/workflows/report_publish.yml",
+      "size": 1032
+    },
+    {
+      "path": ".github/workflows/runner-diagnostics.yml",
+      "size": 1524
+    },
+    {
+      "path": ".github/workflows/sbom.yml",
+      "size": 2464
+    },
+    {
+      "path": ".github/workflows/secrets_baseline_check.yml",
+      "size": 537
+    },
+    {
+      "path": ".github/workflows/security_gates.yml",
+      "size": 1526
+    },
+    {
+      "path": ".github/workflows/security_policy_gate.yml",
+      "size": 579
+    },
+    {
+      "path": ".github/workflows/semgrep_sarif.yml",
+      "size": 675
+    },
+    {
+      "path": ".github/workflows/space-audit.yml",
+      "size": 969
+    },
+    {
+      "path": ".github/workflows/status_gate.yml",
+      "size": 710
+    },
+    {
+      "path": ".github/workflows/template_lint.yml",
+      "size": 376
+    },
+    {
+      "path": ".github/workflows/tests.yml",
+      "size": 894
+    },
+    {
+      "path": ".github/workflows/workflow-expiry-enforcer.yml",
+      "size": 1571
+    },
+    {
+      "path": ".venv/lib/python3.12/site-packages/pre_commit/resources/empty_template_environment.yml",
+      "size": 302
+    },
+    {
+      "path": ".yamllint.yml",
+      "size": 138
+    },
+    {
+      "path": "archive/removed/ci.yml",
+      "size": 1701
+    },
+    {
+      "path": "archive/removed/codex-ci.yml",
+      "size": 1408
+    },
+    {
+      "path": "archive/removed/codex-self-hosted-ci.yml",
+      "size": 919
+    },
+    {
+      "path": "archive/removed/codex-self-manage.yml",
+      "size": 1803
+    },
+    {
+      "path": "archive/removed/release.yml",
+      "size": 686
+    },
+    {
+      "path": "docker-compose.override.local.yml",
+      "size": 229
+    },
+    {
+      "path": "docker-compose.override.yml",
+      "size": 185
+    },
+    {
+      "path": "docker-compose.yml",
+      "size": 1466
+    },
+    {
+      "path": "docs/examples/self_hosted_example.yml",
+      "size": 1180
+    },
+    {
+      "path": "great_expectations/checkpoints/clean_checkpoint.yml",
+      "size": 574
+    },
+    {
+      "path": "mkdocs.yml",
+      "size": 2837
+    },
+    {
+      "path": "semgrep_rules/default.yml",
+      "size": 459
+    },
+    {
+      "path": "semgrep_rules/python-basic.yml",
+      "size": 1496
+    },
+    {
+      "path": "semgrep_rules/python/insecure_eval.yml",
+      "size": 307
+    },
+    {
+      "path": "semgrep_rules/python/pickle_load.yml",
+      "size": 161
+    },
+    {
+      "path": "semgrep_rules/python/requests_no_timeout.yml",
+      "size": 865
+    },
+    {
+      "path": "semgrep_rules/python/ssl_verify_off.yml",
+      "size": 591
+    },
+    {
+      "path": "semgrep_rules/python/subprocess_shell.yml",
+      "size": 482
+    },
+    {
+      "path": "semgrep_rules/python/yaml_unsafe_load.yml",
+      "size": 197
+    },
+    {
+      "path": "templates/github_repo_baseline/ISSUE_TEMPLATE/config.yml",
+      "size": 27
+    }
+  ]
+}

--- a/tools/repo_mapper.py
+++ b/tools/repo_mapper.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Generate a JSON repository map for selected file extensions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+# Extensions to include in the repository map
+EXTENSIONS: Tuple[str, ...] = (
+    ".py",
+    ".md",
+    ".yaml",
+    ".yml",
+    ".json",
+    ".toml",
+    ".ini",
+    ".txt",
+    ".ipynb",
+)
+
+# Directory names to exclude anywhere in the path
+EXCLUDED_DIRS: Tuple[str, ...] = (
+    ".git",
+    "__pycache__",
+    "build",
+    "dist",
+)
+
+
+def should_skip(path: Path) -> bool:
+    """Return True if the path is inside an excluded directory."""
+    return any(part in EXCLUDED_DIRS for part in path.parts)
+
+
+def map_repo(root_dir: Path) -> Dict[str, List[Dict[str, int]]]:
+    """Walk the repository and build a mapping of extensions to file info."""
+    results: Dict[str, List[Dict[str, int]]] = {}
+
+    for path in root_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        if should_skip(path):
+            continue
+
+        ext = path.suffix.lower()
+        if ext not in EXTENSIONS:
+            continue
+
+        rel_path = path.relative_to(root_dir).as_posix()
+        size = path.stat().st_size
+        results.setdefault(ext, []).append({"path": rel_path, "size": size})
+
+    for file_list in results.values():
+        file_list.sort(key=lambda entry: entry["path"])
+
+    sorted_results = {ext: results[ext] for ext in sorted(results)}
+    return sorted_results
+
+
+def write_repo_map(root_dir: Path, data: Dict[str, List[Dict[str, int]]]) -> Path:
+    """Write the repository map JSON file to the root directory."""
+    output_path = root_dir / "_codex_repo_map.json"
+    output_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return output_path
+
+
+def log_summary(total_files: int, extension_count: int, output_path: Path) -> None:
+    """Print a summary of the work performed."""
+    print(f"Processed {total_files} files across {extension_count} extensions.")
+    print(f"Repository map written to: {output_path}")
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    root = Path(".").resolve()
+    repo_map = map_repo(root)
+    output_path = write_repo_map(root, repo_map)
+    total_files = sum(len(files) for files in repo_map.values())
+    log_summary(total_files, len(repo_map), output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a repo mapping script that walks the repository and groups files by extension
- generate the `_codex_repo_map.json` file containing the collected metadata

## Testing
- python3 tools/repo_mapper.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d74ed08108331a199017295140b8b)