### PR TITLE
Ensure reward metrics load after plugin init

### DIFF
--- a/src/codex_ml/metrics/registry.py
+++ b/src/codex_ml/metrics/registry.py
@@ -32,6 +32,8 @@ metric_registry = Registry("metric")
 _METRIC_PLUGINS_LOADED = False
 _METRIC_PLUGINS_LOCK = threading.Lock()
 _PLUGIN_CONFLICT_LOGGED: set[str] = set()
+_REWARD_METRICS_LOADED = False
+_REWARD_METRICS_LOCK = threading.Lock()
 
 # Ensure built-in generative metrics are registered on import.
 from . import generative as _generative  # noqa: F401, E402
@@ -252,14 +254,22 @@ def init_metric_plugins(*, force: bool = False) -> int:
 
 
 def _ensure_metric_plugins_loaded() -> None:
+    global _REWARD_METRICS_LOADED
+
+    if not _REWARD_METRICS_LOADED:
+        with _REWARD_METRICS_LOCK:
+            if not _REWARD_METRICS_LOADED:
+                # Register built-in reward metrics alongside generative
+                # defaults without creating import cycles at module import
+                # time.
+                from . import reward as _reward  # noqa: WPS433
+
+                _ = _reward
+                _REWARD_METRICS_LOADED = True
+
     if _METRIC_PLUGINS_LOADED:
         return
 
-    # Register built-in reward metrics alongside generative defaults without
-    # creating import cycles at module import time.
-    from . import reward as _reward  # noqa: WPS433
-
-    _ = _reward
     init_metric_plugins()
 
 


### PR DESCRIPTION
## Summary
- ensure reward metrics are imported before plugin load checks so they register even when plugins were initialized early
- keep plugin initialization idempotent while gating reward metric import with a dedicated lock

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_reward_metrics.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692536beb5388331a3ae0355da27b99f)