### PR TITLE
Address rename ADR validation gap in archival compliance checker

### DIFF
--- a/scripts/archival/check_archival_compliance.py
+++ b/scripts/archival/check_archival_compliance.py
@@ -42,6 +42,19 @@ class DiffEntry:
     original_path: str | None = None
 
 
+@dataclass
+class CheckResult:
+    missing_stub: list[str]
+    missing_adr: list[str]
+    missing_evidence: list[str]
+
+    @property
+    def return_code(self) -> int:
+        if self.missing_stub or self.missing_adr:
+            return 2
+        return 0
+
+
 def git_relevant_changes(base: str, head: str) -> list[DiffEntry]:
     cmd = ["git", "diff", "--name-status", f"{base}..{head}"]
     out = subprocess.run(cmd, capture_output=True, text=True)
@@ -104,6 +117,43 @@ def evidence_has_entry(original_path: str) -> bool:
     return False
 
 
+def evaluate_entries(diff_entries: list[DiffEntry]) -> CheckResult:
+    missing_stub: list[str] = []
+    missing_adr: list[str] = []
+    missing_evidence: list[str] = []
+
+    for entry in diff_entries:
+        original_path = entry.original_path or entry.path
+        stub_path = Path(original_path)
+        status = entry.status.upper()
+
+        if not stub_path.exists():
+            # For deletes and renames we expect a tombstone stub at the original path.
+            missing_stub.append(original_path)
+            continue
+
+        if status.startswith("M"):
+            if not tombstone_exists(stub_path.as_posix()):
+                # Standard modification; not a tombstone conversion.
+                continue
+        elif status.startswith("D") or status.startswith("R") or status.startswith("C"):
+            pass  # Stub existence already validated above.
+        else:
+            continue
+
+        if not adr_linked_in_stub(stub_path.as_posix()):
+            missing_adr.append(original_path)
+
+        if not evidence_has_entry(original_path):
+            missing_evidence.append(original_path)
+
+    return CheckResult(
+        missing_stub=missing_stub,
+        missing_adr=missing_adr,
+        missing_evidence=missing_evidence,
+    )
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument("--base", default="HEAD~1", help="Base ref for diff")
@@ -129,62 +179,31 @@ def main(argv=None):
         except RuntimeError:
             return 3
 
-    missing_stub = []
-    missing_adr = []
-    missing_evidence = []
+    result = evaluate_entries(diff_entries)
 
-    for entry in diff_entries:
-        original_path = entry.original_path or entry.path
-        stub_path = Path(original_path)
-        status = entry.status.upper()
-
-        if not stub_path.exists():
-            # For deletes and renames we expect a tombstone stub at the original path.
-            missing_stub.append(original_path)
-            continue
-
-        if status.startswith("M"):
-            if not tombstone_exists(stub_path.as_posix()):
-                # Standard modification; not a tombstone conversion.
-                continue
-        elif entry.status.startswith("D"):
-            pass  # No additional check needed; stub existence already handled
-        else:
-            continue
-
-        if not adr_linked_in_stub(stub_path.as_posix()):
-            missing_adr.append(original_path)
-
-        if not evidence_has_entry(original_path):
-            missing_evidence.append(original_path)
-
-    # Summarize results
-    rc = 0
-    if missing_stub:
+    if result.missing_stub:
         print("[FAIL] Missing tombstone stub for removed paths:", file=sys.stderr)
-        for p in missing_stub:
+        for p in result.missing_stub:
             print(f"  - {p}", file=sys.stderr)
-        rc = 2
 
-    if missing_adr:
+    if result.missing_adr:
         print("[FAIL] Tombstone exists but missing ADR reference:", file=sys.stderr)
-        for p in missing_adr:
+        for p in result.missing_adr:
             print(f"  - {p}", file=sys.stderr)
-        rc = 2
 
-    if missing_evidence:
+    if result.missing_evidence:
         print(
             "[WARN] Evidence entries not found for removed paths (append to .codex/evidence/archive_ops.jsonl):",
             file=sys.stderr,
         )
-        for p in missing_evidence:
+        for p in result.missing_evidence:
             print(f"  - {p}", file=sys.stderr)
         # warn only -> non-fatal, but return code may be adjusted by policy
 
-    if rc == 0:
+    if result.return_code == 0:
         print("[OK] Archival compliance checks passed (basic).")
 
-    return rc
+    return result.return_code
 
 
 if __name__ == "__main__":

--- a/tests/archival/test_archival_tombstone_required.py
+++ b/tests/archival/test_archival_tombstone_required.py
@@ -13,6 +13,7 @@ Tests attempt to remove empty directories after cleanup to minimize artifact acc
 """
 
 import json
+import os
 import subprocess
 import sys
 import uuid
@@ -142,3 +143,49 @@ def test_tombstone_and_evidence_pass():
         else:
             if EVIDENCE_FILE.exists():
                 EVIDENCE_FILE.unlink()
+
+
+def test_rename_without_adr_is_flagged():
+    """Ensure rename entries require ADR/evidence like deletions."""
+
+    # Import inside test to allow monkeypatching the evidence path safely.
+    from scripts.archival import check_archival_compliance as compliance
+
+    test_id = str(uuid.uuid4())[:8]
+    original_relative = f".codex/test_artifacts/archival/renamed_original_{test_id}.py"
+    destination_relative = f".codex/test_artifacts/archival/renamed_destination_{test_id}.py"
+
+    stub_path = REPO_ROOT / original_relative
+    stub_path.parent.mkdir(parents=True, exist_ok=True)
+    stub_path.write_text("# TOMBSTONE\n", encoding="utf-8")
+
+    # Point compliance checker to an isolated evidence file for this test.
+    previous_evidence = compliance.EVIDENCE
+    compliance.EVIDENCE = REPO_ROOT / f".codex/test_artifacts/archival/evidence_{test_id}.jsonl"
+    if compliance.EVIDENCE.exists():
+        compliance.EVIDENCE.unlink()
+
+    entry = compliance.DiffEntry(status="R100", path=destination_relative, original_path=original_relative)
+
+    try:
+        previous_cwd = Path.cwd()
+        os.chdir(REPO_ROOT)
+        try:
+            result = compliance.evaluate_entries([entry])
+        finally:
+            os.chdir(previous_cwd)
+        assert original_relative in result.missing_adr, "Rename without ADR should be flagged"
+        assert original_relative in result.missing_evidence, "Rename without evidence should be flagged"
+        assert result.return_code == 2, "Missing ADR should cause failure return code"
+    finally:
+        compliance.EVIDENCE = previous_evidence
+        if stub_path.exists():
+            stub_path.unlink()
+        current = stub_path.parent
+        test_artifacts_root = REPO_ROOT / ".codex/test_artifacts"
+        while current != test_artifacts_root and current.exists():
+            try:
+                current.rmdir()
+                current = current.parent
+            except OSError:
+                break


### PR DESCRIPTION
## Summary
- refactor the compliance checker to expose `evaluate_entries` that enforces ADR/evidence validation for rename and copy statuses
- ensure rename diffs participate in stub, ADR, and evidence checks by reusing the new aggregation helper
- add a regression test that simulates a rename without ADR or evidence to confirm the failure path

## Testing
- python -m pytest tests/archival/test_archival_tombstone_required.py -v

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d97802fc883319a75e45eb6047320)