### PR TITLE
Guard nox TOML parsing when tomli is unavailable

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -7,16 +7,10 @@ Local task runner for _codex_ (no CI usage). Provides one-command sessions:
 """
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
+from types import ModuleType
 from typing import Iterable, Optional
-
-try:
-    import tomllib
-except ModuleNotFoundError:
-    try:
-        import tomli as tomllib  # type: ignore[import-not-found,no-redef]
-    except ModuleNotFoundError:
-        tomllib = None  # type: ignore[assignment]
 
 import nox
 
@@ -31,17 +25,41 @@ _EVALUATOR_SCHEMA = Path("schemas/codex_eval_rules.v3.schema.json")
 _CONFIG_VALIDATOR = Path("tools/validate_configs.py")
 
 
+_TOML_MODULE: Optional[ModuleType] = None
+
+
+def _get_toml_module() -> Optional[ModuleType]:
+    """Best-effort loader for tomllib/tomli without hard dependency."""
+
+    global _TOML_MODULE
+    if _TOML_MODULE is not None:
+        return _TOML_MODULE
+
+    for name in ("tomllib", "tomli"):
+        try:
+            module = importlib.import_module(name)
+        except ModuleNotFoundError:
+            continue
+        else:
+            _TOML_MODULE = module
+            return module
+
+    _TOML_MODULE = None
+    return None
+
+
 def _toml_fail_under_from_str(toml_text: str) -> Optional[str]:
     """
     Extract fail_under value from [tool.coverage.report] section in TOML text.
     Returns the value as a string if it's a valid integer, None otherwise.
     """
-    if tomllib is None:
+    toml_module = _get_toml_module()
+    if toml_module is None:
         # TOML library not available, cannot parse
         return None
-    
+
     try:
-        parsed = tomllib.loads(toml_text)
+        parsed = toml_module.loads(toml_text)
         fail_under = parsed.get("tool", {}).get("coverage", {}).get("report", {}).get("fail_under")
         if fail_under is not None and isinstance(fail_under, int):
             return str(fail_under)


### PR DESCRIPTION
## Summary
- lazily resolve tomllib/tomli so the noxfile loads even when tomli is not installed
- reuse the parser when available and fall back to returning None without raising at import time

## Testing
- python -m compileall noxfile.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910018f36648331ac63c3bdd24ec0fe)