### PR TITLE
Address pooling fixture reuse control for pooling tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -28,3 +28,4 @@ markers =
     net: Network-dependent tests
     deferred: Deferred/experimental tests
     interfaces: Interface contract tests
+    pool_disable_reuse: Disable connection reuse during pooling fixtures

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,15 +169,16 @@ def pooling_db_manager(tmp_path, request):
     # temporarily disable pool reuse during acquisition while keeping pooling on
     # for close_connection. Tests that explicitly verify reuse keep the default
     # behavior.
-    if request.node.name != "test_connection_reuse_from_pool":
+    if request.node.get_closest_marker("pool_disable_reuse"):
         original_get = manager.get_connection
 
         def _get_connection_no_reuse(*args, **kwargs):
+            original_pooling_state = DBManager._POOL_ENABLED
             DBManager._POOL_ENABLED = False
             try:
                 return original_get(*args, **kwargs)
             finally:
-                DBManager._POOL_ENABLED = True
+                DBManager._POOL_ENABLED = original_pooling_state
 
         manager.get_connection = _get_connection_no_reuse  # type: ignore[attr-defined]
 

--- a/tests/test_pooling_advanced.py
+++ b/tests/test_pooling_advanced.py
@@ -9,10 +9,13 @@ Tests advanced pooling scenarios:
 
 import threading
 
+import pytest
+
 
 class TestPoolingBehavior:
     """Test connection pooling behavior with fixtures."""
 
+    @pytest.mark.pool_disable_reuse
     def test_multiple_connections_pooled(self, pooling_db_manager, pool_state_tracker):
         """Test that multiple connections are correctly pooled."""
         # Get and return 3 connections


### PR DESCRIPTION
## Summary
- add a dedicated pytest marker to disable connection reuse only when tests require distinct pooled connections
- update the pooling_db_manager fixture to honor the marker while restoring the original pooling flag after each acquisition
- register the marker and apply it to the multiple-connections pooling test

## Testing
- pytest tests/test_pooling_advanced.py::TestPoolingBehavior::test_concurrent_pool_access -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f6ed673cc83319af98f27815f67a7)