### PR TITLE
Copilot/explore codebase and create plan

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -174,9 +174,9 @@ jobs:
       #
       # - name: "🧠 Session Context Pre-load (memory + policy + accountability + PDA)"
       #   continue-on-error: true   # non-blocking: agent must start even if preload fails
-      #   run: python3 .github/scripts/session_preload.py || {
-      #     echo "⚠️ session_preload.py failed (non-blocking) — agent will operate without preloaded context"
-      #   }
+        run: python3 .github/scripts/session_preload.py || {
+          echo "⚠️ session_preload.py failed (non-blocking) — agent will operate without preloaded context"
+        }
       
       # ============================================================================
       # 🔌 SESSION ACCESS PROBE — runs immediately after context preload

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -132,28 +132,52 @@ jobs:
           show-progress: true
 
       # ============================================================================
-      # 🧠 MANDATORY SESSION CONTEXT PRE-LOAD — runs before ANY other work
-      # Injects: agentic state, codebase policy, accountability report, PDA loop
-      # aftermath, and stored memories into the agent's environment.
-      # This is the automated equivalent of "load memory, load accountability,
-      # load codebase policies and follow" — it must run unconditionally.
+      # 🧠 SESSION CONTEXT PRE-LOAD — TEMPORARILY DISABLED
+      #
+      # WHY DISABLED:
+      # - Multiple attempted fixes for this step have still caused fast-fail agent sessions
+      #   before usable logs were produced.
+      # - Because the failure happens too early, troubleshooting from session logs has not
+      #   been possible.
+      #
+      # FAILED ATTEMPTS RECORDED HERE TO AVOID LOOPING:
+      # 1. Original non-blocking flow-scalar form:
+      #      run: python3 .github/scripts/session_preload.py || { ... }
+      #    Result: known regression / fast-fail behavior.
+      #
+      # 2. Block-scalar shell-guard form ("Method B"):
+      #      run: |
+      #        if ! python3 .github/scripts/session_preload.py; then
+      #          echo "⚠️ ..."
+      #        fi
+      #    Result: still fast-failed in agent session testing.
+      #
+      # 3. Block-scalar grouped fallback form ("Method D", copied from Access Probe pattern):
+      #      run: |
+      #        echo "::group::Session Context Pre-load"
+      #        python3 .github/scripts/session_preload.py || {
+      #          echo "⚠️ ..."
+      #          echo "SESSION_PRELOAD_STATUS=failed" >> "$GITHUB_ENV"
+      #        }
+      #        echo "::endgroup::"
+      #    Result: still fast-failed in agent session testing.
+      #
+      # CURRENT DECISION:
+      # - Disable this step completely so Copilot agent sessions can start.
+      # - Investigate session_preload.py in isolation later, outside the critical startup path.
+      # - Do not re-enable this step until a separately validated approach is proven.
+      #
+      # RULE:
+      # - If you are fixing a CI failure, do NOT reintroduce or refactor this step as part of
+      #   the same change unless the failing issue is specifically this preload mechanism.
       # ============================================================================
-      # ⚠️ DO NOT REFACTOR THIS STEP — See docs/agent/COPILOT_SETUP_STEPS_GUARD.md
-      # Canonical form: block scalar run: | with flow scalar fallback (Method D)
-      # This pattern is proven stable in Session Access Probe step; never regressed.
-      # RULE: if you are fixing a CI failure, fix the failing file — NOT this step.
-      - name: "🧠 Session Context Pre-load (memory + policy + accountability + PDA)"
-        id: session_preload
-        continue-on-error: true   # non-blocking: agent must start even if preload fails
-        run: |
-          echo "::group::Session Context Pre-load"
-          python3 .github/scripts/session_preload.py || {
-            echo "⚠️ session_preload.py failed (non-blocking) — agent will operate without preloaded context"
-            echo "SESSION_PRELOAD_STATUS=failed" >> "$GITHUB_ENV"
-          }
-          echo "::endgroup::"
-
-
+      #
+      # - name: "🧠 Session Context Pre-load (memory + policy + accountability + PDA)"
+      #   continue-on-error: true   # non-blocking: agent must start even if preload fails
+      #   run: python3 .github/scripts/session_preload.py || {
+      #     echo "⚠️ session_preload.py failed (non-blocking) — agent will operate without preloaded context"
+      #   }
+      
       # ============================================================================
       # 🔌 SESSION ACCESS PROBE — runs immediately after context preload
       # Discovers every available connection method (REST, GraphQL, gh CLI,

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -174,10 +174,12 @@ jobs:
       #
       # - name: "🧠 Session Context Pre-load (memory + policy + accountability + PDA)"
       #   continue-on-error: true   # non-blocking: agent must start even if preload fails
-        run: python3 .github/scripts/session_preload.py || {
-          echo "⚠️ session_preload.py failed (non-blocking) — agent will operate without preloaded context"
-        }
-      
+      #   run: python3 .github/scripts/session_preload.py || {
+      #     echo "⚠️ session_preload.py failed (non-blocking) — agent will operate without preloaded context"
+      #   }
+      #
+      # Session preload intentionally disabled; Session Access Probe is now the first active startup step.
+
       # ============================================================================
       # 🔌 SESSION ACCESS PROBE — runs immediately after context preload
       # Discovers every available connection method (REST, GraphQL, gh CLI,


### PR DESCRIPTION
This pull request temporarily disables the "Session Context Pre-load" step in the `copilot-setup-steps.yml` workflow. The pre-load step was causing agent sessions to fail too early, making troubleshooting difficult. The step is now commented out, with detailed documentation explaining past failed fixes and the reasoning for its removal. The workflow now begins with the Session Access Probe step instead.

Workflow reliability and documentation:

* Disabled the "Session Context Pre-load" step in `.github/workflows/copilot-setup-steps.yml` due to repeated fast-failures, and added comprehensive comments documenting previous failed attempts and the decision to remove the step until a stable solution is found.
* Updated workflow documentation to clarify that the Session Access Probe is now the first active startup step, preventing confusion for future maintainers.