### PR TITLE
Guard torch-dependent modules with availability checks

### DIFF
--- a/src/codex_ml/model_registry.py
+++ b/src/codex_ml/model_registry.py
@@ -13,9 +13,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, MutableMapping, Optional, Sequence, Union
 
-import torch
+from src.common.torch_support import ensure_torch_install
 from codex_ml.models import registry as _registry
 from codex_ml.models.utils.peft import apply_lora_if_available
+
+torch = ensure_torch_install()
 
 __all__ = ["LoraRequest", "ModelRequest", "get_model", "list_models", "register_model"]
 

--- a/src/codex_ml/models/decoder_only.py
+++ b/src/codex_ml/models/decoder_only.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from typing import Optional
-from typing import Optional
 
-import torch
-from torch import nn
-from torch.nn import functional as F
+from src.common.torch_support import ensure_torch_install
+
+torch = ensure_torch_install()
+nn = torch.nn
+F = torch.nn.functional
 
 
 @dataclass(frozen=True)

--- a/src/codex_ml/models/generate.py
+++ b/src/codex_ml/models/generate.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from typing import Optional
 
-import torch
+from src.common.torch_support import ensure_torch_install
+
+torch = ensure_torch_install()
 
 
 def _sample(logits: torch.Tensor, temperature: float, top_k: int, top_p: float) -> torch.Tensor:

--- a/src/codex_ml/models/minilm.py
+++ b/src/codex_ml/models/minilm.py
@@ -9,8 +9,10 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional
 
-import torch
-from torch import nn
+from src.common.torch_support import ensure_torch_install
+
+torch = ensure_torch_install()
+nn = torch.nn
 
 from codex_ml.utils.checkpointing import load_checkpoint
 

--- a/src/codex_ml/models/reasoning.py
+++ b/src/codex_ml/models/reasoning.py
@@ -6,11 +6,13 @@ import logging
 from collections import deque
 from dataclasses import dataclass
 from typing import Any, Mapping
-from typing import Any, Mapping
 
-import torch
+from src.common.torch_support import ensure_torch_install
+
 from codex_ml.config import ReasoningConfig, ReasoningHeadConfig, ToolAdapterConfig
-from torch import nn
+
+torch = ensure_torch_install()
+nn = torch.nn
 
 logger = logging.getLogger(__name__)
 

--- a/src/codex_ml/models/registry.py
+++ b/src/codex_ml/models/registry.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
-from typing import TYPE_CHECKING, Any, cast
 
-import torch
+from src.common.torch_support import ensure_torch_install
 from codex_ml.peft.peft_adapter import apply_lora
 from codex_ml.registry.base import Registry
 from codex_ml.utils.hf_pinning import load_from_pretrained
 from codex_ml.utils.optional import optional_import
+
+torch = ensure_torch_install()
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from transformers import PreTrainedModel as HF_PreTrainedModel  # type: ignore

--- a/src/common/torch_support.py
+++ b/src/common/torch_support.py
@@ -1,0 +1,99 @@
+"""Utilities for handling optional PyTorch availability.
+
+These helpers make it easy to guard features that require a real PyTorch
+installation.  They surface consistent, actionable guidance when PyTorch is
+missing or only a lightweight stub is available, and optionally validate CUDA
+support when GPU execution is requested.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Final
+
+from codex_ml.utils.torch_checks import REINSTALL_COMMAND, inspect_torch
+
+__all__ = [
+    "MissingTorchError",
+    "ensure_torch_install",
+    "is_torch_available",
+    "maybe_import_torch",
+]
+
+_DEFAULT_MESSAGE: Final[str] = (
+    "PyTorch is required for this functionality. Install the 'codex-ml[torch]' "
+    "extra or run: "
+    f"{REINSTALL_COMMAND}"
+)
+
+
+class MissingTorchError(ModuleNotFoundError):
+    """Raised when a required PyTorch feature is unavailable."""
+
+    def __init__(self, detail: str | None = None) -> None:
+        message = detail or _DEFAULT_MESSAGE
+        super().__init__(message)
+        self.detail = message
+
+
+def ensure_torch_install(*, require_cuda: bool = False) -> ModuleType:
+    """Return a real :mod:`torch` module or raise :class:`MissingTorchError`.
+
+    Parameters
+    ----------
+    require_cuda:
+        When ``True``, the helper also verifies that ``torch.cuda.is_available``
+        returns ``True``.  This is useful for call sites that *must* run on a
+        GPU; callers that can gracefully fallback to CPU should keep the default
+        ``False``.
+    """
+
+    try:
+        module = importlib.import_module("torch")
+    except ModuleNotFoundError as exc:  # pragma: no cover - defensive guard
+        raise MissingTorchError() from exc
+
+    version = getattr(module, "__version__", "")
+    if version == "0.0.0-stub":
+        raise MissingTorchError(
+            "Detected the lightweight 'torch' compatibility shim. Install a "
+            "full PyTorch build to enable this feature. Suggested command: "
+            f"{REINSTALL_COMMAND}"
+        )
+
+    status = inspect_torch(module)
+    if not status.ok:
+        hint = status.detail
+        if status.reinstall_hint:
+            hint = f"{status.detail}. Reinstall via: {status.reinstall_hint}"
+        raise MissingTorchError(
+            "PyTorch installation appears incomplete. " f"{hint}"
+        )
+
+    if require_cuda:
+        cuda = getattr(module, "cuda", None)
+        available = bool(cuda and getattr(cuda, "is_available", lambda: False)())
+        if not available:
+            raise MissingTorchError(
+                "CUDA support was requested but torch.cuda.is_available() is False. "
+                "Install a CUDA-enabled PyTorch build or disable CUDA for this "
+                "operation."
+            )
+
+    return module
+
+
+def maybe_import_torch(*, require_cuda: bool = False) -> ModuleType | None:
+    """Best-effort import of :mod:`torch` returning ``None`` when unavailable."""
+
+    try:
+        return ensure_torch_install(require_cuda=require_cuda)
+    except MissingTorchError:
+        return None
+
+
+def is_torch_available(*, require_cuda: bool = False) -> bool:
+    """Return ``True`` when a suitable PyTorch install is importable."""
+
+    return maybe_import_torch(require_cuda=require_cuda) is not None

--- a/src/evaluation/metrics.py
+++ b/src/evaluation/metrics.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import math
 from collections.abc import Callable, Mapping, Sequence
 
-import torch
-import torch.nn.functional as F
+from src.common.torch_support import ensure_torch_install
+
+torch = ensure_torch_install()
+F = torch.nn.functional
 
 
 def accuracy(logits: torch.Tensor, targets: torch.Tensor) -> float:

--- a/training/data_utils.py
+++ b/training/data_utils.py
@@ -11,7 +11,9 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 import numpy as np
 import numpy.typing as npt
 
-import torch
+from src.common.torch_support import ensure_torch_install
+
+torch = ensure_torch_install()
 
 try:  # pragma: no cover - fcntl unavailable on Windows
     import fcntl  # type: ignore[attr-defined]

--- a/training/datasets.py
+++ b/training/datasets.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import Dict, Iterable, Iterator, Sequence
 
 import numpy as np
-import torch
+
+from src.common.torch_support import ensure_torch_install
+
+torch = ensure_torch_install()
 
 try:  # optional dependency
     from datasets import Dataset  # type: ignore

--- a/training/functional_training.py
+++ b/training/functional_training.py
@@ -14,9 +14,11 @@ from typing import Any, Callable, Dict, Mapping, Optional, Sequence
 
 import numpy as np
 
-import torch
-from torch.nn.utils import clip_grad_norm_
-from torch.utils.data import DataLoader
+from src.common.torch_support import ensure_torch_install
+
+torch = ensure_torch_install()
+clip_grad_norm_ = torch.nn.utils.clip_grad_norm_
+DataLoader = torch.utils.data.DataLoader
 
 from codex_ml.logging.file_logger import FileLogger
 from codex_ml.logging.run_metadata import log_run_metadata


### PR DESCRIPTION
## Summary
- add a common torch_support helper that surfaces actionable errors when PyTorch is missing or stubbed
- update training and modeling modules to require a real torch install before accessing tensor utilities
- ensure evaluation metrics rely on the helper so dtype/device checks fail gracefully without PyTorch

## Testing
- python -m compileall src/common/torch_support.py training/data_utils.py training/datasets.py training/functional_training.py src/codex_ml/models/minilm.py src/codex_ml/models/decoder_only.py src/codex_ml/models/generate.py src/codex_ml/models/reasoning.py src/codex_ml/models/registry.py src/codex_ml/model_registry.py src/evaluation/metrics.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ef5617c58833194752d71af208b21)