### PR TITLE
Fix CLI config handling and CSV metrics writer robustness

### DIFF
--- a/src/codex/cli.py
+++ b/src/codex/cli.py
@@ -378,22 +378,38 @@ def train_cmd(engine: str, engine_args: tuple[str, ...]) -> None:
             "lora_task_type": args.lora_task_type,
             "seed": args.seed,
         }
-        hydra_cfg: dict[str, object] = {
-            "gradient_accumulation_steps": args.gradient_accumulation_steps,
-            "precision": args.precision,
-            "seed": args.seed,
+
+        hydra_cfg: dict[str, object] = {}
+        defaults = {
+            "gradient_accumulation_steps": parser.get_default("gradient_accumulation_steps"),
+            "precision": parser.get_default("precision"),
+            "seed": parser.get_default("seed"),
+            "lora_r": parser.get_default("lora_r"),
+            "lora_alpha": parser.get_default("lora_alpha"),
+            "lora_dropout": parser.get_default("lora_dropout"),
+            "lora_task_type": parser.get_default("lora_task_type"),
         }
+
+        if args.gradient_accumulation_steps != defaults["gradient_accumulation_steps"]:
+            hydra_cfg["gradient_accumulation_steps"] = args.gradient_accumulation_steps
+        if args.precision is not None:
+            hydra_cfg["precision"] = args.precision
+        if args.seed != defaults["seed"]:
+            hydra_cfg["seed"] = args.seed
+
         lora_section: dict[str, object] = {}
-        if args.lora_r:
+        if args.lora_r and args.lora_r != defaults["lora_r"]:
             lora_section["r"] = args.lora_r
-        if args.lora_alpha is not None:
+        if args.lora_alpha is not None and args.lora_alpha != defaults["lora_alpha"]:
             lora_section["alpha"] = args.lora_alpha
-        if args.lora_dropout:
+        if args.lora_dropout and args.lora_dropout != defaults["lora_dropout"]:
             lora_section["dropout"] = args.lora_dropout
         if args.lora_task_type:
             lora_section["task_type"] = args.lora_task_type
         if lora_section:
             hydra_cfg["lora"] = lora_section
+        if not hydra_cfg:
+            hydra_cfg = None
         if args.config_path:
             kw["config_path"] = args.config_path
         if hydra_cfg:

--- a/training/engine_hf_trainer.py
+++ b/training/engine_hf_trainer.py
@@ -664,15 +664,33 @@ class CSVMetricsWriter:
             row = obj.redacted().dict()
         else:
             row = dict(obj)
+        new_keys = set(row)
         if self._header is None:
-            self._header = sorted(row)
+            self._header = sorted(new_keys)
             with self.path.open("w", encoding="utf-8", newline="") as fh:
-                writer = csv.DictWriter(fh, fieldnames=self._header)
+                writer = csv.DictWriter(fh, fieldnames=self._header, extrasaction="ignore")
                 writer.writeheader()
                 writer.writerow(row)
             return
+
+        existing_keys = set(self._header)
+        if new_keys - existing_keys:
+            # Expand the header to accommodate new metrics and rewrite the CSV.
+            self._header = sorted(existing_keys | new_keys)
+            existing_rows: list[dict[str, Any]] = []
+            with self.path.open("r", encoding="utf-8", newline="") as fh:
+                reader = csv.DictReader(fh)
+                existing_rows.extend(reader)
+            existing_rows.append(row)
+            with self.path.open("w", encoding="utf-8", newline="") as fh:
+                writer = csv.DictWriter(fh, fieldnames=self._header, extrasaction="ignore")
+                writer.writeheader()
+                for rec in existing_rows:
+                    writer.writerow(rec)
+            return
+
         with self.path.open("a", encoding="utf-8", newline="") as fh:
-            writer = csv.DictWriter(fh, fieldnames=self._header)
+            writer = csv.DictWriter(fh, fieldnames=self._header, extrasaction="ignore")
             writer.writerow(row)
 
     def close(self) -> None:  # pragma: no cover - no persistent handles
@@ -746,16 +764,18 @@ def load_training_arguments(
 ) -> TrainingArguments:
     """Load ``TrainingArguments`` from YAML and apply runtime overrides."""
     cfg: Dict[str, object] = {}
-    # Load base config from Hydra when provided
-    if hydra_cfg is not None:
-        cfg.update(hydra_cfg)
-    elif path is not None:
+
+    # Always honor user-provided config files, then layer Hydra overrides when supplied.
+    if path is not None:
         if path.exists():
             loaded = OmegaConf.to_container(OmegaConf.load(path), resolve=True)
             if isinstance(loaded, dict):
                 cfg.update(loaded)
         else:
             print(f"[warning] config {path} missing, using default training args")
+
+    if hydra_cfg is not None:
+        cfg.update(hydra_cfg)
     cfg.setdefault("output_dir", str(output_dir))
     cfg["output_dir"] = str(output_dir)
 


### PR DESCRIPTION
## Summary
- honor user-provided training config files by merging Hydra overrides instead of replacing configs
- only forward Hydra overrides from CLI when users specify non-default values, keeping config files authoritative
- make CSV metrics writer resilient to evolving metric keys by expanding headers and ignoring extras

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/metrics/test_writers.py tests/test_metrics_writers.py -k csv

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692402230dd88331931283e8b9ea0822)