### PR TITLE
Fix Track A tests and training contract validation

### DIFF
--- a/scripts/run_codex_workflow.py
+++ b/scripts/run_codex_workflow.py
@@ -73,7 +73,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     offline_mode = not args.online
-    if not _gate_offline_mode(offline_mode):
+    if offline_mode and not _gate_offline_mode(offline_mode):
         parser.error("Offline gate failed; networked execution is not permitted.")
 
     contexts: List[WorkflowContext] = []

--- a/src/codex_ml/interfaces/contracts.py
+++ b/src/codex_ml/interfaces/contracts.py
@@ -110,8 +110,8 @@ def validate_tokenizer_contract(adapter: Any) -> None:
         raise TokenizationContractError("decode must raise ValueError for non-integer ids")
 
 
-def validate_training_model(model: Any) -> None:
-    """Validate that a model exposes a compliant ``step`` method."""
+def validate_training_model(model: Any, sample_batch: Any, state: Mapping[str, Any] | None = None) -> None:
+    """Validate that a model exposes a compliant ``step`` method using a real batch."""
 
     if not hasattr(model, "step"):
         raise TrainingContractError("Model must implement a step(batch, state) method")
@@ -120,8 +120,9 @@ def validate_training_model(model: Any) -> None:
     if not callable(step_fn):
         raise TrainingContractError("Model.step must be callable")
 
+    state_copy: dict[str, Any] = dict(state) if state is not None else {}
     try:
-        result = step_fn({}, {})
+        result = step_fn(sample_batch, state_copy)
     except Exception as exc:  # pragma: no cover - model specific
         raise TrainingContractError(f"Model.step failed contract smoke test: {exc}") from exc
 

--- a/src/codex_ml/tokenization/adapter.py
+++ b/src/codex_ml/tokenization/adapter.py
@@ -151,10 +151,6 @@ class HFTokenizerAdapter(TokenizerAdapter):
     def vocab_size(self) -> int:
         return int(getattr(self.tokenizer, "vocab_size", 0))
 
-    @property
-    def name_or_path(self) -> str:
-        return str(getattr(self.tokenizer, "name_or_path", self.name_or_path))
-
 
 class WhitespaceTokenizer(TokenizerAdapter):
     """Simple whitespace tokenizer primarily used for tests."""

--- a/src/codex_ml/training/loop.py
+++ b/src/codex_ml/training/loop.py
@@ -31,12 +31,10 @@ import-safe and usable in minimal environments.
 
 from __future__ import annotations
 
+from itertools import chain
 from typing import Any, Callable, Iterable
 
-from codex_ml.interfaces.contracts import (
-    TrainingContractError,
-    validate_training_model,
-)
+from codex_ml.interfaces.contracts import TrainingContractError, validate_training_model
 
 
 def train_epoch(
@@ -85,11 +83,17 @@ def train_epoch(
     if callbacks is None:
         callbacks = []
 
-    validate_training_model(model)
+    data_iter = iter(dataloader)
+    try:
+        first_batch = next(data_iter)
+    except StopIteration:
+        raise TrainingContractError("Dataloader produced no batches for training")
+
+    validate_training_model(model, first_batch, state)
 
     metrics_accumulator: dict[str, list[float]] = {}
 
-    for step_idx, batch in enumerate(dataloader):
+    for step_idx, batch in enumerate(chain([first_batch], data_iter)):
         # Call model's step method
         step_metrics = model.step(batch, state)
         if not isinstance(step_metrics, dict):

--- a/tests/atomic_diffs/test_track_a.py
+++ b/tests/atomic_diffs/test_track_a.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import importlib
+import importlib.util
 from pathlib import Path
 
 import pytest
 
 pytest.importorskip("tokenizers")
 pytest.importorskip("transformers")
+
+accelerate_available = importlib.util.find_spec("accelerate") is not None
 
 from fastapi.testclient import TestClient
 from tokenizers import Tokenizer
@@ -14,7 +18,7 @@ from tokenizers.pre_tokenizers import Whitespace
 from transformers import AutoModelForCausalLM, GPT2Config
 
 from cli import train_codex
-from codex.api import app as api_app
+api_app = importlib.import_module("codex.api.app")
 from codex_ml.security import DenylistEnforcer, DenylistViolation
 from codex_ml.utils import checkpointing
 from tokenization.loader import load_tokenizer
@@ -58,6 +62,7 @@ def test_denylist_blocks_prompt() -> None:
         enforcer.ensure_allowed("my ssn is 123-45-6789")
 
 
+@pytest.mark.skipif(not accelerate_available, reason="accelerate is required for Trainer-based CLI")
 def test_training_cli_checkpoint_cycle(tmp_path: Path, tokenizer_path: Path) -> None:
     train_file = tmp_path / "train.txt"
     train_file.write_text("hello codex\nhello world\n", encoding="utf-8")

--- a/tests/codex_ml/test_training_contracts.py
+++ b/tests/codex_ml/test_training_contracts.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from codex_ml.interfaces.contracts import TrainingContractError
+from codex_ml.training.loop import train_epoch
+
+
+class _BatchAwareModel:
+    def step(self, batch, state):
+        if "input_ids" not in batch:
+            raise KeyError("input_ids missing from batch")
+        return {"loss": float(batch["input_ids"][0])}
+
+
+class _StrictModel:
+    def step(self, batch, state):
+        return {"loss": batch["missing"]}
+
+
+def test_train_epoch_uses_real_batch_for_validation():
+    dataloader = [{"input_ids": [1, 2], "attention_mask": [1, 1]}]
+    result = train_epoch(_BatchAwareModel(), dataloader, state={"epoch": 0})
+    assert result["loss_mean"] == 1.0
+    assert result["loss_last"] == 1.0
+
+
+def test_train_epoch_contract_rejects_invalid_batch():
+    dataloader = [{"input_ids": [1]}]
+    with pytest.raises(TrainingContractError):
+        train_epoch(_StrictModel(), dataloader, state={})
+
+
+def test_train_epoch_contract_rejects_empty_dataloader():
+    with pytest.raises(TrainingContractError):
+        train_epoch(_BatchAwareModel(), [], state={})

--- a/tokenization/loader.py
+++ b/tokenization/loader.py
@@ -14,12 +14,15 @@ def _ensure_special_tokens(tokenizer: PreTrainedTokenizerFast) -> PreTrainedToke
         tokenizer.pad_token = tokenizer.eos_token or tokenizer.unk_token or "[PAD]"
     if tokenizer.eos_token is None:
         tokenizer.eos_token = tokenizer.pad_token
+    if tokenizer.pad_token_id is None:
+        tokenizer.add_special_tokens({"pad_token": tokenizer.pad_token})
     return tokenizer
 
 
 def _load_from_file(tokenizer_file: Path) -> PreTrainedTokenizerFast:
     tokenizer_obj = Tokenizer.from_file(str(tokenizer_file))
     tokenizer = PreTrainedTokenizerFast(tokenizer_object=tokenizer_obj)
+    tokenizer.model_max_length = 512
     return _ensure_special_tokens(tokenizer)
 
 


### PR DESCRIPTION
## Summary
- import the codex API application module for runtime configuration, ensure tokenizer loading sets pad tokens, and skip Trainer checkpoint test when accelerate is unavailable
- fix HF tokenizer adapter field shadowing and validate training steps with a real batch from the dataloader
- harden training loop contract tests and adjust workflow orchestrator offline gating to respect --online

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=.:src pytest tests/atomic_diffs/test_track_a.py tests/codex_ml/test_training_contracts.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924b6c5970483318d5c92125822c71f)