### PR TITLE
Fix for Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/src/codex_ml/metrics/metric_implementations.py
+++ b/src/codex_ml/metrics/metric_implementations.py
@@ -188,6 +188,8 @@ class F1Score(MetricBase):
             case _:
                 raise ValueError(f"unsupported averaging strategy: {self.average}")
 
+        raise RuntimeError("unreachable: compute() exhausted all averaging strategies")
+
 
 class RecallScore(MetricBase):
     """Recall metric supporting multiple averaging strategies."""


### PR DESCRIPTION
To fix this without changing behavior, add an explicit terminal statement after the `match` block in `F1Score.compute` so there is no possible implicit return path from the analyzer’s perspective.

Best single fix:
- In `src/codex_ml/metrics/metric_implementations.py`, inside `F1Score.compute`, add a final `raise RuntimeError(...)` (or equivalent) after the `match` block.
- This is unreachable in correct execution because `case _` already raises `ValueError`, but it guarantees no implicit `None` return path remains for static analysis.
- No imports or additional dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._