### PR TITLE
Copilot/assess copilot sessions

### DIFF
--- a/.codex/session_startup_packet.json
+++ b/.codex/session_startup_packet.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-20T22:02:02Z",
+  "generated_at": "2026-08-21T06:49:09Z",
   "branch_drift_severity": "UNKNOWN",
   "main_commits_ahead": 0,
   "ci_failure_rate": 7.3,

--- a/.codex/session_startup_packet.json
+++ b/.codex/session_startup_packet.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-20T20:42:04Z",
+  "generated_at": "2026-08-20T22:02:02Z",
   "branch_drift_severity": "UNKNOWN",
   "main_commits_ahead": 0,
   "ci_failure_rate": 7.3,

--- a/src/codex_ml/callbacks/system_metrics.py
+++ b/src/codex_ml/callbacks/system_metrics.py
@@ -31,7 +31,7 @@ try:  # pragma: no cover - optional dependency import
     import pynvml
 
     _NVML_AVAILABLE = True
-except (ImportError, AttributeError):  # pragma: no cover - optional dependency
+except (ImportError, AttributeError, OSError, RuntimeError, ValueError):  # pragma: no cover - optional dependency
     pynvml = None
     _NVML_AVAILABLE = False
 

--- a/src/codex_ml/checkpointing/bestk.py
+++ b/src/codex_ml/checkpointing/bestk.py
@@ -32,8 +32,8 @@ def _read_index(index_path: Path) -> dict[str, Any]:
         return {"entries": []}
     try:
         return json.loads(index_path.read_text())
-    except (IOError, OSError, ModuleNotFoundError, ImportError):
-        logger.warning("Exception occurred", exc_info=True)
+    except (IOError, OSError, ModuleNotFoundError, ImportError, ValueError, TypeError, json.JSONDecodeError):
+        logger.warning("Invalid checkpoint index JSON at %s; resetting to empty index", index_path, exc_info=True)
         return {"entries": []}
 
 

--- a/src/codex_ml/checkpointing/checkpoint_core.py
+++ b/src/codex_ml/checkpointing/checkpoint_core.py
@@ -144,9 +144,9 @@ def load_checkpoint(
         payload = torch_load(
             weights, **kwargs
         )  # nosec B614 - weights_only=False required for optimizer/RNG state
-    except TypeError as exc:
+    except (TypeError, ValueError, RuntimeError) as exc:
         type(exc).__name__
-        logger.debug("TypeError: <ERROR_TYPE>")
+        logger.debug("Checkpoint load rejected with %s: %s", type(exc).__name__, exc)
         if "weights_only" in kwargs and "weights_only" in str(exc):
             kwargs.pop("weights_only", None)
             payload = torch_load(
@@ -159,7 +159,7 @@ def load_checkpoint(
         try:
             with open(metadata, encoding="utf-8") as f:
                 meta = json.load(f)
-        except (IOError, OSError, ModuleNotFoundError, ImportError):
+        except (IOError, OSError, ModuleNotFoundError, ImportError, ValueError):
             logger.warning("Exception occurred", exc_info=True)
             meta = {}
     # Validate schema version for compatibility

--- a/src/codex_ml/checkpointing/checkpoint_core.py
+++ b/src/codex_ml/checkpointing/checkpoint_core.py
@@ -147,13 +147,7 @@ def load_checkpoint(
     except (TypeError, ValueError, RuntimeError) as exc:
         type(exc).__name__
         logger.debug("Checkpoint load rejected with %s: %s", type(exc).__name__, exc)
-        if "weights_only" in kwargs and "weights_only" in str(exc):
-            kwargs.pop("weights_only", None)
-            payload = torch_load(
-                weights, **kwargs
-            )  # nosec B614 - Retrying without weights_only parameter
-        else:
-            raise
+        raise
     meta: dict[str, Any] = {}
     if os.path.exists(metadata):
         try:

--- a/src/codex_ml/monitoring/codex_logging.py
+++ b/src/codex_ml/monitoring/codex_logging.py
@@ -745,18 +745,18 @@ def _codex_sample_system() -> dict[str, Any]:
             metrics["gpu_util_mean"] = util_sum / max(1, len(gpus))
             gpu_done = True
         except Exception as exc:
-            type(exc).__name__
-            get_default_logger().debug("Exception: <ERROR_TYPE>")
-            get_default_logger().debug("NVML sampling failed", exc_info=exc)
+            get_default_logger().debug(
+                "NVML sampling failed (%s)", type(exc).__name__, exc_info=exc
+            )
             gpu_done = False
         finally:
             if nvml_initialized:
                 try:
                     pynvml.nvmlShutdown()
                 except Exception as shutdown_exc:
-                    type(shutdown_exc).__name__
-                    get_default_logger().debug("Exception: <ERROR_TYPE>")
-                    get_default_logger().debug("NVML shutdown failed", exc_info=shutdown_exc)
+                    get_default_logger().debug(
+                        "NVML shutdown failed (%s)", type(shutdown_exc).__name__, exc_info=shutdown_exc
+                    )
 
     if not gpu_done and torch is not None and hasattr(torch, "cuda") and torch.cuda.is_available():
         gpus = []

--- a/src/codex_ml/monitoring/codex_logging.py
+++ b/src/codex_ml/monitoring/codex_logging.py
@@ -63,7 +63,7 @@ if os.getenv("CODEX_DISABLE_NVML") == "1":  # pragma: no cover - env guard
 else:
     try:  # pragma: no cover - optional
         import pynvml  # type: ignore
-    except (ImportError, AttributeError):  # pragma: no cover - nvml not installed
+    except (ImportError, AttributeError, OSError, RuntimeError, ValueError):  # pragma: no cover - nvml not installed
         pynvml = None
 
 try:  # pragma: no cover - optional
@@ -427,7 +427,7 @@ def init_telemetry(profile: str = "min") -> CodexLoggers:
             _nv.nvmlInit()
             # If init succeeds, immediately shutdown to avoid leaking handles; we sample later.
             _nv.nvmlShutdown()
-        except (IOError, OSError, ModuleNotFoundError, ImportError):
+        except Exception:
             get_default_logger().warning("Exception occurred", exc_info=True)
             gpu = False
 
@@ -743,7 +743,7 @@ def _codex_sample_system() -> dict[str, Any]:
             metrics["gpu_util_mean"] = util_sum / max(1, len(gpus))
             pynvml.nvmlShutdown()
             gpu_done = True
-        except (ValueError, TypeError, RuntimeError) as exc:
+        except Exception as exc:
             type(exc).__name__
             get_default_logger().debug("Exception: <ERROR_TYPE>")
             get_default_logger().debug("NVML sampling failed", exc_info=exc)

--- a/src/codex_ml/monitoring/codex_logging.py
+++ b/src/codex_ml/monitoring/codex_logging.py
@@ -716,9 +716,11 @@ def _codex_sample_system() -> dict[str, Any]:
 
     # Prefer NVML for GPU stats with per-device enumeration
     gpu_done = False
+    nvml_initialized = False
     if pynvml is not None:
         try:  # pragma: no cover - depends on GPU/NVML availability
             pynvml.nvmlInit()
+            nvml_initialized = True
             count = pynvml.nvmlDeviceGetCount()
             gpus = []
             util_sum = 0.0
@@ -741,13 +743,20 @@ def _codex_sample_system() -> dict[str, Any]:
                 )
             metrics["gpus"] = gpus
             metrics["gpu_util_mean"] = util_sum / max(1, len(gpus))
-            pynvml.nvmlShutdown()
             gpu_done = True
         except Exception as exc:
             type(exc).__name__
             get_default_logger().debug("Exception: <ERROR_TYPE>")
             get_default_logger().debug("NVML sampling failed", exc_info=exc)
             gpu_done = False
+        finally:
+            if nvml_initialized:
+                try:
+                    pynvml.nvmlShutdown()
+                except Exception as shutdown_exc:
+                    type(shutdown_exc).__name__
+                    get_default_logger().debug("Exception: <ERROR_TYPE>")
+                    get_default_logger().debug("NVML shutdown failed", exc_info=shutdown_exc)
 
     if not gpu_done and torch is not None and hasattr(torch, "cuda") and torch.cuda.is_available():
         gpus = []

--- a/src/codex_ml/monitoring/system_metrics.py
+++ b/src/codex_ml/monitoring/system_metrics.py
@@ -62,7 +62,7 @@ try:  # pragma: no cover - optional dependency
         import pynvml
     else:  # pragma: no cover - GPU polling disabled via feature flag
         pynvml = None
-except (ImportError, AttributeError) as exc:  # pragma: no cover - pynvml missing
+except (ImportError, AttributeError, OSError, RuntimeError, ValueError) as exc:  # pragma: no cover - pynvml missing
     logger.debug(
         "pynvml import failed; GPU metrics disabled",
         exc_info=True,
@@ -269,7 +269,7 @@ def _sample_gpu_metrics() -> Optional[dict[str, Any]]:
 
     try:  # pragma: no cover - depends on NVML
         pynvml.nvmlInit()
-    except (ValueError, TypeError, RuntimeError) as exc:  # pragma: no cover - NVML init failure
+    except Exception as exc:  # pragma: no cover - NVML init failure
         logger.warning(
             "NVML initialisation failed; disabling GPU polling",
             extra={
@@ -302,12 +302,12 @@ def _sample_gpu_metrics() -> Optional[dict[str, Any]]:
                         handle, getattr(pynvml, "NVML_TEMPERATURE_GPU", 0)
                     )
                 )
-            except (ValueError, TypeError, RuntimeError):
+            except Exception:
                 logger.warning("Exception occurred", exc_info=True)
                 entry["temp_c"] = None
             try:
                 entry["power_w"] = float(pynvml.nvmlDeviceGetPowerUsage(handle) / 1000.0)
-            except (ValueError, TypeError, RuntimeError):
+            except Exception:
                 logger.warning("Exception occurred", exc_info=True)
                 entry["power_w"] = None
             devices.append(entry)
@@ -317,7 +317,7 @@ def _sample_gpu_metrics() -> Optional[dict[str, Any]]:
             "gpus": devices,
             "gpu_util_mean": util_sum / max(len(devices), 1) if devices else None,
         }
-    except (ValueError, TypeError, RuntimeError) as exc:  # pragma: no cover - NVML query failure
+    except Exception as exc:  # pragma: no cover - NVML query failure
         logger.warning(
             "NVML sampling failed; disabling GPU polling",
             extra={
@@ -331,7 +331,7 @@ def _sample_gpu_metrics() -> Optional[dict[str, Any]]:
     finally:  # pragma: no cover - depends on NVML
         try:
             pynvml.nvmlShutdown()
-        except (ValueError, TypeError, RuntimeError):
+        except Exception:
             logger.warning("Exception occurred", exc_info=True)
 
 

--- a/src/codex_ml/utils/checkpoint.py
+++ b/src/codex_ml/utils/checkpoint.py
@@ -51,12 +51,15 @@ def _can_retry_without_weights_only(exc: BaseException) -> bool:
     if not isinstance(exc, TypeError):
         return False
     message = str(exc).lower()
+    # Only allow a compatibility fallback for old Torch builds that reject the
+    # `weights_only` keyword entirely. Payload/runtime failures must fail closed.
     return any(
         token in message
         for token in (
-            "weights_only",
-            "unexpected keyword",
-            "unknown keyword",
+            "unexpected keyword argument 'weights_only'",
+            "unknown keyword argument 'weights_only'",
+            "unexpected keyword: weights_only",
+            "unknown keyword: weights_only",
         )
     )
 
@@ -104,12 +107,14 @@ def _torch_load(source: Any, *, map_location: str | None = None) -> Any:
         kwargs["weights_only"] = True
     try:
         return load_fn(source, **kwargs)
-    except (TypeError, ValueError, RuntimeError) as exc:
-        type(exc).__name__
+    except TypeError as exc:
         logger.debug("torch.load rejected payload: %s", exc)
         if _TORCH_SUPPORTS_WEIGHTS_ONLY and "weights_only" in kwargs and _can_retry_without_weights_only(exc):
             kwargs.pop("weights_only", None)
             return load_fn(source, **kwargs)
+        raise
+    except (ValueError, RuntimeError) as exc:
+        logger.debug("torch.load rejected payload: %s", exc)
         raise
 
 

--- a/src/codex_ml/utils/checkpoint.py
+++ b/src/codex_ml/utils/checkpoint.py
@@ -90,9 +90,9 @@ def _torch_load(source: Any, *, map_location: str | None = None) -> Any:
         kwargs["weights_only"] = True
     try:
         return load_fn(source, **kwargs)
-    except TypeError as exc:
+    except (TypeError, ValueError, RuntimeError) as exc:
         type(exc).__name__
-        logger.debug("TypeError: <ERROR_TYPE>")
+        logger.debug("torch.load rejected payload: %s", exc)
         if _TORCH_SUPPORTS_WEIGHTS_ONLY and "weights_only" in str(exc):
             kwargs.pop("weights_only", None)
             return load_fn(source, **kwargs)

--- a/src/codex_ml/utils/checkpoint.py
+++ b/src/codex_ml/utils/checkpoint.py
@@ -47,6 +47,20 @@ def _torch_supports_weights_only() -> bool:
 _TORCH_SUPPORTS_WEIGHTS_ONLY = _torch_supports_weights_only()
 
 
+def _can_retry_without_weights_only(exc: BaseException) -> bool:
+    if not isinstance(exc, TypeError):
+        return False
+    message = str(exc).lower()
+    return any(
+        token in message
+        for token in (
+            "weights_only",
+            "unexpected keyword",
+            "unknown keyword",
+        )
+    )
+
+
 def _torch_rng_get_state() -> Any:
     if torch is None:
         raise RuntimeError("torch is required to capture RNG state")
@@ -93,7 +107,7 @@ def _torch_load(source: Any, *, map_location: str | None = None) -> Any:
     except (TypeError, ValueError, RuntimeError) as exc:
         type(exc).__name__
         logger.debug("torch.load rejected payload: %s", exc)
-        if _TORCH_SUPPORTS_WEIGHTS_ONLY and "weights_only" in str(exc):
+        if _TORCH_SUPPORTS_WEIGHTS_ONLY and "weights_only" in kwargs and _can_retry_without_weights_only(exc):
             kwargs.pop("weights_only", None)
             return load_fn(source, **kwargs)
         raise

--- a/src/codex_ml/utils/checkpoint_core.py
+++ b/src/codex_ml/utils/checkpoint_core.py
@@ -313,25 +313,31 @@ def restore_rng_state(state: Mapping[str, Any]) -> None:
 def capture_environment_summary() -> dict[str, Any]:
     """Collect lightweight environment details for checkpoint metadata.
 
-    Delegates to the richer provenance-based ``environment_summary`` when
-    available, then merges in the lightweight local fields as a fallback
-    or supplement.
+    Keep this summary compact and stable so metadata.json remains small and
+    predictable across environments. The richer provenance report is intentionally
+    not used here because it emits very large package inventories that regress
+    downstream schema expectations and checkpoint metadata readability.
     """
-    # Prefer the provenance-module summary (richer: git SHA, package versions, etc.)
-    if _environment_summary is not None:
-        try:
-            return dict(_environment_summary())
-        except (ImportError, AttributeError) as exc:  # pragma: no cover
-            logger.debug(
-                "provenance.environment_summary failed, using local fallback: %s", exc
-            )  # codeql[py/clear-text-logging-sensitive-data]
-
     summary: dict[str, Any] = {
         "python_version": platform.python_version(),
         "python_implementation": platform.python_implementation(),
         "platform": platform.platform(),
         "machine": platform.machine(),
     }
+    if _environment_summary is not None:
+        try:
+            provenance = dict(_environment_summary())
+            for key in ("python_version", "python_implementation", "platform", "machine"):
+                if key in provenance and provenance[key] is not None:
+                    summary[key] = provenance[key]
+            if "torch_version" in provenance and provenance["torch_version"] is not None:
+                summary["torch_version"] = provenance["torch_version"]
+            if "numpy_version" in provenance and provenance["numpy_version"] is not None:
+                summary["numpy_version"] = provenance["numpy_version"]
+        except (ImportError, AttributeError) as exc:  # pragma: no cover
+            logger.debug(
+                "provenance.environment_summary failed, using local fallback: %s", exc
+            )  # codeql[py/clear-text-logging-sensitive-data]
     try:
         summary["timestamp_utc"] = datetime.now(UTC).replace(microsecond=0).isoformat()
     except (ValueError, TypeError, RuntimeError) as exc:  # pragma: no cover
@@ -520,8 +526,8 @@ def _deserialize_payload(
             kwargs["weights_only"] = True
         try:
             return torch_load(buf, **kwargs)
-        except TypeError as exc:
-            logger.debug("TypeError: %s", exc)  # codeql[py/clear-text-logging-sensitive-data]
+        except (TypeError, ValueError, RuntimeError) as exc:
+            logger.debug("torch.load rejected payload: %s", exc)  # codeql[py/clear-text-logging-sensitive-data]
             if use_weights_only and "weights_only" in kwargs and "weights_only" in str(exc):
                 buf.seek(0)
                 fallback_kwargs = dict(kwargs)
@@ -535,11 +541,6 @@ def _deserialize_payload(
                     buf.seek(0)
             else:
                 buf.seek(0)
-        except ValueError:
-            logger.warning(
-                "Exception occurred", exc_info=True
-            )  # codeql[py/clear-text-logging-sensitive-data]
-            buf.seek(0)
     # Legacy compatibility fallback: older reviewed checkpoints may not be
     # tensor-first payloads that torch.load(..., weights_only=True) can decode.
     # When that happens, keep the fallback on RestrictedUnpickler so the
@@ -866,8 +867,19 @@ def verify_checkpoint(path: str | Path) -> CheckpointMeta:
     raw = _read_bytes(p)
     try:
         obj = _deserialize_payload(raw)
-    except (IOError, OSError, ModuleNotFoundError, ImportError) as exc:
+    except (
+        IOError,
+        OSError,
+        ModuleNotFoundError,
+        ImportError,
+        ValueError,
+        EOFError,
+        RuntimeError,
+        TypeError,
+    ) as exc:
         raise CheckpointIntegrityError(f"Failed to deserialize checkpoint: {p.name}") from exc
+    if not isinstance(obj, dict):
+        raise CheckpointIntegrityError(f"Checkpoint payload for {p.name} is not a mapping")
     meta_dict = obj.get("meta", {})
     version = meta_dict.get("schema_version")
     if version is None:
@@ -910,8 +922,19 @@ def load_checkpoint(
     raw = _read_bytes(p)
     try:
         obj = _deserialize_payload(raw, map_location=map_location)
-    except (IOError, OSError, ModuleNotFoundError, ImportError) as exc:
+    except (
+        IOError,
+        OSError,
+        ModuleNotFoundError,
+        ImportError,
+        ValueError,
+        EOFError,
+        RuntimeError,
+        TypeError,
+    ) as exc:
         raise CheckpointIntegrityError(f"Failed to deserialize checkpoint: {p.name}") from exc
+    if not isinstance(obj, dict):
+        raise CheckpointIntegrityError(f"Checkpoint payload for {p.name} is not a mapping")
     meta_dict = obj.get("meta", {})
     state = obj.get("state", {})
     meta = CheckpointMeta(**{k: meta_dict.get(k) for k in CheckpointMeta.__annotations__})

--- a/src/codex_ml/utils/checkpoint_core.py
+++ b/src/codex_ml/utils/checkpoint_core.py
@@ -21,6 +21,7 @@ import hashlib
 import io
 import json
 import logging
+import pickle
 import platform
 import random
 import re
@@ -324,20 +325,6 @@ def capture_environment_summary() -> dict[str, Any]:
         "platform": platform.platform(),
         "machine": platform.machine(),
     }
-    if _environment_summary is not None:
-        try:
-            provenance = dict(_environment_summary())
-            for key in ("python_version", "python_implementation", "platform", "machine"):
-                if key in provenance and provenance[key] is not None:
-                    summary[key] = provenance[key]
-            if "torch_version" in provenance and provenance["torch_version"] is not None:
-                summary["torch_version"] = provenance["torch_version"]
-            if "numpy_version" in provenance and provenance["numpy_version"] is not None:
-                summary["numpy_version"] = provenance["numpy_version"]
-        except (ImportError, AttributeError) as exc:  # pragma: no cover
-            logger.debug(
-                "provenance.environment_summary failed, using local fallback: %s", exc
-            )  # codeql[py/clear-text-logging-sensitive-data]
     try:
         summary["timestamp_utc"] = datetime.now(UTC).replace(microsecond=0).isoformat()
     except (ValueError, TypeError, RuntimeError) as exc:  # pragma: no cover
@@ -502,6 +489,20 @@ def _torch_supports_weights_only() -> bool:
         return False
 
 
+def _can_retry_without_weights_only(exc: BaseException) -> bool:
+    if not isinstance(exc, TypeError):
+        return False
+    message = str(exc).lower()
+    return any(
+        token in message
+        for token in (
+            "weights_only",
+            "unexpected keyword",
+            "unknown keyword",
+        )
+    )
+
+
 def _deserialize_payload(
     b: bytes, *, map_location: str | torch.device | None = "cpu"
 ) -> dict[str, Any]:
@@ -528,19 +529,14 @@ def _deserialize_payload(
             return torch_load(buf, **kwargs)
         except (TypeError, ValueError, RuntimeError) as exc:
             logger.debug("torch.load rejected payload: %s", exc)  # codeql[py/clear-text-logging-sensitive-data]
-            if use_weights_only and "weights_only" in kwargs and "weights_only" in str(exc):
+            if use_weights_only and "weights_only" in kwargs and _can_retry_without_weights_only(exc):
+                logger.warning(
+                    "Rejecting unsafe weights_only retry path for payload failure; keeping restricted loader boundary.",
+                    exc_info=False,
+                )
                 buf.seek(0)
-                fallback_kwargs = dict(kwargs)
-                fallback_kwargs.pop("weights_only", None)
-                try:
-                    return torch_load(buf, **fallback_kwargs)
-                except (ValueError, TypeError, RuntimeError):
-                    logger.warning(
-                        "Exception occurred", exc_info=True
-                    )  # codeql[py/clear-text-logging-sensitive-data]
-                    buf.seek(0)
-            else:
-                buf.seek(0)
+                raise
+            buf.seek(0)
     # Legacy compatibility fallback: older reviewed checkpoints may not be
     # tensor-first payloads that torch.load(..., weights_only=True) can decode.
     # When that happens, keep the fallback on RestrictedUnpickler so the
@@ -876,6 +872,7 @@ def verify_checkpoint(path: str | Path) -> CheckpointMeta:
         EOFError,
         RuntimeError,
         TypeError,
+        pickle.UnpicklingError,
     ) as exc:
         raise CheckpointIntegrityError(f"Failed to deserialize checkpoint: {p.name}") from exc
     if not isinstance(obj, dict):
@@ -931,6 +928,7 @@ def load_checkpoint(
         EOFError,
         RuntimeError,
         TypeError,
+        pickle.UnpicklingError,
     ) as exc:
         raise CheckpointIntegrityError(f"Failed to deserialize checkpoint: {p.name}") from exc
     if not isinstance(obj, dict):

--- a/src/codex_ml/utils/checkpoint_core.py
+++ b/src/codex_ml/utils/checkpoint_core.py
@@ -493,12 +493,15 @@ def _can_retry_without_weights_only(exc: BaseException) -> bool:
     if not isinstance(exc, TypeError):
         return False
     message = str(exc).lower()
+    # Compatibility fallback is only valid when the Torch API itself rejects the
+    # `weights_only` keyword. Payload/runtime failures must fail closed.
     return any(
         token in message
         for token in (
-            "weights_only",
-            "unexpected keyword",
-            "unknown keyword",
+            "unexpected keyword argument 'weights_only'",
+            "unknown keyword argument 'weights_only'",
+            "unexpected keyword: weights_only",
+            "unknown keyword: weights_only",
         )
     )
 
@@ -527,7 +530,7 @@ def _deserialize_payload(
             kwargs["weights_only"] = True
         try:
             return torch_load(buf, **kwargs)
-        except (TypeError, ValueError, RuntimeError) as exc:
+        except TypeError as exc:
             logger.debug("torch.load rejected payload: %s", exc)  # codeql[py/clear-text-logging-sensitive-data]
             if use_weights_only and "weights_only" in kwargs and _can_retry_without_weights_only(exc):
                 logger.warning(
@@ -536,6 +539,9 @@ def _deserialize_payload(
                 )
                 buf.seek(0)
                 raise
+            buf.seek(0)
+        except (ValueError, RuntimeError) as exc:
+            logger.debug("torch.load rejected payload: %s", exc)  # codeql[py/clear-text-logging-sensitive-data]
             buf.seek(0)
     # Legacy compatibility fallback: older reviewed checkpoints may not be
     # tensor-first payloads that torch.load(..., weights_only=True) can decode.

--- a/src/codex_ml/utils/checkpointing.py
+++ b/src/codex_ml/utils/checkpointing.py
@@ -18,6 +18,7 @@ import inspect
 import io
 import json
 import logging
+import pickle
 import platform
 import random
 import shutil
@@ -431,7 +432,7 @@ def _load_payload(path: Path, *, map_location: Optional[str], fmt: SaveFormat) -
         raise CheckpointLoadError("torch checkpoint format requested but torch is not available")
     try:
         return safe_pickle_load(str(path), use_restricted_unpickler=True)
-    except (IOError, OSError, ModuleNotFoundError, ImportError) as exc:
+    except (IOError, OSError, ModuleNotFoundError, ImportError, ValueError, TypeError, RuntimeError, pickle.UnpicklingError) as exc:
         type(exc).__name__
         logger.debug("Exception: <ERROR_TYPE>")  # codeql[py/clear-text-logging-sensitive-data]
         errors.append(exc)
@@ -517,7 +518,18 @@ def load_checkpoint(
                 if map_location is not None:
                     kwargs["map_location"] = map_location
                 return torch.load(p, **kwargs)  # nosec B614
-            except (ValueError, TypeError) as exc:
+            except (ValueError, TypeError, RuntimeError) as exc:
+                msg = str(exc)
+                if "weights_only" in msg.lower():
+                    try:
+                        fallback_kwargs = {k: v for k, v in kwargs.items() if k != "weights_only"}
+                        if map_location is not None:
+                            fallback_kwargs["map_location"] = map_location
+                        return torch.load(p, **fallback_kwargs)  # nosec B614
+                    except (ValueError, TypeError, RuntimeError) as fallback_exc:
+                        raise CheckpointLoadError(
+                            f"safe load failed for {p}: {fallback_exc}"
+                        ) from fallback_exc
                 raise CheckpointLoadError(f"safe load failed for {p}: {exc}") from exc
 
     try:

--- a/src/codex_ml/utils/checkpointing.py
+++ b/src/codex_ml/utils/checkpointing.py
@@ -519,17 +519,12 @@ def load_checkpoint(
                     kwargs["map_location"] = map_location
                 return torch.load(p, **kwargs)  # nosec B614
             except (ValueError, TypeError, RuntimeError) as exc:
-                msg = str(exc)
-                if "weights_only" in msg.lower():
-                    try:
-                        fallback_kwargs = {k: v for k, v in kwargs.items() if k != "weights_only"}
-                        if map_location is not None:
-                            fallback_kwargs["map_location"] = map_location
-                        return torch.load(p, **fallback_kwargs)  # nosec B614
-                    except (ValueError, TypeError, RuntimeError) as fallback_exc:
-                        raise CheckpointLoadError(
-                            f"safe load failed for {p}: {fallback_exc}"
-                        ) from fallback_exc
+                msg = str(exc).lower()
+                if (
+                    isinstance(exc, TypeError)
+                    and any(token in msg for token in ("weights_only", "unexpected keyword", "unknown keyword"))
+                ):
+                    raise CheckpointLoadError(f"safe load failed for {p}: {exc}") from exc
                 raise CheckpointLoadError(f"safe load failed for {p}: {exc}") from exc
 
     try:

--- a/src/codex_ml/utils/system_metrics.py
+++ b/src/codex_ml/utils/system_metrics.py
@@ -15,12 +15,12 @@ except (ImportError, AttributeError):  # pragma: no cover - optional dependency 
 
 try:  # pragma: no cover - optional dependency
     import pynvml
-except (ImportError, AttributeError):  # pragma: no cover - optional dependency may be absent
+except (ImportError, AttributeError, OSError, RuntimeError, ValueError):  # pragma: no cover - optional dependency may be absent
     pynvml = None
 else:  # pragma: no cover - NVML initialisation best effort
     try:
         pynvml.nvmlInit()
-    except (ValueError, TypeError, RuntimeError):  # pragma: no cover - unavailable runtime
+    except Exception:  # pragma: no cover - unavailable runtime
         LOGGER.debug("NVML initialisation failed", exc_info=True)
         pynvml = None
 
@@ -51,7 +51,7 @@ def collect_metrics() -> dict[str, float]:
     if pynvml is not None:
         try:
             device_count = pynvml.nvmlDeviceGetCount()
-        except (ValueError, TypeError, RuntimeError):  # pragma: no cover - NVML failure
+        except Exception:  # pragma: no cover - NVML failure
             LOGGER.debug("NVML device enumeration failed", exc_info=True)
         else:
             for index in range(device_count):
@@ -59,11 +59,7 @@ def collect_metrics() -> dict[str, float]:
                     handle = pynvml.nvmlDeviceGetHandleByIndex(index)
                     utilisation = pynvml.nvmlDeviceGetUtilizationRates(handle)
                     memory = pynvml.nvmlDeviceGetMemoryInfo(handle)
-                except (
-                    ValueError,
-                    TypeError,
-                    RuntimeError,
-                ):  # pragma: no cover - per-device failure best effort
+                except Exception:  # pragma: no cover - per-device failure best effort
                     LOGGER.debug("NVML metrics failed for device %s", index, exc_info=True)
                     continue
                 metrics[f"gpu{index}_util_percent"] = float(utilisation.gpu)

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -494,7 +494,7 @@ def system_metrics() -> dict[str, Any]:
         finally:
             try:
                 pynvml.nvmlShutdown()
-            except (IOError, OSError, ModuleNotFoundError, ImportError, RuntimeError, ValueError):  # pragma: no cover - best-effort shutdown
+            except Exception:  # pragma: no cover - best-effort shutdown
                 LOGGER.debug("NVML shutdown failed", exc_info=True)
 
     return snapshot

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -32,7 +32,7 @@ except (ImportError, AttributeError):  # pragma: no cover - allow execution with
 
 try:  # pragma: no cover - optional GPU metrics dependency
     import pynvml
-except (ImportError, AttributeError):  # pragma: no cover - allow execution without NVML bindings
+except (ImportError, AttributeError, OSError, RuntimeError, ValueError):  # pragma: no cover - allow execution without NVML bindings
     pynvml = None
 
 
@@ -489,12 +489,12 @@ def system_metrics() -> dict[str, Any]:
                     }
                 )
             snapshot["gpus"] = gpus
-        except (ValueError, TypeError, RuntimeError):  # pragma: no cover - NVML metrics best-effort
+        except Exception:  # pragma: no cover - NVML metrics best-effort
             LOGGER.debug("NVML metrics collection failed", exc_info=True)
         finally:
             try:
                 pynvml.nvmlShutdown()
-            except (IOError, OSError, ModuleNotFoundError, ImportError):  # pragma: no cover - best-effort shutdown
+            except (IOError, OSError, ModuleNotFoundError, ImportError, RuntimeError, ValueError):  # pragma: no cover - best-effort shutdown
                 LOGGER.debug("NVML shutdown failed", exc_info=True)
 
     return snapshot

--- a/src/training/checkpointing.py
+++ b/src/training/checkpointing.py
@@ -149,9 +149,6 @@ def _torch_load(path: str, *, map_location: str | torch.device | None) -> Any:
         return load_fn(path, **kwargs)
     except TypeError as exc:
         logger.debug("TypeError: %s", exc)
-        if _TORCH_SUPPORTS_WEIGHTS_ONLY and "weights_only" in str(exc):
-            kwargs.pop("weights_only", None)
-            return load_fn(path, **kwargs)
         raise
 
 

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -147,11 +147,7 @@ def _load_checkpoint_payload(path: Path, *, map_location: Any) -> Mapping[str, A
     except TypeError as exc:
         type(exc).__name__
         logger.debug("TypeError: <ERROR_TYPE>")
-        if _TORCH_SUPPORTS_WEIGHTS_ONLY and "weights_only" in str(exc):
-            kwargs.pop("weights_only", None)
-            result = _TORCH_LOAD_FN(path, **kwargs)
-        else:
-            raise
+        raise
     if not isinstance(result, Mapping):
         return {}
     return result

--- a/src/utils/checkpoint.py
+++ b/src/utils/checkpoint.py
@@ -87,12 +87,15 @@ def _can_retry_without_weights_only(exc: BaseException) -> bool:
     if not isinstance(exc, TypeError):
         return False
     message = str(exc).lower()
+    # Old Torch builds may reject the `weights_only` keyword itself. In that case
+    # we can fall back to the legacy API. Payload/runtime failures are never retried.
     return any(
         token in message
         for token in (
-            "weights_only",
-            "unexpected keyword",
-            "unknown keyword",
+            "unexpected keyword argument 'weights_only'",
+            "unknown keyword argument 'weights_only'",
+            "unexpected keyword: weights_only",
+            "unknown keyword: weights_only",
         )
     )
 
@@ -234,12 +237,14 @@ def _torch_load(path: str, *, map_location: str | None = None) -> Any:
         kwargs["weights_only"] = True
     try:
         return load_fn(path, **kwargs)
-    except (TypeError, ValueError, RuntimeError) as exc:
-        type(exc).__name__
+    except TypeError as exc:
         logger.debug("torch.load rejected payload: %s", exc)
         if _TORCH_SUPPORTS_WEIGHTS_ONLY and "weights_only" in kwargs and _can_retry_without_weights_only(exc):
             kwargs.pop("weights_only", None)
             return load_fn(path, **kwargs)
+        raise
+    except (ValueError, RuntimeError) as exc:
+        logger.debug("torch.load rejected payload: %s", exc)
         raise
 
 

--- a/src/utils/checkpoint.py
+++ b/src/utils/checkpoint.py
@@ -220,9 +220,9 @@ def _torch_load(path: str, *, map_location: str | None = None) -> Any:
         kwargs["weights_only"] = True
     try:
         return load_fn(path, **kwargs)
-    except TypeError as exc:
+    except (TypeError, ValueError, RuntimeError) as exc:
         type(exc).__name__
-        logger.debug("TypeError: <ERROR_TYPE>")
+        logger.debug("torch.load rejected payload: %s", exc)
         if _TORCH_SUPPORTS_WEIGHTS_ONLY and "weights_only" in str(exc):
             kwargs.pop("weights_only", None)
             return load_fn(path, **kwargs)

--- a/src/utils/checkpoint.py
+++ b/src/utils/checkpoint.py
@@ -83,6 +83,20 @@ def _torch_supports_weights_only() -> bool:
 _TORCH_SUPPORTS_WEIGHTS_ONLY = _torch_supports_weights_only()
 
 
+def _can_retry_without_weights_only(exc: BaseException) -> bool:
+    if not isinstance(exc, TypeError):
+        return False
+    message = str(exc).lower()
+    return any(
+        token in message
+        for token in (
+            "weights_only",
+            "unexpected keyword",
+            "unknown keyword",
+        )
+    )
+
+
 def _torch_rng_get_state() -> Any:
     if _torch is None:
         raise RuntimeError("torch is required to capture RNG state")
@@ -223,7 +237,7 @@ def _torch_load(path: str, *, map_location: str | None = None) -> Any:
     except (TypeError, ValueError, RuntimeError) as exc:
         type(exc).__name__
         logger.debug("torch.load rejected payload: %s", exc)
-        if _TORCH_SUPPORTS_WEIGHTS_ONLY and "weights_only" in str(exc):
+        if _TORCH_SUPPORTS_WEIGHTS_ONLY and "weights_only" in kwargs and _can_retry_without_weights_only(exc):
             kwargs.pop("weights_only", None)
             return load_fn(path, **kwargs)
         raise


### PR DESCRIPTION
## Summary of Changes — PR #5496 · `716fcec7` · 2026-08-21T07:26Z

### Recent Commits
- `716fcec7 Merge be97827ce7da025d98563c2a144e0b69c637993c into c43659bfbb55b24d1265336d7dadcf410cc79f74`

---

## 🎯 Merge-Readiness Scorecard

**Score: 84/100 (84%) — 🔴 NOT READY** · _2026-08-21T07:26Z_

| Dimension | Wt | Status |
|-----------|----:|--------|
| auto_fix (0 auto-fixable) | 15 | ✅ 0 auto-fixable |
| sync_tracked_files | 12 | ✅ green |
| action_versions (all approved) | 12 | ✅ all approved |
| ruff (src/ clean) | 10 | ✅ clean |
| github-script ≥ v8 | 8 | ✅ all ≥ v8 |
| Pattern 27 registered | 7 | ✅ registered |
| download-artifact min v5 | 7 | ✅ v5 |
| PDA entry today | 8 | ⚠️ no entry today |
| accountability report today | 8 | ❌ stale |
| AAIS composite 91.4/100 | 13 | ✅ 91.4/100 |

---

## 🔄 Follow-Up Prompt

```
@copilot CTEP Mode: ON

Failing dimensions to fix:
  - PDA entry today
  - accountability report today

Run: python3 scripts/ci/session_wrapup_autofix.py --pr-number <N> --activate-workflows
```

---

---

## 🤖 Agents Used

> **For Copilot Cloud Agent:** List every Custom Agent (from `AGENT_REGISTRY.yaml`) invoked during this session.
> Use `- [x] \`agent_type\`` format.
> Required by CAD-Mandate (Rule 3).

- [ ] `ci-testing-agent`
- [ ] `unified-coverage-agent`
- [ ] `ci-auto-healer-agent`
- [ ] `general-purpose`

---

## 🔄 Workflow Execution Checklist

### ✅ Always Required — fire automatically on every push (cannot be skipped)
- [x] pre-merge-validation.yml — Pre-merge checks (always required)
- [x] comment-review-gate.yml — Comment review gate (always required)
- [x] deferral-language-gate.yml — Deferral language guard (always required)
- [x] agent-auth-delegation.yml — Agent token delegation (always required)
- [x] workflow-execution-gate.yml — WEC gate — parse checklist & arm allowed workflows (always required)

### 🔄 Always Active — fire via push/workflow_run (need approval in Actions tab)
- [x] unified-copilot-management.yml — Copilot Management Suite (agent-checkin, session-done, self-healing)
- [ ] iterative-self-healing-ci.yml — Iterative self-healing CI loop (fires on workflow_run — needs approval)
- [x] cost-gate.yml — Cost governance gate (called by agent-auth-delegation)

### ⚡ Auto-Approve
- [x] auto-approve-workflows — Auto-Approve workflow to run (approves all pending runs on last commit SHA)

### 🧪 Opt-In: Testing & Validation
- [x] validate.yml — Validation Pipeline (detect-secrets, ruff, pre-commit, sync-tracked)
- [x] resilient_validation.yml — Resilient Validation Suite (full pytest, 4 shards)
- [ ] test-rag.yml — RAG Module Tests (coverage ≥95%)
- [ ] nox_gates.yml — Nox quality gates (ruff, mypy, coverage)
- [ ] mypy-baseline.yml — mypy type-check anti-regression gate
- [ ] coverage-with-timeout.yml — Coverage with timeout guards
- [ ] progressive-validation.yml — Progressive Validation Suite
- [ ] pre-flight-validation.yml — Pre-flight CI validation
- [ ] ci-checkpoint-validation.yml — CI Checkpoint Validation
- [ ] data-quality-suite.yml — Data Quality & Determinism Suite
- [ ] auth-tests.yml — Authentication Tests
- [ ] pr-checks.yml — PR Checks (isolated cache, src/ scope)
- [ ] html_visual_regression.yml — HTML Visual Regression Screenshots

### 🔒 Opt-In: Security & Quality
- [x] security-scanning-suite.yml — Full security audit (bandit, pip-audit)
- [ ] codeql-analysis.yml — CodeQL SAST analysis
- [ ] actionlint-audit.yml — Workflow compliance audit (actionlint)
- [ ] semgrep_sarif.yml — Semgrep SAST (SARIF upload)
- [ ] auto-fix-common-issues.yml — Auto-Fix Common CI Issues
- [ ] auto-fix-pr-check.yml — PR Auto-Fix Check
- [ ] code-quality-coverage-suite.yml — Code Quality & Coverage Suite
- [ ] audit-qa-suite.yml — Audit & QA Suite (Unified)
- [ ] template_lint.yml — PR Template Lint
- [x] codeql-alert-fetcher.yml — CodeQL Alert Fetcher (artifact for in-session review)

### 📄 Opt-In: Documentation
- [ ] documentation-link-checker.yml — Documentation link checker
- [ ] pages-pre-merge-validation.yml — Pages pre-merge validation

### ⚙️ Opt-In: Infrastructure & Deployment
- [x] reference-integrity.yml — Reference integrity + agent size gate
- [ ] dependency-submission.yml — Resilient dependency submission
- [ ] docker-build-push.yml — Build & push Docker image (GHCR)
- [ ] rust_swarm_ci.yml — Rust-Python hybrid swarm CI/CD
- [ ] root-org-validation.yml — Root organization validation
- [ ] agent-registry-validation.yml — Agent registry validation
- [ ] e-to-d-transition-gate.yml — E→D transition readiness gate
- [ ] d-capable-promotion-gate.yml — D_CAPABLE agent promotion gate
- [ ] qa-walkthrough.yml — QA walkthrough agent
- [ ] mcp-health.yml — MCP health & metrics gate (src/mcp/ scope)

> **⚠️ HARDENED AGENT INSTRUCTION (non-negotiable):** This entire WEC block MUST be
> appended verbatim to **every** PR body update — including every `report_progress` call.
> **ALWAYS generate the WEC block via the CLI** before calling `report_progress`:
>
>     python scripts/ci/session_wrapup_autofix.py --print-wec-block --pr-number <N>
>
> This command fetches the live PR body, detects human-vs-agent checkbox changes,
> and returns the correct WEC block with ALL human grants preserved as sticky `[x]`.
> Never reconstruct the block manually — human grants recorded in `.codex/wec_state.json`
> MUST be applied or the maintainer's autonomy grants will be silently lost.
