### PR TITLE
Handle audit orchestrator step failures

### DIFF
--- a/tests/audit/test_codex_audit_orchestrator.py
+++ b/tests/audit/test_codex_audit_orchestrator.py
@@ -58,3 +58,20 @@ def test_list_steps_subprocess(tmp_path):
 
     assert result.returncode == 0
     assert "step_1_1_resolve_repo_root_and_branches" in result.stdout
+
+
+def test_main_exits_non_zero_on_step_failure(tmp_path, monkeypatch):
+    """`main` should propagate failures instead of masking them."""
+
+    _patch_output_roots(tmp_path)
+
+    def failing_step(ctx):
+        raise RuntimeError("Simulated failure")
+
+    failing_wrapped = orchestrator.phase_step(1, "1.1", "Test step")(failing_step)
+    monkeypatch.setattr(orchestrator, "step_1_1_resolve_repo_root_and_branches", failing_wrapped)
+    monkeypatch.setattr(orchestrator, "PHASE_FUNCTIONS", [failing_wrapped])
+
+    exit_code = orchestrator.main(["--steps", "1.1"])
+
+    assert exit_code == 1

--- a/tools/codex_audit_orchestrator.py
+++ b/tools/codex_audit_orchestrator.py
@@ -79,6 +79,15 @@ class StepContext:
     description: str
 
 
+class StepFailure(RuntimeError):
+    """Raised when a phase step fails and has already been captured."""
+
+    def __init__(self, ctx: StepContext, original: BaseException):
+        super().__init__(f"Step {ctx.phase_id}.{ctx.step_id} failed: {original}")
+        self.ctx = ctx
+        self.original = original
+
+
 # ---- Utility helpers -------------------------------------------------------------------------
 
 
@@ -173,7 +182,7 @@ def phase_step(phase_id: int, step_id: str, description: str):
             except Exception as exc:  # noqa: BLE001
                 log(f"ERROR {ctx.phase_id}.{ctx.step_id} - {exc}")
                 error_capture(exc, ctx, brief_context=f"args={args}, kwargs={kwargs}")
-                return None
+                raise StepFailure(ctx, exc) from exc
 
         wrapper.phase_id = phase_id
         wrapper.step_label = step_id
@@ -529,7 +538,11 @@ def main(argv: Optional[List[str]] = None) -> int:
             continue
 
         log(f"Running {label} ({fn.__name__})")
-        fn()
+        try:
+            fn()
+        except StepFailure as exc:
+            log(f"Aborting after failure in {label}: {exc}")
+            return 1
 
     log("Finished codex_audit_orchestrator run")
     return 0
@@ -537,3 +550,4 @@ def main(argv: Optional[List[str]] = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- raise a StepFailure when audit steps error so failures are surfaced
- abort orchestration on failed steps to avoid masking partial runs
- add regression test confirming main exits non-zero when a step fails

## Testing
- python -m pytest tests/audit/test_codex_audit_orchestrator.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922afa6a0b08331bee5f2bc5fd95e46)