### PR TITLE
Add dataset registry alias and fast tokenizer tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,6 +313,9 @@ token_accuracy_plugin = "examples.plugins.metrics_token_accuracy_plugin:TokenAcc
 [project.entry-points."codex_ml.data_loaders"]
 lines = "codex_ml.data.registry:load_line_dataset"
 
+[project.entry-points."codex_ml.datasets"]
+lines = "codex_ml.data.registry:load_line_dataset"
+
 [project.entry-points."codex_ml.trainers"]
 functional = "codex_ml.registry.trainers:_load_functional_trainer"
 

--- a/src/codex_ml/data/registry.py
+++ b/src/codex_ml/data/registry.py
@@ -35,7 +35,10 @@ def _load_loader_attr(module: str, attr: str) -> Any:
 class _DatasetRegistry:
     """Registry that supports explicit and entry-point registrations."""
 
-    _ENTRY_POINT_GROUP = "codex_ml.data_loaders"
+    _ENTRY_POINT_GROUPS: tuple[str, ...] = (
+        "codex_ml.data_loaders",
+        "codex_ml.datasets",
+    )
 
     def __init__(self) -> None:
         self._items: dict[str, Any] = {}
@@ -75,25 +78,32 @@ class _DatasetRegistry:
         self._ensure_entry_points_loaded()
         return sorted(self._items.keys())
 
+    def available(self) -> dict[str, Any]:
+        """Return a copy of registered datasets after loading entry points."""
+
+        self._ensure_entry_points_loaded()
+        return dict(self._items)
+
     def _ensure_entry_points_loaded(self) -> None:
         if self._entry_points_loaded:
             return
 
-        try:
-            entry_points = metadata.entry_points(group=self._ENTRY_POINT_GROUP)
-        except Exception:  # pragma: no cover - metadata backend failure
-            entry_points = ()
-
-        for entry_point in entry_points:
-            key = self._normalise(entry_point.name)
-            if key in self._items:
-                continue
+        for group in self._ENTRY_POINT_GROUPS:
             try:
-                value = entry_point.load()
-            except Exception as exc:  # pragma: no cover - plugin failure
-                self._failed_entry_points[key] = exc
-                continue
-            self._items[key] = value
+                entry_points = metadata.entry_points(group=group)
+            except Exception:  # pragma: no cover - metadata backend failure
+                entry_points = ()
+
+            for entry_point in entry_points:
+                key = self._normalise(entry_point.name)
+                if key in self._items:
+                    continue
+                try:
+                    value = entry_point.load()
+                except Exception as exc:  # pragma: no cover - plugin failure
+                    self._failed_entry_points[key] = exc
+                    continue
+                self._items[key] = value
 
         self._entry_points_loaded = True
 
@@ -121,6 +131,12 @@ def get_dataset(name: str, **kwargs: Any) -> Any:
 
 def list_datasets() -> list[str]:
     return data_loader_registry.list()
+
+
+def available_datasets() -> dict[str, Any]:
+    """Return a mapping of dataset names to loader callables."""
+
+    return data_loader_registry.available()
 
 
 def split_dataset(

--- a/src/tokenizer/fast_tokenizer.py
+++ b/src/tokenizer/fast_tokenizer.py
@@ -41,6 +41,25 @@ class FastTokenizerWrapper:
     def decode(self, token_ids: Iterable[int]) -> str:
         return self.tokenizer.decode(list(token_ids))
 
+    def encode(
+        self,
+        text: str,
+        *,
+        padding: str | bool = False,
+        truncation: bool | None = None,
+        max_length: int | None = None,
+    ) -> list[int]:
+        """Encode text to token IDs with optional padding/truncation."""
+
+        encoding = self.tokenizer.encode(text)
+        ids = list(encoding.ids)
+        if max_length is not None:
+            if truncation:
+                ids = ids[:max_length]
+            if padding == "max_length" and len(ids) < max_length:
+                ids = ids + [0] * (max_length - len(ids))
+        return ids
+
     @property
     def vocab_size(self) -> int:
         """Expose the underlying vocabulary size."""
@@ -62,13 +81,12 @@ class FastTokenizerWrapper:
     ) -> dict[str, list[int]]:
         """Provide a minimal call interface returning input ids."""
 
-        encoding = self.tokenizer.encode(text)
-        ids = list(encoding.ids)
-        if padding == "max_length" and max_length is not None:
-            if len(ids) < max_length:
-                ids = ids + [0] * (max_length - len(ids))
-            else:
-                ids = ids[:max_length]
+        ids = self.encode(
+            text,
+            padding=padding,
+            truncation=True if max_length is not None else False,
+            max_length=max_length,
+        )
         return {"input_ids": ids}
 
 

--- a/tests/codex_ml/test_data_registry_entrypoints.py
+++ b/tests/codex_ml/test_data_registry_entrypoints.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+from importlib import metadata
+import pytest
+
+from codex_ml.data import registry
+
+
+@dataclass
+class _DummyEntryPoint:
+    name: str
+    value: object
+
+    def load(self) -> object:  # pragma: no cover - simple passthrough
+        return self.value
+
+
+def test_entry_points_loaded_from_multiple_groups(monkeypatch):
+    dataset_name = f"alias-{uuid4().hex}"
+    calls: list[str] = []
+
+    def fake_entry_points(group: str):
+        calls.append(group)
+        if group == registry._DatasetRegistry._ENTRY_POINT_GROUPS[1]:
+            return (_DummyEntryPoint(dataset_name, lambda: "ok"),)
+        return ()
+
+    reg = registry._DatasetRegistry()
+    monkeypatch.setattr(metadata, "entry_points", fake_entry_points)
+
+    reg._ensure_entry_points_loaded()
+
+    assert dataset_name in reg.list()
+    assert reg.get(dataset_name)() == "ok"
+    assert set(calls) >= set(registry._DatasetRegistry._ENTRY_POINT_GROUPS)
+
+
+def test_available_datasets_includes_registered_loader():
+    dataset_name = f"ephemeral-{uuid4().hex}"
+
+    @registry.register_dataset(dataset_name)
+    def _loader():
+        return {"name": dataset_name}
+
+    available = registry.available_datasets()
+    assert dataset_name in available
+    assert available[dataset_name]() == {"name": dataset_name}

--- a/tests/tokenization/test_fast_tokenizer_wrapper.py
+++ b/tests/tokenization/test_fast_tokenizer_wrapper.py
@@ -1,0 +1,48 @@
+"""Unit tests for :mod:`tokenizer.fast_tokenizer` thin wrapper."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from tokenizer.fast_tokenizer import FastTokenizerWrapper
+
+
+@pytest.fixture()
+def trained_tokenizer_json(tmp_path):
+    _tokenizers = pytest.importorskip("tokenizers")
+    try:
+        from tokenizers import Tokenizer  # type: ignore
+        from tokenizers.models import WordLevel  # type: ignore
+        from tokenizers.pre_tokenizers import Whitespace  # type: ignore
+        from tokenizers.trainers import WordLevelTrainer  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency not fully available
+        pytest.skip(f"tokenizers dependency incomplete: {exc}")
+
+    corpus = ["hello world", "foo bar baz", "chatbot"]
+    tok = Tokenizer(WordLevel(unk_token="[UNK]"))
+    tok.pre_tokenizer = Whitespace()
+    trainer = WordLevelTrainer(special_tokens=["[UNK]"])
+    tok.train_from_iterator(corpus, trainer=trainer)
+    target = tmp_path / f"tokenizer-{uuid4().hex}.json"
+    tok.save(str(target))
+    return target
+
+
+def test_round_trip(trained_tokenizer_json):
+    wrapper = FastTokenizerWrapper(str(trained_tokenizer_json))
+    text = "hello world"
+    ids = wrapper.encode(text)
+    assert wrapper.decode(ids).strip() == text
+
+
+def test_padding_and_truncation(trained_tokenizer_json):
+    wrapper = FastTokenizerWrapper(str(trained_tokenizer_json))
+    padded = wrapper.encode(
+        "foo bar baz", padding="max_length", truncation=True, max_length=6
+    )
+    assert len(padded) == 6
+    assert padded[-1] == 0
+    truncated = wrapper.encode("foo bar baz", truncation=True, max_length=2)
+    assert len(truncated) == 2


### PR DESCRIPTION
## Summary
- add an encode helper for the fast tokenizer wrapper and cover it with round-trip and padding tests
- extend the dataset registry to load datasets from both data_loaders and datasets entry-point groups and expose available datasets
- register the new datasets entry-point group in pyproject

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/tokenization/test_fast_tokenizer_wrapper.py tests/codex_ml/test_data_registry_entrypoints.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f56ac875c8331b0ae71d8176e1d49)