### PR TITLE
Normalize migrate CLI version detection

### DIFF
--- a/src/codex_ml/cli/migrate_data.py
+++ b/src/codex_ml/cli/migrate_data.py
@@ -40,7 +40,9 @@ def migrate(
     if from_version == "auto":
         with open(input_path, encoding="utf-8") as f:
             data = json.load(f)
-            from_version = data.get("version", "1.0")
+            detected_version = data.get("version", "1.0")
+            # Ensure comparisons are reliable even if the version was encoded as a number
+            from_version = str(detected_version)
         typer.echo(f"Auto-detected source version: {from_version}")
 
     # Perform migration


### PR DESCRIPTION
## Summary
- ensure the migrate CLI normalizes auto-detected versions to strings
- prevent numeric JSON versions from skipping supported migration paths

## Testing
- pytest tests/data/test_migration.py -v

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691002d14a548331979484ae7b24d699)