### PR TITLE
fix(tests): harden semgrep URL checks; add CI log retrieval agent and PR #3020 verification artifacts

### DIFF
--- a/.codex/action_log.ndjson
+++ b/.codex/action_log.ndjson
@@ -167,3 +167,24 @@
 {"timestamp":"2026-01-29T23:02:23Z","actor":"assistant","action":"updated","path":"tests/test_rag_end_to_end_pipeline.py","summary":"Clarified module docstring for offline fake components."}
 {"timestamp":"2026-01-29T23:02:23Z","actor":"assistant","action":"updated","path":".codex/results.md","summary":"Logged validation run after docstring updates."}
 {"timestamp":"2026-01-29T23:02:23Z","actor":"assistant","action":"updated","path":".codex/change_log.md","summary":"Recorded docstring update validation."}
+{"timestamp":"2026-01-29T23:28:03Z","actor":"assistant","action":"fetched","path":"artifacts/github_fetch_20260129_232552","summary":"Fetched GitHub run/job/PR pages for PR #3020 verification; unauthenticated HTML captured."}
+{"timestamp":"2026-01-29T23:28:03Z","actor":"assistant","action":"created","path":"reports/pr-3020-ci-alerts-verification_20260129_232722.md","summary":"Recorded CI/alert verification report for PR #3020 and PR #3064 context."}
+{"timestamp":"2026-01-29T23:28:03Z","actor":"assistant","action":"created","path":".codex/plans/path_100_20260129_232722_pr3020-ci-alerts.md","summary":"Added path-to-100% coverage plan for PR #3020 CI/alert verification."}
+{"timestamp":"2026-01-29T23:28:03Z","actor":"assistant","action":"created","path":".github/agents/security-alert-verification-agent.md","summary":"Added Security Alert Verification Agent documentation."}
+{"timestamp":"2026-01-29T23:28:03Z","actor":"assistant","action":"updated","path":"AGENTS.md","summary":"Registered Security Alert Verification Agent in specialized agents table."}
+{"timestamp":"2026-01-29T23:29:43Z","actor":"assistant","action":"tested","path":"tests","summary":"Ran smoke, unit, integration, and coverage pytest commands; failures due to missing dependencies and pytest-cov."}
+{"timestamp":"2026-01-29T23:29:43Z","actor":"assistant","action":"updated","path":".codex/results.md","summary":"Logged PR #3020 verification test attempts and failures."}
+{"timestamp":"2026-01-29T23:29:43Z","actor":"assistant","action":"created","path":"reports/pr-3020-final-fixes-execution-report_20260129_232722.md","summary":"Recorded PR #3020 execution report with partial status and test blockers."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"updated","path":"tests/test_semgrep_suppressions.py","summary":"Replaced URL substring checks with regex-based URL literal detection."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"created","path":".codex/plans/path_100_20260129-235848_semgrep_url_regex.md","summary":"Added semgrep URL regex validation plan using pre-commit terminology."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"created","path":".codex/plans/path_100_20260129_232628_semgrep_url_regex.md","summary":"Added baseline semgrep URL regex plan referenced by PR instructions."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"created","path":".github/agents/ci-log-retrieval-agent.md","summary":"Added CI Log Retrieval Agent documentation."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"updated","path":"AGENTS.md","summary":"Registered CI Log Retrieval Agent in specialized agents table."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"updated","path":"reports/pr-3020-ci-alerts-verification_20260129_232722.md","summary":"Added API log retrieval status and alert access attempts for PR #3020."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"updated","path":"reports/pr-3020-final-fixes-execution-report_20260129_232722.md","summary":"Updated execution report with pre-commit terminology and auth failure notes."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"tested","path":"tests/test_semgrep_suppressions.py","summary":"Ran semgrep suppression tests after URL regex update (52 passed, 3 skipped)."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"tested","path":"tests/test_rag_end_to_end_pipeline.py","summary":"Ran RAG end-to-end pipeline test (1 skipped; no tests collected due to optional deps)."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"tested","path":"tests","summary":"Ran smoke/unit/integration/coverage pytest commands; failures due to missing dependencies and pytest-cov."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"updated","path":".codex/results.md","summary":"Logged CI log access attempts and validation/test outcomes."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"reviewed","path":".codex/results.md","summary":"Recorded five-pass self-review summary per policy."}
+{"timestamp":"2026-01-30T00:00:45Z","actor":"assistant","action":"updated","path":"reports/pr-3020-ci-alerts-verification_20260129_232722.md","summary":"Added acceptance-criteria status checklist with auth blockers."}

--- a/.codex/change_log.md
+++ b/.codex/change_log.md
@@ -790,3 +790,32 @@ Executed comprehensive QA walkthrough to update all `.codex/qa_walkthrough/` fil
 ### 2026-01-29T23:02:23Z - RAG regression docstring updates
 - Clarified docstrings in RAG regression test modules.
 - Re-validated syntax and targeted pytest suites.
+
+### 2026-01-29T23:28:03Z - PR #3020 CI/alert verification artifacts
+- Captured unauthenticated GitHub HTML snapshots for PR #3020 job/run links.
+- Added PR #3020 CI/alert verification report and path-to-100% coverage plan.
+- Added Security Alert Verification Agent documentation and registry entry.
+
+### 2026-01-29T23:29:43Z - PR #3020 verification testing
+- Attempted smoke/unit/integration/coverage pytest runs; failures due to missing optional dependencies and pytest-cov.
+- Logged results in `.codex/results.md`.
+
+### 2026-01-29T23:29:43Z - PR #3020 execution report
+- Added PR #3020 final fixes execution report with partial status and test blockers.
+
+### 2026-01-30T00:00:45Z - Semgrep URL regex hardening + CI log retrieval prep
+- Replaced URL substring checks with regex-based URL literal detection in semgrep suppression tests.
+- Added semgrep URL regex coverage plans (baseline + updated plan) using pre-commit terminology.
+- Added CI Log Retrieval Agent documentation and registered it in AGENTS.md.
+- Updated PR #3020 verification reports with API log retrieval/alert access status.
+
+### 2026-01-30T00:00:45Z - PR #3020 validation updates
+- Attempted GitHub API log and Dependabot alert fetches; unauthorized without token.
+- Ran semgrep suppression tests and RAG end-to-end spot-check; updated results log.
+- Re-ran smoke/unit/integration/coverage suites; failures due to missing dependencies and pytest-cov.
+
+### 2026-01-30T00:00:45Z - Self-review compliance
+- Recorded five-pass self-review summary in `.codex/results.md`.
+
+### 2026-01-30T00:00:45Z - PR #3020 acceptance criteria tracking
+- Added acceptance criteria status checklist to PR #3020 CI/alert verification report.

--- a/.codex/plans/path_100_20260129-235848_semgrep_url_regex.md
+++ b/.codex/plans/path_100_20260129-235848_semgrep_url_regex.md
@@ -1,0 +1,49 @@
+# Path to 100% Coverage Plan - semgrep URL regex validation
+
+**Scope:** Replace URL substring checks in semgrep suppression tests with regex-based detection and verify coverage for related security checks.
+
+## Phase 1: Semgrep suppression test hardening
+
+### Pre-commit 1-2: Update URL detection
+
+**Goal:** Replace substring checks with regex-based URL literal detection to satisfy security guidance and prevent bypasses.
+
+**Tasks:**
+- [ ] Replace `"http" in line` checks with regex `\bhttps?://` in `tests/test_semgrep_suppressions.py`.
+- [ ] Add reusable compiled regex for URL literal detection.
+- [ ] Confirm no remaining substring checks in semgrep suppression tests.
+
+**Success Criteria:**
+- [ ] Semgrep suppression tests use regex-based URL detection exclusively.
+- [ ] No `url-substring-check` findings for the updated test module.
+
+**Files to Modify:**
+- `tests/test_semgrep_suppressions.py`
+
+### Review, Verify, Commit
+- [ ] Run targeted pytest for semgrep suppression tests.
+- [ ] Run RAG end-to-end test module (integration coverage spot-check).
+- [ ] Update audit logs and results.
+
+## Phase 2: Coverage confirmation
+
+### Pre-commit 3-4: Validation & documentation
+
+**Goal:** Document validation output and ensure coverage expectations remain satisfied.
+
+**Tasks:**
+- [ ] Record validation results in `.codex/results.md`.
+- [ ] Append entry in `.codex/change_log.md` with changes and validation.
+- [ ] Append action log entries for all updated artifacts.
+
+**Success Criteria:**
+- [ ] Tests run and results captured in audit logs.
+- [ ] Coverage plan reflects completion status and next steps.
+
+---
+
+## Fix Strategy Notes
+- Use regex detection for URL literals instead of substring checks to align with semgrep guidance.
+- Keep suppression discovery logic unchanged, only update URL detection utilities and assertions.
+- Maintain existing file-scoped suppressions to avoid broadening suppression scope.
+- Leverage `mappings/shared_mappings.json` for any related refactor tooling updates to stay aligned with tokenization mapping conventions.

--- a/.codex/plans/path_100_20260129_232628_semgrep_url_regex.md
+++ b/.codex/plans/path_100_20260129_232628_semgrep_url_regex.md
@@ -1,0 +1,51 @@
+# Path to 100% Coverage Plan - semgrep URL regex validation (baseline)
+
+**Scope:** Replace URL substring checks in semgrep suppression tests with regex-based detection and verify coverage for related security checks.
+
+## Phase 1: Semgrep suppression test hardening
+
+### Pre-commit 1-2: Update URL detection
+
+**Goal:** Replace substring checks with regex-based URL literal detection to satisfy security guidance and prevent bypasses.
+
+**Tasks:**
+- [ ] Replace `"http" in line` checks with regex `\bhttps?://` in `tests/test_semgrep_suppressions.py`.
+- [ ] Add reusable compiled regex for URL literal detection.
+- [ ] Confirm no remaining substring checks in semgrep suppression tests.
+
+**Success Criteria:**
+- [ ] Semgrep suppression tests use regex-based URL detection exclusively.
+- [ ] No `url-substring-check` findings for the updated test module.
+
+**Files to Modify:**
+- `tests/test_semgrep_suppressions.py`
+
+### Review, Verify, Commit
+- [ ] Run targeted pytest for semgrep suppression tests.
+- [ ] Run RAG end-to-end test module (integration coverage spot-check).
+- [ ] Update audit logs and results.
+
+## Phase 2: Coverage confirmation
+
+### Pre-commit 3-4: Validation & documentation
+
+**Goal:** Document validation output and ensure coverage expectations remain satisfied.
+
+**Tasks:**
+- [ ] Record validation results in `.codex/results.md`.
+- [ ] Append entry in `.codex/change_log.md` with changes and validation.
+- [ ] Append action log entries for all updated artifacts.
+
+**Success Criteria:**
+- [ ] Tests run and results captured in audit logs.
+- [ ] Coverage plan reflects completion status and next steps.
+
+---
+
+## Fix Strategy Notes
+- Use regex detection for URL literals instead of substring checks to align with semgrep guidance.
+- Keep suppression discovery logic unchanged, only update URL detection utilities and assertions.
+- Maintain existing file-scoped suppressions to avoid broadening suppression scope.
+
+## Related Plans
+- `.codex/plans/path_100_20260129-235848_semgrep_url_regex.md`

--- a/.codex/plans/path_100_20260129_232722_pr3020-ci-alerts.md
+++ b/.codex/plans/path_100_20260129_232722_pr3020-ci-alerts.md
@@ -1,0 +1,49 @@
+# Path to 100% Coverage Plan: PR #3020 CI + Alert Verification
+
+**Timestamp**: 2026-01-29T23:27:22Z  
+**Owner**: ai_org_repo_admin
+
+## Goal
+Reach ≥70% coverage for changes linked to PR #3020 verification and establish a path to 100% coverage for CI/alert validation workflows.
+
+## Current Context
+- CI log access requires authenticated GitHub access.
+- Recent commit af85e53 focuses on regression tests and audit logs, not direct remediation of CI or security alerts.
+- Tokenization/import mapping structure available in `mappings/shared_mappings.json` for refactor alignment.
+
+## Coverage Targets
+1. **CI failure diagnostics**
+   - Add tests for CI log parsing utilities once logs are accessible.
+   - Ensure fallback paths for unauthenticated HTML fetches are covered.
+2. **Security alert triage**
+   - Add fixtures for dependency vulnerability parsing once alert data is retrieved.
+3. **Tokenization/import mapping usage**
+   - Validate mapping-driven refactor tooling by covering usage of `mappings/shared_mappings.json` in remediation scripts.
+
+## Plan Steps
+1. **Authenticate & capture logs**
+   - Use `gh auth login` (or injected token) to retrieve CI job logs and alert details.
+   - Store logs under `artifacts/` for deterministic test fixtures.
+2. **Add tests**
+   - Create targeted unit tests for any parsing/utilities added to process logs and alerts.
+   - Add integration tests to ensure CI failure classification matches expected categories.
+3. **Coverage validation**
+   - Run `pytest --cov=src --cov-report=term-missing --cov-fail-under=70` on new tests.
+   - Iterate until coverage meets or exceeds 70%.
+4. **Edge-case checks**
+   - Confirm handling for signed-out HTML, missing sections, and malformed JSON responses.
+5. **Document results**
+   - Update `.codex/results.md` with coverage and test outcomes.
+   - Record changes in `.codex/change_log.md`.
+
+## Risks & Mitigations
+- **Risk**: CI logs inaccessible due to auth constraints.
+  - **Mitigation**: Coordinate with repo admin for tokenized fetch.
+- **Risk**: Alerts span multiple subsystems.
+  - **Mitigation**: Prioritize critical alerts first, then high/medium.
+
+## Verification Commands
+- `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest -m "smoke"`
+- `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest tests/unit`
+- `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest tests/integration -m "integration"`
+- `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest --cov=src --cov-report=term-missing --cov-fail-under=70`

--- a/.codex/results.md
+++ b/.codex/results.md
@@ -509,3 +509,30 @@ Supporting files:
 ## 2026-01-29T23:02:23Z - RAG regression docstring update validation
 - Syntax check: `PYENV_VERSION=3.12.12 python -m py_compile tests/test_rag_meta_tensor_regression.py tests/test_rag_initialization_patterns.py tests/test_semgrep_suppressions.py tests/test_rag_end_to_end_pipeline.py`.
 - Test run: `PYENV_VERSION=3.12.12 python -m pytest tests/test_rag_meta_tensor_regression.py tests/test_rag_initialization_patterns.py tests/test_semgrep_suppressions.py tests/test_rag_end_to_end_pipeline.py` (61 passed, 5 skipped; pytest-timeout config warnings and Hydra extra warning).
+
+## 2026-01-29T23:29:43Z - PR #3020 CI/alert verification
+- Fetched GitHub run/job/PR pages into `artifacts/github_fetch_20260129_232552/` (unauthenticated HTML requires sign-in to view logs).
+- Test run (smoke marker): `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest -m "smoke"` (failed during collection: missing numpy, yaml, pydantic, torch, mlflow, hydra, typer attribute errors).
+- Test run (unit): `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest tests/unit` (failed during collection: missing yaml, numpy, pydantic, torch, mlflow, hydra).
+- Test run (integration): `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest tests/integration -m "integration"` (failed during collection: missing yaml, torch, mlflow, hydra).
+- Coverage run: `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest --cov=src --cov-report=term-missing --cov-fail-under=70` (failed: pytest-cov plugin unavailable; same missing dependency stack).
+
+## 2026-01-30T00:00:45Z - PR #3020 CI log access + semgrep URL regex validation
+- GitHub API log fetch attempts:
+  - `curl -sS -o /dev/null -w "%{http_code}" https://api.github.com/repos/Aries-Serpent/_codex_/actions/jobs/61934477962/logs` → 403
+  - `curl -sS -o /dev/null -w "%{http_code}" https://api.github.com/repos/Aries-Serpent/_codex_/actions/jobs/61935610904/logs` → 403
+  - `curl -sS -o /dev/null -w "%{http_code}" https://api.github.com/repos/Aries-Serpent/_codex_/actions/jobs/61934477813/logs` → 403
+  - `curl -sS -o /dev/null -w "%{http_code}" https://api.github.com/repos/Aries-Serpent/_codex_/dependabot/alerts` → 401
+- Test run: `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest tests/test_semgrep_suppressions.py` (52 passed, 3 skipped; Hydra extras + pytest-timeout config warnings).
+- Test run: `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest tests/test_rag_end_to_end_pipeline.py` (1 skipped; exit code 5 due to no tests collected; Hydra extras + pytest-timeout warnings).
+- Test run: `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest -m "smoke"` (failed during collection: missing numpy, yaml, pydantic, torch, mlflow, hydra; typer attribute errors).
+- Test run: `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest tests/unit` (failed during collection: missing yaml, numpy, pydantic, torch, mlflow, hydra).
+- Test run: `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest tests/integration -m "integration"` (failed during collection: missing yaml, torch, mlflow, hydra).
+- Coverage run: `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest --cov=src --cov-report=term-missing --cov-fail-under=70` (failed: pytest-cov plugin unavailable; missing dependency stack).
+
+## 2026-01-30T00:00:45Z - Self-review iterations (5 passes)
+1. Pass 1 (Code correctness): verified semgrep regex update and plan/report edits.
+2. Pass 2 (Testing): executed semgrep/RAG spot-check and mandatory smoke/unit/integration/coverage commands.
+3. Pass 3 (Docs): validated report updates and agent registrations for completeness.
+4. Pass 4 (Security): confirmed no secrets added; noted auth requirements for logs/alerts.
+5. Pass 5 (Integration): ensured audit logs updated and plan references aligned with instructions.

--- a/.github/agents/ci-log-retrieval-agent.md
+++ b/.github/agents/ci-log-retrieval-agent.md
@@ -1,0 +1,48 @@
+---
+name: CI Log Retrieval Agent
+description: Specialized agent for authenticated GitHub Actions log retrieval and failure summarization
+version: 1.0.0
+created: 2026-01-29
+updated: 2026-01-29
+---
+
+# CI Log Retrieval Agent
+
+## Overview
+
+Specialized GitHub Copilot agent for retrieving GitHub Actions job logs (authenticated), extracting failing steps, and producing actionable summaries for CI remediation in the _codex_ repository.
+
+## Core Responsibilities
+
+1. **Authenticated Log Fetch**: Retrieve job logs via GitHub API with tokenized access.
+2. **Failure Summarization**: Extract failing steps, stack traces, and exit codes.
+3. **Artifact Preservation**: Store log excerpts in `reports/` and raw logs in `artifacts/` when allowed.
+4. **Remediation Guidance**: Map failures to modules/tests and recommend fixes.
+
+## Activation
+
+```
+@copilot Use the CI Log Retrieval Agent to collect Actions job logs and summarize root-cause failures.
+```
+
+## Workflow
+
+1. Validate authentication (`gh` or token env).
+2. Fetch logs using the Actions API endpoints.
+3. Parse logs into step summaries and error highlights.
+4. Output a report in `reports/` and update audit logs.
+
+## Verification Checklist
+
+- [ ] Authenticated access confirmed
+- [ ] Logs downloaded for each job ID
+- [ ] Failures summarized with file/test references
+- [ ] Reports and audit logs updated
+
+## Output Artifacts
+
+- Markdown report in `reports/`
+- Log archive in `artifacts/` (if permitted)
+- Change log entries in `.codex/change_log.md`
+
+**Last Updated**: 2026-01-29T23:58:48Z

--- a/.github/agents/security-alert-verification-agent.md
+++ b/.github/agents/security-alert-verification-agent.md
@@ -1,0 +1,50 @@
+---
+name: Security Alert Verification Agent
+description: Specialized agent for validating GitHub security alerts, vulnerability triage, and remediation guidance
+version: 1.0.0
+created: 2026-01-29
+updated: 2026-01-29
+---
+
+# Security Alert Verification Agent
+
+## Overview
+
+Specialized GitHub Copilot agent for verifying GitHub security alert details, mapping alerts to code ownership, and proposing remediation steps in the _codex_ repository.
+
+## Core Responsibilities
+
+1. **Alert Verification**: Fetch and parse security alerts, severity levels, and affected packages.
+2. **Impact Mapping**: Map alert metadata to repository files, dependencies, and ownership.
+3. **Remediation Planning**: Provide targeted upgrade or patch guidance.
+4. **Validation**: Recommend tests and verification steps after fixes.
+
+## Activation
+
+```
+@copilot Use the Security Alert Verification Agent to triage PR security alerts and provide remediation steps.
+```
+
+## Workflow
+
+1. Gather alert data (GitHub UI/API).
+2. Classify by severity and scope.
+3. Map to dependency tree (requirements/lockfiles).
+4. Propose fixes with minimal blast radius.
+5. Validate with targeted tests and coverage checks.
+
+## Verification Checklist
+
+- [ ] Alerts fetched with authenticated access
+- [ ] Severity classification recorded
+- [ ] Impacted dependencies identified
+- [ ] Fix strategy documented
+- [ ] Tests executed and results logged
+
+## Output Artifacts
+
+- Markdown report in `reports/`
+- JSON summary in `artifacts/`
+- Change log entries in `.codex/change_log.md`
+
+**Last Updated**: 2026-01-29T23:27:22Z

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,8 @@ The repository includes specialized GitHub Copilot agents designed for specific 
 | **CI Testing Agent** | Debug CI/CD pipelines, test failures, import errors | [.github/agents/ci-testing-agent.md](.github/agents/ci-testing-agent.md) | ✅ Active |
 | **Codex Reviewer** | Code review and quality checks | [.github/agents/codex-reviewer.agent.yml](.github/agents/codex-reviewer.agent.yml) | ✅ Active |
 | **Security Agent** | Security vulnerability scanning and fixes | [.github/copilot-security/security_agent.py](.github/copilot-security/security_agent.py) | ✅ Active |
+| **Security Alert Verification Agent** | Verify GitHub security alerts and propose remediation steps | [.github/agents/security-alert-verification-agent.md](.github/agents/security-alert-verification-agent.md) | ✅ Active |
+| **CI Log Retrieval Agent** | Retrieve authenticated GitHub Actions logs and summarize failures | [.github/agents/ci-log-retrieval-agent.md](.github/agents/ci-log-retrieval-agent.md) | ✅ Active |
 | **QA Walkthrough Agent** | Repository-wide QA walkthrough execution and audit evidence | [.github/agents/qa-walkthrough-agent.md](.github/agents/qa-walkthrough-agent.md) | ✅ Active |
 | **Dependency Conflict Agent** | Diagnose pip resolver conflicts and recommend compatible pins | [.github/agents/dependency-conflict-agent.md](.github/agents/dependency-conflict-agent.md) | ✅ Active |
 | **Coverage Gapfill Agent** | Target low-coverage modules and add deterministic tests | [.github/agents/coverage-gapfill-agent.md](.github/agents/coverage-gapfill-agent.md) | ✅ Active |

--- a/reports/pr-3020-ci-alerts-verification_20260129_232722.md
+++ b/reports/pr-3020-ci-alerts-verification_20260129_232722.md
@@ -1,0 +1,59 @@
+# PR #3020 CI/Alert Verification Report
+
+**Generated**: 2026-01-29T23:27:22Z  
+**Scope**: Failing GitHub jobs + security alerts for PR #3020; PR #3064 review context.
+
+## Source Fetch Results
+
+The requested GitHub pages were fetched into `artifacts/github_fetch_20260129_232552/`. Each page returned a signed-out view that prompts authentication ("Sign in" / "Sign in to view logs"), so the CI job logs and PR review details are not accessible in this environment without credentials.
+
+- Actions run overview: `artifacts/github_fetch_20260129_232552/github.com_Aries-Serpent__codex__runs_61934594355.html`
+- Job 61934477962: `artifacts/github_fetch_20260129_232552/github.com_Aries-Serpent__codex__actions_runs_21497061297_job_61934477962.html`
+- Job 61935610904: `artifacts/github_fetch_20260129_232552/github.com_Aries-Serpent__codex__actions_runs_21497061297_job_61935610904.html`
+- Job 61934477813: `artifacts/github_fetch_20260129_232552/github.com_Aries-Serpent__codex__actions_runs_21497061246_job_61934477813.html`
+- PR #3064 review anchor: `artifacts/github_fetch_20260129_232552/github.com_Aries-Serpent__codex__pull_3064_pullrequestreview-3725480618.html`
+- PR #3064 file view (af85e53): `artifacts/github_fetch_20260129_232552/github.com_Aries-Serpent__codex__pull_3064_files_af85e53f65af1ee56d34f123bfaad90313134294.html`
+
+## CI Log Retrieval Attempts (GitHub API)
+
+Unauthenticated API requests to the Actions job log endpoints returned authorization errors.
+
+- Job 61934477962 logs: `GET https://api.github.com/repos/Aries-Serpent/_codex_/actions/jobs/61934477962/logs` → **403** (requires auth).
+- Job 61935610904 logs: `GET https://api.github.com/repos/Aries-Serpent/_codex_/actions/jobs/61935610904/logs` → **403** (requires auth).
+- Job 61934477813 logs: `GET https://api.github.com/repos/Aries-Serpent/_codex_/actions/jobs/61934477813/logs` → **403** (requires auth).
+
+## Security Alert Retrieval Attempts
+
+Unauthenticated API requests to Dependabot alerts returned authorization errors.
+
+- Alerts endpoint: `GET https://api.github.com/repos/Aries-Serpent/_codex_/dependabot/alerts` → **401** (requires auth).
+
+## Local Commit Verification (af85e53)
+
+Commit `af85e53f65af1ee56d34f123bfaad90313134294` exists in the local repository and updates RAG regression tests plus audit logs. The changes include only test/docstring adjustments and log updates, which indicates the commit does **not** directly remediate security vulnerabilities or CI failures without further code changes.
+
+Updated files in the commit scope include:
+- RAG regression tests (`tests/test_rag_meta_tensor_regression.py`, `tests/test_rag_initialization_patterns.py`, `tests/test_rag_end_to_end_pipeline.py`, `tests/test_semgrep_suppressions.py`).
+- Audit trail entries (`.codex/action_log.ndjson`, `.codex/change_log.md`, `.codex/results.md`).
+
+## Verification Gaps
+
+- CI job failures and alert details cannot be confirmed without authenticated access to the GitHub logs.
+- The 118 alerts (including 3 critical) remain unverified because the alerts page is not accessible in the signed-out HTML.
+
+## Applied Patchset Notes
+
+- Semgrep suppression URL checks were updated to regex-based detection in `tests/test_semgrep_suppressions.py`.
+- Added semgrep URL regex coverage plan to `.codex/plans/` to track validation and follow-up steps.
+
+## Next Steps (Recommended)
+
+1. Re-run the fetch with authenticated GitHub access (token or `gh` auth) to confirm the failing job steps and the alert breakdown.
+2. Map failing job steps to the relevant test/log output (likely semgrep, RAG regression, or integration suites).
+3. If security alerts persist, identify the flagged dependencies/files and apply targeted fixes.
+
+## Acceptance Criteria Status
+
+- ❌ CI job steps and tracebacks listed (blocked by GitHub auth; API returns 403).
+- ❌ 118 alerts (including 3 critical) listed with affected files/dependencies (blocked by GitHub auth; alerts API returns 401).
+- ❌ Remediation plan per critical alert (requires alert details).

--- a/reports/pr-3020-final-fixes-execution-report_20260129_232722.md
+++ b/reports/pr-3020-final-fixes-execution-report_20260129_232722.md
@@ -1,0 +1,99 @@
+# PR #3020 Final Fixes - Execution Report
+
+**Date**: 2026-01-29 23:29:43 UTC  
+**Operator**: mbaetiong  
+**Branch**: work  
+**Status**: ⚠️ PARTIAL (auth + dependency gaps)
+
+---
+
+## Execution Summary
+
+### Phase 1: Development
+- **Pre-commit cycles**: 2
+- **Commits**: 0
+- **Files Modified**: 6
+- **Status**: ⚠️ PARTIAL
+
+**Changes**:
+- Captured unauthenticated GitHub HTML fetches for PR #3020 CI job links.
+- Added PR #3020 CI/alert verification report.
+- Added Security Alert Verification Agent documentation.
+- Logged actions/results per `.codex` audit trail.
+
+---
+
+### Phase 2: Testing
+- **Pre-commit cycles**: 2
+- **Test Suites**: 4 attempted
+- **Test Cases**: N/A (collection failed)
+- **Success Rate**: 0% (dependency blockers)
+- **Status**: ❌ FAILED
+
+**Results**:
+- Smoke/Unit/Integration: collection failures (missing numpy, yaml, pydantic, torch, mlflow, hydra).
+- Coverage: pytest-cov not available in environment.
+- CI log retrieval attempts: GitHub API returned 403/401 (auth required).
+
+---
+
+### Phase 3: Test Generation
+- **Pre-commit cycles**: 0
+- **Test Files**: 0
+- **Total Test Cases**: 0
+- **Status**: ⏸️ NOT STARTED
+
+---
+
+## CI Status
+
+**Pull Request**: #3020  
+**Checks**: ❓ Unable to verify (auth required)
+
+- Semgrep: ❓
+- Comprehensive Tests: ❓
+- RAG Module Tests: ❓
+- Pre-commit Hooks: ❓
+
+---
+
+## Metrics Achieved
+
+| Metric | Target | Actual | Status |
+|--------|--------|--------|--------|
+| Pre-commit cycles | < 6 | 4 | ⚠️ |
+| Semgrep warnings | 0 | Unknown | ❓ |
+| Meta tensor errors | 0 | Unknown | ❓ |
+| Test failures | 0 | 151+ (env) | ❌ |
+| CI checks passing | 100% | Unknown | ❓ |
+| New test cases | 29+ | 0 | ⚠️ |
+
+---
+
+## Next Steps
+
+1. ✅ Request authenticated GitHub access to fetch CI logs and security alerts.
+2. ⏳ Install test dependencies (numpy, PyYAML, pydantic, torch, mlflow, hydra-core, pytest-cov).
+3. ⏳ Re-run smoke/unit/integration/coverage suites.
+4. ⏳ Generate targeted tests once alert details are confirmed.
+
+---
+
+## Lessons Learned
+
+### What Worked Well
+- HTML fetch captured confirmation that authentication is required for job logs.
+- Audit trail and verification plan logged.
+
+### Challenges Encountered
+- CI logs and alerts are inaccessible without GitHub authentication.
+- Local environment missing critical test dependencies.
+
+### Recommendations for Future
+- Provide a GitHub token or run `gh auth login` before log retrieval.
+- Use a pre-provisioned test environment with dependencies installed.
+
+---
+
+**Report Generated**: 2026-01-29T23:29:43Z  
+**Operator Signature**: mbaetiong

--- a/tests/test_semgrep_suppressions.py
+++ b/tests/test_semgrep_suppressions.py
@@ -34,6 +34,8 @@ EXPECTED_SUPPRESSION_FILES: Dict[str, int] = {
     "scripts/github_user_provision.py": 1,
 }
 
+URL_LITERAL_REGEX = re.compile(r"\bhttps?://", re.IGNORECASE)
+
 
 @pytest.fixture()
 def repo_root() -> Path:
@@ -58,7 +60,9 @@ def _find_suppression_lines(content: str) -> List[int]:
 
 def _find_nearby_url_line(lines: List[str], start_index: int, window: int = 20) -> str:
     for offset in range(1, window + 1):
-        if start_index + offset < len(lines) and "http" in lines[start_index + offset]:
+        if start_index + offset < len(lines) and URL_LITERAL_REGEX.search(
+            lines[start_index + offset]
+        ):
             return lines[start_index + offset]
     return ""
 
@@ -139,4 +143,6 @@ def test_suppression_comment_targets_url_literals(repo_root: Path, filepath: str
     for index in _find_suppression_lines("\n".join(lines)):
         url_line = _find_nearby_url_line(lines, index)
         assert url_line, f"No URL literal found near suppression in {filepath}"
-        assert "http" in url_line, f"Expected URL literal near suppression in {filepath}"
+        assert URL_LITERAL_REGEX.search(url_line), (
+            f"Expected URL literal near suppression in {filepath}"
+        )


### PR DESCRIPTION
### Motivation
- Harden semgrep suppression tests to detect true URL literals (prevent substring bypasses) and ensure suppression comments are correctly targeted. 
- Capture and document attempts to retrieve CI job logs and Dependabot alerts for PR #3020 and make the retrieval workflow reproducible. 
- Provide plans and an agent to perform authenticated log/alert retrieval and triage so human reviewers can complete remediation and coverage work.

### Description
- Replaced substring URL detection with a compiled regex `URL_LITERAL_REGEX` in `tests/test_semgrep_suppressions.py` and updated nearby-line validation to use the regex. 
- Added CI/alert verification artifacts and execution report updates in `reports/pr-3020-ci-alerts-verification_20260129_232722.md` and `reports/pr-3020-final-fixes-execution-report_20260129_232722.md`, and updated audit files (`.codex/action_log.ndjson`, `.codex/change_log.md`, `.codex/results.md`). 
- Added a `CI Log Retrieval Agent` (`.github/agents/ci-log-retrieval-agent.md`) and a `Security Alert Verification Agent` (`.github/agents/security-alert-verification-agent.md`), registered the CI agent in `AGENTS.md`, and created semgrep URL regex coverage plans under `.codex/plans/` to track validation to 100% coverage.

### Testing
- Ran `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest tests/test_semgrep_suppressions.py` which completed successfully: `52 passed, 3 skipped` (warnings about Hydra extras and pytest-timeout config). 
- Ran `PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest tests/test_rag_end_to_end_pipeline.py` as a spot-check which produced `1 skipped` / no tests collected due to optional dependencies (exit code 5) and Hydra warnings. 
- Attempted broader validation commands (`PYENV_VERSION=3.11.14 PYTHONPATH=src python -m pytest -m "smoke"`, `python -m pytest tests/unit`, `python -m pytest tests/integration -m "integration"`, and `python -m pytest --cov=src --cov-report=term-missing --cov-fail-under=70`) but they failed during collection due to missing environment dependencies (`numpy`, `PyYAML`, `pydantic`, `torch`, `mlflow`, `hydra`) and missing `pytest-cov` plugin, and are therefore documented as blocked. 
- Attempted unauthenticated API retrievals for Actions logs/Dependabot alerts which returned auth errors (`GET .../actions/jobs/<id>/logs` → `403`, `GET .../dependabot/alerts` → `401`), so CI job steps, tracebacks, and the referenced 118 alerts (including 3 critical) remain unverified until authenticated access is provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bec0b1f748331b245a94355a7bf0d)