### PR TITLE
Harden environment snapshot redaction

### DIFF
--- a/docs/reproducibility/env_and_dependency_snapshot.md
+++ b/docs/reproducibility/env_and_dependency_snapshot.md
@@ -8,7 +8,7 @@ This guide describes the lightweight, offline tooling that captures the local ex
 
 - Python version and executable path
 - Host platform metadata (system, release, machine)
-- Full environment variables (sorted for determinism)
+- Selected environment variables (safe prefixes only; sensitive keys redacted)
 - Installed distributions via `importlib.metadata`
 
 Example usage:

--- a/tools/codex_env_snapshot.py
+++ b/tools/codex_env_snapshot.py
@@ -16,7 +16,7 @@ import platform
 import sys
 from importlib import metadata
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List
 
 
 def _installed_packages() -> List[Dict[str, str]]:
@@ -27,10 +27,57 @@ def _installed_packages() -> List[Dict[str, str]]:
     return packages
 
 
-def _environment_variables() -> Dict[str, str]:
+_SAFE_PREFIXES: tuple[str, ...] = (
+    "CODEX_",
+    "PYTHON",
+    "PIP_",
+    "VIRTUAL_ENV",
+    "CONDA",
+    "PATH",
+    "LD_",
+    "LANG",
+    "LC_",
+    "HOSTNAME",
+    "HOME",
+    "SHELL",
+    "USER",
+    "LOGNAME",
+    "TERM",
+    "TZ",
+)
+
+
+_SENSITIVE_TOKENS: tuple[str, ...] = (
+    "KEY",
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "PASS",
+    "CREDENTIAL",
+    "AUTH",
+    "PRIVATE",
+)
+
+
+def _is_sensitive(key: str) -> bool:
+    key_upper = key.upper()
+    return any(token in key_upper for token in _SENSITIVE_TOKENS)
+
+
+def _is_safe(key: str) -> bool:
+    return key.startswith(_SAFE_PREFIXES)
+
+
+def _redact_environment(env: Iterable[tuple[str, str]]) -> Dict[str, str]:
     captured: Dict[str, str] = {}
-    for key, value in sorted(os.environ.items()):
-        captured[key] = value
+    for key, value in sorted(env):
+        if _is_sensitive(key):
+            captured[key] = "<redacted>"
+            continue
+
+        if _is_safe(key):
+            captured[key] = value
+
     return captured
 
 
@@ -45,7 +92,7 @@ def build_snapshot() -> Dict[str, Any]:
             "release": platform.release(),
             "machine": platform.machine(),
         },
-        "environment": _environment_variables(),
+        "environment": _redact_environment(os.environ.items()),
         "installed_packages": _installed_packages(),
     }
 


### PR DESCRIPTION
## Summary
- restrict environment snapshot output to safe prefixes and redact sensitive keys
- refresh documentation to describe the filtered environment capture

## Testing
- PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/tools/test_codex_env_snapshot.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693106229c948331bd5b03895cc49b75)