### PR TITLE
Fix quoting in atomic patch task sequence

### DIFF
--- a/automation/atomic_patch_task_sequence.yaml
+++ b/automation/atomic_patch_task_sequence.yaml
@@ -73,7 +73,7 @@ tasks:
             - "Provide available() helper returning copy of registry."
         - file: "pyproject.toml"
           actions:
-            - "Add project.entry-points."codex_ml.datasets" group for external loaders."
+            - "Add project.entry-points.\"codex_ml.datasets\" group for external loaders."
     validation:
       - "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -k dataset_registry"
       - "python -c \"import codex_ml.data.registry as r; print(r.available())\""


### PR DESCRIPTION
## Summary
- escape inner quotes in dataset registry action so atomic_patch_task_sequence.yaml parses with standard YAML loaders

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f60d8a2e48331ac7f0d2616a22ffe)